### PR TITLE
Render active batch vector map

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1486,7 +1486,10 @@ class DreameLawnMowerClient:
                 "error": str(err),
             }
 
-        vector_map = parse_batch_vector_map(batch_data)
+        vector_map = parse_batch_vector_map(
+            batch_data,
+            current_map_index=self._sync_get_current_app_map_index(),
+        )
         if vector_map is None:
             return {
                 "available": False,
@@ -1842,7 +1845,10 @@ class DreameLawnMowerClient:
                 ),
             )
 
-        vector_map = parse_batch_vector_map(batch_data)
+        vector_map = parse_batch_vector_map(
+            batch_data,
+            current_map_index=self._sync_get_current_app_map_index(),
+        )
         if vector_map is None:
             return DreameLawnMowerMapView(
                 source=source,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -567,11 +567,13 @@ class DreameLawnMowerClient:
         self,
         *,
         label_scale: float = 1.0,
+        current_map_index: int | None = None,
     ) -> DreameLawnMowerMapView:
         """Refresh the batch/vector map path used for live mowing overlays."""
         return await asyncio.to_thread(
             self._sync_refresh_vector_map_view,
             label_scale=label_scale,
+            current_map_index=current_map_index,
         )
 
     async def async_get_app_schedules(
@@ -1807,7 +1809,10 @@ class DreameLawnMowerClient:
         )
 
         vector_view = self._with_fallback_app_maps(
-            self._sync_refresh_vector_map_view(label_scale=label_scale),
+            self._sync_refresh_vector_map_view(
+                label_scale=label_scale,
+                current_map_index=_map_view_current_app_map_index(app_view),
+            ),
             app_view,
         )
         if _map_view_has_live_path(vector_view):
@@ -1830,6 +1835,7 @@ class DreameLawnMowerClient:
         self,
         *,
         label_scale: float = 1.0,
+        current_map_index: int | None = None,
     ) -> DreameLawnMowerMapView:
         source = "batch_vector_map"
         try:
