### PR TITLE
Release 0.1.9

### DIFF
--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -19,5 +19,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.1.8"
+  "version": "0.1.9"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.1.8"
+version = "0.1.9"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- bump integration/package version to `0.1.9`
- prepares release containing the merged maintenance counter, reset, warning, returning-state, and rain-delay follow-ups

## Release highlights
- expose blade, cleaning brush, and robot maintenance remaining sensors
- expose Maintenance Due and Maintenance Warning binary sensors for Home Assistant automations
- add guarded maintenance reset buttons/services
- map returning mower state to Home Assistant `RETURNING`
- treat `rain_protect_end_time=0` as inactive rain delay

## Validation
- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest --ignore=tests/components/dreame_lawn_mower/test_config_flow.py` (458 passed)