### PR TITLE
Add maintenance warning state and fix rain-delay parsing

### DIFF
--- a/custom_components/dreame_lawn_mower/binary_sensor.py
+++ b/custom_components/dreame_lawn_mower/binary_sensor.py
@@ -268,6 +268,7 @@ async def async_setup_entry(
         + [DreameLawnMowerAutomaticFirmwareUpdatesBinarySensor(coordinator)]
         + [DreameLawnMowerRainProtectionEnabledBinarySensor(coordinator)]
         + [DreameLawnMowerRainDelayActiveBinarySensor(coordinator)]
+        + [DreameLawnMowerMaintenanceWarningBinarySensor(coordinator)]
         + [DreameLawnMowerMaintenanceDueBinarySensor(coordinator)]
     )
 
@@ -540,6 +541,40 @@ class DreameLawnMowerMaintenanceDueBinarySensor(
         if not isinstance(status, dict):
             return None
         value = status.get("due")
+        return value if isinstance(value, bool) else None
+
+    @property
+    def available(self) -> bool:
+        """Return whether cached maintenance data exists."""
+        return self.coordinator.data is not None and self.is_on is not None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return safe cached maintenance attributes."""
+        return maintenance_status_attributes(self.coordinator.maintenance_status)
+
+
+class DreameLawnMowerMaintenanceWarningBinarySensor(
+    DreameLawnMowerEntity,
+    BinarySensorEntity,
+):
+    """Expose whether any CMS maintenance counter is nearing replacement."""
+
+    _attr_name = "Maintenance Warning"
+    _attr_icon = "mdi:wrench-alert"
+    _attr_entity_category = EntityCategory.DIAGNOSTIC
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_maintenance_warning"
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return whether any known maintenance item is nearing replacement."""
+        status = self.coordinator.maintenance_status
+        if not isinstance(status, dict):
+            return None
+        value = status.get("warning")
         return value if isinstance(value, bool) else None
 
     @property

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -44,18 +44,18 @@ from .debug_ota_catalog import (
     normalize_debug_ota_catalog_payload,
 )
 from .exceptions import DeviceException, InvalidActionException
-from .map_probe import (
-    MAP_HISTORY_PROPERTY_KEYS,
-    MAP_PROBE_PROPERTY_KEYS,
-    build_cloud_property_summary,
-    build_map_probe_payload,
-)
 from .maintenance import (
     CMS_GET_REQUEST,
     build_cms_set_request,
     maintenance_item_status,
     maintenance_status_from_app_data,
     reset_cms_counter,
+)
+from .map_probe import (
+    MAP_HISTORY_PROPERTY_KEYS,
+    MAP_PROBE_PROPERTY_KEYS,
+    build_cloud_property_summary,
+    build_map_probe_payload,
 )
 from .models import (
     SUPPORTED_ACCOUNT_TYPES,
@@ -4758,18 +4758,27 @@ def _weather_protection_summary(config: Mapping[str, Any]) -> dict[str, Any]:
 
 def _weather_protection_active_summary(result: Mapping[str, Any]) -> dict[str, Any]:
     summary: dict[str, Any] = {}
-    end_time = result.get("rain_protect_end_time")
+    end_time = _rain_protect_end_time_timestamp(result.get("rain_protect_end_time"))
     end_time_present = bool(result.get("rain_protect_end_time_present"))
 
-    if end_time_present:
+    if end_time is not None:
         summary["rain_protection_active"] = True
         end_time_iso = _epoch_to_iso(end_time)
         if end_time_iso is not None:
             summary["rain_protect_end_time_iso"] = end_time_iso
-    elif result.get("available"):
+    elif end_time_present or result.get("available"):
         summary["rain_protection_active"] = False
 
     return summary
+
+
+def _rain_protect_end_time_timestamp(value: Any) -> int | None:
+    """Return a future rain-protection end timestamp, ignoring empty sentinels."""
+    parsed = _positive_int(value)
+    if parsed is None or parsed <= 0:
+        return None
+    timestamp = parsed / 1000 if parsed > 10_000_000_000 else parsed
+    return parsed if timestamp > datetime.now(UTC).timestamp() else None
 
 
 def _voice_settings_summary(config: Mapping[str, Any]) -> dict[str, Any]:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance.py
@@ -7,6 +7,7 @@ from dataclasses import dataclass
 from typing import Any
 
 CMS_GET_REQUEST: dict[str, str] = {"m": "g", "t": "CMS"}
+MAINTENANCE_WARNING_PERCENT = 20.0
 
 
 @dataclass(frozen=True, slots=True)
@@ -19,6 +20,7 @@ class MaintenanceItem:
     total_minutes: int
     icon: str
     aliases: tuple[str, ...] = ()
+    warning_percent: float = MAINTENANCE_WARNING_PERCENT
 
     @property
     def total_hours(self) -> float:
@@ -70,7 +72,9 @@ def normalize_maintenance_item(value: str | MaintenanceItem) -> MaintenanceItem:
         return _MAINTENANCE_ITEM_ALIASES[key]
     except KeyError as err:
         allowed = ", ".join(item.key for item in MAINTENANCE_ITEMS)
-        raise ValueError(f"Unknown maintenance item {value!r}; expected {allowed}.") from err
+        raise ValueError(
+            f"Unknown maintenance item {value!r}; expected {allowed}."
+        ) from err
 
 
 def build_cms_set_request(values: Sequence[Any]) -> dict[str, Any]:
@@ -138,6 +142,7 @@ def maintenance_status_from_cms(
         if item.index < len(counters)
     ]
     due_items = [item["key"] for item in items if item.get("due")]
+    warning_items = [item["key"] for item in items if item.get("warning")]
     return {
         "source": source,
         "available": bool(items),
@@ -146,6 +151,8 @@ def maintenance_status_from_cms(
         "extra_values": counters[len(MAINTENANCE_ITEMS) :],
         "due": bool(due_items),
         "due_items": due_items,
+        "warning": bool(warning_items),
+        "warning_items": warning_items,
     }
 
 
@@ -177,6 +184,8 @@ def maintenance_status_attributes(status: Mapping[str, Any] | None) -> dict[str,
         "extra_values": status.get("extra_values"),
         "due": status.get("due"),
         "due_items": status.get("due_items"),
+        "warning": status.get("warning"),
+        "warning_items": status.get("warning_items"),
     }
     return {key: value for key, value in attributes.items() if value is not None}
 
@@ -191,6 +200,9 @@ def _maintenance_item_status(
         0.0,
         round((remaining_minutes / item.total_minutes) * 100, 1),
     )
+    due = used_minutes >= item.total_minutes
+    warning = due or remaining_percent <= item.warning_percent
+    status = "due" if due else "replace_soon" if warning else "normal"
     return {
         "key": item.key,
         "name": item.name,
@@ -202,7 +214,10 @@ def _maintenance_item_status(
         "total_minutes": item.total_minutes,
         "total_hours": item.total_hours,
         "remaining_percent": remaining_percent,
-        "due": used_minutes >= item.total_minutes,
+        "warning_percent": item.warning_percent,
+        "status": status,
+        "warning": warning,
+        "due": due,
     }
 
 

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -412,6 +412,9 @@ class DreameLawnMowerMaintenanceRemainingSensor(
                     "remaining_hours": item.get("remaining_hours"),
                     "total_minutes": item.get("total_minutes"),
                     "total_hours": item.get("total_hours"),
+                    "status": item.get("status"),
+                    "warning": item.get("warning"),
+                    "warning_percent": item.get("warning_percent"),
                     "due": item.get("due"),
                 }
             )

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -12,6 +12,7 @@ from custom_components.dreame_lawn_mower.binary_sensor import (
     DreameLawnMowerBluetoothConnectedBinarySensor,
     DreameLawnMowerCurrentAppMapLivePathBinarySensor,
     DreameLawnMowerMaintenanceDueBinarySensor,
+    DreameLawnMowerMaintenanceWarningBinarySensor,
     DreameLawnMowerRainDelayActiveBinarySensor,
     DreameLawnMowerRainProtectionEnabledBinarySensor,
 )
@@ -375,6 +376,8 @@ def test_maintenance_remaining_sensor_uses_cached_cms_status() -> None:
     assert entity.native_value == 18.4
     assert entity.extra_state_attributes["item"] == "blade"
     assert entity.extra_state_attributes["remaining_hours"] == 18.4
+    assert entity.extra_state_attributes["status"] == "replace_soon"
+    assert entity.extra_state_attributes["warning"] is True
 
 
 def test_maintenance_remaining_sensor_unavailable_without_cms_status() -> None:
@@ -402,6 +405,36 @@ def test_maintenance_due_binary_sensor_uses_cached_status() -> None:
     assert entity.available is True
     assert entity.is_on is True
     assert entity.extra_state_attributes["due_items"] == ["robot"]
+
+
+def test_maintenance_warning_binary_sensor_uses_cached_status() -> None:
+    entity = object.__new__(DreameLawnMowerMaintenanceWarningBinarySensor)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(raw_attributes={}),
+        maintenance_status=maintenance_status_from_cms(
+            [4896, 16752, 6849, -1],
+            source="test",
+        ),
+    )
+
+    assert entity.available is True
+    assert entity.is_on is True
+    assert entity.extra_state_attributes["warning_items"] == ["blade", "robot"]
+
+
+def test_maintenance_warning_binary_sensor_clears_for_fresh_counters() -> None:
+    entity = object.__new__(DreameLawnMowerMaintenanceWarningBinarySensor)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(raw_attributes={}),
+        maintenance_status=maintenance_status_from_cms(
+            [0, 0, 0, -1],
+            source="test",
+        ),
+    )
+
+    assert entity.available is True
+    assert entity.is_on is False
+    assert entity.extra_state_attributes["warning_items"] == []
 
 
 def test_last_maintenance_reset_sensor_summarizes_result() -> None:

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -13,6 +13,7 @@ from custom_components.dreame_lawn_mower.binary_sensor import (
     DreameLawnMowerBluetoothConnectedBinarySensor,
     DreameLawnMowerFirmwareUpdateAvailableBinarySensor,
     DreameLawnMowerMaintenanceDueBinarySensor,
+    DreameLawnMowerMaintenanceWarningBinarySensor,
     DreameLawnMowerRainDelayActiveBinarySensor,
     DreameLawnMowerRainProtectionEnabledBinarySensor,
 )
@@ -247,6 +248,15 @@ def test_rain_delay_active_binary_sensor_is_diagnostic() -> None:
 def test_maintenance_due_binary_sensor_is_diagnostic() -> None:
     assert (
         DreameLawnMowerMaintenanceDueBinarySensor.__dict__["__attr_entity_category"]
+        == "diagnostic"
+    )
+
+
+def test_maintenance_warning_binary_sensor_is_diagnostic() -> None:
+    assert (
+        DreameLawnMowerMaintenanceWarningBinarySensor.__dict__[
+            "__attr_entity_category"
+        ]
         == "diagnostic"
     )
 

--- a/tests/test_maintenance.py
+++ b/tests/test_maintenance.py
@@ -82,11 +82,36 @@ def test_maintenance_status_decodes_known_cms_counters() -> None:
     assert status["raw_cms"] == [4896, 16752, 6849, -1]
     assert status["extra_values"] == [-1]
     assert status["due_items"] == ["robot"]
+    assert status["warning_items"] == ["blade", "robot"]
+    assert status["warning"] is True
     assert blade["remaining_percent"] == 18.4
     assert blade["used_hours"] == 81.6
+    assert blade["status"] == "replace_soon"
+    assert blade["warning"] is True
     assert brush["remaining_hours"] == 220.8
+    assert brush["status"] == "normal"
+    assert brush["warning"] is False
     assert robot["due"] is True
+    assert robot["status"] == "due"
+    assert robot["warning"] is True
     assert robot["remaining_percent"] == 0.0
+
+
+def test_maintenance_status_marks_fresh_counters_good() -> None:
+    status = maintenance_status_from_cms(
+        [0, 0, 0, -1],
+        source="test",
+    )
+
+    assert status["due"] is False
+    assert status["due_items"] == []
+    assert status["warning"] is False
+    assert status["warning_items"] == []
+    assert [item["status"] for item in status["items"]] == [
+        "normal",
+        "normal",
+        "normal",
+    ]
 
 
 def test_maintenance_status_accepts_direct_cms_and_cfg_payloads() -> None:

--- a/tests/test_weather_protection.py
+++ b/tests/test_weather_protection.py
@@ -9,9 +9,15 @@ from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 class _FakeWeatherCloud:
     logged_in = True
 
-    def __init__(self, *, rpet_error: bool = False) -> None:
+    def __init__(
+        self,
+        *,
+        rpet_error: bool = False,
+        rain_protect_end_time: int = 4102444800,
+    ) -> None:
         self.calls: list[dict[str, object]] = []
         self.rpet_error = rpet_error
+        self.rain_protect_end_time = rain_protect_end_time
 
     def call_app_action(
         self,
@@ -33,7 +39,7 @@ class _FakeWeatherCloud:
                         "d": {
                             "WRF": True,
                             "WRP": [1, 8],
-                            "rainProtectEndTime": 1776600000,
+                            "rainProtectEndTime": self.rain_protect_end_time,
                         },
                     }
                 ]
