### PR TITLE
Fix Dreame firmware update state handling

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
@@ -152,6 +152,9 @@ def decode_batch_ota_info(
         "ota_info": None,
         "update_available": None,
         "auto_upgrade_enabled": None,
+        "ota_state": None,
+        "ota_state_name": None,
+        "ota_progress": None,
         "errors": [],
     }
 
@@ -164,11 +167,11 @@ def decode_batch_ota_info(
                 ota_info, (str, bytes, bytearray)
             ):
                 values = list(ota_info)
-                result["update_available"] = (
-                    bool(_to_int(values[0])) if values else None
-                )
+                ota_state = _to_int(values[0]) if values else None
+                result["ota_state"] = ota_state
+                result["ota_state_name"] = _ota_state_name(ota_state)
                 if len(values) > 1:
-                    result["ota_status"] = _to_int(values[1])
+                    result["ota_progress"] = _to_int(values[1])
             result["available"] = True
             if include_raw:
                 result["raw_text"] = payload_text
@@ -181,6 +184,18 @@ def decode_batch_ota_info(
         result["available"] = True
 
     return result
+
+
+def _ota_state_name(value: int | None) -> str | None:
+    """Return the app OTA state label used by the mower plugin."""
+    return {
+        0: "undefined",
+        1: "idle",
+        2: "upgrading",
+        3: "upgrade_success",
+        4: "upgrade_failed",
+        5: "cannot_upgrade",
+    }.get(value)
 
 
 def batch_data_text(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -4,8 +4,10 @@ from __future__ import annotations
 
 import asyncio
 import hashlib
+import html
 import json
 import math
+import re
 import time
 import urllib.request
 from collections.abc import Mapping, Sequence
@@ -3933,7 +3935,121 @@ def _parse_firmware_description(
                 },
             )
 
+    parsed_text = _firmware_description_text(parsed)
+    if parsed_text is not None:
+        return parsed_text, True, None
+
     return text, True, None
+
+
+_FIRMWARE_DESCRIPTION_PREFERRED_KEYS = (
+    "en",
+    "en_us",
+    "en-us",
+    "default",
+    "content",
+    "contents",
+    "text",
+    "detail",
+    "details",
+    "description",
+    "desc",
+    "release_note",
+    "release_notes",
+    "releasenote",
+    "releasenotes",
+    "changelog",
+    "change_log",
+    "update_content",
+    "updatecontent",
+    "upgrade_content",
+    "upgradecontent",
+    "data",
+)
+_FIRMWARE_DESCRIPTION_METADATA_KEYS = {
+    "code",
+    "success",
+    "status",
+    "curversion",
+    "newversion",
+    "firmwaretype",
+    "hasnewfirmware",
+    "force",
+    "url",
+    "md5",
+    "size",
+}
+
+
+def _firmware_description_text(value: Any) -> str | None:
+    parts = _firmware_description_parts(value)
+    if not parts:
+        return None
+
+    cleaned: list[str] = []
+    seen: set[str] = set()
+    for part in parts:
+        normalized = _normalize_firmware_description_text(part)
+        if normalized is None:
+            continue
+        dedupe_key = normalized.casefold()
+        if dedupe_key in seen:
+            continue
+        cleaned.append(normalized)
+        seen.add(dedupe_key)
+
+    return "\n".join(cleaned) if cleaned else None
+
+
+def _firmware_description_parts(value: Any) -> list[str]:
+    if isinstance(value, str):
+        text = _as_optional_text(value)
+        if text is None:
+            return []
+        try:
+            parsed = json.loads(text)
+        except (TypeError, ValueError):
+            return [text]
+        nested = _firmware_description_parts(parsed)
+        return nested or [text]
+
+    if isinstance(value, Mapping):
+        preferred_parts: list[str] = []
+        fallback_parts: list[str] = []
+        for key, item in value.items():
+            normalized_key = str(key).strip().lower().replace("-", "_")
+            if normalized_key in _FIRMWARE_DESCRIPTION_METADATA_KEYS:
+                continue
+            item_parts = _firmware_description_parts(item)
+            if not item_parts:
+                continue
+            if (
+                normalized_key in _FIRMWARE_DESCRIPTION_PREFERRED_KEYS
+                or normalized_key.isnumeric()
+            ):
+                preferred_parts.extend(item_parts)
+            else:
+                fallback_parts.extend(item_parts)
+        return preferred_parts or fallback_parts
+
+    if isinstance(value, Sequence) and not isinstance(value, bytes | bytearray):
+        parts: list[str] = []
+        for item in value:
+            parts.extend(_firmware_description_parts(item))
+        return parts
+
+    return []
+
+
+def _normalize_firmware_description_text(value: str) -> str | None:
+    text = html.unescape(value)
+    text = re.sub(r"(?i)<br\s*/?>", "\n", text)
+    text = re.sub(r"(?i)</p\s*>", "\n", text)
+    text = re.sub(r"<[^>]+>", "", text)
+    text = text.replace("\r\n", "\n").replace("\r", "\n")
+    text = "\n".join(line.strip() for line in text.splitlines())
+    text = re.sub(r"\n{3,}", "\n\n", text).strip()
+    return text or None
 
 
 def _normalize_cloud_firmware_check(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map.py
@@ -27,7 +27,7 @@ from PIL import (
     PngImagePlugin,
     ImageFilter,
 )
-from typing import Any
+from typing import Any, Mapping
 from time import sleep
 from io import BytesIO
 from typing import Optional, Tuple
@@ -291,6 +291,14 @@ class DreameMapMowerMapManager:
             _LOGGER.warning("DreameMapMowerMapManager._request_map failed: %s", ex)
         return None
 
+    def _map_action_succeeded(self, result: Any) -> bool:
+        """Return whether an app action response contains a successful map payload."""
+        if not isinstance(result, Mapping):
+            if result is not None:
+                _LOGGER.debug("Ignoring non-mapping map response: %s", result)
+            return False
+        return result.get(MAP_PARAMETER_CODE) == 0
+
     def _request_i_map(self, start_time: int = None) -> bool:
         if not self._request_i_map_available and not self._protocol.dreame_cloud:
             return self.request_new_map()
@@ -305,7 +313,7 @@ class DreameMapMowerMapManager:
             parameters[MAP_PARAMETER_TIME] = start_time
 
         result = self._request_map(parameters)
-        if result and result[MAP_PARAMETER_CODE] == 0:
+        if self._map_action_succeeded(result):
             out = result[MAP_PARAMETER_OUT]
             _LOGGER.debug("Response from device %s", out)
             has_map = False
@@ -387,7 +395,7 @@ class DreameMapMowerMapManager:
                 MAP_REQUEST_PARAMETER_FRAME_TYPE: MapFrameType.P.name,
             }
         )
