### PR TITLE
Report returning mower activity

### DIFF
--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -63,7 +63,7 @@ ACTIVITY_MAP = {
     ACTIVITY_IDLE: LawnMowerActivity.DOCKED,
     ACTIVITY_MOWING: LawnMowerActivity.MOWING,
     ACTIVITY_PAUSED: LawnMowerActivity.PAUSED,
-    ACTIVITY_RETURNING: LawnMowerActivity.MOWING,
+    ACTIVITY_RETURNING: LawnMowerActivity.RETURNING,
 }
 
 

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
+from homeassistant.components.lawn_mower import LawnMowerActivity
 from homeassistant.exceptions import HomeAssistantError
 
 from custom_components.dreame_lawn_mower.control_options import (
@@ -230,6 +231,13 @@ def _snapshot(**overrides: object) -> SimpleNamespace:
     }
     values.update(overrides)
     return SimpleNamespace(**values)
+
+
+def test_lawn_mower_activity_reports_returning_to_dock() -> None:
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(data=_snapshot(activity="returning"))
+
+    assert entity.activity is LawnMowerActivity.RETURNING
 
 
 def test_current_zone_entries_filter_global_and_edge_area_ids() -> None:


### PR DESCRIPTION
## Summary
- map Dreame `returning` activity to Home Assistant's native `RETURNING` lawn mower activity
- keep the existing dock action unchanged; this only corrects the state shown while the mower is returning to base
- add a regression test for the Home Assistant activity contract

## Validation
- `python -m ruff check custom_components/dreame_lawn_mower/lawn_mower.py tests/test_current_map_controls.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests/test_current_map_controls.py tests/test_dreame_models.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --ignore=tests/components/dreame_lawn_mower`