### PR TITLE
Add Dreame OTA firmware approval flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,8 +83,19 @@ region/account details are especially helpful for moving a device from
 
 The following areas are intentionally cautious:
 
-- firmware OTA availability is reported as unknown unless a verified mower OTA
-  signal is found
+- firmware OTA now exposes a Home Assistant update entity using the app's
+  approved `checkDeviceVersion` target and `manualFirmwareUpdate` approval
+  step, but release notes remain best-effort because the live A2 endpoint still
+  embeds a `missing lang` error string in the changelog field
+  the live Dreame A2 verification on April 22, 2026 completed from
+  `4.3.6_0320` to `4.3.6_0447`
+- a read-only debug OTA catalog probe exists for version-trace work, but it is
+  not treated as authoritative latest-version, changelog, or install approval
+  data because it is a manual catalog rather than the mobile app's approved OTA
+  response
+- firmware diagnostics now include those debug-catalog candidate versions when
+  available, so operation snapshots can show plausible newer builds without
+  conflating them with the app-approved update target
 - rain-protection writes are not exposed yet
 - mowing-preference writes are guarded, validated on a supervised A2 no-op write, and still need broader model and firmware validation
 - map rendering is read-only; no-go editing, virtual-wall editing, and other map

--- a/custom_components/dreame_lawn_mower/api.py
+++ b/custom_components/dreame_lawn_mower/api.py
@@ -6,6 +6,7 @@ from .dreame_lawn_mower_client import (
     DreameLawnMowerConnectionError,
     DreameLawnMowerDescriptor,
     DreameLawnMowerError,
+    DreameLawnMowerFirmwareUpdateSupport,
     DreameLawnMowerSnapshot,
     DreameLawnMowerTwoFactorRequiredError,
 )
@@ -16,7 +17,7 @@ __all__ = [
     "DreameLawnMowerConnectionError",
     "DreameLawnMowerDescriptor",
     "DreameLawnMowerError",
+    "DreameLawnMowerFirmwareUpdateSupport",
     "DreameLawnMowerSnapshot",
     "DreameLawnMowerTwoFactorRequiredError",
 ]
-