-        return bool(result and result[MAP_PARAMETER_CODE] == 0)
+        return self._map_action_succeeded(result)
 
     def _request_next_p_map(self, map_id: int, frame_id: int) -> bool:
         key = f"{map_id}:{frame_id}"
@@ -404,7 +412,7 @@ class DreameMapMowerMapManager:
                 MAP_REQUEST_PARAMETER_FRAME_TYPE: MapFrameType.P.name,
             }
         )
-        if result and result[MAP_PARAMETER_CODE] == 0:
+        if self._map_action_succeeded(result):
             del self._request_queue[key]
 
             object_name = None
@@ -442,7 +450,7 @@ class DreameMapMowerMapManager:
 
     def _request_t_map(self) -> None:
         result = self._request_map({MAP_REQUEST_PARAMETER_FRAME_TYPE: "T"})
-        if result and result[MAP_PARAMETER_CODE] == 0:
+        if self._map_action_succeeded(result):
             self.request_map_list()
 
     def _request_w_map(self) -> None:
@@ -1366,7 +1374,7 @@ class DreameMapMowerMapManager:
             return self._request_i_map()
         else:
             result = self._request_map()
-            if result and result[MAP_PARAMETER_CODE] == 0 and not self._protocol.dreame_cloud:
+            if self._map_action_succeeded(result) and not self._protocol.dreame_cloud:
                 self._request_map_from_cloud()
 
     def request_next_map(self) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -278,6 +278,9 @@ class DreameLawnMowerFirmwareUpdateSupport:
     batch_ota_available: bool | None = None
     auto_upgrade_enabled: bool | None = None
     ota_status: int | str | None = None