@@ -1847,7 +1853,11 @@ class DreameLawnMowerClient:
 
         vector_map = parse_batch_vector_map(
             batch_data,
-            current_map_index=self._sync_get_current_app_map_index(),
+            current_map_index=(
+                current_map_index
+                if current_map_index is not None
+                else self._sync_get_current_app_map_index()
+            ),
         )
         if vector_map is None:
             return DreameLawnMowerMapView(
@@ -2698,15 +2708,13 @@ class DreameLawnMowerClient:
 
     def _sync_get_current_app_map_index(self) -> int | None:
         try:
-            app_maps = self._sync_get_app_maps(
-                chunk_size=400,
-                include_payload=False,
-                include_objects=False,
-                include_object_urls=False,
-            )
+            map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
         except Exception:  # noqa: BLE001 - best-effort hint only
             return None
-        return _positive_int(app_maps.get("current_map_index"))
+        for entry in _normalize_app_map_entries(map_list_result):
+            if entry.get("current"):
+                return _positive_int(entry.get("idx"))
+        return None
 
     def _sync_get_mowing_preferences(
         self,
@@ -4542,6 +4550,13 @@ def _select_app_map_payload(app_maps: Mapping[str, Any]) -> Mapping[str, Any] | 
         if item.get("idx") == current_idx:
             return item
     return available_maps[0] if available_maps else None
+
+
+def _map_view_current_app_map_index(view: DreameLawnMowerMapView) -> int | None:
+    app_maps = view.app_maps
+    if not isinstance(app_maps, Mapping):
+        return None
+    return _positive_int(app_maps.get("current_map_index"))
 
 
 def _vector_map_batch_keys() -> list[str]:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -2709,11 +2709,11 @@ class DreameLawnMowerClient:
     def _sync_get_current_app_map_index(self) -> int | None:
         try:
             map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
+            for entry in _normalize_app_map_entries(map_list_result):
+                if entry.get("current"):
+                    return _positive_int(entry.get("idx"))
         except Exception:  # noqa: BLE001 - best-effort hint only
             return None
-        for entry in _normalize_app_map_entries(map_list_result):
-            if entry.get("current"):
-                return _positive_int(entry.get("idx"))
         return None
 
     def _sync_get_mowing_preferences(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -148,6 +148,8 @@ class DreameLawnMowerVectorMap:
 
 def parse_batch_vector_map(
     batch_data: Mapping[str, Any] | None,
+    *,
+    current_map_index: int | None = None,
 ) -> DreameLawnMowerVectorMap | None:
     """Parse cloud batch-map response data into a normalized vector map."""
     if not isinstance(batch_data, Mapping) or not batch_data:
@@ -177,10 +179,7 @@ def parse_batch_vector_map(
     if not parsed_maps:
         return None
 
-    primary = next(
-        (vector_map for vector_map in parsed_maps if vector_map.map_index == 0),
-        parsed_maps[0],
-    )
+    primary = _select_primary_vector_map(parsed_maps, current_map_index)
 
     available_maps = tuple(
         DreameLawnMowerAvailableMap(
@@ -199,11 +198,34 @@ def parse_batch_vector_map(
     for vector_map in parsed_maps_by_id.values():
         vector_map.available_maps = available_maps
         vector_map.mow_paths = mow_paths
+        vector_map.maps = parsed_maps_by_id
 
     primary.available_maps = available_maps
     primary.mow_paths = mow_paths
     primary.maps = parsed_maps_by_id
     return primary
+
+
+def _select_primary_vector_map(
+    parsed_maps: Sequence[DreameLawnMowerVectorMap],
+    current_map_index: int | None,
+) -> DreameLawnMowerVectorMap:
+    if current_map_index is not None:
+        selected = next(
+            (
+                vector_map
+                for vector_map in parsed_maps
+                if vector_map.map_index == current_map_index
+            ),
+            None,
+        )
+        if selected is not None:
+            return selected
+
+    return next(
+        (vector_map for vector_map in parsed_maps if vector_map.map_index == 0),
+        parsed_maps[0],
+    )
 
 
 def render_vector_map_png(

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -372,11 +372,16 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
 
 def test_map_view_prefers_vector_render_when_live_path_is_available() -> None:
     client = _client()
+    vector_refresh_kwargs: dict[str, object] = {}
     app_view = DreameLawnMowerMapView(
         source="app_action_map",
         summary=DreameLawnMowerMapSummary(available=True, map_id=0),
         image_png=b"app",
-        app_maps={"source": "app_action_map", "map_count": 2},
+        app_maps={
+            "source": "app_action_map",
+            "map_count": 2,
+            "current_map_index": 1,
+        },
         details={"has_live_path": False},
     )
     vector_view = DreameLawnMowerMapView(
@@ -387,7 +392,9 @@ def test_map_view_prefers_vector_render_when_live_path_is_available() -> None:
     )
 
     client._sync_refresh_app_map_view = lambda **kwargs: app_view
-    client._sync_refresh_vector_map_view = lambda **kwargs: vector_view
+    client._sync_refresh_vector_map_view = lambda **kwargs: (
+        vector_refresh_kwargs.update(kwargs) or vector_view
+    )
     client._sync_refresh_legacy_map_view = lambda timeout, interval: (
         _ for _ in ()
     ).throw(  # noqa: ARG005
@@ -399,7 +406,12 @@ def test_map_view_prefers_vector_render_when_live_path_is_available() -> None:
     assert view.source == "batch_vector_map"
     assert view.image_png == b"vector"
     assert view.details == {"has_live_path": True, "mow_path_point_count": 42}
-    assert view.app_maps == {"source": "app_action_map", "map_count": 2}
+    assert view.app_maps == {
+        "source": "app_action_map",
+        "map_count": 2,
+        "current_map_index": 1,
+    }
+    assert vector_refresh_kwargs["current_map_index"] == 1
 
 
 def test_map_view_keeps_app_render_when_vector_has_no_live_path() -> None:

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -229,6 +229,20 @@ def test_parse_batch_vector_map_handles_map_info_split_and_mow_paths() -> None:
     )
 
 
+def test_parse_batch_vector_map_can_select_current_map_index() -> None:
+    vector_map = parse_batch_vector_map(_batch_payload(), current_map_index=1)
+
+    assert vector_map is not None
+    assert vector_map.map_index == 1
+    assert vector_map.map_id == 2
+    assert vector_map.zones[0].name == "Back Yard"
+    assert vector_map.boundary is not None
+    assert vector_map.boundary.width == 50
+    assert sorted(vector_map.maps) == [1, 2]
+    assert vector_map.maps[1].zones[0].name == "Front Yard"
+    assert len(vector_map.mow_paths) == 1
+
+
 def test_vector_map_summary_and_renderer_return_drawable_output() -> None:
     vector_map = parse_batch_vector_map(_batch_payload())
 
@@ -412,3 +426,27 @@ def test_vector_map_view_includes_cached_runtime_track_overlay() -> None:
     assert view.details["runtime_pose_y"] == 40
     assert view.details["runtime_heading_deg"] == 90.0
     assert view.details["has_live_path"] is True
+
+
+def test_vector_map_view_renders_current_app_map_index() -> None:
+    client = _client()
+    client._sync_get_app_maps = lambda **kwargs: {  # noqa: ARG005
+        "source": "app_action_map",
+        "current_map_index": 1,
+        "maps": [],
+    }
+    client._sync_get_vector_map_batch_data = lambda: _batch_payload()
+    client._safe_map_diagnostics = lambda **kwargs: None
+
+    view = client._sync_refresh_vector_map_view()
+
+    assert view.source == "batch_vector_map"
+    assert view.available is True
+    assert view.image_png is not None
+    assert view.image_png.startswith(b"\x89PNG")
+    assert view.summary is not None
+    assert view.summary.map_id == 1
+    assert view.summary.width == 50
+    assert view.details is not None
+    assert view.details["map_index"] == 1
+    assert view.details["zone_names"] == ["Back Yard"]

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -455,3 +455,19 @@ def test_vector_map_view_renders_current_app_map_index() -> None:
     assert view.details["map_index"] == 1
     assert view.details["zone_names"] == ["Back Yard"]
     assert app_action_calls == [{"m": "g", "t": "MAPL"}]
+
+
+def test_vector_map_view_falls_back_when_map_list_errors() -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload, **kwargs: {"r": 1}  # noqa: ARG005
+    client._sync_get_vector_map_batch_data = lambda: _batch_payload()
+    client._safe_map_diagnostics = lambda **kwargs: None
+
+    view = client._sync_refresh_vector_map_view()
+
+    assert view.source == "batch_vector_map"
+    assert view.available is True
+    assert view.summary is not None
+    assert view.summary.map_id == 0
+    assert view.details is not None
+    assert view.details["map_index"] == 0

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -430,11 +430,15 @@ def test_vector_map_view_includes_cached_runtime_track_overlay() -> None:
 
 def test_vector_map_view_renders_current_app_map_index() -> None:
     client = _client()
-    client._sync_get_app_maps = lambda **kwargs: {  # noqa: ARG005
-        "source": "app_action_map",
-        "current_map_index": 1,
-        "maps": [],
-    }
+    app_action_calls: list[dict[str, object]] = []
+
+    def call_app_action(payload: dict[str, object], **kwargs) -> dict:  # noqa: ARG001
+        app_action_calls.append(payload)
+        if payload.get("t") == "MAPL":
+            return {"r": 0, "d": [[0, 0, 1, 1, 0], [1, 1, 1, 1, 0]]}
+        raise AssertionError(f"unexpected app action call: {payload}")
+
+    client._sync_call_app_action = call_app_action
     client._sync_get_vector_map_batch_data = lambda: _batch_payload()
     client._safe_map_diagnostics = lambda **kwargs: None
 
@@ -450,3 +454,4 @@ def test_vector_map_view_renders_current_app_map_index() -> None:
     assert view.details is not None
     assert view.details["map_index"] == 1
     assert view.details["zone_names"] == ["Back Yard"]
+    assert app_action_calls == [{"m": "g", "t": "MAPL"}]


### PR DESCRIPTION
## Summary
- Selects the parsed batch vector map by the active app map index before rendering.
- Keeps the previous map 0 fallback when the active index is unavailable or not present in the batch payload.
- Uses the lightweight MAPL metadata path for standalone vector refreshes and reuses already-fetched app-map metadata in the full Map camera refresh.
- Adds regression coverage for map index 1 so the Map and Live Path Map cameras do not combine map 0 geometry with the active map path.

Closes #11

## Related PR
- #10 is merged and this branch has been rebased on top of its map-label scaling changes.

## Validation
- `python -m ruff check custom_components\dreame_lawn_mower\dreame_lawn_mower_client\client.py custom_components\dreame_lawn_mower\dreame_lawn_mower_client\vector_map.py tests\test_vector_map.py tests\test_app_maps.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest -q tests\test_vector_map.py tests\test_app_maps.py tests\test_map_camera.py -k "map or render or vector"`