--- a/custom_components/dreame_lawn_mower/binary_sensor.py
+++ b/custom_components/dreame_lawn_mower/binary_sensor.py
@@ -100,8 +100,10 @@ BINARY_SENSORS = [
     DreameBinarySensorDescription(
         key="device_connected",
         name="Device Connected",
-        value_fn=lambda snapshot: snapshot.device_connected,
-        exists_fn=lambda snapshot: snapshot.device_connected is not None,
+        value_fn=lambda snapshot: getattr(snapshot, "device_connected", None),
+        exists_fn=lambda snapshot: (
+            getattr(snapshot, "device_connected", None) is not None
+        ),
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -109,8 +111,9 @@ BINARY_SENSORS = [
     DreameBinarySensorDescription(
         key="cloud_connected",
         name="Cloud Connected",
-        value_fn=lambda snapshot: snapshot.cloud_connected,
-        exists_fn=lambda snapshot: snapshot.cloud_connected is not None,
+        value_fn=lambda snapshot: getattr(snapshot, "cloud_connected", None),
+        exists_fn=lambda snapshot: getattr(snapshot, "cloud_connected", None)
+        is not None,
         device_class=BinarySensorDeviceClass.CONNECTIVITY,
         entity_category=EntityCategory.DIAGNOSTIC,
         entity_registry_enabled_default=False,
@@ -214,8 +217,8 @@ BINARY_SENSORS = [
     DreameBinarySensorDescription(
         key="child_lock",
         name="Child Lock",
-        value_fn=lambda snapshot: snapshot.child_lock,
-        exists_fn=lambda snapshot: snapshot.child_lock is not None,
+        value_fn=lambda snapshot: getattr(snapshot, "child_lock", None),
+        exists_fn=lambda snapshot: getattr(snapshot, "child_lock", None) is not None,
         icon="mdi:lock-outline",
         entity_registry_enabled_default=False,
     ),

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -195,7 +195,9 @@ class DreameLawnMowerLivePathMapCamera(DreameLawnMowerMapCamera):
             self.async_write_ha_state()
             return view
         except Exception as err:
-            _LOGGER.warning("Failed to refresh Dreame mower live-path map image: %s", err)
+            _LOGGER.warning(
+                "Failed to refresh Dreame mower live-path map image: %s", err
+            )
             view = self._map_cache.store_error(str(err), source="batch_vector_map")
             self.async_write_ha_state()
             return view

--- a/custom_components/dreame_lawn_mower/const.py
+++ b/custom_components/dreame_lawn_mower/const.py
@@ -37,8 +37,10 @@ PLATFORMS: list[Platform] = [
     Platform.BINARY_SENSOR,
     Platform.BUTTON,
     Platform.LAWN_MOWER,
+    Platform.NUMBER,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.SWITCH,
     Platform.UPDATE,
 ]
 

--- a/custom_components/dreame_lawn_mower/const.py
+++ b/custom_components/dreame_lawn_mower/const.py
@@ -39,6 +39,7 @@ PLATFORMS: list[Platform] = [
     Platform.LAWN_MOWER,
     Platform.SELECT,
     Platform.SENSOR,
+    Platform.UPDATE,
 ]
 
 ACTIVITY_MOWING = "mowing"

--- a/custom_components/dreame_lawn_mower/control_options.py
+++ b/custom_components/dreame_lawn_mower/control_options.py
@@ -138,7 +138,10 @@ def current_contour_entries(
 
     result: list[dict[str, Any]] = []
     for map_entry in maps:
-        if not isinstance(map_entry, Mapping) or map_entry.get("map_index") != current_idx:
+        if (
+            not isinstance(map_entry, Mapping)
+            or map_entry.get("map_index") != current_idx
+        ):
             continue
         contour_ids = map_entry.get("contour_ids")
         if not isinstance(contour_ids, Sequence) or isinstance(
@@ -264,7 +267,9 @@ def map_entries(
 
 def mowing_action_label(action: str) -> str:
     """Return the display label for a mowing action key."""
-    return MOWING_ACTION_LABELS.get(action, MOWING_ACTION_LABELS[MOWING_ACTION_ALL_AREA])
+    return MOWING_ACTION_LABELS.get(
+        action, MOWING_ACTION_LABELS[MOWING_ACTION_ALL_AREA]
+    )
 
 
 def map_label(map_index: int, name: str | None = None) -> str:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -44,6 +44,7 @@ APP_MAP_REFRESH_INTERVAL = timedelta(minutes=5)
 APP_MAP_OBJECT_REFRESH_INTERVAL = timedelta(minutes=30)
 VECTOR_MAP_REFRESH_INTERVAL = timedelta(minutes=5)
 WEATHER_PROTECTION_REFRESH_INTERVAL = timedelta(minutes=5)
+VOICE_SETTINGS_REFRESH_INTERVAL = timedelta(minutes=5)
 FIRMWARE_UPDATE_REFRESH_INTERVAL = timedelta(minutes=15)
 
 
@@ -83,6 +84,8 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         self.vector_map_details_refreshed_at: datetime | None = None
         self.weather_protection: dict[str, Any] | None = None
         self.weather_protection_refreshed_at: datetime | None = None
+        self.voice_settings: dict[str, Any] | None = None
+        self.voice_settings_refreshed_at: datetime | None = None
         self.selected_mowing_action = "all_area"
         self.selected_map_index: int | None = None
         self.selected_contour_id: tuple[int, int] | None = None
@@ -144,6 +147,7 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         await self.async_refresh_app_map_objects(force=False)
         await self.async_refresh_vector_map_details(force=False)
         await self.async_refresh_weather_protection(force=False)
+        await self.async_refresh_voice_settings(force=False)
         return snapshot
 
     async def async_refresh_batch_device_data(
@@ -164,9 +168,11 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
             return self.batch_device_data
 
         try:
-            batch_schedule, batch_mowing_preferences, batch_ota_info = await (
-                self._async_fetch_batch_device_data()
-            )
+            (
+                batch_schedule,
+                batch_mowing_preferences,
+                batch_ota_info,
+            ) = await self._async_fetch_batch_device_data()
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh batch device data: %s", err)
             return self.batch_device_data
@@ -348,6 +354,39 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         payload["source"] = source
         self.weather_protection = payload
         self.weather_protection_refreshed_at = now
+        return payload
+
+    async def async_refresh_voice_settings(
+        self,
+        *,
+        force: bool = False,
+        source: str = "voice_settings_auto",
+    ) -> dict[str, Any] | None:
+        """Refresh cached voice/language settings without failing the main poll."""
+        now = datetime.now(UTC)
+        if (
+            not force
+            and self.voice_settings is not None
+            and self.voice_settings_refreshed_at is not None
+            and now - self.voice_settings_refreshed_at < VOICE_SETTINGS_REFRESH_INTERVAL
+        ):
+            return self.voice_settings
+
+        try:
+            voice_settings = await self.client.async_get_voice_settings(
+                include_raw=False
+            )
+        except Exception as err:  # noqa: BLE001 - best-effort extra metadata
+            _LOGGER.debug("Failed to refresh voice settings: %s", err)
+            return self.voice_settings
+
+        payload = {
+            "captured_at": now.isoformat(),
+            "source": source,
+            "voice_settings": voice_settings,
+        }
+        self.voice_settings = payload
+        self.voice_settings_refreshed_at = now
         return payload
 
     async def async_shutdown(self) -> None:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -14,9 +14,9 @@ from .api import (
     DreameLawnMowerClient,
     DreameLawnMowerConnectionError,
     DreameLawnMowerDescriptor,
+    DreameLawnMowerFirmwareUpdateSupport,
     DreameLawnMowerSnapshot,
 )
-from .dreame_lawn_mower_client.models import DreameLawnMowerStatusBlob
 from .const import (
     CONF_ACCOUNT_TYPE,
     CONF_COUNTRY,
@@ -32,7 +32,10 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_SECONDS,
     DOMAIN,
 )
-from .dreame_lawn_mower_client.models import display_name_for_model
+from .dreame_lawn_mower_client.models import (
+    DreameLawnMowerStatusBlob,
+    display_name_for_model,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -41,6 +44,7 @@ APP_MAP_REFRESH_INTERVAL = timedelta(minutes=5)
 APP_MAP_OBJECT_REFRESH_INTERVAL = timedelta(minutes=30)
 VECTOR_MAP_REFRESH_INTERVAL = timedelta(minutes=5)
 WEATHER_PROTECTION_REFRESH_INTERVAL = timedelta(minutes=5)
+FIRMWARE_UPDATE_REFRESH_INTERVAL = timedelta(minutes=15)
 
 
 class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot]):
@@ -73,6 +77,8 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         self.app_map_objects_refreshed_at: datetime | None = None
         self.batch_device_data: dict[str, Any] | None = None
         self.batch_device_data_refreshed_at: datetime | None = None
+        self.firmware_update_support: DreameLawnMowerFirmwareUpdateSupport | None = None
+        self.firmware_update_support_refreshed_at: datetime | None = None
         self.vector_map_details: dict[str, Any] | None = None
         self.vector_map_details_refreshed_at: datetime | None = None
         self.weather_protection: dict[str, Any] | None = None
@@ -133,6 +139,7 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
             _LOGGER.debug("Failed to refresh Bluetooth connection state: %s", err)
             self.bluetooth_connected = None
         await self.async_refresh_batch_device_data(force=False)
+        await self.async_refresh_firmware_update_support(force=False)
         await self.async_refresh_app_maps(force=False)
         await self.async_refresh_app_map_objects(force=False)
         await self.async_refresh_vector_map_details(force=False)
@@ -184,6 +191,36 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
             self.client.async_get_batch_mowing_preferences(include_raw=False),
             self.client.async_get_batch_ota_info(include_raw=False),
         )
+
+    async def async_refresh_firmware_update_support(
+        self,
+        *,
+        force: bool = False,
+    ) -> DreameLawnMowerFirmwareUpdateSupport | None:
+        """Refresh cached firmware/update support without failing the main poll."""
+        now = datetime.now(UTC)
+        if (
+            not force
+            and self.firmware_update_support is not None
+            and self.firmware_update_support_refreshed_at is not None
+            and now - self.firmware_update_support_refreshed_at
+            < FIRMWARE_UPDATE_REFRESH_INTERVAL
+        ):
+            return self.firmware_update_support
+
+        try:
+            support = await self.client.async_get_firmware_update_support(
+                refresh=False,
+                include_cloud=True,
+                language="en",
+            )
+        except Exception as err:  # noqa: BLE001 - best-effort extra metadata
+            _LOGGER.debug("Failed to refresh firmware update support: %s", err)
+            return self.firmware_update_support
+
+        self.firmware_update_support = support
+        self.firmware_update_support_refreshed_at = now
+        return support
 
     async def async_refresh_app_map_objects(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -48,6 +48,12 @@ from .client import (
     DreameLawnMowerTwoFactorRequiredError,
     render_app_map_payload_png,
 )
+from .debug_ota_catalog import (
+    DEBUG_OTA_LIST_URL,
+    DEBUG_OTA_TRACKS,
+    build_debug_ota_catalog_url,
+    normalize_debug_ota_catalog_payload,
+)
 from .map_probe import (
     MAP_HISTORY_PROPERTY_KEYS,
     MAP_PROBE_PROPERTY_KEYS,
@@ -124,6 +130,8 @@ __all__ = [
     "DISPLAY_NAME_ALIASES",
     "MODEL_NAME_MAP",
     "CAMERA_PROBE_PROPERTY_KEYS",
+    "DEBUG_OTA_LIST_URL",
+    "DEBUG_OTA_TRACKS",
     "MAP_PROBE_PROPERTY_KEYS",
     "MAP_HISTORY_PROPERTY_KEYS",
     "MOWER_BLUETOOTH_PROPERTY_KEY",
@@ -150,6 +158,7 @@ __all__ = [
     "batch_data_text",
     "build_jadx_command",
     "build_camera_probe_payload",
+    "build_debug_ota_catalog_url",
     "build_cloud_key_definition_summary",
     "build_cloud_property_history_summary",
     "build_cloud_property_summary",
@@ -176,6 +185,7 @@ __all__ = [
     "map_diagnostics_from_device",
     "map_summary_from_map_data",
     "map_summary_to_dict",
+    "normalize_debug_ota_catalog_payload",
     "mowing_preference_mode_name",
     "normalize_mowing_preference_mode",
     "remote_control_block_reason",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -320,9 +320,7 @@ class DreameLawnMowerClient:
     ) -> Any:
         """Start spot mowing for one or more center points."""
         normalized = [
-            [int(point[0]), int(point[1])]
-            for point in points
-            if len(point) >= 2
+            [int(point[0]), int(point[1])] for point in points if len(point) >= 2
         ]
         return await asyncio.to_thread(self._sync_clean_spots, normalized)
 
@@ -394,6 +392,7 @@ class DreameLawnMowerClient:
         *,
         refresh: bool = False,
         include_cloud: bool = True,
+        include_debug_ota_catalog: bool = False,
         language: str | None = "en",
     ) -> DreameLawnMowerFirmwareUpdateSupport:
         """Return firmware/update evidence without guessing availability."""
@@ -401,6 +400,7 @@ class DreameLawnMowerClient:
             self._sync_get_firmware_update_support,
             refresh,
             include_cloud,
+            include_debug_ota_catalog,
             language,
         )
 
@@ -1160,6 +1160,7 @@ class DreameLawnMowerClient:
         self,
         refresh: bool = False,
         include_cloud: bool = True,
+        include_debug_ota_catalog: bool = False,
         language: str | None = "en",
     ) -> DreameLawnMowerFirmwareUpdateSupport:
         if refresh:
@@ -1191,7 +1192,7 @@ class DreameLawnMowerClient:
         except DreameLawnMowerConnectionError as err:
             if cloud_error is None:
                 cloud_error = str(err)
-        if include_cloud:
+        if include_debug_ota_catalog:
             try:
                 debug_ota_catalog = self._sync_get_debug_ota_catalog(
                     current_version=_as_optional_text(
@@ -1372,6 +1373,7 @@ class DreameLawnMowerClient:
                 payload["firmware_update"] = self._sync_get_firmware_update_support(
                     refresh=False,
                     include_cloud=True,
+                    include_debug_ota_catalog=True,
                     language=language,
                 ).as_dict()
             except Exception as err:  # noqa: BLE001 - probe snapshots keep evidence
@@ -1477,9 +1479,7 @@ class DreameLawnMowerClient:
         except (DeviceException, InvalidActionException) as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
         if result is None:
-            raise DreameLawnMowerConnectionError(
-                "GET_PHOTO_INFO returned no response."
-            )
+            raise DreameLawnMowerConnectionError("GET_PHOTO_INFO returned no response.")
         return result
 
     def _sync_probe_camera_sources(
@@ -1634,8 +1634,7 @@ class DreameLawnMowerClient:
         status = getattr(device, "status", None)
         snapshot = snapshot_from_device(self._descriptor, device)
         raw_running = bool(
-            snapshot.raw_attributes.get("running")
-            or getattr(status, "running", False)
+            snapshot.raw_attributes.get("running") or getattr(status, "running", False)
         )
         if snapshot.mowing or snapshot.returning or raw_running:
             raise DreameLawnMowerConnectionError(
@@ -1809,11 +1808,18 @@ class DreameLawnMowerClient:
             details["runtime_track_segment_count"] = len(runtime_track_segments)
             details["runtime_track_point_count"] = runtime_track_point_count
             details["runtime_track_length_m"] = round(
-                sum(_coordinate_path_length_m(segment) for segment in runtime_track_segments),
+                sum(
+                    _coordinate_path_length_m(segment)
+                    for segment in runtime_track_segments
+                ),
                 2,
             )
-            details["runtime_pose_x"] = getattr(runtime_blob, "candidate_runtime_pose_x", None)
-            details["runtime_pose_y"] = getattr(runtime_blob, "candidate_runtime_pose_y", None)
+            details["runtime_pose_x"] = getattr(
+                runtime_blob, "candidate_runtime_pose_x", None
+            )
+            details["runtime_pose_y"] = getattr(
+                runtime_blob, "candidate_runtime_pose_y", None
+            )
             details["runtime_heading_deg"] = getattr(
                 runtime_blob,
                 "candidate_runtime_heading_deg",
@@ -1823,7 +1829,8 @@ class DreameLawnMowerClient:
             if summary is not None:
                 summary = replace(
                     summary,
-                    path_point_count=summary.path_point_count + runtime_track_point_count,
+                    path_point_count=summary.path_point_count
+                    + runtime_track_point_count,
                 )
         try:
             image_png = render_vector_map_png(
@@ -2053,7 +2060,11 @@ class DreameLawnMowerClient:
         result = _normalize_cloud_firmware_check(
             raw,
             current_version=_as_optional_text(
-                getattr(getattr(self._ensure_device(), "info", None), "firmware_version", None)
+                getattr(
+                    getattr(self._ensure_device(), "info", None),
+                    "firmware_version",
+                    None,
+                )
             ),
         )
         if include_raw:
@@ -2082,9 +2093,7 @@ class DreameLawnMowerClient:
             success = raw.get("success")
             data = raw.get("data")
             inner_code = data.get("code") if isinstance(data, Mapping) else None
-            inner_success = (
-                data.get("success") if isinstance(data, Mapping) else None
-            )
+            inner_success = data.get("success") if isinstance(data, Mapping) else None
             accepted = bool(success) if isinstance(success, bool) else code == 0
             result.update(
                 {
@@ -2372,7 +2381,9 @@ class DreameLawnMowerClient:
             for request in requests:
                 response = self._sync_call_app_action(request)
                 response_data = _app_action_data(response)
-                if isinstance(response_data, Mapping) and response_data.get("r") not in (
+                if isinstance(response_data, Mapping) and response_data.get(
+                    "r"
+                ) not in (
                     None,
                     0,
                 ):
@@ -2557,7 +2568,8 @@ class DreameLawnMowerClient:
                 ]
                 if not execute
                 else [
-                    "Preference write executed through the PRE/PREP request sequence after "
+                    "Preference write executed through the PRE/PREP request "
+                    "sequence after "
                     "explicit confirmation.",
                 ]
             ),
@@ -2568,7 +2580,9 @@ class DreameLawnMowerClient:
             for request in request_sequence:
                 response = self._sync_call_app_action(request)
                 response_data = _app_action_data(response)
-                if isinstance(response_data, Mapping) and response_data.get("r") not in (
+                if isinstance(response_data, Mapping) and response_data.get(
+                    "r"
+                ) not in (
                     None,
                     0,
                 ):
@@ -2909,7 +2923,7 @@ class DreameLawnMowerClient:
                 key for key in result["config_keys"] if key in config
             ]
             result.update(_voice_settings_summary(config))
-            result["available"] = True
+            result["available"] = bool(result["present_config_keys"])
         except Exception as err:  # noqa: BLE001 - diagnostic probe should return evidence
             result["errors"].append({"stage": "config", "error": str(err)})
 
@@ -3058,8 +3072,7 @@ class DreameLawnMowerClient:
         try:
             map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
             detected = [
-                entry["idx"]
-                for entry in _normalize_app_map_entries(map_list_result)
+                entry["idx"] for entry in _normalize_app_map_entries(map_list_result)
             ]
         except Exception:  # noqa: BLE001 - fall back to the two likely map slots
             detected = [0, 1]
@@ -3115,9 +3128,7 @@ class DreameLawnMowerClient:
                             chunk_size=chunk_size,
                         )
                     )
-                    payload_hash = hashlib.md5(
-                        payload_text.encode("utf-8")
-                    ).hexdigest()
+                    payload_hash = hashlib.md5(payload_text.encode("utf-8")).hexdigest()
                     parsed_payload = json.loads(payload_text)
                     hash_match = (
                         expected_hash == payload_hash
@@ -3350,7 +3361,7 @@ class DreameLawnMowerClient:
 
         all_entries: list[dict[str, Any]] = []
         for offset in range(0, len(normalized_keys), max(chunk_size, 1)):
-            chunk = normalized_keys[offset: offset + max(chunk_size, 1)]
+            chunk = normalized_keys[offset : offset + max(chunk_size, 1)]
             response = self._sync_get_cloud_properties(chunk)
             all_entries.extend(self._normalize_cloud_property_entries(response))
 
@@ -3464,9 +3475,7 @@ class DreameLawnMowerClient:
 
         try:
             text = (
-                content.decode("utf-8")
-                if isinstance(content, bytes)
-                else str(content)
+                content.decode("utf-8") if isinstance(content, bytes) else str(content)
             )
             result["payload"] = json.loads(text)
             result["fetched"] = True
@@ -3893,11 +3902,15 @@ def _parse_firmware_description(
         if (isinstance(success, bool) and not success) or (
             isinstance(code, int) and code != 0
         ):
-            return None, False, {
-                "code": code,
-                "success": success,
-                "msg": msg,
-            }
+            return (
+                None,
+                False,
+                {
+                    "code": code,
+                    "success": success,
+                    "msg": msg,
+                },
+            )
 
     return text, True, None
 
@@ -4052,11 +4065,7 @@ def _schedule_plan_overview(
             str | bytes | bytearray,
         ):
             week_items = [week for week in weeks if isinstance(week, Mapping)]
-        tasks = [
-            task
-            for week in week_items
-            for task in _schedule_week_tasks(week)
-        ]
+        tasks = [task for week in week_items for task in _schedule_week_tasks(week)]
         type_names = sorted(
             {
                 str(task["type_name"])
@@ -4131,11 +4140,7 @@ def _mowing_preference_map_overview(entry: Mapping[str, Any]) -> dict[str, Any]:
         "mode_name": entry.get("mode_name"),
         "area_count": entry.get("area_count"),
         "preference_count": len(
-            [
-                item
-                for item in entry.get("preferences", [])
-                if isinstance(item, Mapping)
-            ]
+            [item for item in entry.get("preferences", []) if isinstance(item, Mapping)]
         ),
     }
 
@@ -4162,9 +4167,7 @@ def _mowing_preference_overview(preference: Mapping[str, Any]) -> dict[str, Any]
         "cutter_position_name": preference.get("cutter_position_name"),
         "edge_mowing_num": preference.get("edge_mowing_num"),
         "obstacle_avoidance_enabled": preference.get("obstacle_avoidance_enabled"),
-        "obstacle_avoidance_height_cm": preference.get(
-            "obstacle_avoidance_height_cm"
-        ),
+        "obstacle_avoidance_height_cm": preference.get("obstacle_avoidance_height_cm"),
         "obstacle_avoidance_distance_cm": preference.get(
             "obstacle_avoidance_distance_cm"
         ),
@@ -4388,11 +4391,7 @@ def _weather_protection_summary(config: Mapping[str, Any]) -> dict[str, Any]:
     if end_time is not None:
         summary["rain_protect_end_time"] = end_time
         summary["rain_protect_end_time_present"] = True
-    return {
-        key: value
-        for key, value in summary.items()
-        if value is not None
-    }
+    return {key: value for key, value in summary.items() if value is not None}
 
 
 def _weather_protection_active_summary(result: Mapping[str, Any]) -> dict[str, Any]:
@@ -4419,12 +4418,8 @@ def _voice_settings_summary(config: Mapping[str, Any]) -> dict[str, Any]:
         str | bytes | bytearray,
     ):
         values = list(language)
-        text_language_index = (
-            _as_optional_int(values[0]) if len(values) > 0 else None
-        )
-        voice_language_index = (
-            _as_optional_int(values[1]) if len(values) > 1 else None
-        )
+        text_language_index = _as_optional_int(values[0]) if len(values) > 0 else None
+        voice_language_index = _as_optional_int(values[1]) if len(values) > 1 else None
         summary["text_language_index"] = text_language_index
         summary["voice_language_index"] = voice_language_index
         summary["voice_language_name"] = VOICE_LANGUAGE_INDEX_TO_LABEL.get(
@@ -4438,10 +4433,11 @@ def _voice_settings_summary(config: Mapping[str, Any]) -> dict[str, Any]:
     if volume is not None:
         summary["volume"] = volume
 
-    voice_prompts = _normalize_voice_prompt_flags(config.get("VOICE"))
-    summary["voice_prompts"] = voice_prompts
-    for field_name, enabled in zip(VOICE_PROMPT_FIELDS, voice_prompts, strict=True):
-        summary[field_name] = bool(enabled)
+    if "VOICE" in config:
+        voice_prompts = _normalize_voice_prompt_flags(config.get("VOICE"))
+        summary["voice_prompts"] = voice_prompts
+        for field_name, enabled in zip(VOICE_PROMPT_FIELDS, voice_prompts, strict=True):
+            summary[field_name] = bool(enabled)
 
     return summary
 
@@ -4452,9 +4448,7 @@ def _app_maps_view_metadata(app_maps: Mapping[str, Any]) -> dict[str, Any]:
         maps = []
 
     entries = [
-        _app_map_entry_view_metadata(item)
-        for item in maps
-        if isinstance(item, Mapping)
+        _app_map_entry_view_metadata(item) for item in maps if isinstance(item, Mapping)
     ]
     objects = _app_map_objects_view_metadata(app_maps.get("objects"))
     return {
@@ -4526,11 +4520,7 @@ def _app_map_entry_view_metadata(entry: Mapping[str, Any]) -> dict[str, Any]:
         "cut_relation_count": summary.get("cut_relation_count"),
         "error": entry.get("error"),
     }
-    return {
-        key: value
-        for key, value in result.items()
-        if value not in (None, [], {})
-    }
+    return {key: value for key, value in result.items() if value not in (None, [], {})}
 
 
 def _app_map_view_summary(
@@ -4706,7 +4696,12 @@ def _runtime_blob_position(
         return None
     x = getattr(blob, "candidate_runtime_pose_x", None)
     y = getattr(blob, "candidate_runtime_pose_y", None)
-    if isinstance(x, int) and not isinstance(x, bool) and isinstance(y, int) and not isinstance(y, bool):
+    if (
+        isinstance(x, int)
+        and not isinstance(x, bool)
+        and isinstance(y, int)
+        and not isinstance(y, bool)
+    ):
         return (x, y)
     return None
 
@@ -4775,9 +4770,7 @@ def _camera_feature_advertised(
     video_status: Any,
 ) -> bool:
     permit_tokens = {
-        item.strip().casefold()
-        for item in (permit or "").split(",")
-        if item.strip()
+        item.strip().casefold() for item in (permit or "").split(",") if item.strip()
     }
     return bool(
         camera_streaming

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -95,6 +95,57 @@ from .vector_map import (
 
 REMOTE_CONTROL_MAX_ROTATION = 1000
 REMOTE_CONTROL_MAX_VELOCITY = 1000
+VOICE_LANGUAGE_CODES = (
+    "en",
+    "cn",
+    "de",
+    "fr",
+    "it",
+    "es",
+    "pt",
+    "no",
+    "sv",
+    "da",
+    "fi",
+    "nl",
+    "tr",
+    "pl",
+    "ru",
+    "lt",
+)
+VOICE_LANGUAGE_LABELS = (
+    "English",
+    "Chinese",
+    "German",
+    "French",
+    "Italian",
+    "Spanish",
+    "Portuguese",
+    "Norwegian",
+    "Swedish",
+    "Danish",
+    "Finnish",
+    "Dutch",
+    "Turkish",
+    "Polish",
+    "Russian",
+    "Lithuanian",
+)
+VOICE_LANGUAGE_INDEX_TO_LABEL = {
+    index: label for index, label in enumerate(VOICE_LANGUAGE_LABELS)
+}
+VOICE_LANGUAGE_INDEX_TO_CODE = {
+    index: code for index, code in enumerate(VOICE_LANGUAGE_CODES)
+}
+VOICE_LANGUAGE_LABEL_TO_INDEX = {
+    label: index for index, label in enumerate(VOICE_LANGUAGE_LABELS)
+}
+VOICE_PROMPT_FIELDS = (
+    "general_prompt_voice_enabled",
+    "working_voice_enabled",
+    "special_status_voice_enabled",
+    "fault_voice_enabled",
+)
 
 
 class DreameLawnMowerError(Exception):
@@ -601,6 +652,42 @@ class DreameLawnMowerClient:
         return await asyncio.to_thread(
             self._sync_get_weather_protection,
             include_raw,
+        )
+
+    async def async_get_voice_settings(
+        self,
+        *,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Return read-only voice and language settings from app actions."""
+        return await asyncio.to_thread(
+            self._sync_get_voice_settings,
+            include_raw,
+        )
+
+    async def async_set_voice_language(self, voice_language: int) -> dict[str, Any]:
+        """Set the mower voice language by app language-pack index."""
+        return await asyncio.to_thread(
+            self._sync_set_voice_language,
+            int(voice_language),
+        )
+
+    async def async_set_voice_volume(self, volume: int) -> dict[str, Any]:
+        """Set the mower voice volume from 0 to 100."""
+        return await asyncio.to_thread(
+            self._sync_set_voice_volume,
+            int(volume),
+        )
+
+    async def async_set_voice_prompts(
+        self,
+        prompts: Sequence[int | bool],
+    ) -> dict[str, Any]:
+        """Set the four mower voice prompt toggles."""
+        normalized = _normalize_voice_prompt_flags(prompts)
+        return await asyncio.to_thread(
+            self._sync_set_voice_prompts,
+            normalized,
         )
 
     async def async_get_cloud_device_info(
@@ -2785,6 +2872,135 @@ class DreameLawnMowerClient:
         result.update(_weather_protection_active_summary(result))
         return result
 
+    def _sync_get_voice_settings(
+        self,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch read-only voice and language settings from CFG."""
+        result: dict[str, Any] = {
+            "source": "app_action_voice_settings",
+            "available": False,
+            "config_keys": ["LANG", "VOL", "VOICE"],
+            "errors": [],
+            "warnings": [],
+        }
+
+        try:
+            config_result = self._sync_call_app_action({"m": "g", "t": "CFG"})
+            config = _app_action_data(config_result)
+            if not isinstance(config, Mapping):
+                weather_result = self._sync_get_weather_protection(include_raw=True)
+                weather_raw_config = (
+                    weather_result.get("raw_config")
+                    if isinstance(weather_result, Mapping)
+                    else None
+                )
+                weather_data = _app_action_data(weather_raw_config)
+                if isinstance(weather_data, Mapping):
+                    config_result = weather_raw_config
+                    config = weather_data
+            if include_raw:
+                result["raw_config"] = _json_safe(config_result, max_depth=4)
+            if not isinstance(config, Mapping):
+                raise DreameLawnMowerConnectionError(
+                    f"CFG returned invalid voice config: {config_result}"
+                )
+            result["present_config_keys"] = [
+                key for key in result["config_keys"] if key in config
+            ]
+            result.update(_voice_settings_summary(config))
+            result["available"] = True
+        except Exception as err:  # noqa: BLE001 - diagnostic probe should return evidence
+            result["errors"].append({"stage": "config", "error": str(err)})
+
+        return result
+
+    def _sync_set_voice_language(self, voice_language: int) -> dict[str, Any]:
+        """Set the mower voice language and return the confirmed response."""
+        request = {
+            "m": "s",
+            "t": "LANG",
+            "d": {
+                "type": "voice",
+                "value": int(voice_language),
+            },
+        }
+        response = self._sync_call_app_action(request)
+        data = _app_action_data(response)
+        if not isinstance(data, Mapping):
+            raise DreameLawnMowerConnectionError(
+                f"LANG voice write returned invalid data: {response}"
+            )
+        confirmed_voice_language = _as_optional_int(data.get("voice"))
+        confirmed_text_language = _as_optional_int(data.get("text"))
+        return {
+            "source": "app_action_voice_settings_write",
+            "action": "set_voice_language",
+            "request": _json_safe(request, max_depth=4),
+            "response_data": _json_safe(response, max_depth=4),
+            "text_language_index": confirmed_text_language,
+            "voice_language_index": confirmed_voice_language,
+            "voice_language_name": VOICE_LANGUAGE_INDEX_TO_LABEL.get(
+                confirmed_voice_language
+            ),
+            "voice_language_code": VOICE_LANGUAGE_INDEX_TO_CODE.get(
+                confirmed_voice_language
+            ),
+        }
+
+    def _sync_set_voice_volume(self, volume: int) -> dict[str, Any]:
+        """Set the mower voice volume and return the confirmed response."""
+        if volume < 0 or volume > 100:
+            raise ValueError("volume must be between 0 and 100")
+        request = {
+            "m": "s",
+            "t": "VOL",
+            "d": {
+                "value": int(volume),
+            },
+        }
+        response = self._sync_call_app_action(request)
+        data = _app_action_data(response)
+        if not isinstance(data, Mapping):
+            raise DreameLawnMowerConnectionError(
+                f"VOL write returned invalid data: {response}"
+            )
+        return {
+            "source": "app_action_voice_settings_write",
+            "action": "set_voice_volume",
+            "request": _json_safe(request, max_depth=4),
+            "response_data": _json_safe(response, max_depth=4),
+            "volume": _as_optional_int(data.get("value")),
+        }
+
+    def _sync_set_voice_prompts(self, prompts: Sequence[int]) -> dict[str, Any]:
+        """Set the mower voice prompt flags and return the confirmed response."""
+        normalized = _normalize_voice_prompt_flags(prompts)
+        request = {
+            "m": "s",
+            "t": "VOICE",
+            "d": {
+                "value": normalized,
+            },
+        }
+        response = self._sync_call_app_action(request)
+        data = _app_action_data(response)
+        if not isinstance(data, Mapping):
+            raise DreameLawnMowerConnectionError(
+                f"VOICE write returned invalid data: {response}"
+            )
+        confirmed = _normalize_voice_prompt_flags(data.get("value"))
+        result = {
+            "source": "app_action_voice_settings_write",
+            "action": "set_voice_prompts",
+            "request": _json_safe(request, max_depth=4),
+            "response_data": _json_safe(response, max_depth=4),
+            "voice_prompts": confirmed,
+        }
+        for field_name, enabled in zip(VOICE_PROMPT_FIELDS, confirmed, strict=True):
+            result[field_name] = bool(enabled)
+        return result
+
     def _sync_get_app_schedule_text(
         self,
         *,
@@ -4195,6 +4411,41 @@ def _weather_protection_active_summary(result: Mapping[str, Any]) -> dict[str, A
     return summary
 
 
+def _voice_settings_summary(config: Mapping[str, Any]) -> dict[str, Any]:
+    summary: dict[str, Any] = {}
+    language = config.get("LANG")
+    if isinstance(language, Sequence) and not isinstance(
+        language,
+        str | bytes | bytearray,
+    ):
+        values = list(language)
+        text_language_index = (
+            _as_optional_int(values[0]) if len(values) > 0 else None
+        )
+        voice_language_index = (
+            _as_optional_int(values[1]) if len(values) > 1 else None
+        )
+        summary["text_language_index"] = text_language_index
+        summary["voice_language_index"] = voice_language_index
+        summary["voice_language_name"] = VOICE_LANGUAGE_INDEX_TO_LABEL.get(
+            voice_language_index
+        )
+        summary["voice_language_code"] = VOICE_LANGUAGE_INDEX_TO_CODE.get(
+            voice_language_index
+        )
+
+    volume = _as_optional_int(config.get("VOL"))
+    if volume is not None:
+        summary["volume"] = volume
+
+    voice_prompts = _normalize_voice_prompt_flags(config.get("VOICE"))
+    summary["voice_prompts"] = voice_prompts
+    for field_name, enabled in zip(VOICE_PROMPT_FIELDS, voice_prompts, strict=True):
+        summary[field_name] = bool(enabled)
+
+    return summary
+
+
 def _app_maps_view_metadata(app_maps: Mapping[str, Any]) -> dict[str, Any]:
     maps = app_maps.get("maps") if isinstance(app_maps, Mapping) else None
     if not isinstance(maps, Sequence) or isinstance(maps, str | bytes | bytearray):
@@ -4804,6 +5055,28 @@ def _json_safe(value: Any, *, max_depth: int = 4) -> Any:
     if name is not None:
         return str(name).lower()
     return str(value)
+
+
+def _as_optional_int(value: Any) -> int | None:
+    if isinstance(value, bool):
+        return None
+    if isinstance(value, int):
+        return value
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalize_voice_prompt_flags(value: Any) -> list[int]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        return [0, 0, 0, 0]
+    normalized: list[int] = []
+    for item in list(value)[:4]:
+        normalized.append(1 if bool(item) else 0)
+    if len(normalized) < 4:
+        normalized.extend([0] * (4 - len(normalized)))
+    return normalized
 
 
 def _validate_remote_control_step(*, rotation: int, velocity: int) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -7,6 +7,7 @@ import hashlib
 import json
 import math
 import time
+import urllib.request
 from collections.abc import Mapping, Sequence
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -36,6 +37,10 @@ from .batch_device_data import (
     decode_batch_schedule_payload,
 )
 from .camera_probe import CAMERA_PROBE_PROPERTY_KEYS, build_camera_probe_payload
+from .debug_ota_catalog import (
+    build_debug_ota_catalog_url,
+    normalize_debug_ota_catalog_payload,
+)
 from .exceptions import DeviceException, InvalidActionException
 from .map_probe import (
     MAP_HISTORY_PROPERTY_KEYS,
@@ -622,6 +627,27 @@ class DreameLawnMowerClient:
         """Fetch read-only cloud OTC metadata from the mobile app endpoint."""
         return await asyncio.to_thread(self._sync_get_cloud_device_otc_info, language)
 
+    async def async_get_cloud_firmware_check(
+        self,
+        *,
+        language: str | None = None,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch the app-approved mower firmware check payload."""
+        return await asyncio.to_thread(
+            self._sync_get_cloud_firmware_check,
+            language,
+            include_raw,
+        )
+
+    async def async_approve_firmware_update(
+        self,
+        *,
+        language: str | None = None,
+    ) -> dict[str, Any]:
+        """Trigger the cloud firmware approval step used by the mobile app."""
+        return await asyncio.to_thread(self._sync_approve_firmware_update, language)
+
     async def async_get_app_plugin_version(
         self,
         *,
@@ -685,6 +711,21 @@ class DreameLawnMowerClient:
     ) -> dict[str, Any]:
         """Fetch and decode OTA state from batch device data."""
         return await asyncio.to_thread(self._sync_get_batch_ota_info, include_raw)
+
+    async def async_get_debug_ota_catalog(
+        self,
+        *,
+        model_name: str | None = None,
+        current_version: str | None = None,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch the public debug/manual OTA catalog for the mower model."""
+        return await asyncio.to_thread(
+            self._sync_get_debug_ota_catalog,
+            model_name,
+            current_version,
+            include_raw,
+        )
 
     async def async_get_app_map_objects(
         self,
@@ -1041,6 +1082,9 @@ class DreameLawnMowerClient:
 
         cloud_device_info = None
         cloud_device_list_page = None
+        cloud_firmware_check = None
+        batch_ota_info = None
+        debug_ota_catalog = None
         cloud_error = None
         if include_cloud:
             try:
@@ -1052,13 +1096,35 @@ class DreameLawnMowerClient:
                     master=None,
                     shared_status=None,
                 )
+                cloud_firmware_check = self._sync_get_cloud_firmware_check(language)
             except DreameLawnMowerConnectionError as err:
                 cloud_error = str(err)
+        try:
+            batch_ota_info = self._sync_get_batch_ota_info()
+        except DreameLawnMowerConnectionError as err:
+            if cloud_error is None:
+                cloud_error = str(err)
+        if include_cloud:
+            try:
+                debug_ota_catalog = self._sync_get_debug_ota_catalog(
+                    current_version=_as_optional_text(
+                        getattr(getattr(device, "info", None), "firmware_version", None)
+                    )
+                )
+            except DreameLawnMowerConnectionError as err:
+                debug_ota_catalog = {
+                    "source": "debug_ota_catalog",
+                    "available": False,
+                    "errors": [{"stage": "fetch", "error": str(err)}],
+                }
 
         return firmware_update_support_from_device(
             device,
             cloud_device_info=cloud_device_info,
             cloud_device_list_page=cloud_device_list_page,
+            cloud_firmware_check=cloud_firmware_check,
+            batch_ota_info=batch_ota_info,
+            debug_ota_catalog=debug_ota_catalog,
             cloud_error=cloud_error,
         )
 
@@ -1885,6 +1951,72 @@ class DreameLawnMowerClient:
         except DeviceException as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
 
+    def _sync_get_cloud_firmware_check(
+        self,
+        language: str | None = None,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        cloud = self._sync_get_cloud_protocol()
+
+        try:
+            raw = cloud.check_device_version(language)
+        except DeviceException as err:
+            raise DreameLawnMowerConnectionError(str(err)) from err
+
+        result = _normalize_cloud_firmware_check(
+            raw,
+            current_version=_as_optional_text(
+                getattr(getattr(self._ensure_device(), "info", None), "firmware_version", None)
+            ),
+        )
+        if include_raw:
+            result["raw"] = _json_safe(raw, max_depth=4)
+        return result
+
+    def _sync_approve_firmware_update(
+        self,
+        language: str | None = None,
+    ) -> dict[str, Any]:
+        cloud = self._sync_get_cloud_protocol()
+
+        try:
+            raw = cloud.manual_firmware_update(language)
+        except DeviceException as err:
+            raise DreameLawnMowerConnectionError(str(err)) from err
+
+        result: dict[str, Any] = {
+            "source": "cloud_manual_firmware_update",
+            "available": isinstance(raw, Mapping),
+            "accepted": False,
+            "success": False,
+        }
+        if isinstance(raw, Mapping):
+            code = raw.get("code")
+            success = raw.get("success")
+            data = raw.get("data")
+            inner_code = data.get("code") if isinstance(data, Mapping) else None
+            inner_success = (
+                data.get("success") if isinstance(data, Mapping) else None
+            )
+            accepted = bool(success) if isinstance(success, bool) else code == 0
+            result.update(
+                {
+                    "code": code,
+                    "accepted": accepted,
+                    "success": accepted,
+                    "msg": _as_optional_text(raw.get("msg")),
+                    "data": _json_safe(data, max_depth=3),
+                    "wrapper_success": success if isinstance(success, bool) else None,
+                    "inner_code": inner_code,
+                    "inner_success": (
+                        inner_success if isinstance(inner_success, bool) else None
+                    ),
+                }
+            )
+        else:
+            result["errors"] = [{"stage": "response", "error": "invalid_response"}]
+        return result
+
     def _sync_get_app_plugin_version(
         self,
         app_version_code: int = 2050300,
@@ -2545,6 +2677,48 @@ class DreameLawnMowerClient:
                 ],
             }
         return decode_batch_ota_info(batch_data, include_raw=include_raw)
+
+    def _sync_get_debug_ota_catalog(
+        self,
+        model_name: str | None = None,
+        current_version: str | None = None,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Fetch the public debug/manual OTA catalog for the mower model."""
+        short_model = _debug_ota_model_name(model_name or self._descriptor.model)
+        if not short_model:
+            raise DreameLawnMowerConnectionError(
+                "Could not determine a short model name for the debug OTA catalog."
+            )
+
+        resolved_current_version = current_version
+        if resolved_current_version is None:
+            try:
+                device = self._sync_update_device()
+            except DreameLawnMowerConnectionError:
+                device = None
+            if device is not None:
+                resolved_current_version = _as_optional_text(
+                    getattr(getattr(device, "info", None), "firmware_version", None)
+                )
+
+        url = build_debug_ota_catalog_url(short_model)
+        try:
+            with urllib.request.urlopen(url, timeout=20) as response:
+                payload = json.load(response)
+        except Exception as err:  # noqa: BLE001 - network/protocol errors vary here
+            raise DreameLawnMowerConnectionError(
+                f"Debug OTA catalog fetch failed: {err}"
+            ) from err
+
+        result = normalize_debug_ota_catalog_payload(
+            payload,
+            model_name=short_model,
+            current_version=resolved_current_version,
+            include_raw=include_raw,
+        )
+        result["url"] = url
+        return result
 
     def _sync_get_weather_protection(
         self,
@@ -3484,6 +3658,95 @@ def _as_optional_text(value: Any) -> str | None:
     return text or None
 
 
+def _parse_firmware_description(
+    value: Any,
+) -> tuple[str | None, bool, Mapping[str, Any] | None]:
+    text = _as_optional_text(value)
+    if text is None:
+        return None, False, None
+
+    try:
+        parsed = json.loads(text)
+    except (TypeError, ValueError):
+        return text, True, None
+
+    if isinstance(parsed, Mapping):
+        code = parsed.get("code")
+        success = parsed.get("success")
+        msg = _as_optional_text(parsed.get("msg"))
+        if (isinstance(success, bool) and not success) or (
+            isinstance(code, int) and code != 0
+        ):
+            return None, False, {
+                "code": code,
+                "success": success,
+                "msg": msg,
+            }
+
+    return text, True, None
+
+
+def _normalize_cloud_firmware_check(
+    value: Any,
+    *,
+    current_version: str | None = None,
+) -> dict[str, Any]:
+    result: dict[str, Any] = {
+        "source": "cloud_check_device_version",
+        "available": False,
+        "update_available": None,
+        "current_version": current_version,
+        "latest_version": None,
+        "firmware_type": None,
+        "force_update": None,
+        "status": None,
+        "changelog": None,
+        "changelog_available": False,
+    }
+    if not isinstance(value, Mapping):
+        result["errors"] = [{"stage": "response", "error": "invalid_response"}]
+        return result
+
+    result["available"] = True
+    current_version_value = _as_optional_text(value.get("curVersion"))
+    if current_version_value is not None:
+        result["current_version"] = current_version_value
+
+    latest_version = _as_optional_text(value.get("newVersion"))
+    if latest_version is not None:
+        result["latest_version"] = latest_version
+
+    firmware_type = _as_optional_text(value.get("firmwareType"))
+    if firmware_type is not None:
+        result["firmware_type"] = firmware_type
+
+    force_update = value.get("force")
+    if isinstance(force_update, bool):
+        result["force_update"] = force_update
+
+    result["status"] = value.get("status")
+
+    has_new_firmware = value.get("hasNewFirmware")
+    if isinstance(has_new_firmware, bool):
+        result["update_available"] = has_new_firmware
+    elif (
+        latest_version is not None
+        and result["current_version"] is not None
+        and latest_version != result["current_version"]
+    ):
+        result["update_available"] = True
+
+    changelog, changelog_available, changelog_error = _parse_firmware_description(
+        value.get("description")
+    )
+    result["changelog"] = changelog
+    result["changelog_available"] = changelog_available
+    if changelog_error is not None:
+        result["changelog_error"] = dict(changelog_error)
+
+    return result
+
+
 def _optional_bool(value: Any) -> bool | None:
     if value is None:
         return None
@@ -3875,6 +4138,15 @@ def _batch_ota_keys() -> list[str]:
         "OTA_INFO.info",
         "prop.s_auto_upgrade",
     ]
+
+
+def _debug_ota_model_name(model_name: Any) -> str | None:
+    text = _as_optional_text(model_name)
+    if not text:
+        return None
+    if "." in text:
+        text = text.rsplit(".", 1)[-1]
+    return text.lower()
 
 
 def _weather_protection_summary(config: Mapping[str, Any]) -> dict[str, Any]:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1177,6 +1177,13 @@ class DreameLawnMowerClient:
         if include_cloud:
             try:
                 cloud_device_info = self._sync_get_cloud_device_info(language)
+            except DreameLawnMowerConnectionError as err:
+                cloud_error = _merge_error_text(
+                    cloud_error,
+                    "cloud_device_info",
+                    str(err),
+                )
+            try:
                 cloud_device_list_page = self._sync_get_cloud_device_list_page(
                     current=1,
                     size=20,
@@ -1184,14 +1191,28 @@ class DreameLawnMowerClient:
                     master=None,
                     shared_status=None,
                 )
+            except DreameLawnMowerConnectionError as err:
+                cloud_error = _merge_error_text(
+                    cloud_error,
+                    "cloud_device_list_page",
+                    str(err),
+                )
+            try:
                 cloud_firmware_check = self._sync_get_cloud_firmware_check(language)
             except DreameLawnMowerConnectionError as err:
-                cloud_error = str(err)
+                cloud_error = _merge_error_text(
+                    cloud_error,
+                    "cloud_firmware_check",
+                    str(err),
+                )
         try:
             batch_ota_info = self._sync_get_batch_ota_info()
         except DreameLawnMowerConnectionError as err:
-            if cloud_error is None:
-                cloud_error = str(err)
+            cloud_error = _merge_error_text(
+                cloud_error,
+                "batch_ota_info",
+                str(err),
+            )
         if include_debug_ota_catalog:
             try:
                 debug_ota_catalog = self._sync_get_debug_ota_catalog(
@@ -3936,6 +3957,22 @@ def _normalize_cloud_firmware_check(
         result["errors"] = [{"stage": "response", "error": "invalid_response"}]
         return result
 
+    code = value.get("code")
+    success = value.get("success")
+    if (isinstance(code, int) and code != 0) or (
+        isinstance(success, bool) and not success
+    ):
+        result["errors"] = [
+            {
+                "stage": "response",
+                "error": "cloud_error",
+                "code": code,
+                "success": success if isinstance(success, bool) else None,
+                "msg": _as_optional_text(value.get("msg")),
+            }
+        ]
+        return result
+
     result["available"] = True
     current_version_value = _as_optional_text(value.get("curVersion"))
     if current_version_value is not None:
@@ -3974,6 +4011,17 @@ def _normalize_cloud_firmware_check(
         result["changelog_error"] = dict(changelog_error)
 
     return result
+
+
+def _merge_error_text(
+    existing: str | None,
+    stage: str,
+    error: str,
+) -> str:
+    entry = f"{stage}: {error}"
+    if existing:
+        return f"{existing}; {entry}"
+    return entry
 
 
 def _optional_bool(value: Any) -> bool | None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/debug_ota_catalog.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/debug_ota_catalog.py
@@ -1,0 +1,188 @@
+"""Helpers for Dreame's debug/manual OTA catalog endpoint."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+DEBUG_OTA_LIST_URL = "https://ota.tsingting.tech/api/version/{model_name}/?name={model_name}"
+DEBUG_OTA_TRACKS = ("BUILD", "FEATURE", "PREBUILD")
+_CHANGELOG_FIELDS = (
+    "changelog",
+    "description",
+    "note",
+    "releaseNote",
+    "releaseNotes",
+)
+
+
+def build_debug_ota_catalog_url(model_name: str) -> str:
+    """Return the public debug OTA catalog URL for a short model name."""
+    return DEBUG_OTA_LIST_URL.format(model_name=model_name)
+
+
+def normalize_debug_ota_catalog_payload(
+    payload: Mapping[str, Any],
+    *,
+    model_name: str | None = None,
+    current_version: str | None = None,
+    include_raw: bool = False,
+) -> dict[str, Any]:
+    """Summarize the public debug OTA catalog without treating it as approved OTA."""
+    result: dict[str, Any] = {
+        "source": "debug_ota_catalog",
+        "available": False,
+        "model_name": model_name,
+        "current_version": current_version,
+        "current_version_present": None,
+        "changelog_available": False,
+        "warnings": [
+            "debug_catalog_unverified",
+            "debug_catalog_not_device_approved",
+        ],
+        "tracks": {},
+        "latest_release_candidates": [],
+        "errors": [],
+    }
+    if include_raw:
+        result["raw"] = payload
+
+    data = payload.get("data")
+    if not isinstance(data, Mapping):
+        result["errors"].append(
+            {"stage": "parse", "error": "Debug OTA catalog payload has no data map."}
+        )
+        return result
+
+    current_version_present = False if current_version else None
+    latest_release_candidates: list[dict[str, Any]] = []
+    changelog_available = False
+    available = False
+
+    for track in DEBUG_OTA_TRACKS:
+        entries = _normalize_track_entries(data.get(track))
+        available = available or bool(entries)
+        release_entries = [entry for entry in entries if not entry["debug_build"]]
+        latest_release = release_entries[-1] if release_entries else None
+        track_current_present = None
+        if current_version:
+            track_current_present = any(
+                entry.get("version") == current_version for entry in release_entries
+            )
+            current_version_present = bool(
+                current_version_present or track_current_present
+            )
+
+        track_changelog_available = any(
+            _entry_changelog(entry) for entry in release_entries
+        )
+        changelog_available = changelog_available or track_changelog_available
+
+        track_summary = {
+            "entry_count": len(entries),
+            "release_entry_count": len(release_entries),
+            "current_version_present": track_current_present,
+            "changelog_available": track_changelog_available,
+            "recent_release_versions": [
+                entry["version"]
+                for entry in release_entries[-5:]
+                if entry.get("version")
+            ],
+        }
+        if latest_release:
+            track_summary.update(_latest_release_summary(latest_release))
+            latest_release_candidates.append(
+                {
+                    "track": track,
+                    **_latest_release_summary(latest_release),
+                }
+            )
+        result["tracks"][track] = track_summary
+
+    if not changelog_available:
+        result["warnings"].append("debug_catalog_has_no_changelog")
+
+    result["available"] = available
+    result["current_version_present"] = current_version_present
+    result["changelog_available"] = changelog_available
+    result["latest_release_candidates"] = latest_release_candidates
+    return result
+
+
+def _normalize_track_entries(value: Any) -> list[dict[str, Any]]:
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    for index, item in enumerate(value):
+        if not isinstance(item, Mapping):
+            continue
+        version = item.get("version")
+        normalized.append(
+            {
+                "index": index,
+                "id": _positive_int(item.get("id")),
+                "version": str(version) if version is not None else None,
+                "sha256sum": _as_optional_str(item.get("sha256sum")),
+                "url_endpoint": _as_optional_str(item.get("url_endpoint")),
+                "url": _as_optional_str(item.get("url")),
+                "download_url": _download_url(item),
+                "debug_build": _is_debug_build(item),
+                "changelog": _entry_changelog(item),
+            }
+        )
+
+    normalized.sort(
+        key=lambda entry: (entry["id"] is None, entry["id"], entry["index"])
+    )
+    return normalized
+
+
+def _latest_release_summary(entry: Mapping[str, Any]) -> dict[str, Any]:
+    return {
+        "latest_release_version": entry.get("version"),
+        "latest_release_id": entry.get("id"),
+        "latest_release_sha256": entry.get("sha256sum"),
+        "latest_release_path": entry.get("url"),
+        "latest_release_download_url": entry.get("download_url"),
+    }
+
+
+def _download_url(entry: Mapping[str, Any]) -> str | None:
+    endpoint = _as_optional_str(entry.get("url_endpoint"))
+    path = _as_optional_str(entry.get("url"))
+    if endpoint and path:
+        return f"{endpoint.rstrip('/')}/{path.lstrip('/')}"
+    return endpoint or path
+
+
+def _entry_changelog(entry: Mapping[str, Any]) -> str | None:
+    for field in _CHANGELOG_FIELDS:
+        value = _as_optional_str(entry.get(field))
+        if value:
+            return value
+    return None
+
+
+def _is_debug_build(entry: Mapping[str, Any]) -> bool:
+    version = _as_optional_str(entry.get("version")) or ""
+    if version.endswith("_debug"):
+        return True
+
+    url = _as_optional_str(entry.get("url")) or ""
+    return "/debug-" in url.lower() or "_debug" in url.lower()
+
+
+def _as_optional_str(value: Any) -> str | None:
+    if value is None:
+        return None
+    text = str(value).strip()
+    return text or None
+
+
+def _positive_int(value: Any) -> int | None:
+    try:
+        parsed = int(value)
+    except (TypeError, ValueError):
+        return None
+    return parsed if parsed >= 0 else None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import asdict, dataclass, field
 from typing import Any
 
@@ -261,8 +261,11 @@ class DreameLawnMowerFirmwareUpdateSupport:
     """Read-only firmware/update evidence from device and cloud metadata."""
 
     current_version: str | None = None
+    latest_version: str | None = None
     hardware_version: str | None = None
     cloud_update_time: str | None = None
+    release_summary: str | None = None
+    release_summary_available: bool | None = None
     latest_status: int | str | None = None
     plugin_force_update: bool | None = None
     plugin_force_update_sources: Mapping[str, bool] = field(default_factory=dict)
@@ -270,6 +273,17 @@ class DreameLawnMowerFirmwareUpdateSupport:
     firmware_develop_type: str | None = None
     device_info_release_at: str | None = None
     device_info_updated_at: str | None = None
+    cloud_check_available: bool | None = None
+    cloud_check_update_available: bool | None = None
+    batch_ota_available: bool | None = None
+    auto_upgrade_enabled: bool | None = None
+    ota_status: int | str | None = None
+    debug_catalog_available: bool | None = None
+    debug_catalog_current_version_present: bool | None = None
+    debug_catalog_changelog_available: bool | None = None
+    debug_catalog_latest_release_candidates: Sequence[Mapping[str, Any]] = field(
+        default_factory=tuple
+    )
     update_state: str | None = None
     update_available: bool | None = None
     cloud_error: str | None = None
@@ -758,6 +772,9 @@ def firmware_update_support_from_device(
     *,
     cloud_device_info: Mapping[str, Any] | None = None,
     cloud_device_list_page: Mapping[str, Any] | None = None,
+    cloud_firmware_check: Mapping[str, Any] | None = None,
+    batch_ota_info: Mapping[str, Any] | None = None,
+    debug_ota_catalog: Mapping[str, Any] | None = None,
     cloud_error: str | None = None,
 ) -> DreameLawnMowerFirmwareUpdateSupport:
     """Build firmware/update evidence without guessing OTA availability."""
@@ -799,6 +816,53 @@ def firmware_update_support_from_device(
         evidence["cloud_device_list_page"] = _compact_mapping_evidence(
             cloud_device_list_page
         )
+    if cloud_firmware_check is not None:
+        evidence["cloud_firmware_check"] = {
+            key: _compact_update_candidate_value(cloud_firmware_check.get(key))
+            for key in (
+                "source",
+                "available",
+                "update_available",
+                "current_version",
+                "latest_version",
+                "firmware_type",
+                "force_update",
+                "status",
+                "changelog",
+                "changelog_available",
+                "changelog_error",
+                "errors",
+            )
+            if key in cloud_firmware_check
+        }
+    if batch_ota_info is not None:
+        evidence["batch_ota_info"] = {
+            key: batch_ota_info.get(key)
+            for key in (
+                "source",
+                "available",
+                "update_available",
+                "auto_upgrade_enabled",
+                "ota_status",
+            )
+            if key in batch_ota_info
+        }
+    if debug_ota_catalog is not None:
+        evidence["debug_ota_catalog"] = {
+            key: _compact_update_candidate_value(debug_ota_catalog.get(key))
+            for key in (
+                "source",
+                "available",
+                "model_name",
+                "current_version",
+                "current_version_present",
+                "changelog_available",
+                "latest_release_candidates",
+                "warnings",
+                "errors",
+            )
+            if key in debug_ota_catalog
+        }
 
     candidate_update_fields = _collect_update_candidate_fields(
         {
@@ -806,6 +870,9 @@ def firmware_update_support_from_device(
             "deviceInfo": device_info,
             "cloud_device_info": cloud_device_info,
             "cloud_device_list_page": cloud_device_list_page,
+            "cloud_firmware_check": cloud_firmware_check,
+            "batch_ota_info": batch_ota_info,
+            "debug_ota_catalog": debug_ota_catalog,
         }
     )
 
@@ -825,8 +892,91 @@ def firmware_update_support_from_device(
         if len(unique_plugin_values) > 1:
             warnings.append("plugin_force_update_conflict")
 
+    batch_ota_available = None
+    auto_upgrade_enabled = None
+    ota_status = None
+    latest_version = None
+    release_summary = None
+    release_summary_available = None
+    cloud_check_available = None
+    cloud_check_update_available = None
+    debug_catalog_available = None
+    debug_catalog_current_version_present = None
+    debug_catalog_changelog_available = None
+    debug_catalog_latest_release_candidates: tuple[Mapping[str, Any], ...] = ()
+    update_available = None
+    if isinstance(cloud_firmware_check, Mapping):
+        available = cloud_firmware_check.get("available")
+        if isinstance(available, bool):
+            cloud_check_available = available
+
+        check_update_available = cloud_firmware_check.get("update_available")
+        if isinstance(check_update_available, bool):
+            cloud_check_update_available = check_update_available
+            update_available = check_update_available
+
+        latest_version = _as_optional_str(cloud_firmware_check.get("latest_version"))
+        release_summary = _as_optional_str(cloud_firmware_check.get("changelog"))
+
+        changelog_available = cloud_firmware_check.get("changelog_available")
+        if isinstance(changelog_available, bool):
+            release_summary_available = changelog_available
+
+    if isinstance(batch_ota_info, Mapping):
+        available = batch_ota_info.get("available")
+        if isinstance(available, bool):
+            batch_ota_available = available
+
+        auto_upgrade = batch_ota_info.get("auto_upgrade_enabled")
+        if isinstance(auto_upgrade, bool):
+            auto_upgrade_enabled = auto_upgrade
+
+        ota_status = batch_ota_info.get("ota_status")
+        batch_update_available = batch_ota_info.get("update_available")
+        if isinstance(batch_update_available, bool) and update_available is None:
+            update_available = batch_update_available
+    if isinstance(debug_ota_catalog, Mapping):
+        available = debug_ota_catalog.get("available")
+        if isinstance(available, bool):
+            debug_catalog_available = available
+
+        current_version_present = debug_ota_catalog.get("current_version_present")
+        if isinstance(current_version_present, bool):
+            debug_catalog_current_version_present = current_version_present
+
+        changelog_available = debug_ota_catalog.get("changelog_available")
+        if isinstance(changelog_available, bool):
+            debug_catalog_changelog_available = changelog_available
+
+        latest_candidates = debug_ota_catalog.get("latest_release_candidates")
+        if isinstance(latest_candidates, Sequence) and not isinstance(
+            latest_candidates, str | bytes | bytearray
+        ):
+            debug_catalog_latest_release_candidates = tuple(
+                item for item in latest_candidates if isinstance(item, Mapping)
+            )
+
     reason = "No verified mower firmware update availability signal was found."
-    if "plugin_force_update_conflict" in warnings:
+    if cloud_check_update_available is True and batch_ota_info is not None:
+        reason = (
+            "Cloud checkDeviceVersion and batch OTA info both report that a mower "
+            "firmware update is available."
+        )
+    elif cloud_check_update_available is True:
+        reason = (
+            "Cloud checkDeviceVersion reports that a mower firmware update is "
+            "available."
+        )
+    elif cloud_check_update_available is False and batch_ota_info is None:
+        reason = (
+            "Cloud checkDeviceVersion reports that no mower firmware update is "
+            "available."
+        )
+    elif update_available is True:
+        reason = "Batch OTA info reports that a mower firmware update is available."
+    elif update_available is False:
+        reason = "Batch OTA info reports that no mower firmware update is available."
+    elif "plugin_force_update_conflict" in warnings:
         reason = (
             "pluginForceUpdate differs across cloud metadata sources, so it is "
             "not treated as verified mower firmware update availability."
@@ -842,8 +992,11 @@ def firmware_update_support_from_device(
     return DreameLawnMowerFirmwareUpdateSupport(
         current_version=_as_optional_str(info_raw.get("ver"))
         or _as_optional_str(getattr(info, "firmware_version", None)),
+        latest_version=latest_version,
         hardware_version=_as_optional_str(getattr(info, "hardware_version", None)),
         cloud_update_time=_as_optional_str(info_raw.get("updateTime")),
+        release_summary=release_summary,
+        release_summary_available=release_summary_available,
         latest_status=info_raw.get("latestStatus"),
         plugin_force_update=plugin_force_update,
         plugin_force_update_sources=plugin_force_update_sources,
@@ -853,8 +1006,17 @@ def firmware_update_support_from_device(
         ),
         device_info_release_at=_as_optional_str(device_info.get("releaseAt")),
         device_info_updated_at=_as_optional_str(device_info.get("updatedAt")),
+        cloud_check_available=cloud_check_available,
+        cloud_check_update_available=cloud_check_update_available,
+        batch_ota_available=batch_ota_available,
+        auto_upgrade_enabled=auto_upgrade_enabled,
+        ota_status=ota_status,
+        debug_catalog_available=debug_catalog_available,
+        debug_catalog_current_version_present=debug_catalog_current_version_present,
+        debug_catalog_changelog_available=debug_catalog_changelog_available,
+        debug_catalog_latest_release_candidates=debug_catalog_latest_release_candidates,
         update_state=update_state,
-        update_available=None,
+        update_available=update_available,
         cloud_error=cloud_error,
         candidate_update_fields=candidate_update_fields,
         evidence=evidence,
@@ -1131,6 +1293,7 @@ _UPDATE_CANDIDATE_KEY_TOKENS = (
 _UPDATE_CANDIDATE_EXACT_KEYS = {
     "lateststatus",
     "ota",
+    "otastatus",
     "pluginforceupdate",
     "releaseat",
     "ver",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -413,6 +413,29 @@ class DreameMowerDreameHomeCloudProtocol:
             return response["data"]
         return None
 
+    def check_device_version(self, lang: str | None = None) -> Any:
+        params = {"did": self._did}
+        if lang:
+            params["lang"] = lang
+
+        response = self.request(
+            f"{self.get_api_url()}/dreame-user-iot/iotuserbind/checkDeviceVersion",
+            json.dumps(params, separators=(",", ":")),
+        )
+        if response and response.get("code") == 0 and "data" in response:
+            return response["data"]
+        return response
+
+    def manual_firmware_update(self, lang: str | None = None) -> Any:
+        params = {"did": self._did}
+        if lang:
+            params["lang"] = lang
+
+        return self.request(
+            f"{self.get_api_url()}/dreame-user-iot/iotuserbind/manualFirmwareUpdate",
+            json.dumps(params, separators=(",", ":")),
+        )
+
     def get_device_otc_info(self, lang: str | None = None) -> Any:
         params = {"did": self._did}
         if lang:

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -230,7 +230,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             selected_map_index,
             maps,
         )
-        available_vector_map_names = self._available_vector_map_names(vector_map_details)
+        available_vector_map_names = self._available_vector_map_names(
+            vector_map_details
+        )
         return {
             "state": snapshot.state,
             "state_name": snapshot.state_name,
@@ -312,7 +314,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             "selected_spot_id": self._selected_spot_id(spot_entries),
             "available_map_indices": [entry["map_index"] for entry in maps],
             "available_map_labels": [entry["label"] for entry in maps],
-            "available_contour_ids": [list(entry["contour_id"]) for entry in contour_entries],
+            "available_contour_ids": [
+                list(entry["contour_id"]) for entry in contour_entries
+            ],
             "available_contour_labels": [entry["label"] for entry in contour_entries],
             "available_zone_ids": [entry["area_id"] for entry in zone_entries],
             "available_spot_ids": [entry["spot_id"] for entry in spot_entries],
@@ -341,14 +345,10 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             "current_vector_map_name": self._current_vector_map_name(
                 current_vector_map
             ),
-            "current_vector_map_contour_count": current_vector_map.get(
-                "contour_count"
-            )
+            "current_vector_map_contour_count": current_vector_map.get("contour_count")
             if current_vector_map
             else None,
-            "current_vector_map_has_live_path": current_vector_map.get(
-                "has_live_path"
-            )
+            "current_vector_map_has_live_path": current_vector_map.get("has_live_path")
             if current_vector_map
             else None,
             "current_vector_map_mow_path_point_count": current_vector_map.get(
@@ -371,7 +371,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             )
             contour_id = self._selected_contour_id(contour_entries)
             if contour_id is None:
-                raise HomeAssistantError("No current-map edge contour is available to start.")
+                raise HomeAssistantError(
+                    "No current-map edge contour is available to start."
+                )
             await self.coordinator.client.async_start_edge_mowing([list(contour_id)])
         elif action == MOWING_ACTION_ZONE:
             self._ensure_selected_map_matches_active()
@@ -476,13 +478,13 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         selected_map_index = self._selected_map_index(maps)
         if selected_map_index is None:
             raise HomeAssistantError(
-                "No selected or current map is available for mowing preference planning."
+                "No selected or current map is available for mowing "
+                "preference planning."
             )
 
         requested_changes = preference_change_request(changes)
         zone_scoped_change = any(
-            key != ATTR_PREFERENCE_MODE
-            for key in requested_changes
+            key != ATTR_PREFERENCE_MODE for key in requested_changes
         )
 
         zone_entries: list[dict[str, object]] = []
@@ -731,9 +733,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 "mowing_direction_mode_name": preference.get(
                     "mowing_direction_mode_name"
                 ),
-                "mowing_direction_degrees": preference.get(
-                    "mowing_direction_degrees"
-                ),
+                "mowing_direction_degrees": preference.get("mowing_direction_degrees"),
                 "edge_mowing_auto": preference.get("edge_mowing_auto"),
                 "edge_mowing_walk_mode_name": preference.get(
                     "edge_mowing_walk_mode_name"
@@ -784,12 +784,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             "mode": preference_map.get("mode"),
             "mode_name": preference_map.get("mode_name"),
             "area_count": preference_map.get("area_count"),
-            "preference_count": len(preferences) if isinstance(preferences, list) else None,
+            "preference_count": len(preferences)
+            if isinstance(preferences, list)
+            else None,
         }
         return {
-            key: value
-            for key, value in summary.items()
-            if value not in (None, [], {})
+            key: value for key, value in summary.items() if value not in (None, [], {})
         }
 
     def _batch_preference_map_entry(
@@ -868,9 +868,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         names = vector_map_details.get("map_names")
         if isinstance(names, list):
             return [
-                name.strip()
-                for name in names
-                if isinstance(name, str) and name.strip()
+                name.strip() for name in names if isinstance(name, str) and name.strip()
             ]
 
         result: list[str] = []

--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -19,5 +19,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.1.2"
+  "version": "0.1.3"
 }

--- a/custom_components/dreame_lawn_mower/number.py
+++ b/custom_components/dreame_lawn_mower/number.py
@@ -1,0 +1,66 @@
+"""Number entities for Dreame mower configuration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.number import NumberEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import DreameLawnMowerCoordinator
+from .entity import DreameLawnMowerEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Dreame mower number entities."""
+    coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([DreameLawnMowerVoiceVolumeNumber(coordinator)])
+
+
+class DreameLawnMowerVoiceVolumeNumber(DreameLawnMowerEntity, NumberEntity):
+    """Expose the mower voice volume from the app CFG payload."""
+
+    _attr_name = "Voice Volume"
+    _attr_icon = "mdi:volume-high"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = 0
+    _attr_native_max_value = 100
+    _attr_native_step = 1
+    _attr_native_unit_of_measurement = "%"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_voice_volume"
+
+    @property
+    def available(self) -> bool:
+        """Return whether cached voice settings are available."""
+        return self.coordinator.data is not None and self.native_value is not None
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the configured mower voice volume."""
+        section = _voice_settings_section(self.coordinator.voice_settings)
+        if section is None:
+            return None
+        value = section.get("volume")
+        return float(value) if isinstance(value, int) else None
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist the selected mower voice volume."""
+        await self.coordinator.client.async_set_voice_volume(round(value))
+        await self.coordinator.async_refresh_voice_settings(force=True)
+        self.coordinator.async_update_listeners()
+
+
+def _voice_settings_section(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    section = value.get("voice_settings") if isinstance(value, dict) else None
+    return section if isinstance(section, dict) and section.get("available") else None

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -2,9 +2,12 @@
 
 from __future__ import annotations
 
+from typing import Any
+
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
@@ -15,16 +18,21 @@ from .control_options import (
     MOWING_ACTION_ZONE,
     contour_label,
     current_contour_entries,
-    map_entries,
+    current_map_index,
     current_spot_entries,
     current_zone_entries,
-    current_map_index,
+    map_entries,
     map_label,
     mowing_action_label,
     spot_label,
     zone_label,
 )
 from .coordinator import DreameLawnMowerCoordinator
+from .dreame_lawn_mower_client.client import (
+    VOICE_LANGUAGE_INDEX_TO_LABEL,
+    VOICE_LANGUAGE_LABEL_TO_INDEX,
+    VOICE_LANGUAGE_LABELS,
+)
 from .entity import DreameLawnMowerEntity
 
 
@@ -37,6 +45,7 @@ async def async_setup_entry(
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
+            DreameLawnMowerVoiceLanguageSelect(coordinator),
             DreameLawnMowerMapSelect(coordinator),
             DreameLawnMowerMowingActionSelect(coordinator),
             DreameLawnMowerEdgeSelect(coordinator),
@@ -48,6 +57,47 @@ async def async_setup_entry(
 
 class DreameLawnMowerSelectEntity(DreameLawnMowerEntity, SelectEntity):
     """Shared base class for current-map selector entities."""
+
+
+class DreameLawnMowerVoiceLanguageSelect(DreameLawnMowerSelectEntity):
+    """Choose the mower voice prompt language."""
+
+    _attr_name = "Voice Language"
+    _attr_icon = "mdi:translate"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_voice_language"
+
+    @property
+    def available(self) -> bool:
+        """Return whether cached voice settings are available."""
+        return self.coordinator.data is not None and self.current_option is not None
+
+    @property
+    def options(self) -> list[str]:
+        """Return the known mower voice languages."""
+        return list(VOICE_LANGUAGE_LABELS)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected mower voice language label."""
+        section = _voice_settings_section(self.coordinator.voice_settings)
+        if section is None:
+            return None
+        value = section.get("voice_language_index")
+        return VOICE_LANGUAGE_INDEX_TO_LABEL.get(value)
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the selected mower voice language."""
+        if option not in VOICE_LANGUAGE_LABEL_TO_INDEX:
+            raise ValueError(f"Unknown voice language option: {option}")
+        await self.coordinator.client.async_set_voice_language(
+            VOICE_LANGUAGE_LABEL_TO_INDEX[option]
+        )
+        await self.coordinator.async_refresh_voice_settings(force=True)
+        self.coordinator.async_update_listeners()
 
 
 class DreameLawnMowerMapSelect(DreameLawnMowerSelectEntity):
@@ -331,3 +381,8 @@ class DreameLawnMowerSpotSelect(DreameLawnMowerSelectEntity):
                 self.coordinator.async_update_listeners()
                 return
         raise ValueError(f"Unknown spot option: {option}")
+
+
+def _voice_settings_section(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    section = value.get("voice_settings") if isinstance(value, dict) else None
+    return section if isinstance(section, dict) and section.get("available") else None

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -73,7 +73,10 @@ class DreameLawnMowerVoiceLanguageSelect(DreameLawnMowerSelectEntity):
     @property
     def available(self) -> bool:
         """Return whether cached voice settings are available."""
-        return self.coordinator.data is not None and self.current_option is not None
+        return (
+            self.coordinator.data is not None
+            and _voice_settings_section(self.coordinator.voice_settings) is not None
+        )
 
     @property
     def options(self) -> list[str]:

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -120,9 +120,9 @@ SENSORS = [
     DreameSensorDescription(
         key="error_code",
         name="Error Code",
-        value_fn=lambda snapshot: "none"
-        if snapshot.error_code in (None, -1, 0)
-        else snapshot.error_code,
+        value_fn=lambda snapshot: (
+            "none" if snapshot.error_code in (None, -1, 0) else snapshot.error_code
+        ),
         icon="mdi:numeric",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),
@@ -199,8 +199,10 @@ SENSORS = [
         key="cleaning_mode",
         name="Cleaning Mode",
         value_fn=lambda snapshot: snapshot.cleaning_mode_name,
-        exists_fn=lambda snapshot: bool(snapshot.cleaning_mode_name)
-        and snapshot.cleaning_mode_name != "unknown",
+        exists_fn=lambda snapshot: (
+            bool(snapshot.cleaning_mode_name)
+            and snapshot.cleaning_mode_name != "unknown"
+        ),
         icon="mdi:grass",
         entity_registry_enabled_default=False,
     ),
@@ -253,10 +255,7 @@ async def async_setup_entry(
     """Set up mower sensors."""
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [
-            DreameLawnMowerSensor(coordinator, description)
-            for description in SENSORS
-        ]
+        [DreameLawnMowerSensor(coordinator, description) for description in SENSORS]
         + [DreameLawnMowerAppMapCountSensor(coordinator)]
         + [DreameLawnMowerAvailableVectorMapCountSensor(coordinator)]
         + [DreameLawnMowerSelectedMowingActionSensor(coordinator)]
@@ -410,11 +409,7 @@ def schedule_write_result_attributes(
         attributes["target_schedule"] = target_schedule
     if result.get("response_data") is not None:
         attributes["response_data"] = result.get("response_data")
-    return {
-        key: value
-        for key, value in attributes.items()
-        if value is not None
-    }
+    return {key: value for key, value in attributes.items() if value is not None}
 
 
 class DreameLawnMowerLastPreferenceWriteSensor(
@@ -493,11 +488,7 @@ def preference_write_result_attributes(
         attributes["selection_scope"] = result.get("selection_scope")
     if result.get("response_data") is not None:
         attributes["response_data"] = result.get("response_data")
-    return {
-        key: value
-        for key, value in attributes.items()
-        if value is not None
-    }
+    return {key: value for key, value in attributes.items() if value is not None}
 
 
 class DreameLawnMowerFirmwareUpdateStatusSensor(
@@ -546,9 +537,7 @@ class DreameLawnMowerWeatherProtectionStatusSensor(
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = (
-            f"{self._descriptor.unique_id}_weather_protection_status"
-        )
+        self._attr_unique_id = f"{self._descriptor.unique_id}_weather_protection_status"
 
     @property
     def native_value(self) -> str | None:
@@ -583,9 +572,7 @@ class DreameLawnMowerRainProtectionDurationSensor(
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = (
-            f"{self._descriptor.unique_id}_rain_protection_duration"
-        )
+        self._attr_unique_id = f"{self._descriptor.unique_id}_rain_protection_duration"
 
     @property
     def native_value(self) -> int | None:
@@ -1977,9 +1964,7 @@ class DreameLawnMowerRuntimeTrackLengthSensor(
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = (
-            f"{self._descriptor.unique_id}_runtime_live_track_length"
-        )
+        self._attr_unique_id = f"{self._descriptor.unique_id}_runtime_live_track_length"
 
     @property
     def native_value(self) -> float | int | None:
@@ -2059,9 +2044,7 @@ class DreameLawnMowerConfiguredScheduleCountSensor(
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
-        self._attr_unique_id = (
-            f"{self._descriptor.unique_id}_configured_schedule_count"
-        )
+        self._attr_unique_id = f"{self._descriptor.unique_id}_configured_schedule_count"
 
     @property
     def native_value(self) -> int | None:
@@ -2173,9 +2156,7 @@ def schedule_probe_result_attributes(
         attributes["error_count"] = len(errors)
         attributes["errors"] = errors
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2258,9 +2239,7 @@ def batch_device_data_probe_result_attributes(
         "batch_ota_info": _batch_ota_probe_summary(ota),
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2275,9 +2254,7 @@ def batch_schedule_attributes(result: dict[str, Any] | None) -> dict[str, Any]:
         "batch_schedule": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2292,9 +2269,7 @@ def app_map_object_attributes(result: dict[str, Any] | None) -> dict[str, Any]:
         "app_map_objects": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2312,9 +2287,7 @@ def app_map_attributes(
         "app_maps": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2329,9 +2302,7 @@ def vector_map_attributes(result: dict[str, Any] | None) -> dict[str, Any]:
         "vector_maps": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2349,9 +2320,7 @@ def current_app_map_attributes(
         "current_app_map": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2370,9 +2339,7 @@ def current_vector_map_attributes(
         "current_vector_map": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2387,9 +2354,7 @@ def batch_preference_attributes(result: dict[str, Any] | None) -> dict[str, Any]
         "batch_mowing_preferences": summary,
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2405,9 +2370,7 @@ def batch_ota_attributes(result: dict[str, Any] | None) -> dict[str, Any]:
         "ota_status_name": _batch_ota_status_name(result),
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2429,18 +2392,20 @@ def _runtime_status_blob_summary(blob: Any) -> dict[str, Any]:
         return {}
     track_segments = getattr(blob, "candidate_runtime_track_segments", ()) or ()
     track_point_count = sum(
-        len(segment)
-        for segment in track_segments
-        if isinstance(segment, (list, tuple))
+        len(segment) for segment in track_segments if isinstance(segment, (list, tuple))
     )
-    track_length_m = round(
-        sum(
-            _coordinate_path_length_m(segment)
-            for segment in track_segments
-            if isinstance(segment, (list, tuple))
-        ),
-        2,
-    ) if track_point_count else None
+    track_length_m = (
+        round(
+            sum(
+                _coordinate_path_length_m(segment)
+                for segment in track_segments
+                if isinstance(segment, (list, tuple))
+            ),
+            2,
+        )
+        if track_point_count
+        else None
+    )
     attributes = {
         "source": getattr(blob, "source", None),
         "length": getattr(blob, "length", None),
@@ -2464,9 +2429,7 @@ def _runtime_status_blob_summary(blob: Any) -> dict[str, Any]:
         "notes": list(getattr(blob, "notes", ()) or ()),
     }
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -2768,7 +2731,10 @@ def _selected_map_preference_summary(coordinator: Any) -> dict[str, Any]:
     )
 
     for map_entry in maps:
-        if not isinstance(map_entry, dict) or map_entry.get("idx") != selected_map_index:
+        if (
+            not isinstance(map_entry, dict)
+            or map_entry.get("idx") != selected_map_index
+        ):
             continue
         preferences = map_entry.get("preferences")
         summary = {
@@ -2777,12 +2743,12 @@ def _selected_map_preference_summary(coordinator: Any) -> dict[str, Any]:
             "mode": map_entry.get("mode"),
             "mode_name": map_entry.get("mode_name"),
             "area_count": map_entry.get("area_count"),
-            "preference_count": len(preferences) if isinstance(preferences, list) else None,
+            "preference_count": len(preferences)
+            if isinstance(preferences, list)
+            else None,
         }
         return {
-            key: value
-            for key, value in summary.items()
-            if value not in (None, [], {})
+            key: value for key, value in summary.items() if value not in (None, [], {})
         }
     return {}
 
@@ -2809,9 +2775,7 @@ def _selected_zone_preference_summary(coordinator: Any) -> dict[str, Any]:
     if not isinstance(selected_zone_id, int) or not any(
         entry["area_id"] == selected_zone_id for entry in zone_entries
     ):
-        selected_zone_id = (
-            int(zone_entries[0]["area_id"]) if zone_entries else None
-        )
+        selected_zone_id = int(zone_entries[0]["area_id"]) if zone_entries else None
     if selected_zone_id is None:
         return {}
 
@@ -2830,11 +2794,7 @@ def _selected_zone_preference_summary(coordinator: Any) -> dict[str, Any]:
         getattr(coordinator, "selected_map_index", None),
     )
     zone_entry = next(
-        (
-            entry
-            for entry in zone_entries
-            if entry["area_id"] == selected_zone_id
-        ),
+        (entry for entry in zone_entries if entry["area_id"] == selected_zone_id),
         None,
     )
     zone_label_value = (
@@ -2871,9 +2831,7 @@ def _selected_zone_preference_summary(coordinator: Any) -> dict[str, Any]:
                 "mowing_direction_mode_name": preference.get(
                     "mowing_direction_mode_name"
                 ),
-                "mowing_direction_degrees": preference.get(
-                    "mowing_direction_degrees"
-                ),
+                "mowing_direction_degrees": preference.get("mowing_direction_degrees"),
                 "edge_mowing_auto": preference.get("edge_mowing_auto"),
                 "edge_mowing_walk_mode_name": preference.get(
                     "edge_mowing_walk_mode_name"
@@ -2928,9 +2886,7 @@ def _selected_run_scope_attributes(coordinator: Any) -> dict[str, Any]:
     }
     attributes.update(_selected_target_summary(coordinator))
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -3162,11 +3118,7 @@ def _app_map_object_summary(value: Any) -> dict[str, Any] | None:
     error = value.get("error")
     if error is not None:
         summary["error"] = error
-    return {
-        key: item
-        for key, item in summary.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in summary.items() if item not in (None, [], {})}
 
 
 def _app_maps_summary(
@@ -3192,11 +3144,7 @@ def _app_maps_summary(
         summary["error_count"] = len(errors)
         if errors:
             summary["errors"] = errors
-    return {
-        key: item
-        for key, item in summary.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in summary.items() if item not in (None, [], {})}
 
 
 def _vector_map_summary(value: Any) -> dict[str, Any] | None:
@@ -3221,11 +3169,7 @@ def _vector_map_summary(value: Any) -> dict[str, Any] | None:
         ],
         "maps": maps,
     }
-    return {
-        key: item
-        for key, item in summary.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in summary.items() if item not in (None, [], {})}
 
 
 def _current_app_map_summary(
@@ -3294,11 +3238,7 @@ def _app_map_entry_summary(entry: dict[str, Any]) -> dict[str, Any]:
         "has_live_path": bool(summary.get("trajectory_point_count")),
         "error": entry.get("error"),
     }
-    return {
-        key: item
-        for key, item in result.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in result.items() if item not in (None, [], {})}
 
 
 def _vector_map_entry_summary(entry: dict[str, Any]) -> dict[str, Any]:
@@ -3326,11 +3266,7 @@ def _vector_map_entry_summary(entry: dict[str, Any]) -> dict[str, Any]:
         "runtime_heading_deg": entry.get("runtime_heading_deg"),
         "has_live_path": entry.get("has_live_path"),
     }
-    return {
-        key: item
-        for key, item in result.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in result.items() if item not in (None, [], {})}
 
 
 def _schedule_probe_entry_summary(schedule: dict[str, Any]) -> dict[str, Any]:
@@ -3343,11 +3279,7 @@ def _schedule_probe_entry_summary(schedule: dict[str, Any]) -> dict[str, Any]:
         "enabled_plan_count": schedule.get("enabled_plan_count"),
         "error": schedule.get("error"),
     }
-    return {
-        key: value
-        for key, value in summary.items()
-        if value is not None
-    }
+    return {key: value for key, value in summary.items() if value is not None}
 
 
 class DreameLawnMowerLastPreferenceProbeSensor(
@@ -3414,9 +3346,7 @@ def preference_probe_result_attributes(
         attributes["error_count"] = len(errors)
         attributes["errors"] = errors
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -3535,9 +3465,7 @@ def weather_probe_result_attributes(
         attributes["warning_count"] = len(warnings)
         attributes["warnings"] = warnings
     return {
-        key: value
-        for key, value in attributes.items()
-        if value not in (None, [], {})
+        key: value for key, value in attributes.items() if value not in (None, [], {})
     }
 
 
@@ -3558,11 +3486,7 @@ def _preference_probe_map_summary(map_entry: dict[str, Any]) -> dict[str, Any]:
         "preferences": preferences,
         "error": map_entry.get("error"),
     }
-    return {
-        key: value
-        for key, value in summary.items()
-        if value not in (None, [], {})
-    }
+    return {key: value for key, value in summary.items() if value not in (None, [], {})}
 
 
 def _preference_probe_entry_summary(preference: dict[str, Any]) -> dict[str, Any]:
@@ -3593,11 +3517,7 @@ def _preference_probe_entry_summary(preference: dict[str, Any]) -> dict[str, Any
             "obstacle_avoidance_ai_classes",
         ),
     }
-    return {
-        key: value
-        for key, value in summary.items()
-        if value not in (None, [], {})
-    }
+    return {key: value for key, value in summary.items() if value not in (None, [], {})}
 
 
 def _batch_schedule_probe_summary(value: Any) -> dict[str, Any] | None:
@@ -3620,11 +3540,7 @@ def _batch_schedule_probe_summary(value: Any) -> dict[str, Any] | None:
         summary["error_count"] = len(errors)
         if errors:
             summary["errors"] = errors
-    return {
-        key: item
-        for key, item in summary.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in summary.items() if item not in (None, [], {})}
 
 
 def _batch_preference_probe_summary(value: Any) -> dict[str, Any] | None:
@@ -3647,11 +3563,7 @@ def _batch_preference_probe_summary(value: Any) -> dict[str, Any] | None:
         summary["error_count"] = len(errors)
         if errors:
             summary["errors"] = errors
-    return {
-        key: item
-        for key, item in summary.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in summary.items() if item not in (None, [], {})}
 
 
 def _batch_ota_probe_summary(value: Any) -> dict[str, Any] | None:
@@ -3670,8 +3582,4 @@ def _batch_ota_probe_summary(value: Any) -> dict[str, Any] | None:
         summary["error_count"] = len(errors)
         if errors:
             summary["errors"] = errors
-    return {
-        key: item
-        for key, item in summary.items()
-        if item not in (None, [], {})
-    }
+    return {key: item for key, item in summary.items() if item not in (None, [], {})}

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -209,24 +209,26 @@ SENSORS = [
     DreameSensorDescription(
         key="current_cleaned_area",
         name="Current Cleaned Area",
-        value_fn=lambda snapshot: snapshot.cleaned_area,
-        exists_fn=lambda snapshot: snapshot.cleaned_area is not None,
+        value_fn=lambda snapshot: getattr(snapshot, "cleaned_area", None),
+        exists_fn=lambda snapshot: getattr(snapshot, "cleaned_area", None) is not None,
         icon="mdi:texture-box",
         native_unit_of_measurement="m²",
     ),
     DreameSensorDescription(
         key="current_cleaning_time",
         name="Current Cleaning Time",
-        value_fn=lambda snapshot: snapshot.cleaning_time,
-        exists_fn=lambda snapshot: snapshot.cleaning_time is not None,
+        value_fn=lambda snapshot: getattr(snapshot, "cleaning_time", None),
+        exists_fn=lambda snapshot: getattr(snapshot, "cleaning_time", None) is not None,
         icon="mdi:timer-sand",
         native_unit_of_measurement="min",
     ),
     DreameSensorDescription(
         key="active_segment_count",
         name="Active Segment Count",
-        value_fn=lambda snapshot: snapshot.active_segment_count,
-        exists_fn=lambda snapshot: snapshot.active_segment_count is not None,
+        value_fn=lambda snapshot: getattr(snapshot, "active_segment_count", None),
+        exists_fn=lambda snapshot: (
+            getattr(snapshot, "active_segment_count", None) is not None
+        ),
         icon="mdi:vector-square",
     ),
     DreameSensorDescription(

--- a/custom_components/dreame_lawn_mower/services.py
+++ b/custom_components/dreame_lawn_mower/services.py
@@ -421,11 +421,7 @@ def preference_change_request(data: dict[str, Any]) -> dict[str, Any]:
         ATTR_OBSTACLE_AVOIDANCE_AI_CLASSES,
         ATTR_EDGE_MOWING_SAFE,
     )
-    changes = {
-        key: data[key]
-        for key in supported_fields
-        if key in data
-    }
+    changes = {key: data[key] for key in supported_fields if key in data}
     if not changes:
         raise HomeAssistantError(
             "At least one mowing preference field must be provided for planning."
@@ -550,7 +546,11 @@ def _mowing_preference_notification(result: dict[str, Any]) -> tuple[str, str]:
     if area_id is not None:
         scope = f"{scope} area {area_id}"
 
-    if current_mode is not None and target_mode is not None and current_mode != target_mode:
+    if (
+        current_mode is not None
+        and target_mode is not None
+        and current_mode != target_mode
+    ):
         mode_text = f"mode {current_mode} -> {target_mode}"
     elif target_mode is not None:
         mode_text = f"mode={target_mode}"

--- a/custom_components/dreame_lawn_mower/switch.py
+++ b/custom_components/dreame_lawn_mower/switch.py
@@ -1,0 +1,127 @@
+"""Switch entities for Dreame mower voice prompt settings."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.switch import SwitchEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import DreameLawnMowerCoordinator
+from .entity import DreameLawnMowerEntity
+
+VOICE_PROMPT_SWITCHES = (
+    (
+        "general_prompt_voice",
+        "General Prompt Voice",
+        0,
+        "mdi:message-text-outline",
+    ),
+    (
+        "working_voice",
+        "Working Voice",
+        1,
+        "mdi:robot-mower-outline",
+    ),
+    (
+        "special_status_voice",
+        "Special Status Voice",
+        2,
+        "mdi:information-outline",
+    ),
+    (
+        "fault_voice",
+        "Fault Voice",
+        3,
+        "mdi:alert-circle-outline",
+    ),
+)
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up Dreame mower switch entities."""
+    coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            DreameLawnMowerVoicePromptSwitch(
+                coordinator,
+                key=key,
+                name=name,
+                index=index,
+                icon=icon,
+            )
+            for key, name, index, icon in VOICE_PROMPT_SWITCHES
+        ]
+    )
+
+
+class DreameLawnMowerVoicePromptSwitch(DreameLawnMowerEntity, SwitchEntity):
+    """Expose one prompt category from the mower VOICE flag array."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        *,
+        key: str,
+        name: str,
+        index: int,
+        icon: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._voice_key = key
+        self._voice_index = index
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_unique_id = f"{self._descriptor.unique_id}_{key}"
+
+    @property
+    def available(self) -> bool:
+        """Return whether cached voice settings are available."""
+        return self.coordinator.data is not None and self.is_on is not None
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether the prompt category is enabled."""
+        section = _voice_settings_section(self.coordinator.voice_settings)
+        if section is None:
+            return None
+        prompts = section.get("voice_prompts")
+        if not isinstance(prompts, list) or len(prompts) <= self._voice_index:
+            return None
+        return bool(prompts[self._voice_index])
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable the prompt category."""
+        await self._async_set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable the prompt category."""
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, enabled: bool) -> None:
+        section = _voice_settings_section(self.coordinator.voice_settings)
+        if section is None:
+            raise ValueError("Voice settings are not available.")
+        prompts = section.get("voice_prompts")
+        if not isinstance(prompts, list) or len(prompts) < 4:
+            raise ValueError("Voice prompt settings are not available.")
+        updated = [1 if bool(value) else 0 for value in prompts[:4]]
+        updated[self._voice_index] = 1 if enabled else 0
+        await self.coordinator.client.async_set_voice_prompts(updated)
+        await self.coordinator.async_refresh_voice_settings(force=True)
+        self.coordinator.async_update_listeners()
+
+
+def _voice_settings_section(value: dict[str, Any] | None) -> dict[str, Any] | None:
+    section = value.get("voice_settings") if isinstance(value, dict) else None
+    return section if isinstance(section, dict) and section.get("available") else None

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -67,8 +67,9 @@ class DreameLawnMowerFirmwareUpdateEntity(
     @property
     def in_progress(self) -> bool | int | None:
         """Return whether the mower reports an update in progress."""
-        if live_state := _snapshot_update_state(self.coordinator):
-            return live_state in {"upgrading", "updating"}
+        live_in_progress = _snapshot_update_in_progress(self.coordinator)
+        if live_in_progress is not None:
+            return live_in_progress
         support = self.coordinator.firmware_update_support
         if support is None:
             return None
@@ -160,4 +161,29 @@ def _snapshot_update_state(coordinator: DreameLawnMowerCoordinator) -> str | Non
         normalized = value.strip().lower()
         if normalized in {"upgrading", "updating"}:
             return normalized
+    return None
+
+
+def _snapshot_update_in_progress(
+    coordinator: DreameLawnMowerCoordinator,
+) -> bool | None:
+    """Return a live in-progress signal when the snapshot exposes any state."""
+    snapshot = coordinator.data
+    saw_live_state = False
+    for value in (
+        getattr(snapshot, "state_name", None),
+        getattr(snapshot, "activity", None),
+        getattr(snapshot, "task_status_name", None),
+    ):
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip().lower()
+        if not normalized:
+            continue
+        saw_live_state = True
+        if normalized in {"upgrading", "updating"}:
+            return True
+
+    if saw_live_state:
+        return False
     return None

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -45,18 +45,18 @@ class DreameLawnMowerFirmwareUpdateEntity(
     def available(self) -> bool:
         """Return whether the entity is currently available."""
         return (
-            super().available
-            and self.coordinator.firmware_update_support is not None
+            super().available and self.coordinator.firmware_update_support is not None
         )
 
     @property
     def installed_version(self) -> str | None:
         """Return the currently installed firmware version."""
+        if version := _snapshot_firmware_version(self.coordinator):
+            return version
         support = self.coordinator.firmware_update_support
         if support is not None and support.current_version:
             return support.current_version
-        snapshot = self.coordinator.data
-        return getattr(snapshot, "firmware_version", None)
+        return None
 
     @property
     def latest_version(self) -> str | None:
@@ -67,6 +67,8 @@ class DreameLawnMowerFirmwareUpdateEntity(
     @property
     def in_progress(self) -> bool | int | None:
         """Return whether the mower reports an update in progress."""
+        if live_state := _snapshot_update_state(self.coordinator):
+            return live_state in {"upgrading", "updating"}
         support = self.coordinator.firmware_update_support
         if support is None:
             return None
@@ -134,3 +136,28 @@ class DreameLawnMowerFirmwareUpdateEntity(
             source="firmware_update_install",
         )
         await self.coordinator.async_request_refresh()
+
+
+def _snapshot_firmware_version(coordinator: DreameLawnMowerCoordinator) -> str | None:
+    """Return the latest firmware version from the live coordinator snapshot."""
+    snapshot = coordinator.data
+    version = getattr(snapshot, "firmware_version", None)
+    if isinstance(version, str) and version.strip():
+        return version
+    return None
+
+
+def _snapshot_update_state(coordinator: DreameLawnMowerCoordinator) -> str | None:
+    """Return the current live update state when the snapshot exposes one."""
+    snapshot = coordinator.data
+    for value in (
+        getattr(snapshot, "state_name", None),
+        getattr(snapshot, "activity", None),
+        getattr(snapshot, "task_status_name", None),
+    ):
+        if not isinstance(value, str):
+            continue
+        normalized = value.strip().lower()
+        if normalized in {"upgrading", "updating"}:
+            return normalized
+    return None

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -1,0 +1,136 @@
+"""Firmware update entity for Dreame lawn mowers."""
+
+from __future__ import annotations
+
+from homeassistant.components.update import (
+    UpdateDeviceClass,
+    UpdateEntity,
+    UpdateEntityFeature,
+)
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import DreameLawnMowerCoordinator
+from .entity import DreameLawnMowerEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up mower firmware update entities."""
+    coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities([DreameLawnMowerFirmwareUpdateEntity(coordinator)])
+
+
+class DreameLawnMowerFirmwareUpdateEntity(
+    DreameLawnMowerEntity,
+    UpdateEntity,
+):
+    """Expose the approved mower firmware update path."""
+
+    _attr_name = "Firmware"
+    _attr_device_class = UpdateDeviceClass.FIRMWARE
+    _attr_supported_features = UpdateEntityFeature.INSTALL
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_firmware"
+
+    @property
+    def available(self) -> bool:
+        """Return whether the entity is currently available."""
+        return (
+            super().available
+            and self.coordinator.firmware_update_support is not None
+        )
+
+    @property
+    def installed_version(self) -> str | None:
+        """Return the currently installed firmware version."""
+        support = self.coordinator.firmware_update_support
+        if support is not None and support.current_version:
+            return support.current_version
+        snapshot = self.coordinator.data
+        return getattr(snapshot, "firmware_version", None)
+
+    @property
+    def latest_version(self) -> str | None:
+        """Return the app-approved target firmware version."""
+        support = self.coordinator.firmware_update_support
+        return None if support is None else support.latest_version
+
+    @property
+    def in_progress(self) -> bool | int | None:
+        """Return whether the mower reports an update in progress."""
+        support = self.coordinator.firmware_update_support
+        if support is None:
+            return None
+        return support.update_state in {"upgrading", "updating"}
+
+    @property
+    def release_summary(self) -> str | None:
+        """Return release notes when the cloud endpoint provides them."""
+        support = self.coordinator.firmware_update_support
+        if support is None or not support.release_summary_available:
+            return None
+        return support.release_summary
+
+    @property
+    def extra_state_attributes(self) -> dict[str, object]:
+        """Return extra firmware/update diagnostics."""
+        support = self.coordinator.firmware_update_support
+        if support is None:
+            return {}
+        return {
+            "update_available": support.update_available,
+            "update_state": support.update_state,
+            "cloud_check_available": support.cloud_check_available,
+            "cloud_check_update_available": support.cloud_check_update_available,
+            "batch_ota_available": support.batch_ota_available,
+            "auto_upgrade_enabled": support.auto_upgrade_enabled,
+            "ota_status": support.ota_status,
+            "release_summary_available": support.release_summary_available,
+            "reason": support.reason,
+            "warnings": list(support.warnings),
+        }
+
+    async def async_install(
+        self,
+        version: str | None,
+        backup: bool,
+        **kwargs,
+    ) -> None:
+        """Trigger the cloud firmware approval step."""
+        support = self.coordinator.firmware_update_support
+        if support is None:
+            raise HomeAssistantError("Firmware update support is not available.")
+
+        latest_version = support.latest_version
+        if (
+            version is not None
+            and latest_version is not None
+            and version != latest_version
+        ):
+            raise HomeAssistantError(
+                "Requested firmware version "
+                f"{version} does not match approved target {latest_version}."
+            )
+
+        result = await self.coordinator.client.async_approve_firmware_update(
+            language="en",
+        )
+        if not result.get("success"):
+            message = result.get("msg") or "Firmware approval failed."
+            raise HomeAssistantError(str(message))
+
+        await self.coordinator.async_refresh_firmware_update_support(force=True)
+        await self.coordinator.async_refresh_batch_device_data(
+            force=True,
+            source="firmware_update_install",
+        )
+        await self.coordinator.async_request_refresh()

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -352,6 +352,18 @@ Last updated: 2026-04-21
 - `pluginForceUpdate` is not treated as firmware update availability. It is
   conflicting across cloud metadata sources and appears to be app/plugin
   metadata rather than a verified mower OTA signal.
+- The live A2 `checkDeviceVersion` endpoint now confirms an app-approved target
+  of `4.3.6_0447` from current firmware `4.3.6_0320`. The returned
+  `description` field is still not trustworthy because it currently contains an
+  embedded backend error about missing `lang`, not human release notes.
+- The live A2 `manualFirmwareUpdate` approval flow was exercised on
+  2026-04-22. After the approval request, the mower entered `upgrading` and
+  later reported firmware `4.3.6_0447` with `checkDeviceVersion` no longer
+  advertising an available update.
+- The public `ota.tsingting.tech` debug catalog can provide candidate version
+  tracks for a short model such as `g2408`, but as of 2026-04-22 it still does
+  not expose changelog text and is treated as an unverified manual catalog
+  rather than the app-approved OTA target.
 - Realtime key meanings are still being learned. Known useful keys include
   `1.1` as a raw status blob, `1.4` as a runtime status blob, `2.1` as mower
   state, `2.2` as mower error, `2.50` as task status, `2.51` as device time,
@@ -587,8 +599,10 @@ credentials into repo files.
 
 - Keep adding fixtures for real mower transitions such as idle, returning,
   docked-charging, charging, and fault recovery.
-- Do not expose a Home Assistant firmware update entity yet. Keep firmware as
-  diagnostics until a verified latest-version or OTA-available field is found.
+- Validate the live `manualFirmwareUpdate` response path on a supervised mower
+  when it is acceptable to trigger the real approval step. The Home Assistant
+  update entity is now wired to the app-approved check and approval endpoints,
+  but the cloud-side side effects still need one live confirmation.
 - Improve the simple app-map renderer into a polished mower-specific renderer
   once more fixtures are available. The confirmed payload keys are `map`,
   `spot`, `point`, `semantic`, `trajectory`, `total_area`, `name`, and

--- a/dreame_lawn_mower_client/debug_ota_catalog.py
+++ b/dreame_lawn_mower_client/debug_ota_catalog.py
@@ -1,0 +1,8 @@
+"""Wrapper module for the reusable debug OTA catalog helpers."""
+
+from ._loader import load_internal_module
+
+_internal = load_internal_module("debug_ota_catalog")
+
+__all__ = [name for name in dir(_internal) if not name.startswith("_")]
+globals().update({name: getattr(_internal, name) for name in __all__})

--- a/examples/debug_ota_catalog_probe.py
+++ b/examples/debug_ota_catalog_probe.py
@@ -1,0 +1,91 @@
+"""Read-only probe for Dreame's debug/manual OTA catalog."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from dreame_lawn_mower_client import DreameLawnMowerClient
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Read-only probe for Dreame's debug/manual OTA catalog."
+    )
+    parser.add_argument(
+        "--include-raw",
+        action="store_true",
+        help="Include the raw catalog payload in addition to the summary.",
+    )
+    parser.add_argument(
+        "--device-index",
+        type=int,
+        default=0,
+        help="Zero-based discovered mower index to probe.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Optional JSON output file. Prints to stdout when omitted.",
+    )
+    return parser
+
+
+async def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    username = os.environ["DREAME_USERNAME"]
+    password = os.environ["DREAME_PASSWORD"]
+    country = os.environ.get("DREAME_COUNTRY", "eu")
+    account_type = os.environ.get("DREAME_ACCOUNT_TYPE", "dreame")
+
+    devices = await DreameLawnMowerClient.async_discover_devices(
+        username=username,
+        password=password,
+        country=country,
+        account_type=account_type,
+    )
+    if not devices:
+        raise RuntimeError("No mower devices found.")
+    if args.device_index < 0 or args.device_index >= len(devices):
+        raise RuntimeError(
+            f"Invalid device index {args.device_index}; found {len(devices)}."
+        )
+
+    client = DreameLawnMowerClient(
+        username=username,
+        password=password,
+        country=country,
+        account_type=account_type,
+        descriptor=devices[args.device_index],
+    )
+    try:
+        snapshot = await client.async_refresh()
+        catalog = await client.async_get_debug_ota_catalog(
+            current_version=snapshot.firmware_version,
+            include_raw=args.include_raw,
+        )
+        payload = {
+            "descriptor": {
+                "name": devices[args.device_index].name,
+                "model": devices[args.device_index].model,
+                "display_model": devices[args.device_index].display_model,
+            },
+            "current_firmware_version": snapshot.firmware_version,
+            "debug_ota_catalog": catalog,
+        }
+        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if args.out:
+            args.out.write_text(rendered, encoding="utf-8")
+        else:
+            print(rendered, end="")
+    finally:
+        await client.async_close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/examples/extract_ha_payload.py
+++ b/examples/extract_ha_payload.py
@@ -164,13 +164,41 @@ def summarize_payload(payload: dict[str, Any]) -> dict[str, Any]:
         summary["app_maps"] = _app_maps_summary(app_maps)
 
     if firmware_update:
-        summary["firmware_update"] = {
+        firmware_summary = {
             "current_version": firmware_update.get("current_version"),
             "update_state": firmware_update.get("update_state"),
             "update_available": firmware_update.get("update_available"),
             "warnings": firmware_update.get("warnings", []),
             "reason": firmware_update.get("reason"),
         }
+        latest_version = firmware_update.get("latest_version")
+        if latest_version is not None:
+            firmware_summary["latest_version"] = latest_version
+        for key in (
+            "cloud_check_available",
+            "cloud_check_update_available",
+            "release_summary_available",
+            "debug_catalog_available",
+            "debug_catalog_current_version_present",
+            "debug_catalog_changelog_available",
+        ):
+            value = firmware_update.get(key)
+            if value is not None:
+                firmware_summary[key] = value
+
+        debug_latest_versions = [
+            item.get("latest_release_version")
+            for item in (
+                firmware_update.get("debug_catalog_latest_release_candidates") or []
+            )
+            if isinstance(item, dict) and item.get("latest_release_version")
+        ]
+        if debug_latest_versions:
+            firmware_summary["debug_catalog_latest_release_versions"] = (
+                debug_latest_versions
+            )
+
+        summary["firmware_update"] = firmware_summary
 
     if remote_control_support:
         summary["remote_control_support"] = {

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -92,9 +92,7 @@ class _FakeAppMapCloud:
                         "m": "r",
                         "r": 0,
                         "d": {
-                            "name": [
-                                "ali_dreame/2025/04/23/device/map-one.0233.bin"
-                            ]
+                            "name": ["ali_dreame/2025/04/23/device/map-one.0233.bin"]
                         },
                     }
                 ]
@@ -355,7 +353,9 @@ def test_map_view_prefers_vector_render_when_live_path_is_available() -> None:
 
     client._sync_refresh_app_map_view = lambda **kwargs: app_view
     client._sync_refresh_vector_map_view = lambda: vector_view
-    client._sync_refresh_legacy_map_view = lambda timeout, interval: (_ for _ in ()).throw(  # noqa: ARG005
+    client._sync_refresh_legacy_map_view = lambda timeout, interval: (
+        _ for _ in ()
+    ).throw(  # noqa: ARG005
         AssertionError("legacy map path should not run when live vector data exists")
     )
 
@@ -385,7 +385,9 @@ def test_map_view_keeps_app_render_when_vector_has_no_live_path() -> None:
 
     client._sync_refresh_app_map_view = lambda **kwargs: app_view
     client._sync_refresh_vector_map_view = lambda: vector_view
-    client._sync_refresh_legacy_map_view = lambda timeout, interval: (_ for _ in ()).throw(  # noqa: ARG005
+    client._sync_refresh_legacy_map_view = lambda timeout, interval: (
+        _ for _ in ()
+    ).throw(  # noqa: ARG005
         AssertionError("legacy map path should not run when app map works")
     )
 

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -1,0 +1,157 @@
+"""Regression checks for Codex review findings in the client helpers."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from dreame_lawn_mower_client import DreameLawnMowerClient
+from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
+
+
+def _client() -> DreameLawnMowerClient:
+    return DreameLawnMowerClient(
+        username="user@example.invalid",
+        password="secret",
+        country="eu",
+        account_type="dreame",
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-1",
+            name="Garden Mower",
+            model="dreame.mower.g2408",
+            display_model="A2",
+            account_type="dreame",
+            country="eu",
+        ),
+    )
+
+
+def _firmware_device() -> SimpleNamespace:
+    return SimpleNamespace(
+        info=SimpleNamespace(
+            firmware_version="1.0.0",
+            raw={},
+        ),
+        status=SimpleNamespace(),
+        data={},
+    )
+
+
+def test_get_voice_settings_does_not_synthesize_prompt_flags() -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload: {  # type: ignore[method-assign]
+        "m": "r",
+        "r": 0,
+        "d": {"LANG": [8, 13], "VOL": 100},
+    }
+
+    result = client._sync_get_voice_settings()
+
+    assert result["available"] is True
+    assert result["present_config_keys"] == ["LANG", "VOL"]
+    assert result["voice_language_index"] == 13
+    assert result["volume"] == 100
+    assert "voice_prompts" not in result
+    assert "general_prompt_voice" not in result
+
+
+def test_get_voice_settings_requires_supported_keys() -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload: {  # type: ignore[method-assign]
+        "m": "r",
+        "r": 0,
+        "d": {"OTHER": 1},
+    }
+
+    result = client._sync_get_voice_settings()
+
+    assert result["available"] is False
+    assert result["present_config_keys"] == []
+    assert "voice_prompts" not in result
+
+
+def test_get_firmware_update_support_skips_debug_catalog_by_default(
+    monkeypatch,
+) -> None:
+    client = _client()
+
+    monkeypatch.setattr(client, "_ensure_device", lambda: _firmware_device())
+    monkeypatch.setattr(client, "_sync_get_cloud_device_info", lambda language: None)
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_device_list_page",
+        lambda current, size, language, master, shared_status: None,
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_firmware_check",
+        lambda language: {
+            "available": True,
+            "update_available": False,
+        },
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_batch_ota_info",
+        lambda: {
+            "available": True,
+            "update_available": False,
+        },
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_debug_ota_catalog",
+        lambda **kwargs: (_ for _ in ()).throw(
+            AssertionError("debug OTA catalog should be opt-in")
+        ),
+    )
+
+    result = client._sync_get_firmware_update_support()
+
+    assert result.debug_catalog_available is None
+    assert "debug_ota_catalog" not in result.evidence
+
+
+def test_get_firmware_update_support_fetches_debug_catalog_when_requested(
+    monkeypatch,
+) -> None:
+    client = _client()
+
+    monkeypatch.setattr(client, "_ensure_device", lambda: _firmware_device())
+    monkeypatch.setattr(client, "_sync_get_cloud_device_info", lambda language: None)
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_device_list_page",
+        lambda current, size, language, master, shared_status: None,
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_firmware_check",
+        lambda language: {
+            "available": True,
+            "update_available": False,
+        },
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_batch_ota_info",
+        lambda: {
+            "available": True,
+            "update_available": False,
+        },
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_debug_ota_catalog",
+        lambda **kwargs: {
+            "source": "debug_ota_catalog",
+            "available": True,
+        },
+    )
+
+    result = client._sync_get_firmware_update_support(include_debug_ota_catalog=True)
+
+    assert result.debug_catalog_available is True
+    assert result.evidence["debug_ota_catalog"] == {
+        "source": "debug_ota_catalog",
+        "available": True,
+    }

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from dreame_lawn_mower_client import DreameLawnMowerClient
+from dreame_lawn_mower_client.client import DreameLawnMowerConnectionError
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 
 
@@ -155,3 +156,77 @@ def test_get_firmware_update_support_fetches_debug_catalog_when_requested(
         "source": "debug_ota_catalog",
         "available": True,
     }
+
+
+def test_get_firmware_update_support_still_checks_firmware_after_metadata_error(
+    monkeypatch,
+) -> None:
+    client = _client()
+
+    monkeypatch.setattr(client, "_ensure_device", lambda: _firmware_device())
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_device_info",
+        lambda language: (_ for _ in ()).throw(
+            DreameLawnMowerConnectionError("device info unavailable")
+        ),
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_device_list_page",
+        lambda current, size, language, master, shared_status: None,
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_cloud_firmware_check",
+        lambda language: {
+            "available": True,
+            "update_available": True,
+            "latest_version": "1.1.0",
+        },
+    )
+    monkeypatch.setattr(
+        client,
+        "_sync_get_batch_ota_info",
+        lambda: {
+            "available": True,
+            "update_available": False,
+        },
+    )
+
+    result = client._sync_get_firmware_update_support()
+
+    assert result.cloud_check_available is True
+    assert result.cloud_check_update_available is True
+    assert result.latest_version == "1.1.0"
+    assert result.cloud_error is not None
+    assert "cloud_device_info: device info unavailable" in result.cloud_error
+
+
+def test_cloud_firmware_check_marks_error_response_unavailable(monkeypatch) -> None:
+    client = _client()
+
+    class _Cloud:
+        def check_device_version(self, language=None):
+            return {
+                "code": 500,
+                "success": False,
+                "msg": "backend unavailable",
+            }
+
+    monkeypatch.setattr(client, "_sync_get_cloud_protocol", lambda: _Cloud())
+    monkeypatch.setattr(client, "_ensure_device", lambda: _firmware_device())
+
+    result = client._sync_get_cloud_firmware_check()
+
+    assert result["available"] is False
+    assert result["update_available"] is None
+    assert result["errors"] == [
+        {
+            "stage": "response",
+            "error": "cloud_error",
+            "code": 500,
+            "success": False,
+            "msg": "backend unavailable",
+        }
+    ]

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -111,7 +111,7 @@ def _batch_device_data() -> dict:
                         },
                         {"area_id": 202, "map_index": 1},
                     ],
-                }
+                },
             ]
         }
     }
@@ -999,7 +999,9 @@ def test_lawn_mower_plan_map_preference_mode_update_uses_selected_map() -> None:
     coordinator.async_request_refresh.assert_not_awaited()
 
 
-def test_lawn_mower_plan_map_preference_mode_update_can_execute_confirmed_write() -> None:
+def test_lawn_mower_plan_map_preference_mode_update_can_execute_confirmed_write() -> (
+    None
+):
     client = SimpleNamespace(
         async_plan_app_mowing_preference_update=AsyncMock(
             return_value={

--- a/tests/test_debug_ota_catalog.py
+++ b/tests/test_debug_ota_catalog.py
@@ -1,0 +1,110 @@
+"""Tests for the debug/manual OTA catalog summary helpers."""
+
+from dreame_lawn_mower_client.debug_ota_catalog import (
+    build_debug_ota_catalog_url,
+    normalize_debug_ota_catalog_payload,
+)
+
+
+def test_build_debug_ota_catalog_url() -> None:
+    assert (
+        build_debug_ota_catalog_url("g2408")
+        == "https://ota.tsingting.tech/api/version/g2408/?name=g2408"
+    )
+
+
+def test_normalize_debug_ota_catalog_payload_summarizes_tracks() -> None:
+    payload = {
+        "code": 0,
+        "data": {
+            "BUILD": [
+                {
+                    "id": 2,
+                    "version": "4.3.6_0320",
+                    "sha256sum": "aaa",
+                    "url_endpoint": "https://packages.example",
+                    "url": "G2408/BUILD/2/Release-arm/G2408_update-4.3.6_0320.img",
+                },
+                {
+                    "id": 3,
+                    "version": "4.3.6_0320_debug",
+                    "sha256sum": "bbb",
+                    "url_endpoint": "https://packages.example",
+                    "url": (
+                        "G2408/BUILD/2/Debug-arm/"
+                        "G2408_update-4.3.6_0320_debug_debug.img"
+                    ),
+                },
+                {
+                    "id": 4,
+                    "version": "4.3.6_0562",
+                    "sha256sum": "ccc",
+                    "url_endpoint": "https://packages.example",
+                    "url": "G2408/BUILD/57/Release-arm/G2408_update-4.3.6_0562.img",
+                },
+            ],
+            "FEATURE": [
+                {
+                    "id": 10,
+                    "version": "202604181249Feature_G2408-0415-3294",
+                    "sha256sum": "ddd",
+                    "url_endpoint": "https://packages.example",
+                    "url": (
+                        "G2408/FEATURE/105/Release-arm/"
+                        "G2408_update-202604181249Feature_G2408-0415-3294.img"
+                    ),
+                }
+            ],
+            "PREBUILD": [
+                {
+                    "id": 8,
+                    "version": "4.3.6_0550",
+                    "sha256sum": "eee",
+                    "url_endpoint": "https://packages.example",
+                    "url": (
+                        "G2408/PREBUILD/20260411-11/Release-arm/"
+                        "G2408_update-4.3.6_0550.img"
+                    ),
+                }
+            ],
+        },
+    }
+
+    result = normalize_debug_ota_catalog_payload(
+        payload,
+        model_name="g2408",
+        current_version="4.3.6_0320",
+    )
+
+    assert result["available"] is True
+    assert result["model_name"] == "g2408"
+    assert result["current_version"] == "4.3.6_0320"
+    assert result["current_version_present"] is True
+    assert result["changelog_available"] is False
+    assert "debug_catalog_has_no_changelog" in result["warnings"]
+    assert result["tracks"]["BUILD"]["entry_count"] == 3
+    assert result["tracks"]["BUILD"]["release_entry_count"] == 2
+    assert result["tracks"]["BUILD"]["current_version_present"] is True
+    assert result["tracks"]["BUILD"]["latest_release_version"] == "4.3.6_0562"
+    assert result["tracks"]["PREBUILD"]["latest_release_version"] == "4.3.6_0550"
+    assert (
+        result["tracks"]["FEATURE"]["latest_release_version"]
+        == "202604181249Feature_G2408-0415-3294"
+    )
+    assert result["latest_release_candidates"][0]["track"] == "BUILD"
+    assert (
+        result["latest_release_candidates"][0]["latest_release_download_url"]
+        == "https://packages.example/G2408/BUILD/57/Release-arm/G2408_update-4.3.6_0562.img"
+    )
+
+
+def test_normalize_debug_ota_catalog_payload_handles_missing_data() -> None:
+    result = normalize_debug_ota_catalog_payload({})
+
+    assert result["available"] is False
+    assert result["errors"] == [
+        {
+            "stage": "parse",
+            "error": "Debug OTA catalog payload has no data map.",
+        }
+    ]

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -884,6 +884,184 @@ def test_firmware_update_support_marks_update_state() -> None:
     assert support.reason == "Mower reports an update-related state."
 
 
+def test_firmware_update_support_uses_verified_batch_ota_signal() -> None:
+    device = _FakeDevice()
+
+    support = firmware_update_support_from_device(
+        device,
+        cloud_device_info={
+            "ver": "4.3.6_0320",
+            "deviceInfo": {"pluginForceUpdate": False},
+        },
+        batch_ota_info={
+            "source": "batch_device_data_ota_info",
+            "available": True,
+            "update_available": True,
+            "auto_upgrade_enabled": False,
+            "ota_status": 0,
+        },
+    )
+
+    assert support.update_available is True
+    assert support.batch_ota_available is True
+    assert support.auto_upgrade_enabled is False
+    assert support.ota_status == 0
+    assert support.reason == (
+        "Batch OTA info reports that a mower firmware update is available."
+    )
+    assert support.candidate_update_fields["batch_ota_info.update_available"] is True
+    assert (
+        support.candidate_update_fields["batch_ota_info.auto_upgrade_enabled"]
+        is False
+    )
+    assert support.candidate_update_fields["batch_ota_info.ota_status"] == 0
+    assert support.evidence["batch_ota_info"] == {
+        "source": "batch_device_data_ota_info",
+        "available": True,
+        "update_available": True,
+        "auto_upgrade_enabled": False,
+        "ota_status": 0,
+    }
+    assert support.plugin_force_update_sources == {
+        "cached_device_info": True,
+        "cloud_device_info": False,
+    }
+    assert support.warnings == ("plugin_force_update_conflict",)
+
+
+def test_firmware_update_support_uses_cloud_firmware_check_target() -> None:
+    device = _FakeDevice()
+
+    support = firmware_update_support_from_device(
+        device,
+        cloud_firmware_check={
+            "source": "cloud_check_device_version",
+            "available": True,
+            "update_available": True,
+            "current_version": "4.3.6_0320",
+            "latest_version": "4.3.6_0447",
+            "firmware_type": "PLATFORM",
+            "force_update": False,
+            "status": 1,
+            "changelog": None,
+            "changelog_available": False,
+            "changelog_error": {
+                "code": 10005,
+                "msg": "missing required request parameter: lang",
+                "success": False,
+            },
+        },
+        batch_ota_info={
+            "source": "batch_device_data_ota_info",
+            "available": True,
+            "update_available": True,
+            "auto_upgrade_enabled": False,
+            "ota_status": 0,
+        },
+    )
+
+    assert support.update_available is True
+    assert support.cloud_check_available is True
+    assert support.cloud_check_update_available is True
+    assert support.latest_version == "4.3.6_0447"
+    assert support.release_summary is None
+    assert support.release_summary_available is False
+    assert support.reason == (
+        "Cloud checkDeviceVersion and batch OTA info both report that a mower "
+        "firmware update is available."
+    )
+    assert support.candidate_update_fields["cloud_firmware_check.latest_version"] == (
+        "4.3.6_0447"
+    )
+    assert support.evidence["cloud_firmware_check"]["firmware_type"] == "PLATFORM"
+    assert support.evidence["cloud_firmware_check"]["changelog_available"] is False
+
+
+def test_firmware_update_support_uses_batch_ota_no_update_signal() -> None:
+    device = _FakeDevice()
+
+    support = firmware_update_support_from_device(
+        device,
+        batch_ota_info={
+            "source": "batch_device_data_ota_info",
+            "available": True,
+            "update_available": False,
+            "auto_upgrade_enabled": True,
+            "ota_status": 1,
+        },
+    )
+
+    assert support.update_available is False
+    assert support.batch_ota_available is True
+    assert support.auto_upgrade_enabled is True
+    assert support.ota_status == 1
+    assert support.reason == (
+        "Batch OTA info reports that no mower firmware update is available."
+    )
+
+
+def test_firmware_update_support_tracks_debug_catalog_candidates() -> None:
+    device = _FakeDevice()
+
+    support = firmware_update_support_from_device(
+        device,
+        batch_ota_info={
+            "source": "batch_device_data_ota_info",
+            "available": True,
+            "update_available": True,
+            "auto_upgrade_enabled": False,
+            "ota_status": 0,
+        },
+        debug_ota_catalog={
+            "source": "debug_ota_catalog",
+            "available": True,
+            "model_name": "g2408",
+            "current_version": "4.3.6_0320",
+            "current_version_present": False,
+            "changelog_available": False,
+            "latest_release_candidates": [
+                {
+                    "track": "BUILD",
+                    "latest_release_version": "4.3.6_0562",
+                },
+                {
+                    "track": "PREBUILD",
+                    "latest_release_version": "4.3.6_0550",
+                },
+            ],
+            "warnings": [
+                "debug_catalog_unverified",
+                "debug_catalog_not_device_approved",
+                "debug_catalog_has_no_changelog",
+            ],
+        },
+    )
+
+    assert support.update_available is True
+    assert support.debug_catalog_available is True
+    assert support.debug_catalog_current_version_present is False
+    assert support.debug_catalog_changelog_available is False
+    assert support.debug_catalog_latest_release_candidates == (
+        {
+            "track": "BUILD",
+            "latest_release_version": "4.3.6_0562",
+        },
+        {
+            "track": "PREBUILD",
+            "latest_release_version": "4.3.6_0550",
+        },
+    )
+    assert (
+        support.candidate_update_fields[
+            "debug_ota_catalog.latest_release_candidates[0].latest_release_version"
+        ]
+        == "4.3.6_0562"
+    )
+    assert support.evidence["debug_ota_catalog"]["model_name"] == "g2408"
+    assert support.evidence["debug_ota_catalog"]["current_version_present"] is False
+    assert support.evidence["debug_ota_catalog"]["changelog_available"] is False
+
+
 def test_firmware_update_support_summarizes_root_records() -> None:
     device = _FakeDevice()
 

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -45,10 +45,10 @@ from custom_components.dreame_lawn_mower.sensor import (
     DreameLawnMowerRuntimeTrackLengthSensor,
     DreameLawnMowerRuntimeTrackPointCountSensor,
     DreameLawnMowerRuntimeTrackSegmentCountSensor,
-    DreameLawnMowerSelectedMapSensor,
     DreameLawnMowerSelectedMapPreferenceAreaCountSensor,
     DreameLawnMowerSelectedMapPreferenceCountSensor,
     DreameLawnMowerSelectedMapPreferenceModeSensor,
+    DreameLawnMowerSelectedMapSensor,
     DreameLawnMowerSelectedMowingActionSensor,
     DreameLawnMowerSelectedTargetSensor,
     DreameLawnMowerSelectedZoneDirectionModeSensor,
@@ -437,8 +437,9 @@ def test_bluetooth_connected_binary_sensor_uses_cached_cloud_state() -> None:
     }
 
 
-def test_bluetooth_connected_binary_sensor_is_unavailable_without_cached_value(
-    ) -> None:
+def test_bluetooth_connected_binary_sensor_is_unavailable_without_cached_value() -> (
+    None
+):
     entity = object.__new__(DreameLawnMowerBluetoothConnectedBinarySensor)
     entity.coordinator = SimpleNamespace(
         data=SimpleNamespace(),
@@ -1806,33 +1807,23 @@ def test_selected_zone_preference_sensors_expose_read_only_zone_settings() -> No
         },
     )
 
-    height_entity = object.__new__(
-        DreameLawnMowerSelectedZoneMowingHeightSensor
-    )
+    height_entity = object.__new__(DreameLawnMowerSelectedZoneMowingHeightSensor)
     height_entity.coordinator = coordinator
-    efficiency_entity = object.__new__(
-        DreameLawnMowerSelectedZoneEfficiencyModeSensor
-    )
+    efficiency_entity = object.__new__(DreameLawnMowerSelectedZoneEfficiencyModeSensor)
     efficiency_entity.coordinator = coordinator
-    direction_entity = object.__new__(
-        DreameLawnMowerSelectedZoneDirectionModeSensor
-    )
+    direction_entity = object.__new__(DreameLawnMowerSelectedZoneDirectionModeSensor)
     direction_entity.coordinator = coordinator
     avoidance_entity = object.__new__(
         DreameLawnMowerSelectedZoneObstacleAvoidanceSensor
     )
     avoidance_entity.coordinator = coordinator
-    distance_entity = object.__new__(
-        DreameLawnMowerSelectedZoneObstacleDistanceSensor
-    )
+    distance_entity = object.__new__(DreameLawnMowerSelectedZoneObstacleDistanceSensor)
     distance_entity.coordinator = coordinator
     height_limit_entity = object.__new__(
         DreameLawnMowerSelectedZoneObstacleHeightSensor
     )
     height_limit_entity.coordinator = coordinator
-    classes_entity = object.__new__(
-        DreameLawnMowerSelectedZoneObstacleClassSensor
-    )
+    classes_entity = object.__new__(DreameLawnMowerSelectedZoneObstacleClassSensor)
     classes_entity.coordinator = coordinator
 
     assert height_entity.available is True

--- a/tests/test_extract_ha_payload.py
+++ b/tests/test_extract_ha_payload.py
@@ -1155,3 +1155,80 @@ def test_summarize_payload_includes_task_status_probe_summary() -> None:
         ],
         "error_count": 0,
     }
+
+
+def test_summarize_payload_includes_debug_catalog_firmware_summary() -> None:
+    payload = {
+        "firmware_update": {
+            "current_version": "4.3.6_0320",
+            "update_available": True,
+            "debug_catalog_available": True,
+            "debug_catalog_current_version_present": False,
+            "debug_catalog_changelog_available": False,
+            "debug_catalog_latest_release_candidates": [
+                {
+                    "track": "BUILD",
+                    "latest_release_version": "4.3.6_0562",
+                },
+                {
+                    "track": "PREBUILD",
+                    "latest_release_version": "4.3.6_0550",
+                },
+            ],
+            "warnings": ["plugin_force_update_conflict"],
+            "reason": (
+                "Batch OTA info reports that a mower firmware update is available."
+            ),
+        }
+    }
+
+    assert summarize_payload(payload) == {
+        "firmware_update": {
+            "current_version": "4.3.6_0320",
+            "update_available": True,
+            "debug_catalog_available": True,
+            "debug_catalog_current_version_present": False,
+            "debug_catalog_changelog_available": False,
+            "debug_catalog_latest_release_versions": [
+                "4.3.6_0562",
+                "4.3.6_0550",
+            ],
+            "warnings": ["plugin_force_update_conflict"],
+            "reason": (
+                "Batch OTA info reports that a mower firmware update is available."
+            ),
+        }
+    }
+
+
+def test_summarize_payload_includes_cloud_firmware_check_summary() -> None:
+    payload = {
+        "firmware_update": {
+            "current_version": "4.3.6_0320",
+            "latest_version": "4.3.6_0447",
+            "update_available": True,
+            "cloud_check_available": True,
+            "cloud_check_update_available": True,
+            "release_summary_available": False,
+            "warnings": [],
+            "reason": (
+                "Cloud checkDeviceVersion and batch OTA info both report that a "
+                "mower firmware update is available."
+            ),
+        }
+    }
+
+    assert summarize_payload(payload) == {
+        "firmware_update": {
+            "current_version": "4.3.6_0320",
+            "latest_version": "4.3.6_0447",
+            "update_available": True,
+            "cloud_check_available": True,
+            "cloud_check_update_available": True,
+            "release_summary_available": False,
+            "reason": (
+                "Cloud checkDeviceVersion and batch OTA info both report that a "
+                "mower firmware update is available."
+            ),
+        }
+    }

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 from io import BytesIO
 from typing import Any
 
+from homeassistant.const import Platform
 from PIL import Image, ImageFont
 
 from custom_components.dreame_lawn_mower import image as image_helpers
@@ -22,6 +23,7 @@ from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerCaptureWeatherProbeButton,
     schedule_probe_payload,
 )
+from custom_components.dreame_lawn_mower.const import PLATFORMS
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     DreameLawnMowerClient,
 )
@@ -65,6 +67,9 @@ from custom_components.dreame_lawn_mower.task_status_probe import (
     task_status_probe_payload,
     task_status_probe_result_attributes,
 )
+from custom_components.dreame_lawn_mower.update import (
+    DreameLawnMowerFirmwareUpdateEntity,
+)
 
 
 def test_sensor_description_exposes_ha_compat_fields() -> None:
@@ -102,6 +107,10 @@ def test_binary_sensor_description_exposes_ha_compat_fields() -> None:
     assert description.unit_of_measurement is None
 
 
+def test_platforms_include_update() -> None:
+    assert Platform.UPDATE in PLATFORMS
+
+
 def test_schedule_probe_button_is_diagnostic_disabled_by_default() -> None:
     assert (
         DreameLawnMowerCaptureScheduleProbeButton.__dict__["__attr_entity_category"]
@@ -127,6 +136,15 @@ def test_batch_device_data_probe_button_is_diagnostic_disabled_by_default() -> N
             "__attr_entity_registry_enabled_default"
         ]
         is False
+    )
+
+
+def test_firmware_update_entity_supports_install() -> None:
+    assert DreameLawnMowerFirmwareUpdateEntity.__dict__["__attr_device_class"] == (
+        "firmware"
+    )
+    assert (
+        DreameLawnMowerFirmwareUpdateEntity.__dict__["__attr_supported_features"] > 0
     )
 
 
@@ -463,7 +481,10 @@ def test_task_status_probe_payload_keeps_compact_app_state() -> None:
                     "source": None,
                     "raw": (),
                     "length": 33,
-                    "hex": "ce4f02804d002d0701007d0122017d013201f6ffeaff01645e056ccf007f1c00ce",
+                    "hex": (
+                        "ce4f02804d002d0701007d0122017d013201f6ffeaff01645e056ccf"
+                        "007f1c00ce"
+                    ),
                     "frame_start": 206,
                     "frame_end": 206,
                     "frame_valid": True,

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -44,10 +44,14 @@ class _FakePreferenceCloud:
             }
         if command == "PREI":
             idx = int(payload["d"]["idx"])
-            data = {"type": 1, "ver": [[11, 8], [12, 9]]} if idx == 0 else {
-                "type": 0,
-                "ver": [],
-            }
+            data = (
+                {"type": 1, "ver": [[11, 8], [12, 9]]}
+                if idx == 0
+                else {
+                    "type": 0,
+                    "ver": [],
+                }
+            )
             return {"out": [{"m": "r", "r": 0, "d": data}]}
         if command == "PRE":
             if payload.get("m") == "s":
@@ -363,7 +367,9 @@ def test_plan_app_mowing_preference_update_can_execute_mode_only_request() -> No
     assert [call["t"] for call in cloud.calls] == ["PREI", "PRE", "PRE", "PREP"]
 
 
-def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequence() -> None:
+def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequence() -> (
+    None
+):
     client = _client()
     requests: list[dict[str, object]] = []
     client._sync_get_mowing_preferences = lambda *args, **kwargs: {
@@ -421,18 +427,28 @@ def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequenc
     assert result["request_candidate"] == {
         "sequence": [
             {"m": "s", "t": "PREP", "d": {"idx": 1, "value": 1}},
-            {"m": "s", "t": "PRE", "d": [10, 1, 5, 1, 40, 1, 170, 1, 0, 1, 0, 1, 1, 5, 10, 7, 1]},
+            {
+                "m": "s",
+                "t": "PRE",
+                "d": [10, 1, 5, 1, 40, 1, 170, 1, 0, 1, 0, 1, 1, 5, 10, 7, 1],
+            },
         ]
     }
     assert result["request_candidates"] == [
         {"m": "s", "t": "PREP", "d": {"idx": 1, "value": 1}},
-        {"m": "s", "t": "PRE", "d": [10, 1, 5, 1, 40, 1, 170, 1, 0, 1, 0, 1, 1, 5, 10, 7, 1]},
+        {
+            "m": "s",
+            "t": "PRE",
+            "d": [10, 1, 5, 1, 40, 1, 170, 1, 0, 1, 0, 1, 1, 5, 10, 7, 1],
+        },
     ]
     assert result["response_data"] == [{"r": 0, "ok": True}, {"r": 0, "ok": True}]
     assert [request["t"] for request in requests] == ["PREP", "PRE"]
 
 
-def test_plan_app_mowing_preference_update_rejects_global_mode_with_zone_changes() -> None:
+def test_plan_app_mowing_preference_update_rejects_global_mode_with_zone_changes() -> (
+    None
+):
     client = _client()
     cloud = _FakePreferenceCloud()
     client._sync_get_cloud_protocol = lambda: cloud

--- a/tests/test_python_package.py
+++ b/tests/test_python_package.py
@@ -2,6 +2,8 @@
 
 from dreame_lawn_mower_client import (
     CAMERA_PROBE_PROPERTY_KEYS,
+    DEBUG_OTA_LIST_URL,
+    DEBUG_OTA_TRACKS,
     DEFAULT_APK_RESEARCH_TERMS,
     DEFAULT_DECOMPILED_SOURCE_SUFFIXES,
     DEFAULT_DREAMEHOME_ASSET_TERMS,
@@ -36,6 +38,7 @@ from dreame_lawn_mower_client import (
     build_cloud_key_definition_summary,
     build_cloud_property_history_summary,
     build_cloud_property_summary,
+    build_debug_ota_catalog_url,
     build_jadx_command,
     build_map_probe_payload,
     build_schedule_enable_status_request,
@@ -59,6 +62,7 @@ from dreame_lawn_mower_client import (
     mower_realtime_property_name,
     mower_state_key,
     mower_state_label,
+    normalize_debug_ota_catalog_payload,
     remote_control_block_reason,
     remote_control_state_safe,
     run_jadx_decompile,
@@ -102,6 +106,7 @@ def test_public_package_exports_map_helpers() -> None:
     assert callable(analyze_dreamehome_assets)
     assert callable(analyze_dreamehome_apk)
     assert callable(build_camera_probe_payload)
+    assert callable(build_debug_ota_catalog_url)
     assert callable(build_cloud_key_definition_summary)
     assert callable(build_cloud_property_history_summary)
     assert callable(build_cloud_property_summary)
@@ -114,9 +119,12 @@ def test_public_package_exports_map_helpers() -> None:
     assert callable(decode_batch_schedule_payload)
     assert callable(decode_mowing_preference_payload)
     assert callable(encode_mowing_preference_payload)
+    assert callable(normalize_debug_ota_catalog_payload)
     assert callable(run_jadx_decompile)
     assert callable(summarize_mowing_preference_info)
     assert "10001.1" in CAMERA_PROBE_PROPERTY_KEYS
+    assert "BUILD" in DEBUG_OTA_TRACKS
+    assert "https://ota.tsingting.tech/api/version/" in DEBUG_OTA_LIST_URL
     assert "sendAction" in DEFAULT_APK_RESEARCH_TERMS
     assert ".java" in DEFAULT_DECOMPILED_SOURCE_SUFFIXES
     assert "object_name" in DEFAULT_DREAMEHOME_ASSET_TERMS
@@ -134,6 +142,8 @@ def test_public_package_client_has_cloud_probe_helpers() -> None:
     assert hasattr(DreameLawnMowerClient, "async_get_cloud_properties")
     assert hasattr(DreameLawnMowerClient, "async_scan_cloud_properties")
     assert hasattr(DreameLawnMowerClient, "async_get_cloud_key_definition")
+    assert hasattr(DreameLawnMowerClient, "async_get_cloud_firmware_check")
+    assert hasattr(DreameLawnMowerClient, "async_approve_firmware_update")
     assert hasattr(DreameLawnMowerClient, "async_probe_map_sources")
     assert hasattr(DreameLawnMowerClient, "async_get_camera_feature_support")
     assert hasattr(DreameLawnMowerClient, "async_get_firmware_update_support")
@@ -152,6 +162,7 @@ def test_public_package_client_has_cloud_probe_helpers() -> None:
     assert hasattr(DreameLawnMowerClient, "async_plan_app_schedule_upload")
     assert hasattr(DreameLawnMowerClient, "async_get_batch_mowing_preferences")
     assert hasattr(DreameLawnMowerClient, "async_get_batch_ota_info")
+    assert hasattr(DreameLawnMowerClient, "async_get_debug_ota_catalog")
     assert hasattr(DreameLawnMowerClient, "async_get_weather_protection")
     assert hasattr(DreameLawnMowerClient, "async_set_app_schedule_plan_enabled")
 

--- a/tests/test_select_voice_language.py
+++ b/tests/test_select_voice_language.py
@@ -1,0 +1,24 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from custom_components.dreame_lawn_mower.select import (
+    DreameLawnMowerVoiceLanguageSelect,
+)
+
+
+def test_voice_language_select_stays_available_for_unknown_index() -> None:
+    entity = object.__new__(DreameLawnMowerVoiceLanguageSelect)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data=SimpleNamespace(),
+        voice_settings={
+            "voice_settings": {
+                "available": True,
+                "voice_language_index": 999,
+            }
+        },
+    )
+
+    assert entity.available is True
+    assert entity.current_option is None

--- a/tests/test_services.py
+++ b/tests/test_services.py
@@ -9,11 +9,11 @@ import voluptuous as vol
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.dreame_lawn_mower.services import (
-    PLAN_SCHEDULE_UPLOAD_SCHEMA,
+    ATTR_PREFERENCE_MODE,
     PLAN_MOWING_PREFERENCE_UPDATE_SCHEMA,
+    PLAN_SCHEDULE_UPLOAD_SCHEMA,
     REMOTE_CONTROL_STEP_SCHEMA,
     SET_SCHEDULE_PLAN_ENABLED_SCHEMA,
-    ATTR_PREFERENCE_MODE,
     _guard_preference_write_request,
     _guard_remote_control_step,
     _guard_schedule_write_request,

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -1,0 +1,127 @@
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
+    DreameLawnMowerClient,
+)
+from custom_components.dreame_lawn_mower.update import (
+    DreameLawnMowerFirmwareUpdateEntity,
+)
+
+
+def test_firmware_update_entity_uses_cached_support() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data=SimpleNamespace(firmware_version="4.3.6_0320"),
+        firmware_update_support=SimpleNamespace(
+            current_version="4.3.6_0320",
+            latest_version="4.3.6_0447",
+            update_state=None,
+            release_summary=None,
+            release_summary_available=False,
+            update_available=True,
+            cloud_check_available=True,
+            cloud_check_update_available=True,
+            batch_ota_available=True,
+            auto_upgrade_enabled=False,
+            ota_status=0,
+            reason=(
+                "Cloud checkDeviceVersion and batch OTA info both report that a mower "
+                "firmware update is available."
+            ),
+            warnings=(),
+        ),
+    )
+
+    assert entity.available is True
+    assert entity.installed_version == "4.3.6_0320"
+    assert entity.latest_version == "4.3.6_0447"
+    assert entity.in_progress is False
+    assert entity.release_summary is None
+    assert entity.extra_state_attributes["cloud_check_update_available"] is True
+    assert entity.extra_state_attributes["batch_ota_available"] is True
+
+
+def test_approve_firmware_update_treats_wrapper_success_as_accepted() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+
+    class _Cloud:
+        def manual_firmware_update(self, language=None):
+            return {
+                "code": 0,
+                "success": True,
+                "msg": "ok",
+                "data": {
+                    "code": 2,
+                    "success": False,
+                },
+            }
+
+    client._sync_get_cloud_protocol = lambda: _Cloud()
+
+    result = client._sync_approve_firmware_update("en")
+
+    assert result["accepted"] is True
+    assert result["success"] is True
+    assert result["code"] == 0
+    assert result["wrapper_success"] is True
+    assert result["inner_code"] == 2
+    assert result["inner_success"] is False
+
+
+def test_firmware_update_entity_install_refreshes_after_success() -> None:
+    calls: list[tuple[str, object]] = []
+
+    class _Client:
+        async def async_approve_firmware_update(self, language="en"):
+            calls.append(("approve", language))
+            return {
+                "accepted": True,
+                "success": True,
+                "code": 0,
+            }
+
+    class _Coordinator:
+        def __init__(self):
+            self.client = _Client()
+            self.firmware_update_support = SimpleNamespace(latest_version="4.3.6_0447")
+
+        async def async_refresh_firmware_update_support(self, force=False):
+            calls.append(("refresh_support", force))
+
+        async def async_refresh_batch_device_data(self, force=False, source=None):
+            calls.append(("refresh_batch", force, source))
+
+        async def async_request_refresh(self):
+            calls.append(("request_refresh", None))
+
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = _Coordinator()
+
+    asyncio.run(entity.async_install("4.3.6_0447", backup=False))
+
+    assert calls == [
+        ("approve", "en"),
+        ("refresh_support", True),
+        ("refresh_batch", True, "firmware_update_install"),
+        ("request_refresh", None),
+    ]
+
+
+def test_firmware_update_entity_install_rejects_wrong_version() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        firmware_update_support=SimpleNamespace(latest_version="4.3.6_0447")
+    )
+
+    try:
+        asyncio.run(entity.async_install("4.3.6_0550", backup=False))
+    except HomeAssistantError as err:
+        assert "does not match approved target 4.3.6_0447" in str(err)
+    else:
+        raise AssertionError("Expected HomeAssistantError")

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -52,6 +52,36 @@ def test_firmware_update_entity_prefers_live_snapshot_state() -> None:
     assert entity.extra_state_attributes["batch_ota_available"] is True
 
 
+def test_firmware_update_entity_prefers_live_non_update_state() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data=SimpleNamespace(
+            firmware_version="4.3.6_0447",
+            state_name="mowing",
+            activity="mowing",
+            task_status_name=None,
+        ),
+        firmware_update_support=SimpleNamespace(
+            current_version="4.3.6_0320",
+            latest_version="4.3.6_0550",
+            update_state="upgrading",
+            release_summary=None,
+            release_summary_available=False,
+            update_available=True,
+            cloud_check_available=True,
+            cloud_check_update_available=True,
+            batch_ota_available=True,
+            auto_upgrade_enabled=False,
+            ota_status=0,
+            reason="Mower reports an update-related state.",
+            warnings=(),
+        ),
+    )
+
+    assert entity.in_progress is False
+
+
 def test_approve_firmware_update_treats_wrapper_success_as_accepted() -> None:
     client = object.__new__(DreameLawnMowerClient)
 

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -13,14 +13,19 @@ from custom_components.dreame_lawn_mower.update import (
 )
 
 
-def test_firmware_update_entity_uses_cached_support() -> None:
+def test_firmware_update_entity_prefers_live_snapshot_state() -> None:
     entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
     entity.coordinator = SimpleNamespace(
         last_update_success=True,
-        data=SimpleNamespace(firmware_version="4.3.6_0320"),
+        data=SimpleNamespace(
+            firmware_version="4.3.6_0447",
+            state_name="upgrading",
+            activity="mowing",
+            task_status_name=None,
+        ),
         firmware_update_support=SimpleNamespace(
             current_version="4.3.6_0320",
-            latest_version="4.3.6_0447",
+            latest_version="4.3.6_0550",
             update_state=None,
             release_summary=None,
             release_summary_available=False,
@@ -39,9 +44,9 @@ def test_firmware_update_entity_uses_cached_support() -> None:
     )
 
     assert entity.available is True
-    assert entity.installed_version == "4.3.6_0320"
-    assert entity.latest_version == "4.3.6_0447"
-    assert entity.in_progress is False
+    assert entity.installed_version == "4.3.6_0447"
+    assert entity.latest_version == "4.3.6_0550"
+    assert entity.in_progress is True
     assert entity.release_summary is None
     assert entity.extra_state_attributes["cloud_check_update_available"] is True
     assert entity.extra_state_attributes["batch_ota_available"] is True

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -210,7 +210,10 @@ def test_parse_batch_vector_map_handles_map_info_split_and_mow_paths() -> None:
     assert len(vector_map.contours) == 1
     assert vector_map.contours[0].contour_id == (1, 0)
     assert vector_map.clean_points == ((25, 25),)
-    assert [(entry.map_id, entry.map_index, entry.name) for entry in vector_map.available_maps] == [
+    assert [
+        (entry.map_id, entry.map_index, entry.name)
+        for entry in vector_map.available_maps
+    ] == [
         (1, 0, "Primary"),
         (2, 1, ""),
     ]
@@ -312,9 +315,12 @@ def test_vector_map_details_report_live_path_counts() -> None:
 def test_client_edge_and_map_actions_use_expected_app_task_payloads() -> None:
     client = _client()
     recorded_payloads: list[dict] = []
-    client._sync_call_app_action = lambda payload, **kwargs: recorded_payloads.append(  # type: ignore[method-assign]  # noqa: ARG005
-        payload
-    ) or {"ok": True}
+    client._sync_call_app_action = lambda payload, **kwargs: (
+        recorded_payloads.append(  # type: ignore[method-assign]  # noqa: ARG005
+            payload
+        )
+        or {"ok": True}
+    )
 
     assert client._sync_start_edge_mowing([[1, 0]]) == {"ok": True}
     assert client._sync_switch_current_map(1) == {"ok": True}
@@ -365,9 +371,7 @@ def test_vector_map_view_includes_cached_runtime_track_overlay() -> None:
     client.update_runtime_live_tracking(
         SimpleNamespace(
             hex="runtime-1",
-            candidate_runtime_track_segments=(
-                ((10, 20), (30, 40), (50, 40)),
-            ),
+            candidate_runtime_track_segments=(((10, 20), (30, 40), (50, 40)),),
             candidate_runtime_pose_x=50,
             candidate_runtime_pose_y=40,
             candidate_runtime_heading_deg=90.0,


### PR DESCRIPTION
## Summary
- add a Home Assistant firmware update entity that uses Dreame's approved cloud OTA flow
- surface cloud firmware checks, batch OTA metadata, and debug catalog diagnostics in the client models
- add regression coverage and examples for firmware detection, approval, and payload summarization

## Verification
- Live Dreame A2 check on April 22, 2026 detected approved target firmware 4.3.6_0447 from installed 4.3.6_0320
- Live approval/update flow completed and the mower reported installed firmware 4.3.6_0447
- PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest -q tests/test_dreame_models.py tests/test_extract_ha_payload.py tests/test_ha_compatibility.py tests/test_python_package.py tests/test_update_entity.py tests/test_debug_ota_catalog.py
- uff check custom_components/dreame_lawn_mower/coordinator.py custom_components/dreame_lawn_mower/dreame_lawn_mower_client/debug_ota_catalog.py custom_components/dreame_lawn_mower/update.py tests/test_debug_ota_catalog.py tests/test_dreame_models.py tests/test_extract_ha_payload.py tests/test_ha_compatibility.py tests/test_python_package.py tests/test_update_entity.py
- git diff --check

## Notes
- Dreame's checkDeviceVersion response did not provide reliable release notes; the description field still includes a backend missing-lang error string
- the public debug OTA catalog may list newer-looking builds, but this change treats the app-approved cloud target as authoritative for update actions