### PR TITLE
Support MOVA LiDAX Ultra 1000 state properties

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Support levels in this table mean:
 | Scope | Status | Notes |
 | --- | --- | --- |
 | Dreame A2 (`dreame.mower.g2408`) | Validated | Primary live development device, including schedules, maps, remote control, guarded preference writes, and diagnostics |
+| MOVA LiDAX Ultra 1000 (`mova.mower.g2529c`) | Recognized | Added from a MOVAhome EU diagnostics report; commands and battery are reported working, state handling now accepts model-specific cloud property ids |
 | Newer A-series mower (`dreame.mower.g3255`) | Recognized | Raw model has been observed in code mapping, but the public retail name is still unverified |
 | Dreame A1 (`dreame.mower.p2255`) | Recognized | Model mapping is present; needs fixtures and live validation |
 | Dreame A1 Pro (`dreame.mower.g2422`) | Recognized | Model mapping is present; needs fixtures and live validation |

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -28,15 +28,17 @@ MOWER_PROPERTY_HINTS: Final[dict[str, str]] = {
 }
 MOWER_STATE_LABELS: Final[dict[str, dict[str, str]]] = {
     "en": {
-        "1": "Working",
+        "1": "Mowing",
         "2": "Standby",
-        "3": "Working",
-        "4": "Paused",
+        "3": "Paused",
+        "4": "Paused due to errors",
         "5": "Returning Charge",
         "6": "Charging",
         "11": "Mapping",
         "13": "Charging Completed",
         "14": "Upgrading",
+        "15": "Charging paused: battery temperature is too high",
+        "16": "Charging paused: battery temperature is too low",
     },
     "zh": {
         "1": "割草中",
@@ -53,12 +55,15 @@ MOWER_STATE_LABELS: Final[dict[str, dict[str, str]]] = {
 MOWER_STATE_KEYS: Final[dict[str, str]] = {
     "1": "mowing",
     "2": "standby",
+    "3": "paused",
     "4": "paused",
     "5": "returning",
     "6": "charging",
     "11": "mapping",
     "13": "charging_completed",
     "14": "upgrading",
+    "15": "charging_paused_high_temperature",
+    "16": "charging_paused_low_temperature",
 }
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -366,46 +366,48 @@ class DreameMowerDevice:
             if not isinstance(prop, dict):
                 continue
             did = int(prop["did"])
-            property_enum = self._property_enum(did)
-            property_name = self._property_name(did)
+            property_enum = self._property_enum_from_payload(prop, did)
+            data_id = property_enum.value if property_enum is not None else did
+            property_name = self._property_name(data_id)
             if property_enum is None:
                 self._remember_unknown_property(did, prop)
             if prop["code"] == 0 and "value" in prop:
                 value = prop["value"]
-                if did in self._dirty_data:
+                if data_id in self._dirty_data:
                     if (
-                        self._dirty_data[did].value != value
-                        and time.time() - self._dirty_data[did].update_time < self._discard_timeout
+                        self._dirty_data[data_id].value != value
+                        and time.time() - self._dirty_data[data_id].update_time
+                        < self._discard_timeout
                     ):
                         _LOGGER.info(
                             "Property %s Value Discarded: %s <- %s",
                             property_name,
-                            self._dirty_data[did].value,
+                            self._dirty_data[data_id].value,
                             value,
                         )
-                        del self._dirty_data[did]
+                        del self._dirty_data[data_id]
                         continue
-                    del self._dirty_data[did]
+                    del self._dirty_data[data_id]
 
-                current_value = self.data.get(did)
+                current_value = self.data.get(data_id)
 
                 if current_value != value:
                     # Do not call external listener when map and json properties changed
                     if not (
-                        did == DreameMowerProperty.MAP_LIST.value
-                        or did == DreameMowerProperty.RECOVERY_MAP_LIST.value
-                        or did == DreameMowerProperty.MAP_DATA.value
-                        or did == DreameMowerProperty.OBJECT_NAME.value
-                        or did == DreameMowerProperty.AUTO_SWITCH_SETTINGS.value
-                        or did == DreameMowerProperty.AI_DETECTION.value
+                        data_id == DreameMowerProperty.MAP_LIST.value
+                        or data_id == DreameMowerProperty.RECOVERY_MAP_LIST.value
+                        or data_id == DreameMowerProperty.MAP_DATA.value
+                        or data_id == DreameMowerProperty.OBJECT_NAME.value
+                        or data_id == DreameMowerProperty.AUTO_SWITCH_SETTINGS.value
+                        or data_id == DreameMowerProperty.AI_DETECTION.value
                         # or did == DreameMowerProperty.SELF_TEST_STATUS.value
                     ):
                         changed = True
                     custom_property = (
-                        did == DreameMowerProperty.AUTO_SWITCH_SETTINGS.value
-                        or did == DreameMowerProperty.AI_DETECTION.value
-                        or did == DreameMowerProperty.MAP_LIST.value
-                        or did == DreameMowerProperty.SERIAL_NUMBER.value
+                        data_id == DreameMowerProperty.AUTO_SWITCH_SETTINGS.value
+                        or data_id == DreameMowerProperty.AI_DETECTION.value
+                        or data_id == DreameMowerProperty.MAP_LIST.value
+                        or data_id == DreameMowerProperty.SERIAL_NUMBER.value
                     )
                     if not custom_property:
                         if current_value is not None:
@@ -421,14 +423,14 @@ class DreameMowerDevice:
                                 property_name,
                                 value,
                             )
-                    self.data[did] = value
-                    if did in self._property_update_callback:
+                    self.data[data_id] = value
+                    if data_id in self._property_update_callback:
                         _LOGGER.debug(
                             "Property %s Callbacks: %s",
                             property_name,
-                            self._property_update_callback[did],
+                            self._property_update_callback[data_id],
                         )
-                        for callback in self._property_update_callback[did]:
+                        for callback in self._property_update_callback[data_id]:
                             if not self._ready and custom_property:
                                 callback(current_value)
                             else:
@@ -482,6 +484,35 @@ class DreameMowerDevice:
             return DreameMowerProperty(did)
         except ValueError:
             return None
+
+    def _property_enum_from_payload(
+        self,
+        payload: dict[str, Any],
+        did: int,
+    ) -> DreameMowerProperty | None:
+        """Return the known property enum for a payload.
+
+        Some MOVA mower cloud responses use generated negative ``did`` values
+        even for standard properties. In that case the siid/piid pair is still
+        authoritative and lets us update the normal property cache.
+        """
+        property_enum = self._property_enum(did)
+        if property_enum is not None:
+            return property_enum
+
+        siid = payload.get("siid")
+        piid = payload.get("piid")
+        if siid is None or piid is None:
+            return None
+
+        for prop, mapping in self.property_mapping.items():
+            if (
+                "aiid" not in mapping
+                and siid == mapping["siid"]
+                and piid == mapping["piid"]
+            ):
+                return prop
+        return None
 
     def _property_name(self, did: int) -> str:
         """Return a safe log/debug name for a property id."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -16,6 +16,7 @@ MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
     "dreame.mower.g2408": "A2",
+    "mova.mower.g2529c": "LiDAX Ultra 1000",
 }
 
 DISPLAY_NAME_ALIASES = {
@@ -24,6 +25,7 @@ DISPLAY_NAME_ALIASES = {
     "a2": "A2",
     "awd 1000": "AWD 1000",
     "lidax ultra 800": "LiDAX Ultra 800",
+    "lidax ultra 1000": "LiDAX Ultra 1000",
     "lidax ultra 1200": "LiDAX Ultra 1200",
     "viax 300": "Viax 300",
     "vivax 250": "Vivax 250",

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -173,6 +173,23 @@ def test_display_name_for_model_prefers_known_mapping_over_fallback_name() -> No
     )
 
 
+def test_descriptor_maps_lidax_ultra_1000_model_name() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-5",
+            "model": "mova.mower.g2529c",
+            "customName": "Mowercedes",
+            "deviceInfo": {"displayName": "Lidax Ultra 1000"},
+        },
+        account_type="mova",
+        country="eu",
+    )
+
+    assert descriptor is not None
+    assert descriptor.display_model == "LiDAX Ultra 1000"
+    assert descriptor.title == "Mowercedes (LiDAX Ultra 1000)"
+
+
 def test_snapshot_uses_state_name_before_boolean_helpers() -> None:
     descriptor = descriptor_from_cloud_record(
         {

--- a/tests/test_python_package.py
+++ b/tests/test_python_package.py
@@ -219,11 +219,16 @@ def test_public_package_exports_app_protocol_helpers() -> None:
     )
     assert MOWER_STATE_KEYS["5"] == "returning"
     assert mower_state_key("1") == "mowing"
+    assert mower_state_key("3") == "paused"
     assert mower_state_key(5) == "returning"
     assert mower_state_key("13") == "charging_completed"
+    assert mower_state_key("15") == "charging_paused_high_temperature"
     assert mower_state_key(999) is None
     assert mower_state_label(11) == "Mapping"
     assert mower_state_label("13") == "Charging Completed"
+    assert mower_state_label("15") == (
+        "Charging paused: battery temperature is too high"
+    )
     assert mower_state_label(999) is None
     assert mower_error_label(31) == "Left wheel speed"
     assert mower_error_label(-1) == "No error"

--- a/tests/test_unknown_properties.py
+++ b/tests/test_unknown_properties.py
@@ -69,6 +69,38 @@ def test_handle_properties_tolerates_unknown_property_ids() -> None:
     }
 
 
+def test_handle_properties_matches_model_specific_did_by_siid_piid() -> None:
+    device, updates = _device_stub()
+    model_specific_did = -115364054
+
+    changed = DreameMowerDevice._handle_properties(
+        device,
+        [
+            {
+                "did": str(model_specific_did),
+                "code": 0,
+                "value": 2,
+                "siid": 3,
+                "piid": 2,
+            },
+            {
+                "did": "-115364055",
+                "code": 0,
+                "value": 5,
+                "siid": 2,
+                "piid": 1,
+            },
+        ],
+    )
+
+    assert changed is True
+    assert updates == ["changed"]
+    assert device.data[DreameMowerProperty.CHARGING_STATUS.value] == 2
+    assert device.data[DreameMowerProperty.STATE.value] == 5
+    assert model_specific_did not in device.data
+    assert device.unknown_properties == {}
+
+
 def test_tracks_unavailable_unknown_properties_for_diagnostics() -> None:
     device, updates = _device_stub()
     unknown_did = -115545820


### PR DESCRIPTION
## Summary

- Recognize `mova.mower.g2529c` as MOVA LiDAX Ultra 1000.
- Resolve standard mower properties by `siid`/`piid` when MOVA cloud responses use generated negative `did` values.
- Align bundled mower state labels with the model key definition and document the model in the support matrix.

## Root Cause

The diagnostics in #3 show the mower returning model-specific negative `did` values for standard properties such as `3.2`. The integration treated those as unknown, so state-adjacent values did not update the normal property cache even though commands and battery reporting worked.

Fixes #3

## Validation

- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_unknown_properties.py tests/test_dreame_models.py tests/test_python_package.py tests/test_app_protocol_annotations.py` (`59 passed`)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests --ignore=tests/components` (`419 passed`)

Note: the full suite's Home Assistant fixture test cannot run in this Windows shell with plugin autoload disabled, and the HA pytest plugin itself imports `fcntl` when autoloaded.