### PR TITLE
Fix mower no-error state handling

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -120,6 +120,22 @@ def _realtime_error_code_from_device(device: Any) -> int | None:
     return _active_error_code_from_raw(value)
 
 
+def _status_explicitly_reports_no_error(
+    *,
+    status_has_error: bool,
+    error_code: int | None,
+    error_name: str | None,
+    error_text: str | None,
+) -> bool:
+    """Return whether the normal status stream explicitly says no error."""
+    return bool(
+        not status_has_error
+        and error_code in (-1, 0)
+        and _is_no_error_text(error_name)
+        and _is_no_error_text(error_text)
+    )
+
+
 def _friendly_error_display(
     *,
     error_code: int | None,
@@ -584,7 +600,13 @@ def snapshot_from_device(
         or has_only_bare_error_flag
     )
     error_source: str | None = "status" if has_error else None
-    if not has_error and realtime_error_code is not None:
+    status_reports_no_error = _status_explicitly_reports_no_error(
+        status_has_error=status_has_error,
+        error_code=error_code,
+        error_name=error_name,
+        error_text=error_text,
+    )
+    if not has_error and not status_reports_no_error and realtime_error_code is not None:
         error_code = realtime_error_code
         has_error = True
         error_source = f"realtime_property_{REALTIME_ERROR_PROPERTY_KEY}"

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -304,7 +304,7 @@ def test_snapshot_falls_back_to_error_code_when_label_is_unknown() -> None:
     assert snapshot.error_display == "Error 73"
 
 
-def test_snapshot_uses_realtime_error_when_status_says_no_error() -> None:
+def test_snapshot_keeps_realtime_error_diagnostic_when_status_says_no_error() -> None:
     descriptor = descriptor_from_cloud_record(
         {
             "did": "device-1",
@@ -344,14 +344,14 @@ def test_snapshot_uses_realtime_error_when_status_says_no_error() -> None:
 
     snapshot = snapshot_from_device(descriptor, device)
 
-    assert snapshot.activity == "error"
-    assert snapshot.error_code == 54
+    assert snapshot.activity == "docked"
+    assert snapshot.error_code == -1
     assert snapshot.raw_error_code == -1
     assert snapshot.realtime_error_code == 54
-    assert snapshot.error_source == "realtime_property_2.2"
+    assert snapshot.error_source is None
     assert snapshot.error_name == "no_error"
     assert snapshot.error_text == "No error"
-    assert snapshot.error_display == "Edge"
+    assert snapshot.error_display == "No error"
     assert snapshot.docked is True
     assert snapshot.raw_docked is True
     assert snapshot.charging is True


### PR DESCRIPTION
## Summary
- Keep explicit normal status `No error` authoritative over stale/confusing realtime `2.2` values.
- Preserve realtime error values as diagnostics without forcing the mower into `activity: error`.
- Update model normalization coverage for the docked/charging no-error case.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/test_dreame_models.py tests/test_debug_payload.py tests/test_extract_ha_payload.py tests/test_dynamic_entity_availability.py` -> 106 passed
