### PR TITLE
Recognize A3 model and guard docked video probe

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Support levels in this table mean:
 | --- | --- | --- |
 | Dreame A2 (`dreame.mower.g2408`) | Validated | Primary live development device, including schedules, maps, remote control, guarded preference writes, and diagnostics |
 | MOVA LiDAX Ultra 1000 (`mova.mower.g2529c`) | Recognized | Added from a MOVAhome EU diagnostics report; commands and battery are reported working, state handling now accepts model-specific cloud property ids |
+| Dreame A3 AWD Pro 3500 (`dreame.mower.g2541e`) | Recognized | Added from a Dreamehome EU diagnostics report; needs broader live confirmation before it is considered validated |
 | Newer A-series mower (`dreame.mower.g3255`) | Recognized | Raw model has been observed in code mapping, but the public retail name is still unverified |
 | Dreame A1 (`dreame.mower.p2255`) | Recognized | Model mapping is present; needs fixtures and live validation |
 | Dreame A1 Pro (`dreame.mower.g2422`) | Recognized | Model mapping is present; needs fixtures and live validation |

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1663,7 +1663,13 @@ class DreameLawnMowerClient:
             raise DreameLawnMowerConnectionError(
                 "Camera stream handshake probe is blocked while the mower is active."
             )
-        if snapshot.docked:
+        station_states = {
+            "charging",
+            "charging_completed",
+            "smart_charging",
+            "station_reset",
+        }
+        if snapshot.raw_docked or snapshot.state in station_states:
             raise DreameLawnMowerConnectionError(
                 "Camera stream handshake probe is blocked while the mower is "
                 "docked. The Dreame app requires moving the mower out of the "

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1663,6 +1663,12 @@ class DreameLawnMowerClient:
             raise DreameLawnMowerConnectionError(
                 "Camera stream handshake probe is blocked while the mower is active."
             )
+        if snapshot.docked:
+            raise DreameLawnMowerConnectionError(
+                "Camera stream handshake probe is blocked while the mower is "
+                "docked. The Dreame app requires moving the mower out of the "
+                "station before remote video monitoring can start."
+            )
         if bool(getattr(status, "fast_mapping", False)):
             raise DreameLawnMowerConnectionError(
                 "Camera stream handshake probe is blocked while mapping."

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -16,6 +16,7 @@ MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
     "dreame.mower.g2408": "A2",
+    "dreame.mower.g2541e": "A3 AWD Pro 3500",
     "mova.mower.g2529c": "LiDAX Ultra 1000",
 }
 
@@ -23,6 +24,7 @@ DISPLAY_NAME_ALIASES = {
     "a1": "A1",
     "a1 pro": "A1 Pro",
     "a2": "A2",
+    "a3 awd pro 3500": "A3 AWD Pro 3500",
     "awd 1000": "AWD 1000",
     "lidax ultra 800": "LiDAX Ultra 800",
     "lidax ultra 1000": "LiDAX Ultra 1000",

--- a/tests/test_camera_features.py
+++ b/tests/test_camera_features.py
@@ -47,11 +47,12 @@ class _FakeCameraDevice:
             obstacles=False,
         )
         self.status = SimpleNamespace(
-            state=DreameMowerState.CHARGING,
-            status=DreameMowerStatus.CHARGING,
+            state=DreameMowerState.PAUSED,
+            status=DreameMowerStatus.IDLE,
             started=False,
             running=False,
             returning=False,
+            docked=False,
             fast_mapping=False,
             stream_session="session-1",
             stream_status=DreameMowerStreamStatus.VIDEO,
@@ -290,6 +291,27 @@ def test_camera_stream_handshake_blocks_active_mower() -> None:
         assert "blocked while the mower is active" in str(err)
     else:
         raise AssertionError("Expected active mower stream probe to be blocked")
+
+
+def test_camera_stream_handshake_blocks_docked_mower() -> None:
+    device = _FakeCameraDevice()
+    device.status.state = DreameMowerState.CHARGING_COMPLETED
+    device.status.status = DreameMowerStatus.CHARGING
+    device.status.docked = True
+    client = _client_with_device(device)
+    client._sync_update_device = lambda: device
+
+    try:
+        client._sync_probe_camera_stream_handshake(
+            timeout=0,
+            interval=0.1,
+            operation="monitor",
+            payload_mode="with_session",
+        )
+    except DreameLawnMowerConnectionError as err:
+        assert "blocked while the mower is docked" in str(err)
+    else:
+        raise AssertionError("Expected docked mower stream probe to be blocked")
 
 
 def test_camera_stream_handshake_can_omit_session_key() -> None:

--- a/tests/test_camera_features.py
+++ b/tests/test_camera_features.py
@@ -314,6 +314,26 @@ def test_camera_stream_handshake_blocks_docked_mower() -> None:
         raise AssertionError("Expected docked mower stream probe to be blocked")
 
 
+def test_camera_stream_handshake_allows_idle_undocked_mower() -> None:
+    device = _FakeCameraDevice()
+    device.status.state = DreameMowerState.IDLE
+    device.status.status = DreameMowerStatus.IDLE
+    device.status.docked = False
+    client = _client_with_device(device)
+    client._sync_update_device = lambda: device
+    client._sync_get_cloud_user_features = lambda language=None: ""
+
+    result = client._sync_probe_camera_stream_handshake(
+        timeout=0,
+        interval=0.1,
+        operation="monitor",
+        payload_mode="with_session",
+    )
+
+    assert result["start_result"] == {"code": 0, "result": "started"}
+    assert result["end_result"] == {"code": 0, "result": "ended"}
+
+
 def test_camera_stream_handshake_can_omit_session_key() -> None:
     device = _FakeCameraDevice()
     client = _client_with_device(device)

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -190,6 +190,23 @@ def test_descriptor_maps_lidax_ultra_1000_model_name() -> None:
     assert descriptor.title == "Mowercedes (LiDAX Ultra 1000)"
 
 
+def test_descriptor_maps_a3_awd_pro_3500_model_name() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-6",
+            "model": "dreame.mower.g2541e",
+            "customName": "Back Garden",
+            "deviceInfo": {"displayName": "A3 AWD Pro 3500"},
+        },
+        account_type="dreame",
+        country="eu",
+    )
+
+    assert descriptor is not None
+    assert descriptor.display_model == "A3 AWD Pro 3500"
+    assert descriptor.title == "Back Garden (A3 AWD Pro 3500)"
+
+
 def test_snapshot_uses_state_name_before_boolean_helpers() -> None:
     descriptor = descriptor_from_cloud_record(
         {


### PR DESCRIPTION
## Summary
- recognize `dreame.mower.g2541e` as Dreame A3 AWD Pro 3500
- document the model as recognized in the README support matrix
- add descriptor normalization coverage for the reported model
- block the camera stream handshake while the mower is docked with the same prerequisite the Dreame app surfaces

Fixes #6.

## Validation
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_dreame_models.py -q`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests\test_camera_features.py -q`
- `python -m ruff check .`
- `git diff --check`
- Live read-only camera feature/source probes against the local Dreame A2 showed `video_tx`/`STREAM_VIDEO` support but empty stream properties while docked
- Live guarded stream probe now stops before sending `STREAM_VIDEO` while docked and reports that the mower must be moved out of the station before remote video monitoring can start

## Notes
The local A2 is currently `charging_completed`/docked. The Dreame app bundle includes the matching user-facing constraint that remote video monitoring cannot start while the mower is in the station. This PR therefore fixes the misleading missing-video behavior by making the limitation explicit and safe; proving the actual stream path still needs a supervised undocked mower state.