### PR TITLE
Fix selected zone preferences for app map cards

### DIFF
--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -145,9 +146,9 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh Bluetooth connection state: %s", err)
             self.bluetooth_connected = None
+        await self.async_refresh_app_maps(force=False)
         await self.async_refresh_batch_device_data(force=False)
         await self.async_refresh_firmware_update_support(force=False)
-        await self.async_refresh_app_maps(force=False)
         await self.async_refresh_app_map_objects(force=False)
         await self.async_refresh_vector_map_details(force=False)
         await self.async_refresh_weather_protection(force=False)
@@ -199,7 +200,10 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         """Fetch batch schedule, settings, and OTA payloads in parallel."""
         return await asyncio.gather(
             self.client.async_get_batch_schedules(include_raw=False),
-            self.client.async_get_batch_mowing_preferences(include_raw=False),
+            self.client.async_get_batch_mowing_preferences(
+                include_raw=False,
+                map_index_hints=_app_map_index_hints(self.app_maps),
+            ),
             self.client.async_get_batch_ota_info(include_raw=False),
         )
 
@@ -429,3 +433,22 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""
         await self.client.async_close()
+
+
+def _app_map_index_hints(app_maps: Mapping[str, Any] | None) -> list[int]:
+    """Return known app map ids in display order for batch settings alignment."""
+    maps = app_maps.get("maps") if isinstance(app_maps, Mapping) else None
+    if not isinstance(maps, Sequence) or isinstance(maps, str | bytes | bytearray):
+        return []
+
+    indices: list[int] = []
+    for entry in maps:
+        if not isinstance(entry, Mapping):
+            continue
+        if entry.get("created") is False:
+            continue
+        index = entry.get("idx")
+        if not isinstance(index, int) or index < 0 or index in indices:
+            continue
+        indices.append(index)
+    return indices

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
@@ -89,6 +89,7 @@ def decode_batch_mowing_preferences(
     *,
     include_raw: bool = False,
     map_indices: Sequence[int] | None = None,
+    map_index_hints: Sequence[int] | None = None,
 ) -> dict[str, Any]:
     """Decode `SETTINGS.*` batch device data into readable preference summaries."""
     result: dict[str, Any] = {
@@ -125,7 +126,13 @@ def decode_batch_mowing_preferences(
         if map_indices is not None
         else None
     )
-    for map_index, map_entry in enumerate(payload):
+    index_hints = _map_index_hints(map_index_hints)
+    for payload_index, map_entry in enumerate(payload):
+        map_index = _batch_preference_map_index(
+            map_entry,
+            payload_index=payload_index,
+            map_index_hints=index_hints,
+        )
         if selected_indices is not None and map_index not in selected_indices:
             continue
         entry = _decode_batch_preference_map_entry(
@@ -138,6 +145,35 @@ def decode_batch_mowing_preferences(
         result["maps"].append(entry)
 
     return result
+
+
+def _map_index_hints(values: Sequence[int] | None) -> list[int]:
+    if values is None:
+        return []
+    hints: list[int] = []
+    for value in values:
+        index = _to_int(value)
+        if index is None or index < 0 or index in hints:
+            continue
+        hints.append(index)
+    return hints
+
+
+def _batch_preference_map_index(
+    value: Any,
+    *,
+    payload_index: int,
+    map_index_hints: Sequence[int],
+) -> int:
+    if isinstance(value, Mapping):
+        for key in ("idx", "index", "map_index", "mapIndex", "map_id", "mapId", "id"):
+            index = _to_int(value.get(key))
+            if index is not None and index >= 0:
+                return index
+
+    if payload_index < len(map_index_hints):
+        return int(map_index_hints[payload_index])
+    return payload_index
 
 
 def decode_batch_ota_info(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -834,12 +834,14 @@ class DreameLawnMowerClient:
         *,
         include_raw: bool = False,
         map_indices: Sequence[int] | None = None,
+        map_index_hints: Sequence[int] | None = None,
     ) -> dict[str, Any]:
         """Fetch and decode mower preferences from batch device data."""
         return await asyncio.to_thread(
             self._sync_get_batch_mowing_preferences,
             include_raw,
             map_indices,
+            map_index_hints,
         )
 
     async def async_get_batch_ota_info(
@@ -2843,6 +2845,7 @@ class DreameLawnMowerClient:
         self,
         include_raw: bool = False,
         map_indices: Sequence[int] | None = None,
+        map_index_hints: Sequence[int] | None = None,
     ) -> dict[str, Any]:
         """Fetch and decode mower preferences from batch device data."""
         batch_data = self._sync_get_batch_device_data(_batch_settings_keys())
@@ -2863,6 +2866,7 @@ class DreameLawnMowerClient:
             batch_data,
             include_raw=include_raw,
             map_indices=map_indices,
+            map_index_hints=map_index_hints,
         )
 
     def _sync_get_batch_ota_info(

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -189,6 +189,40 @@ def test_decode_batch_mowing_preferences_decodes_map_settings() -> None:
     assert result["maps"][1]["preferences"][0]["mowing_height_cm"] == 3.5
 
 
+def test_decode_batch_mowing_preferences_aligns_with_app_map_index_hints() -> None:
+    settings_text = _settings_text()
+
+    result = decode_batch_mowing_preferences(
+        {
+            "SETTINGS.0": settings_text[:150],
+            "SETTINGS.1": settings_text[150:300],
+            "SETTINGS.2": settings_text[300:],
+            "SETTINGS.info": str(len(settings_text)),
+        },
+        map_index_hints=[1, 2],
+    )
+
+    assert [entry["idx"] for entry in result["maps"]] == [1, 2]
+    assert result["maps"][0]["preferences"][0]["map_index"] == 1
+    assert result["maps"][0]["preferences"][0]["mowing_height_cm"] == 4.0
+    assert result["maps"][1]["preferences"][0]["map_index"] == 2
+    assert result["maps"][1]["preferences"][0]["mowing_height_cm"] == 3.5
+
+    filtered = decode_batch_mowing_preferences(
+        {
+            "SETTINGS.0": settings_text[:150],
+            "SETTINGS.1": settings_text[150:300],
+            "SETTINGS.2": settings_text[300:],
+            "SETTINGS.info": str(len(settings_text)),
+        },
+        map_indices=[1],
+        map_index_hints=[1, 2],
+    )
+
+    assert [entry["idx"] for entry in filtered["maps"]] == [1]
+    assert filtered["maps"][0]["preferences"][0]["mowing_height_cm"] == 4.0
+
+
 def test_decode_batch_ota_info_decodes_flags() -> None:
     result = decode_batch_ota_info(
         {

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 
 from custom_components.dreame_lawn_mower import button as button_module
@@ -18,6 +19,10 @@ from custom_components.dreame_lawn_mower.binary_sensor import (
 )
 from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerResetMaintenanceButton,
+)
+from custom_components.dreame_lawn_mower.coordinator import _app_map_index_hints
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    decode_batch_mowing_preferences,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.maintenance import (
     MAINTENANCE_ITEM_BY_KEY,
@@ -2039,6 +2044,89 @@ def test_selected_zone_preference_sensors_expose_read_only_zone_settings() -> No
         "obstacle_avoidance_distance_cm": 15.0,
         "obstacle_avoidance_ai_classes": ["people", "animals", "objects"],
     }
+
+
+def test_selected_zone_preferences_follow_hinted_app_map_cards() -> None:
+    settings_text = json.dumps(
+        [
+            {
+                "mode": 0,
+                "settings": {
+                    "3": {
+                        "id": 3,
+                        "version": 17,
+                        "efficientMode": 1,
+                        "mowingHeight": 4.0,
+                    },
+                },
+            },
+            {
+                "mode": 0,
+                "settings": {
+                    "3": {
+                        "id": 3,
+                        "version": 18,
+                        "efficientMode": 0,
+                        "mowingHeight": 6.0,
+                    },
+                },
+            },
+        ],
+        separators=(",", ":"),
+    )
+    app_maps = {
+        "current_map_index": 1,
+        "maps": [
+            {"idx": 0, "created": False, "current": False},
+            {
+                "idx": 1,
+                "created": True,
+                "current": True,
+                "summary": {"name": "Front"},
+            },
+            {
+                "idx": 2,
+                "created": True,
+                "current": False,
+                "summary": {"name": "Back"},
+            },
+        ],
+    }
+    batch_preferences = decode_batch_mowing_preferences(
+        {
+            "SETTINGS.0": settings_text,
+            "SETTINGS.info": str(len(settings_text)),
+        },
+        map_index_hints=_app_map_index_hints(app_maps),
+    )
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(activity="paused"),
+        selected_map_index=1,
+        selected_zone_id=3,
+        app_maps=app_maps,
+        batch_device_data={"batch_mowing_preferences": batch_preferences},
+    )
+
+    height_entity = object.__new__(DreameLawnMowerSelectedZoneMowingHeightSensor)
+    height_entity.coordinator = coordinator
+    efficiency_entity = object.__new__(DreameLawnMowerSelectedZoneEfficiencyModeSensor)
+    efficiency_entity.coordinator = coordinator
+
+    assert height_entity.available is True
+    assert height_entity.native_value == 4.0
+    assert efficiency_entity.available is True
+    assert efficiency_entity.native_value == "efficient"
+    assert height_entity.extra_state_attributes["selected_map_index"] == 1
+    assert height_entity.extra_state_attributes["reported_version"] == 17
+
+    coordinator.selected_map_index = 2
+
+    assert height_entity.available is True
+    assert height_entity.native_value == 6.0
+    assert efficiency_entity.available is True
+    assert efficiency_entity.native_value == "standard"
+    assert height_entity.extra_state_attributes["selected_map_index"] == 2
+    assert height_entity.extra_state_attributes["reported_version"] == 18
 
 
 def test_selected_zone_preference_sensors_hide_unavailable_zone_settings() -> None:


### PR DESCRIPTION
## Summary
- Align decoded batch mowing preferences with the app map/card ids reported by MAPL.
- Refresh app-map metadata before batch settings so selected-zone preference sensors read the correct card.
- Add regression coverage proving both mowing height and efficiency mode switch with the selected app-map card.

Fixes #20

## Affected selected-zone fields
This fixes the shared selected-zone preference source, not only cutting height. The same card alignment is used for height, efficiency mode, direction mode, obstacle avoidance, obstacle distance, obstacle height, and obstacle classes.

## Validation
- `python -m ruff check custom_components/dreame_lawn_mower/coordinator.py custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py tests/test_batch_device_data.py tests/test_dynamic_entity_availability.py`
- `$env:PYTEST_DISABLE_PLUGIN_AUTOLOAD='1'; python -m pytest tests/test_current_map_controls.py tests/test_batch_device_data.py tests/test_dynamic_entity_availability.py -q`

Note: a full Windows run with plugin autoload disabled reaches the config-flow tests, but those need the Home Assistant custom-component plugin fixture; with plugin autoload enabled, the local Windows environment fails earlier on Home Assistant's `fcntl` import.