### PR TITLE
Release 0.1.10

### DIFF
--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -19,5 +19,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.1.9"
+  "version": "0.1.10"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.1.9"
+version = "0.1.10"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary
- bump the package and Home Assistant integration manifest version to 0.1.10

## Release notes
- selected-zone preference sensors now follow the selected app map card instead of reading another card's batch SETTINGS values
- selected-zone height, efficiency mode, direction, and obstacle preferences now align with the selected card on models whose first real app map is not slot 0
- uncreated app-map slots are ignored when matching batch preference payloads to app map cards