### PR TITLE
Release 0.1.8

### DIFF
--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -19,5 +19,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.1.7"
+  "version": "0.1.8"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.1.7"
+version = "0.1.8"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Changes
- Bump the integration package and Home Assistant manifest version to 0.1.8.
- Prepare the release that includes configurable map label scaling and active batch vector map rendering.

## Validation
- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests --ignore=tests/components/dreame_lawn_mower/test_config_flow.py`