+    ota_state: int | None = None
+    ota_state_name: str | None = None
+    ota_progress: int | None = None
     debug_catalog_available: bool | None = None
     debug_catalog_current_version_present: bool | None = None
     debug_catalog_changelog_available: bool | None = None
@@ -844,6 +847,9 @@ def firmware_update_support_from_device(
                 "update_available",
                 "auto_upgrade_enabled",
                 "ota_status",
+                "ota_state",
+                "ota_state_name",
+                "ota_progress",
             )
             if key in batch_ota_info
         }
@@ -895,6 +901,9 @@ def firmware_update_support_from_device(
     batch_ota_available = None
     auto_upgrade_enabled = None
     ota_status = None
+    ota_state = None
+    ota_state_name = None
+    ota_progress = None
     latest_version = None
     release_summary = None
     release_summary_available = None
@@ -932,6 +941,16 @@ def firmware_update_support_from_device(
             auto_upgrade_enabled = auto_upgrade
 
         ota_status = batch_ota_info.get("ota_status")
+        ota_state_value = batch_ota_info.get("ota_state")
+        if isinstance(ota_state_value, int):
+            ota_state = ota_state_value
+        ota_state_name = _as_optional_str(batch_ota_info.get("ota_state_name"))
+        ota_progress_value = batch_ota_info.get("ota_progress")
+        if isinstance(ota_progress_value, int):
+            ota_progress = ota_progress_value
+        if ota_state == 2 or ota_state_name == "upgrading":
+            update_state = "upgrading"
+
         batch_update_available = batch_ota_info.get("update_available")
         if isinstance(batch_update_available, bool) and update_available is None:
             update_available = batch_update_available
@@ -1011,6 +1030,9 @@ def firmware_update_support_from_device(
         batch_ota_available=batch_ota_available,
         auto_upgrade_enabled=auto_upgrade_enabled,
         ota_status=ota_status,
+        ota_state=ota_state,
+        ota_state_name=ota_state_name,
+        ota_progress=ota_progress,
         debug_catalog_available=debug_catalog_available,
         debug_catalog_current_version_present=debug_catalog_current_version_present,
         debug_catalog_changelog_available=debug_catalog_changelog_available,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -570,7 +570,7 @@ class DreameMowerDreameHomeCloudProtocol:
         _LOGGER.debug(
             "DreameMowerDreameHomeCloudProtocol.send api_response: %s", api_response)
         self._id = self._id + 1
-        if api_response and api_response["code"] == 80001:
+        if isinstance(api_response, Mapping) and api_response.get("code") == 80001:
             # Seems to be a valid error message from the server which translates to:
             #   "The device may be offline and the command sending timed out."
             # While the time out was a return value from the server, implying that the
@@ -579,7 +579,25 @@ class DreameMowerDreameHomeCloudProtocol:
                 "DreameMowerDreameHomeCloudProtocol.send 80001, return none: %s", api_response)
             return None
 
-        if api_response is None or "data" not in api_response or "result" not in api_response["data"]:
+        if (
+            isinstance(api_response, Mapping)
+            and api_response.get("code") == 0
+            and api_response.get("success") is True
+            and api_response.get("data") in ("", None)
+        ):
+            _LOGGER.debug(
+                "DreameMowerDreameHomeCloudProtocol.send accepted without result: %s",
+                api_response,
+            )
+            return None
+
+        if (
+            api_response is None
+            or not isinstance(api_response, Mapping)
+            or "data" not in api_response
+            or not isinstance(api_response["data"], Mapping)
+            or "result" not in api_response["data"]
+        ):
             _LOGGER.warning(
                 "DreameMowerDreameHomeCloudProtocol.send failed: %s", api_response)
             return None

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -3076,6 +3076,19 @@ def _batch_ota_status_name(result: dict[str, Any] | None) -> str | None:
     ota = _batch_ota_section(result)
     if ota is None:
         return None
+    state_name = ota.get("ota_state_name")
+    if isinstance(state_name, str) and state_name:
+        return state_name
+    state = ota.get("ota_state")
+    if isinstance(state, int):
+        return {
+            0: "undefined",
+            1: "idle",
+            2: "upgrading",
+            3: "upgrade_success",
+            4: "upgrade_failed",
+            5: "cannot_upgrade",
+        }.get(state, f"state_{state}")
     status = ota.get("ota_status")
     if isinstance(status, str) and status:
         return status
@@ -3578,6 +3591,9 @@ def _batch_ota_probe_summary(value: Any) -> dict[str, Any] | None:
         "auto_upgrade_enabled": value.get("auto_upgrade_enabled"),
         "ota_info": value.get("ota_info"),
         "ota_status": value.get("ota_status"),
+        "ota_state": value.get("ota_state"),
+        "ota_state_name": value.get("ota_state_name"),
+        "ota_progress": value.get("ota_progress"),
     }
     errors = value.get("errors")
     if isinstance(errors, list):

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -169,7 +169,7 @@ class DreameLawnMowerFirmwareUpdateEntity(
         await self.coordinator.async_request_refresh()
 
     def _assumed_install_in_progress(self) -> bool:
-        """Return whether a recent HA install approval should still be treated as active."""
+        """Return whether a recent HA install approval should still be active."""
         install_requested_at = getattr(self, "_install_requested_at", None)
         if install_requested_at is None:
             return False
@@ -191,6 +191,7 @@ class DreameLawnMowerFirmwareUpdateEntity(
             support is not None
             and getattr(support, "update_available", None) is False
             and getattr(support, "update_state", None) is None
+            and target_version is None
         ):
             self._install_requested_at = None
             self._install_target_version = None

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from datetime import UTC, datetime, timedelta
+
 from homeassistant.components.update import (
     UpdateDeviceClass,
     UpdateEntity,
@@ -15,6 +17,8 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from .const import DOMAIN
 from .coordinator import DreameLawnMowerCoordinator
 from .entity import DreameLawnMowerEntity
+
+FIRMWARE_INSTALL_ASSUMED_IN_PROGRESS = timedelta(hours=24)
 
 
 async def async_setup_entry(
@@ -40,6 +44,8 @@ class DreameLawnMowerFirmwareUpdateEntity(
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
         self._attr_unique_id = f"{self._descriptor.unique_id}_firmware"
+        self._install_requested_at: datetime | None = None
+        self._install_target_version: str | None = None
 
     @property
     def available(self) -> bool:
@@ -54,8 +60,9 @@ class DreameLawnMowerFirmwareUpdateEntity(
         if version := _snapshot_firmware_version(self.coordinator):
             return version
         support = self.coordinator.firmware_update_support
-        if support is not None and support.current_version:
-            return support.current_version
+        current_version = getattr(support, "current_version", None)
+        if isinstance(current_version, str) and current_version:
+            return current_version
         return None
 
     @property
@@ -68,12 +75,23 @@ class DreameLawnMowerFirmwareUpdateEntity(
     def in_progress(self) -> bool | int | None:
         """Return whether the mower reports an update in progress."""
         live_in_progress = _snapshot_update_in_progress(self.coordinator)
-        if live_in_progress is not None:
-            return live_in_progress
+        if live_in_progress is True:
+            return True
+        if self._assumed_install_in_progress():
+            return True
+        if live_in_progress is False:
+            return False
         support = self.coordinator.firmware_update_support
         if support is None:
-            return None
-        return support.update_state in {"upgrading", "updating"}
+            return live_in_progress
+        if support.update_state in {
+            "upgrading",
+            "updating",
+            "installing",
+            "downloading",
+        }:
+            return True
+        return live_in_progress
 
     @property
     def release_summary(self) -> str | None:
@@ -97,7 +115,17 @@ class DreameLawnMowerFirmwareUpdateEntity(
             "batch_ota_available": support.batch_ota_available,
             "auto_upgrade_enabled": support.auto_upgrade_enabled,
             "ota_status": support.ota_status,
+            "ota_state": getattr(support, "ota_state", None),
+            "ota_state_name": getattr(support, "ota_state_name", None),
+            "ota_progress": getattr(support, "ota_progress", None),
             "release_summary_available": support.release_summary_available,
+            "install_assumed_in_progress": self._assumed_install_in_progress(),
+            "install_requested_at": (
+                getattr(self, "_install_requested_at", None).isoformat()
+                if getattr(self, "_install_requested_at", None) is not None
+                else None
+            ),
+            "install_target_version": getattr(self, "_install_target_version", None),
             "reason": support.reason,
             "warnings": list(support.warnings),
         }
@@ -131,6 +159,8 @@ class DreameLawnMowerFirmwareUpdateEntity(
             message = result.get("msg") or "Firmware approval failed."
             raise HomeAssistantError(str(message))
 
+        self._install_requested_at = datetime.now(UTC)
+        self._install_target_version = latest_version
         await self.coordinator.async_refresh_firmware_update_support(force=True)
         await self.coordinator.async_refresh_batch_device_data(
             force=True,
@@ -138,10 +168,46 @@ class DreameLawnMowerFirmwareUpdateEntity(
         )
         await self.coordinator.async_request_refresh()
 
+    def _assumed_install_in_progress(self) -> bool:
+        """Return whether a recent HA install approval should still be treated as active."""
+        install_requested_at = getattr(self, "_install_requested_at", None)
+        if install_requested_at is None:
+            return False
+        install_target_version = getattr(self, "_install_target_version", None)
+        support = self.coordinator.firmware_update_support
+        installed_version = self.installed_version
+        target_version = install_target_version or (
+            support.latest_version if support is not None else None
+        )
+        if (
+            installed_version is not None
+            and target_version is not None
+            and installed_version == target_version
+        ):
+            self._install_requested_at = None
+            self._install_target_version = None
+            return False
+        if (
+            support is not None
+            and getattr(support, "update_available", None) is False
+            and getattr(support, "update_state", None) is None
+        ):
+            self._install_requested_at = None
+            self._install_target_version = None
+            return False
+        if (
+            datetime.now(UTC) - install_requested_at
+            > FIRMWARE_INSTALL_ASSUMED_IN_PROGRESS
+        ):
+            self._install_requested_at = None
+            self._install_target_version = None
+            return False
+        return True
+
 
 def _snapshot_firmware_version(coordinator: DreameLawnMowerCoordinator) -> str | None:
     """Return the latest firmware version from the live coordinator snapshot."""
-    snapshot = coordinator.data
+    snapshot = getattr(coordinator, "data", None)
     version = getattr(snapshot, "firmware_version", None)
     if isinstance(version, str) and version.strip():
         return version
@@ -150,7 +216,7 @@ def _snapshot_firmware_version(coordinator: DreameLawnMowerCoordinator) -> str |
 
 def _snapshot_update_state(coordinator: DreameLawnMowerCoordinator) -> str | None:
     """Return the current live update state when the snapshot exposes one."""
-    snapshot = coordinator.data
+    snapshot = getattr(coordinator, "data", None)
     for value in (
         getattr(snapshot, "state_name", None),
         getattr(snapshot, "activity", None),
@@ -159,7 +225,7 @@ def _snapshot_update_state(coordinator: DreameLawnMowerCoordinator) -> str | Non
         if not isinstance(value, str):
             continue
         normalized = value.strip().lower()
-        if normalized in {"upgrading", "updating"}:
+        if normalized in {"upgrading", "updating", "installing", "downloading"}:
             return normalized
     return None
 
@@ -168,7 +234,7 @@ def _snapshot_update_in_progress(
     coordinator: DreameLawnMowerCoordinator,
 ) -> bool | None:
     """Return a live in-progress signal when the snapshot exposes any state."""
-    snapshot = coordinator.data
+    snapshot = getattr(coordinator, "data", None)
     saw_live_state = False
     for value in (
         getattr(snapshot, "state_name", None),
@@ -181,7 +247,7 @@ def _snapshot_update_in_progress(
         if not normalized:
             continue
         saw_live_state = True
-        if normalized in {"upgrading", "updating"}:
+        if normalized in {"upgrading", "updating", "installing", "downloading"}:
             return True
 
     if saw_live_state:

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -202,10 +202,12 @@ def test_decode_batch_ota_info_decodes_flags() -> None:
         "source": "batch_device_data_ota_info",
         "available": True,
         "ota_info": [1, 0],
-        "update_available": True,
+        "update_available": None,
         "auto_upgrade_enabled": False,
+        "ota_state": 1,
+        "ota_state_name": "idle",
+        "ota_progress": 0,
         "errors": [],
-        "ota_status": 0,
     }
 
 
@@ -222,6 +224,8 @@ def test_client_batch_helpers_use_batch_device_data_api() -> None:
     assert schedule_result["schedules"][0]["idx"] == 0
     assert [entry["idx"] for entry in preference_result["maps"]] == [1]
     assert preference_result["maps"][0]["preferences"][0]["mowing_height_cm"] == 3.5
-    assert ota_result["update_available"] is True
+    assert ota_result["update_available"] is None
+    assert ota_result["ota_state_name"] == "idle"
+    assert ota_result["ota_progress"] == 0
     assert ota_result["auto_upgrade_enabled"] is False
     assert len(cloud.calls) == 3

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -5,6 +5,9 @@ from __future__ import annotations
 from types import SimpleNamespace
 
 from dreame_lawn_mower_client import DreameLawnMowerClient
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
+    _normalize_cloud_firmware_check,
+)
 from dreame_lawn_mower_client.client import DreameLawnMowerConnectionError
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 
@@ -230,3 +233,45 @@ def test_cloud_firmware_check_marks_error_response_unavailable(monkeypatch) -> N
             "msg": "backend unavailable",
         }
     ]
+
+
+def test_cloud_firmware_check_flattens_structured_release_notes() -> None:
+    result = _normalize_cloud_firmware_check(
+        {
+            "curVersion": "4.3.6_0447",
+            "newVersion": "4.3.6_0550",
+            "hasNewFirmware": True,
+            "description": (
+                '{"en":["1. Optimize WiFi connection experience.",'
+                '{"content":"2. Optimize recharge logic.<br>3. Improve stability."},'
+                '{"detail":"4. Fix known issues."}]}'
+            ),
+        }
+    )
+
+    assert result["changelog_available"] is True
+    assert result["changelog"] == (
+        "1. Optimize WiFi connection experience.\n"
+        "2. Optimize recharge logic.\n"
+        "3. Improve stability.\n"
+        "4. Fix known issues."
+    )
+
+
+def test_cloud_firmware_check_keeps_error_description_unavailable() -> None:
+    result = _normalize_cloud_firmware_check(
+        {
+            "curVersion": "4.3.6_0320",
+            "newVersion": "4.3.6_0447",
+            "hasNewFirmware": True,
+            "description": '{"code":10005,"success":false,"msg":"missing lang"}',
+        }
+    )
+
+    assert result["changelog"] is None
+    assert result["changelog_available"] is False
+    assert result["changelog_error"] == {
+        "code": 10005,
+        "success": False,
+        "msg": "missing lang",
+    }

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
-from dreame_lawn_mower_client import DreameLawnMowerClient
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     _normalize_cloud_firmware_check,
 )
+from dreame_lawn_mower_client import DreameLawnMowerClient
 from dreame_lawn_mower_client.client import DreameLawnMowerConnectionError
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -884,6 +884,31 @@ def test_firmware_update_support_marks_update_state() -> None:
     assert support.reason == "Mower reports an update-related state."
 
 
+def test_firmware_update_support_marks_batch_ota_upgrading_state() -> None:
+    device = _FakeDevice()
+
+    support = firmware_update_support_from_device(
+        device,
+        batch_ota_info={
+            "source": "batch_device_data_ota_info",
+            "available": True,
+            "update_available": None,
+            "auto_upgrade_enabled": False,
+            "ota_info": [2, 83],
+            "ota_state": 2,
+            "ota_state_name": "upgrading",
+            "ota_progress": 83,
+        },
+    )
+
+    assert support.update_state == "upgrading"
+    assert support.update_available is None
+    assert support.ota_state == 2
+    assert support.ota_state_name == "upgrading"
+    assert support.ota_progress == 83
+    assert support.reason == "Mower reports an update-related state."
+
+
 def test_firmware_update_support_uses_verified_batch_ota_signal() -> None:
     device = _FakeDevice()
 

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -1194,10 +1194,11 @@ def test_batch_ota_attributes_are_compact() -> None:
         "batch_ota_info": {
             "source": "batch_device_data_ota_info",
             "available": True,
-            "update_available": True,
             "auto_upgrade_enabled": False,
             "ota_info": [1, 0],
-            "ota_status": 0,
+            "ota_state": 1,
+            "ota_state_name": "idle",
+            "ota_progress": 0,
             "errors": [],
         },
     }
@@ -1208,13 +1209,14 @@ def test_batch_ota_attributes_are_compact() -> None:
         "batch_ota_info": {
             "source": "batch_device_data_ota_info",
             "available": True,
-            "update_available": True,
             "auto_upgrade_enabled": False,
             "ota_info": [1, 0],
-            "ota_status": 0,
+            "ota_state": 1,
+            "ota_state_name": "idle",
+            "ota_progress": 0,
             "error_count": 0,
         },
-        "ota_status_name": "update_available",
+        "ota_status_name": "idle",
     }
 
 

--- a/tests/test_legacy_map_manager.py
+++ b/tests/test_legacy_map_manager.py
@@ -43,3 +43,11 @@ def test_request_i_map_skips_map_property_without_value() -> None:
     manager._request_map_from_cloud = lambda: False
 
     assert manager._request_i_map() is False
+
+
+def test_request_i_map_ignores_non_mapping_response() -> None:
+    manager = DreameMapMowerMapManager(_DummyProtocol())
+    manager._request_map = lambda payload: []  # noqa: ARG005
+    manager._request_map_from_cloud = lambda: False
+
+    assert manager._request_i_map() is False

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import UTC, datetime
 from types import SimpleNamespace
 
 from homeassistant.exceptions import HomeAssistantError
@@ -124,7 +125,24 @@ def test_firmware_update_entity_install_refreshes_after_success() -> None:
     class _Coordinator:
         def __init__(self):
             self.client = _Client()
-            self.firmware_update_support = SimpleNamespace(latest_version="4.3.6_0447")
+            self.firmware_update_support = SimpleNamespace(
+                current_version="4.3.6_0320",
+                latest_version="4.3.6_0447",
+                update_state=None,
+                release_summary=None,
+                release_summary_available=False,
+                update_available=True,
+                cloud_check_available=True,
+                cloud_check_update_available=True,
+                batch_ota_available=True,
+                auto_upgrade_enabled=False,
+                ota_status=None,
+                ota_state=None,
+                ota_state_name=None,
+                ota_progress=None,
+                reason="Cloud checkDeviceVersion reports that a mower firmware update is available.",
+                warnings=(),
+            )
 
         async def async_refresh_firmware_update_support(self, force=False):
             calls.append(("refresh_support", force))
@@ -146,6 +164,45 @@ def test_firmware_update_entity_install_refreshes_after_success() -> None:
         ("refresh_batch", True, "firmware_update_install"),
         ("request_refresh", None),
     ]
+    assert entity.in_progress is True
+    assert entity.extra_state_attributes["install_assumed_in_progress"] is True
+    assert entity.extra_state_attributes["install_target_version"] == "4.3.6_0447"
+
+
+def test_firmware_update_entity_clears_assumed_install_when_target_installed() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data=SimpleNamespace(
+            firmware_version="4.3.6_0550",
+            state_name="idle",
+            activity="idle",
+            task_status_name=None,
+        ),
+        firmware_update_support=SimpleNamespace(
+            current_version="4.3.6_0550",
+            latest_version="4.3.6_0550",
+            update_state=None,
+            release_summary=None,
+            release_summary_available=False,
+            update_available=False,
+            cloud_check_available=True,
+            cloud_check_update_available=False,
+            batch_ota_available=True,
+            auto_upgrade_enabled=False,
+            ota_status=None,
+            ota_state=3,
+            ota_state_name="upgrade_success",
+            ota_progress=0,
+            reason="Batch OTA info reports that no mower firmware update is available.",
+            warnings=(),
+        ),
+    )
+    entity._install_requested_at = datetime.now(UTC)
+    entity._install_target_version = "4.3.6_0550"
+
+    assert entity.in_progress is False
+    assert entity.extra_state_attributes["install_assumed_in_progress"] is False
 
 
 def test_firmware_update_entity_install_rejects_wrong_version() -> None:

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -140,7 +140,10 @@ def test_firmware_update_entity_install_refreshes_after_success() -> None:
                 ota_state=None,
                 ota_state_name=None,
                 ota_progress=None,
-                reason="Cloud checkDeviceVersion reports that a mower firmware update is available.",
+                reason=(
+                    "Cloud checkDeviceVersion reports that a mower firmware update "
+                    "is available."
+                ),
                 warnings=(),
             )
 
@@ -203,6 +206,45 @@ def test_firmware_update_entity_clears_assumed_install_when_target_installed() -
 
     assert entity.in_progress is False
     assert entity.extra_state_attributes["install_assumed_in_progress"] is False
+
+
+def test_firmware_update_entity_keeps_assumed_install_after_cloud_clear() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        last_update_success=True,
+        data=SimpleNamespace(
+            firmware_version="4.3.6_0447",
+            state_name=None,
+            activity=None,
+            task_status_name=None,
+        ),
+        firmware_update_support=SimpleNamespace(
+            current_version="4.3.6_0447",
+            latest_version="4.3.6_0550",
+            update_state=None,
+            release_summary=None,
+            release_summary_available=False,
+            update_available=False,
+            cloud_check_available=True,
+            cloud_check_update_available=False,
+            batch_ota_available=True,
+            auto_upgrade_enabled=False,
+            ota_status=None,
+            ota_state=None,
+            ota_state_name=None,
+            ota_progress=None,
+            reason=(
+                "Cloud checkDeviceVersion reports that no mower firmware update is "
+                "available."
+            ),
+            warnings=(),
+        ),
+    )
+    entity._install_requested_at = datetime.now(UTC)
+    entity._install_target_version = "4.3.6_0550"
+
+    assert entity.in_progress is True
+    assert entity.extra_state_attributes["install_assumed_in_progress"] is True
 
 
 def test_firmware_update_entity_install_rejects_wrong_version() -> None:


### PR DESCRIPTION
## Summary
- Decode Dreame `OTA_INFO` as app OTA state/progress instead of update availability/status.
- Keep the HA firmware update entity in an assumed installing state after a successful approval while the mower is offline/rebooting, and expose OTA progress diagnostics.
- Preserve full structured firmware release notes from Dreame cloud payloads and tolerate empty/list map responses during offline/update states.

## Root Cause
Dreame stores `OTA_INFO` as `[otaState, otaProgress]`, where state `2` means upgrading. The integration treated the first value as update availability, which could make HA re-offer firmware installs after approval. Dreame also returns successful cloud responses with empty bodies and can return non-map payloads while the mower is offline during firmware installation.

## Validation
- `python -m compileall -q custom_components\dreame_lawn_mower`
- `git diff --check`
- `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests\test_client_review_regressions.py tests\test_batch_device_data.py tests\test_dreame_models.py tests\test_update_entity.py tests\test_legacy_map_manager.py tests\test_ha_compatibility.py -q`