### PR TITLE
Add maintenance reset buttons

### DIFF
--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -17,6 +17,7 @@ from .calendar import schedule_calendar_selection
 from .const import DOMAIN
 from .coordinator import DreameLawnMowerCoordinator
 from .debug import build_debug_payload, sanitize_debug_data
+from .dreame_lawn_mower_client.maintenance import MAINTENANCE_ITEMS, MaintenanceItem
 from .entity import DreameLawnMowerEntity
 from .task_status_probe import TASK_STATUS_PROBE_KEYS, task_status_probe_payload
 
@@ -40,6 +41,10 @@ async def async_setup_entry(
             DreameLawnMowerCaptureScheduleProbeButton(coordinator),
             DreameLawnMowerCapturePreferenceProbeButton(coordinator),
             DreameLawnMowerCaptureWeatherProbeButton(coordinator),
+        ]
+        + [
+            DreameLawnMowerResetMaintenanceButton(coordinator, item)
+            for item in MAINTENANCE_ITEMS
         ]
     )
 
@@ -401,6 +406,79 @@ class DreameLawnMowerCaptureWeatherProbeButton(
                 f"{DOMAIN}_{self.coordinator.entry.entry_id}_weather_probe"
             ),
         )
+
+
+class DreameLawnMowerResetMaintenanceButton(
+    DreameLawnMowerEntity,
+    ButtonEntity,
+):
+    """Reset a live CMS maintenance counter."""
+
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
+
+    def __init__(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        item: MaintenanceItem,
+    ) -> None:
+        super().__init__(coordinator)
+        self._item = item
+        self._attr_name = f"Reset {item.name} Maintenance"
+        self._attr_icon = item.icon
+        self._attr_unique_id = (
+            f"{self._descriptor.unique_id}_reset_maintenance_{item.key}"
+        )
+
+    async def async_press(self) -> None:
+        """Reset the selected maintenance counter and refresh cached status."""
+        result = await self.coordinator.client.async_plan_maintenance_reset(
+            item=self._item.key,
+            execute=True,
+            confirm_write=True,
+        )
+        self.coordinator.last_maintenance_reset_result = result
+        await self.coordinator.async_refresh_maintenance_status(
+            force=True,
+            source="maintenance_reset_button",
+        )
+        self.coordinator.async_update_listeners()
+        _LOGGER.info(
+            "Reset Dreame lawn mower maintenance counter for %s: %s",
+            self._item.name,
+            json.dumps(result, sort_keys=True),
+        )
+        title, message = _maintenance_reset_button_notification(result)
+        persistent_notification.async_create(
+            self.coordinator.hass,
+            message,
+            title=title,
+            notification_id=(
+                f"{DOMAIN}_{self.coordinator.entry.entry_id}_reset_maintenance_"
+                f"{self._item.key}"
+            ),
+        )
+
+
+def _maintenance_reset_button_notification(
+    result: dict[str, object],
+) -> tuple[str, str]:
+    """Return title and message for a maintenance reset button press."""
+    item_name = result.get("item_name") or result.get("item") or "maintenance item"
+    previous = result.get("previous_item")
+    updated = result.get("updated_item")
+    previous_counter = (
+        previous.get("used_minutes") if isinstance(previous, dict) else None
+    )
+    updated_counter = updated.get("used_minutes") if isinstance(updated, dict) else None
+    return (
+        "Dreame Lawn Mower Maintenance Reset",
+        (
+            f"Reset {item_name}: counter {previous_counter} -> "
+            f"{updated_counter}. Enable the Last Maintenance Reset diagnostic "
+            "sensor for full CMS request and response details."
+        ),
+    )
 
 
 def schedule_probe_payload(payload: dict[str, object]) -> dict[str, object]:

--- a/examples/maintenance_reset_probe.py
+++ b/examples/maintenance_reset_probe.py
@@ -1,0 +1,114 @@
+"""Dry-run first probe for mower-native maintenance counter resets."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from dreame_lawn_mower_client import MAINTENANCE_ITEMS, DreameLawnMowerClient
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Build, and optionally execute, Dreame mower CMS maintenance "
+            "counter resets using the app action protocol."
+        )
+    )
+    parser.add_argument(
+        "--item",
+        action="append",
+        choices=[item.key for item in MAINTENANCE_ITEMS],
+        required=True,
+        help="Maintenance item to reset. Repeat to reset several counters.",
+    )
+    parser.add_argument(
+        "--execute",
+        action="store_true",
+        help="Send the reset request. Defaults to dry-run.",
+    )
+    parser.add_argument(
+        "--confirm-maintenance-reset",
+        action="store_true",
+        help="Required together with --execute before any reset is sent.",
+    )
+    parser.add_argument(
+        "--device-index",
+        type=int,
+        default=0,
+        help="Zero-based discovered mower index to inspect.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Optional JSON output file. Prints to stdout when omitted.",
+    )
+    return parser
+
+
+async def main() -> None:
+    parser = _build_parser()
+    args = parser.parse_args()
+
+    username = os.environ["DREAME_USERNAME"]
+    password = os.environ["DREAME_PASSWORD"]
+    country = os.environ.get("DREAME_COUNTRY", "eu")
+    account_type = os.environ.get("DREAME_ACCOUNT_TYPE", "dreame")
+
+    devices = await DreameLawnMowerClient.async_discover_devices(
+        username=username,
+        password=password,
+        country=country,
+        account_type=account_type,
+    )
+    if not devices:
+        raise RuntimeError("No mower devices found.")
+    if args.device_index < 0 or args.device_index >= len(devices):
+        raise RuntimeError(
+            f"Invalid device index {args.device_index}; found {len(devices)}."
+        )
+
+    client = DreameLawnMowerClient(
+        username=username,
+        password=password,
+        country=country,
+        account_type=account_type,
+        descriptor=devices[args.device_index],
+    )
+    try:
+        before = await client.async_get_maintenance_status(include_raw=False)
+        resets = []
+        for item in args.item:
+            resets.append(
+                await client.async_plan_maintenance_reset(
+                    item=item,
+                    execute=args.execute,
+                    confirm_write=args.confirm_maintenance_reset,
+                )
+            )
+        after = await client.async_get_maintenance_status(include_raw=False)
+        payload = {
+            "descriptor": {
+                "title": devices[args.device_index].title,
+                "model": devices[args.device_index].model,
+                "display_model": devices[args.device_index].display_model,
+                "device_index": args.device_index,
+            },
+            "before": before,
+            "resets": resets,
+            "after": after,
+        }
+        rendered = json.dumps(payload, indent=2, sort_keys=True) + "\n"
+        if args.out:
+            args.out.write_text(rendered, encoding="utf-8")
+        else:
+            print(rendered, end="")
+    finally:
+        await client.async_close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -2,8 +2,10 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
+from custom_components.dreame_lawn_mower import button as button_module
 from custom_components.dreame_lawn_mower.binary_sensor import (
     BINARY_SENSORS,
     DreameLawnMowerBinarySensor,
@@ -12,6 +14,9 @@ from custom_components.dreame_lawn_mower.binary_sensor import (
     DreameLawnMowerMaintenanceDueBinarySensor,
     DreameLawnMowerRainDelayActiveBinarySensor,
     DreameLawnMowerRainProtectionEnabledBinarySensor,
+)
+from custom_components.dreame_lawn_mower.button import (
+    DreameLawnMowerResetMaintenanceButton,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.maintenance import (
     MAINTENANCE_ITEM_BY_KEY,
@@ -412,6 +417,83 @@ def test_last_maintenance_reset_sensor_summarizes_result() -> None:
 
     assert entity.native_value == "dry_run"
     assert entity.extra_state_attributes["item"] == "blade"
+
+
+def test_reset_maintenance_button_executes_confirmed_reset(monkeypatch) -> None:
+    notifications = []
+
+    def _capture_notification(hass, message, *, title, notification_id):
+        notifications.append(
+            {
+                "hass": hass,
+                "message": message,
+                "title": title,
+                "notification_id": notification_id,
+            }
+        )
+
+    class _FakeClient:
+        async def async_plan_maintenance_reset(
+            self,
+            *,
+            item,
+            execute,
+            confirm_write,
+        ):
+            self.call = {
+                "item": item,
+                "execute": execute,
+                "confirm_write": confirm_write,
+            }
+            return {
+                "item": item,
+                "item_name": "Blade",
+                "executed": True,
+                "previous_item": {"used_minutes": 4909},
+                "updated_item": {"used_minutes": 0},
+            }
+
+    class _FakeCoordinator:
+        def __init__(self) -> None:
+            self.client = _FakeClient()
+            self.entry = SimpleNamespace(entry_id="entry-1")
+            self.hass = object()
+            self.last_maintenance_reset_result = None
+            self.refresh_call = None
+            self.updated = False
+
+        async def async_refresh_maintenance_status(self, *, force, source):
+            self.refresh_call = {"force": force, "source": source}
+            return {"available": True}
+
+        def async_update_listeners(self):
+            self.updated = True
+
+    monkeypatch.setattr(
+        button_module.persistent_notification,
+        "async_create",
+        _capture_notification,
+    )
+    coordinator = _FakeCoordinator()
+    entity = object.__new__(DreameLawnMowerResetMaintenanceButton)
+    entity.coordinator = coordinator
+    entity._item = MAINTENANCE_ITEM_BY_KEY["blade"]
+
+    asyncio.run(entity.async_press())
+
+    assert coordinator.client.call == {
+        "item": "blade",
+        "execute": True,
+        "confirm_write": True,
+    }
+    assert coordinator.refresh_call == {
+        "force": True,
+        "source": "maintenance_reset_button",
+    }
+    assert coordinator.updated is True
+    assert coordinator.last_maintenance_reset_result["executed"] is True
+    assert notifications[0]["title"] == "Dreame Lawn Mower Maintenance Reset"
+    assert notifications[0]["notification_id"].endswith("_reset_maintenance_blade")
 
 
 def test_raw_returning_binary_sensor_preserves_vendor_flag() -> None:

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -22,6 +22,8 @@ from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerCaptureScheduleProbeButton,
     DreameLawnMowerCaptureTaskStatusProbeButton,
     DreameLawnMowerCaptureWeatherProbeButton,
+    DreameLawnMowerResetMaintenanceButton,
+    _maintenance_reset_button_notification,
     schedule_probe_payload,
 )
 from custom_components.dreame_lawn_mower.const import PLATFORMS
@@ -262,6 +264,19 @@ def test_last_maintenance_reset_sensor_is_diagnostic_disabled_by_default() -> No
     )
 
 
+def test_reset_maintenance_button_is_diagnostic_disabled_by_default() -> None:
+    assert (
+        DreameLawnMowerResetMaintenanceButton.__dict__["__attr_entity_category"]
+        == "diagnostic"
+    )
+    assert (
+        DreameLawnMowerResetMaintenanceButton.__dict__[
+            "__attr_entity_registry_enabled_default"
+        ]
+        is False
+    )
+
+
 def test_maintenance_reset_result_attributes_are_compact() -> None:
     attributes = maintenance_reset_result_attributes(
         {
@@ -283,6 +298,20 @@ def test_maintenance_reset_result_attributes_are_compact() -> None:
     assert attributes["item"] == "blade"
     assert attributes["changed"] is True
     assert attributes["request"] == {"m": "s", "t": "CMS"}
+
+
+def test_maintenance_reset_button_notification_is_compact() -> None:
+    title, message = _maintenance_reset_button_notification(
+        {
+            "item_name": "Blade",
+            "previous_item": {"used_minutes": 4909},
+            "updated_item": {"used_minutes": 0},
+        }
+    )
+
+    assert title == "Dreame Lawn Mower Maintenance Reset"
+    assert "Reset Blade: counter 4909 -> 0" in message
+    assert "Last Maintenance Reset" in message
 
 
 def test_task_status_probe_button_is_diagnostic_disabled_by_default() -> None:

--- a/tests/test_maintenance_reset_probe.py
+++ b/tests/test_maintenance_reset_probe.py
@@ -1,0 +1,16 @@
+"""Regression checks for the maintenance reset probe CLI helper."""
+
+from __future__ import annotations
+
+from examples.maintenance_reset_probe import _build_parser
+
+
+def test_maintenance_reset_probe_parser_defaults_to_dry_run() -> None:
+    parser = _build_parser()
+
+    args = parser.parse_args(["--item", "blade", "--item", "robot"])
+
+    assert args.item == ["blade", "robot"]
+    assert args.execute is False
+    assert args.confirm_maintenance_reset is False
+    assert args.device_index == 0


### PR DESCRIPTION
## Summary
- add disabled-by-default diagnostic buttons to reset blade, cleaning brush, and robot maintenance counters
- store button results in the existing Last Maintenance Reset diagnostic sensor and refresh cached maintenance state
- add a dry-run-first maintenance reset probe script for future hardware validation

## Safety
- buttons use the same confirmed write path that was added in PR #15
- reset buttons are diagnostic and disabled by default
- the live reset path preserves unknown CMS slots such as the trailing `-1` sentinel

## Live validation
- discovered one mower: Dreame A2 Bodzio (A2)
- live reset executed for blade, cleaning brush, and robot maintenance using the merged client API
- CMS changed from `[4909, 16765, 6862, -1]` to `[0, 0, 0, -1]`
- follow-up dry-run through `examples/maintenance_reset_probe.py` confirmed all three counters remain reset and no due items remain

## Local validation
- focused button/entity/probe tests passed
- Windows lightweight suite passed excluding the HA component fixture folder
- ruff passed for touched files