@@ -41,7 +47,15 @@ class _FakeWeatherCloud:
         if command == "RPET":
             if self.rpet_error:
                 raise RuntimeError("not protecting")
-            return {"out": [{"m": "r", "r": 0, "d": {"endTime": 1776600300}}]}
+            return {
+                "out": [
+                    {
+                        "m": "r",
+                        "r": 0,
+                        "d": {"endTime": self.rain_protect_end_time},
+                    }
+                ]
+            }
         raise AssertionError(f"Unexpected app command: {payload}")
 
 
@@ -78,8 +92,8 @@ def test_get_weather_protection_uses_read_only_app_actions() -> None:
     assert result["rain_protection_duration_hours"] == 8
     assert result["rain_sensor_sensitivity"] == 0
     assert result["rain_protection_raw"] == [1, 8, 0]
-    assert result["rain_protect_end_time"] == 1776600300
-    assert result["rain_protect_end_time_iso"] == "2026-04-19T12:05:00+00:00"
+    assert result["rain_protect_end_time"] == 4102444800
+    assert result["rain_protect_end_time_iso"] == "2100-01-01T00:00:00+00:00"
     assert result["rain_protection_active"] is True
     assert result["errors"] == []
     assert result["warnings"] == []
@@ -101,3 +115,20 @@ def test_get_weather_protection_keeps_config_when_rpet_is_unavailable() -> None:
     assert result["warnings"] == [
         {"stage": "rain_end_time", "warning": "not protecting"}
     ]
