### PR TITLE
Verify MQTT TLS certificates

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -258,8 +258,8 @@ class DreameMowerDreameHomeCloudProtocol:
                             self._client.on_disconnect = DreameMowerDreameHomeCloudProtocol._on_client_disconnect
                             self._client.on_message = DreameMowerDreameHomeCloudProtocol._on_client_message
                             self._client.reconnect_delay_set(1, 15)
-                            self._client.tls_set(cert_reqs=ssl.CERT_NONE)
-                            self._client.tls_insecure_set(True)
+                            self._client.tls_set(cert_reqs=ssl.CERT_REQUIRED)
+                            self._client.tls_insecure_set(False)
                             self._set_client_key()
                             self._client.connect(host[0], int(host[1]), 50)
                             self._client.loop_start()

--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -19,5 +19,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.1.6"
+  "version": "0.1.7"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.1.6"
+version = "0.1.7"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import ssl
 from types import SimpleNamespace
 
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import protocol
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     _normalize_cloud_firmware_check,
 )
@@ -38,6 +40,64 @@ def _firmware_device() -> SimpleNamespace:
         status=SimpleNamespace(),
         data={},
     )
+
+
+def test_cloud_mqtt_client_requires_verified_tls(monkeypatch) -> None:
+    mqtt_clients = []
+
+    class _MqttClient:
+        def __init__(self, *args, **kwargs) -> None:
+            self.tls_set_kwargs = None
+            self.tls_insecure = None
+            self.connected_to = None
+            mqtt_clients.append(self)
+
+        def reconnect_delay_set(self, *args) -> None:
+            pass
+
+        def tls_set(self, **kwargs) -> None:
+            self.tls_set_kwargs = kwargs
+
+        def tls_insecure_set(self, value) -> None:
+            self.tls_insecure = value
+
+        def username_pw_set(self, *args) -> None:
+            pass
+
+        def connect(self, host, port, keepalive) -> None:
+            self.connected_to = (host, port, keepalive)
+
+        def loop_start(self) -> None:
+            pass
+
+    monkeypatch.setattr(protocol.mqtt_client, "Client", _MqttClient)
+
+    cloud = protocol.DreameMowerDreameHomeCloudProtocol(
+        "user@example.invalid",
+        "secret",
+        "eu",
+        "device-1",
+    )
+    cloud._logged_in = True
+    cloud._uid = "uid-1"
+    cloud._did = "device-1"
+    cloud._model = "dreame.mower.g2408"
+    cloud._host = "mqtt.example.invalid:8883"
+    cloud._key = "client-key"
+    cloud._uuid = "uuid-1"
+    cloud._strings = [""] * 57
+    cloud._strings[7] = "topic"
+    cloud._strings[53] = "agent-"
+    cloud._strings[54] = "-"
+    monkeypatch.setattr(cloud, "get_device_info", lambda: {"did": "device-1"})
+
+    result = cloud.connect(message_callback=lambda data: None)
+
+    assert result == {"did": "device-1"}
+    assert len(mqtt_clients) == 1
+    assert mqtt_clients[0].tls_set_kwargs == {"cert_reqs": ssl.CERT_REQUIRED}
+    assert mqtt_clients[0].tls_insecure is False
+    assert mqtt_clients[0].connected_to == ("mqtt.example.invalid", 8883, 50)
 
 
 def test_get_voice_settings_does_not_synthesize_prompt_flags() -> None:


### PR DESCRIPTION
## Summary
- enable certificate verification for the Dreame/MOVA cloud MQTT connection
- keep `tls_insecure_set(False)` explicit so the broker hostname/certificate is validated
- bump the integration/package version to 0.1.7 for the follow-up release
- add a regression test covering the MQTT TLS setup

## Validation
- `python -m ruff check .`
- `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests/test_client_review_regressions.py -q`
- `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest -q --ignore=tests/components/dreame_lawn_mower/test_config_flow.py`
- `git diff --check`
- scanned for remaining insecure TLS patterns: `CERT_NONE`, `tls_insecure_set(True)`, `verify=False`, disabled hostname checks

Note: plain `python -m pytest -q` is blocked in this Windows environment before collection because the auto-loaded Home Assistant pytest plugin imports POSIX-only `fcntl`. With plugin autoload disabled, the config-flow test that needs the `hass` fixture is intentionally excluded from the broad local run.