+
+
+def test_get_weather_protection_treats_zero_rain_end_time_as_inactive() -> None:
+    client = _client()
+    cloud = _FakeWeatherCloud(rain_protect_end_time=0)
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    result = client._sync_get_weather_protection()
+
+    assert result["available"] is True
+    assert result["rain_protection_enabled"] is True
+    assert result["rain_protect_end_time"] == 0
+    assert result["rain_protect_end_time_present"] is True
+    assert "rain_protect_end_time_iso" not in result
+    assert result["rain_protection_active"] is False
+    assert result["errors"] == []
+    assert result["warnings"] == []


### PR DESCRIPTION
## Summary
- add per-counter maintenance status and warning attributes for blade, cleaning brush, and robot maintenance
- add a Maintenance Warning binary sensor so Home Assistant automations can notify before a counter reaches due
- treat rain-protection end times of `0` or past timestamps as inactive, fixing the stuck Rain Delay Active symptom from issue #14

## Issue #14 coverage
- blades, cleaning brush, and robot maintenance now expose remaining %, hours, status, due, and warning details
- Maintenance Due remains the hard-stop binary sensor and Maintenance Warning adds the proactive pre-due signal
- reset buttons/services are already present from the previous maintenance PRs
- link-module lifetime/date is not added here because live read-only CFG/cloud payloads did not expose a stable link-module lifetime field

## Live read-only evidence
- robot: Dreame A2 Bodzio / A2 / `dreame.mower.g2408`
- CMS after reset: `[0, 0, 0, -1]`; all maintenance statuses report `normal`, warning=false, due=false
- weather payload: rain protection enabled, `rain_protect_end_time=0`, `rain_protection_active=false`

## Validation
- `python -m ruff check custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance.py custom_components/dreame_lawn_mower/binary_sensor.py custom_components/dreame_lawn_mower/sensor.py tests/test_weather_protection.py tests/test_maintenance.py tests/test_dynamic_entity_availability.py tests/test_ha_compatibility.py`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --ignore=tests/components/dreame_lawn_mower` (458 passed)