### PR TITLE
Improve mower session, docking, and map reliability

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,10 +61,13 @@ region/account details are especially helpful for moving a device from
 - UI config flow with Dreamehome or MOVAhome account login
 - automatic mower discovery from the cloud account
 - `lawn_mower` entity for start, pause, and dock
+- button to dock without ending the current mowing session
+- heartbeat-backed task status and automatic resume of a paused mowing session
 - battery, activity, state, task, firmware, and error sensors
 - current-map selector entities for map, mowing action, edge, zone, and spot scope
 - current-map services for switching maps and starting explicit zone, spot, or edge runs
 - binary sensors for docked, charging, mowing, paused, returning, and error state
+- binary sensors for active and resumable mowing sessions
 - binary sensor for Bluetooth-connected runtime state
 - read-only schedule calendar using the mower-native app schedule protocol
 - disabled-by-default all-schedules calendar for default and per-map schedule diagnosis
@@ -80,6 +83,8 @@ region/account details are especially helpful for moving a device from
 - read-only mowing-preference diagnostics
 - supervised remote-control service for short validation pulses
 - sanitized diagnostics and debug snapshot helpers
+- cloud presence checks that make entities unavailable instead of showing stale
+  mower values while the device is offline
 
 ## Not Yet Public-Ready Features
 
@@ -197,6 +202,8 @@ Common user-facing helpers include:
 - `binary_sensor.<device>_charging`
 - `binary_sensor.<device>_bluetooth_connected`
 - `binary_sensor.<device>_mowing`
+- `binary_sensor.<device>_task_active`
+- `binary_sensor.<device>_task_resumable`
 - `binary_sensor.<device>_rain_delay_active`
 - `binary_sensor.<device>_returning`
 - `calendar.<device>_schedule`
@@ -236,6 +243,10 @@ disabled-by-default `Last Preference Write` diagnostic sensor. It sends a live
 preference write only when both `execute: true` and
 `confirm_preference_write: true` are provided.
 
+The guarded preference fields include per-zone safe edge mowing through
+`edge_mowing_safe`. Use the dry-run result to inspect the candidate payload
+before confirming a live write.
+
 ## Maps
 
 The map camera uses the confirmed app-map JSON path first. The renderer is
@@ -254,6 +265,8 @@ Current map support now includes:
 - services for switching the active mower map and starting explicit zone, spot,
   or edge jobs
 - runtime live-track telemetry surfaced through sensors and map-camera attributes
+- circular and rotated rectangular forbidden areas rendered from their compact
+  mower map representation
 
 Interactive map editing is still intentionally out of scope for now:
 

--- a/custom_components/dreame_lawn_mower/binary_sensor.py
+++ b/custom_components/dreame_lawn_mower/binary_sensor.py
@@ -170,8 +170,20 @@ BINARY_SENSORS = [
     DreameBinarySensorDescription(
         key="task_active",
         name="Task Active",
-        value_fn=lambda snapshot: snapshot.started,
+        value_fn=lambda snapshot: (
+            getattr(snapshot, "mowing_session_active", None)
+            if getattr(snapshot, "mowing_session_active", None) is not None
+            else snapshot.started
+        ),
         icon="mdi:play-circle-outline",
+    ),
+    DreameBinarySensorDescription(
+        key="task_resumable",
+        name="Task Resumable",
+        value_fn=lambda snapshot: getattr(snapshot, "task_resumable", None),
+        exists_fn=lambda snapshot: getattr(snapshot, "task_resumable", None)
+        is not None,
+        icon="mdi:play-pause",
     ),
     DreameBinarySensorDescription(
         key="raw_started",

--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -33,6 +33,7 @@ async def async_setup_entry(
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
         [
+            DreameLawnMowerDockWithoutStoppingButton(coordinator),
             DreameLawnMowerCaptureDebugSnapshotButton(coordinator),
             DreameLawnMowerCaptureOperationSnapshotButton(coordinator),
             DreameLawnMowerCaptureMapProbeButton(coordinator),
@@ -47,6 +48,27 @@ async def async_setup_entry(
             for item in MAINTENANCE_ITEMS
         ]
     )
+
+
+class DreameLawnMowerDockWithoutStoppingButton(
+    DreameLawnMowerEntity,
+    ButtonEntity,
+):
+    """Return the mower to base without ending its current session."""
+
+    _attr_name = "Dock Without Ending Session"
+    _attr_icon = "mdi:home-battery"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{self._descriptor.unique_id}_dock_without_stopping"
+        )
+
+    async def async_press(self) -> None:
+        """Dock directly so the current task remains available to resume."""
+        await self.coordinator.client.async_dock_without_stopping()
+        await self.coordinator.async_request_refresh()
 
 
 class DreameLawnMowerCaptureDebugSnapshotButton(

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -63,6 +63,7 @@ class DreameLawnMowerMapCamera(
     _attr_icon = "mdi:map-search-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
     _attr_entity_registry_enabled_default = False
+    _requires_map_capability = True
 
     def __init__(
         self,
@@ -84,6 +85,7 @@ class DreameLawnMowerMapCamera(
         return map_camera_available(
             self.coordinator.data,
             image_cached=self._map_cache.last_image is not None,
+            requires_map_capability=self._requires_map_capability,
         )
 
     @property
@@ -223,6 +225,7 @@ class DreameLawnMowerMapDataCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "Map Diagnostics"
     _attr_icon = "mdi:code-json"
+    _requires_map_capability = False
 
     def __init__(
         self,
@@ -304,6 +307,7 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "All Maps"
     _attr_icon = "mdi:map-multiple-outline"
+    _requires_map_capability = False
 
     def __init__(
         self,

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -120,6 +120,10 @@ class DreameLawnMowerMapCamera(
         del width, height
         if not self.available:
             return None
+        return await self._async_camera_image_impl()
+
+    async def _async_camera_image_impl(self) -> bytes | None:
+        """Build the camera image after shared availability gating."""
         return await self._async_get_map_image()
 
     async def _async_get_map_image(self) -> bytes | None:
@@ -237,13 +241,8 @@ class DreameLawnMowerMapDataCamera(DreameLawnMowerMapCamera):
             attributes["map_view"] = self._map_cache.last_view.as_dict()
         return attributes
 
-    async def async_camera_image(
-        self,
-        width: int | None = None,
-        height: int | None = None,
-    ) -> bytes | None:
+    async def _async_camera_image_impl(self) -> bytes | None:
         """Return a readable diagnostics card as JPEG bytes."""
-        del width, height
         view = await self._async_refresh_map_view()
         summary = view.summary
         lines = [
@@ -315,13 +314,8 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
         self._attr_unique_id = f"{self._descriptor.unique_id}_all_maps"
         self.content_type = "image/jpeg"
 
-    async def async_camera_image(
-        self,
-        width: int | None = None,
-        height: int | None = None,
-    ) -> bytes | None:
+    async def _async_camera_image_impl(self) -> bytes | None:
         """Return a JPEG contact sheet for every drawable app map."""
-        del width, height
         try:
             app_maps = await self.coordinator.client.async_get_app_maps(
                 include_payload=True,

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -25,7 +25,7 @@ from .image import (
     png_bytes_to_jpeg,
 )
 from .map_attributes import map_camera_attributes
-from .map_cache import DreameLawnMowerMapCameraCache
+from .map_cache import DreameLawnMowerMapCameraCache, map_camera_available
 
 _LOGGER = logging.getLogger(__name__)
 _MAP_CACHE_TTL = timedelta(seconds=60)
@@ -81,13 +81,9 @@ class DreameLawnMowerMapCamera(
     @property
     def available(self) -> bool:
         """Return whether the entity can reasonably provide a map."""
-        snapshot = self.coordinator.data
-        if snapshot is None:
-            return False
-        return (
-            self._map_cache.last_image is not None
-            or snapshot.mapping_available
-            or "map" in snapshot.capabilities
+        return map_camera_available(
+            self.coordinator.data,
+            image_cached=self._map_cache.last_image is not None,
         )
 
     @property
@@ -122,6 +118,8 @@ class DreameLawnMowerMapCamera(
     ) -> bytes | None:
         """Return the latest mower map image as JPEG bytes."""
         del width, height
+        if not self.available:
+            return None
         return await self._async_get_map_image()
 
     async def _async_get_map_image(self) -> bytes | None:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -133,6 +133,8 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         except DreameLawnMowerConnectionError as err:
             raise UpdateFailed(str(err)) from err
         if not snapshot.available:
+            self.runtime_status_blob = None
+            self.client.update_runtime_live_tracking(None, active=False)
             return snapshot
         try:
             self.runtime_status_blob = await self.client.async_get_runtime_status_blob(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -50,6 +50,14 @@ VOICE_SETTINGS_REFRESH_INTERVAL = timedelta(minutes=5)
 FIRMWARE_UPDATE_REFRESH_INTERVAL = timedelta(minutes=15)
 
 
+def _runtime_tracking_active(snapshot: DreameLawnMowerSnapshot) -> bool:
+    """Prefer explicit heartbeat session state over legacy activity state."""
+    session_active = getattr(snapshot, "mowing_session_active", None)
+    if session_active is not None:
+        return bool(session_active)
+    return getattr(snapshot, "activity", None) in {"mowing", "paused", "returning"}
+
+
 class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot]):
     """Manage mower state updates for a single config entry."""
 
@@ -134,9 +142,7 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
             )
             self.client.update_runtime_live_tracking(
                 self.runtime_status_blob,
-                active=bool(getattr(snapshot, "mowing_session_active", False))
-                or getattr(snapshot, "activity", None)
-                in {"mowing", "paused", "returning"},
+                active=_runtime_tracking_active(snapshot),
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh runtime status blob: %s", err)

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -133,8 +133,7 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         except DreameLawnMowerConnectionError as err:
             raise UpdateFailed(str(err)) from err
         if not snapshot.available:
-            self.data = None
-            raise UpdateFailed("Mower is offline; cached state was discarded.")
+            return snapshot
         try:
             self.runtime_status_blob = await self.client.async_get_runtime_status_blob(
                 refresh=False,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -124,6 +124,9 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
             snapshot = await self.client.async_refresh()
         except DreameLawnMowerConnectionError as err:
             raise UpdateFailed(str(err)) from err
+        if not snapshot.available:
+            self.data = None
+            raise UpdateFailed("Mower is offline; cached state was discarded.")
         try:
             self.runtime_status_blob = await self.client.async_get_runtime_status_blob(
                 refresh=False,
@@ -131,7 +134,8 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
             )
             self.client.update_runtime_live_tracking(
                 self.runtime_status_blob,
-                active=getattr(snapshot, "activity", None)
+                active=bool(getattr(snapshot, "mowing_session_active", False))
+                or getattr(snapshot, "activity", None)
                 in {"mowing", "paused", "returning"},
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -207,8 +207,8 @@ def decode_mower_status_blob(
     """Return a conservative structure for app realtime/status byte blobs.
 
     The Dreamehome app exposes this as a framed byte array. We preserve indexed
-    bytes for cross-device comparison, but intentionally avoid assigning
-    semantics until we can prove them from multiple mower states/models.
+    bytes for cross-device comparison and decode only the battery, charging,
+    and task-state fields confirmed by fixtures and supervised transitions.
     """
     raw = _normalize_byte_array(value)
     if raw is None:
@@ -225,8 +225,16 @@ def decode_mower_status_blob(
         notes.append("invalid_frame_markers")
 
     candidate_battery_level = None
-    if frame_valid and len(raw) > 11 and raw[11] <= 100:
-        candidate_battery_level = raw[11]
+    heartbeat_charging = None
+    if frame_valid and len(raw) > 11:
+        raw_battery = raw[11]
+        heartbeat_charging = raw_battery >= 128
+        normalized_battery = raw_battery - 128 if heartbeat_charging else raw_battery
+        if normalized_battery <= 100:
+            candidate_battery_level = normalized_battery
+
+    task_state = _decode_heartbeat_task_state(raw, frame_valid=frame_valid)
+    notes.extend(task_state.pop("notes", ()))
 
     runtime_telemetry = _decode_runtime_blob_candidates(raw, frame_valid=frame_valid)
     notes.extend(runtime_telemetry.pop("notes", ()))
@@ -243,6 +251,12 @@ def decode_mower_status_blob(
         payload=raw[1:-1] if len(raw) >= 2 else (),
         bytes_by_index={str(index): item for index, item in enumerate(raw)},
         candidate_battery_level=candidate_battery_level,
+        heartbeat_charging=heartbeat_charging,
+        main_state=task_state.get("main_state"),
+        sub_state=task_state.get("sub_state"),
+        task_status=task_state.get("task_status"),
+        mowing_session_active=task_state.get("mowing_session_active"),
+        task_resumable=task_state.get("task_resumable"),
         candidate_runtime_region_id=runtime_telemetry.get("region_id"),
         candidate_runtime_task_id=runtime_telemetry.get("task_id"),
         candidate_runtime_progress_percent=runtime_telemetry.get("progress_percent"),
@@ -259,6 +273,55 @@ def decode_mower_status_blob(
         candidate_runtime_track_segments=runtime_telemetry.get("track_segments", ()),
         notes=tuple(notes),
     )
+
+
+_HEARTBEAT_MOWING_MAIN_STATE = 4
+_HEARTBEAT_TASK_SUBSTATE_BASE = 33
+_HEARTBEAT_TASK_STATUSES = {
+    0: "idle",
+    1: "starting",
+    2: "mowing",
+    3: "paused",
+    4: "finished",
+    5: "failed",
+    6: "exit",
+    7: "returning_to_dock",
+}
+_INACTIVE_HEARTBEAT_TASK_STATUSES = frozenset({"idle", "exit"})
+
+
+def _decode_heartbeat_task_state(
+    raw: Sequence[int],
+    *,
+    frame_valid: bool,
+) -> dict[str, object]:
+    """Decode the active mowing session state from a 20-byte heartbeat."""
+    if not frame_valid or len(raw) != 20:
+        return {}
+
+    main_state = (raw[12] & 0x0F) - 1
+    sub_state = raw[13]
+    if main_state != _HEARTBEAT_MOWING_MAIN_STATE:
+        task_status = "idle"
+    else:
+        task_status = _HEARTBEAT_TASK_STATUSES.get(
+            sub_state - _HEARTBEAT_TASK_SUBSTATE_BASE
+        )
+
+    result: dict[str, object] = {
+        "main_state": main_state,
+        "sub_state": sub_state,
+        "task_status": task_status,
+        "mowing_session_active": (
+            task_status not in _INACTIVE_HEARTBEAT_TASK_STATUSES
+            if task_status is not None
+            else None
+        ),
+        "task_resumable": task_status == "paused" if task_status is not None else None,
+    }
+    if task_status is None:
+        result["notes"] = ("unknown_heartbeat_task_substate",)
+    return result
 
 
 def _decode_runtime_blob_candidates(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -287,7 +287,9 @@ _HEARTBEAT_TASK_STATUSES = {
     6: "exit",
     7: "returning_to_dock",
 }
-_INACTIVE_HEARTBEAT_TASK_STATUSES = frozenset({"idle", "exit"})
+_INACTIVE_HEARTBEAT_TASK_STATUSES = frozenset(
+    {"idle", "finished", "failed", "exit"}
+)
 
 
 def _decode_heartbeat_task_state(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -98,6 +98,7 @@ from .schedule import (
 )
 from .runtime_state import (
     RESUME_MOWING_REQUEST,
+    snapshot_session_control_state,
     snapshot_with_cloud_presence,
     snapshot_with_heartbeat_task_state,
 )
@@ -329,7 +330,7 @@ class DreameLawnMowerClient:
         """Start a new task or resume the heartbeat-confirmed paused task."""
         try:
             status_blob = await self.async_get_status_blob(
-                refresh=False,
+                refresh=True,
                 include_cloud=True,
             )
         except DreameLawnMowerConnectionError:
@@ -345,11 +346,11 @@ class DreameLawnMowerClient:
 
     async def async_dock(self) -> None:
         """End an active mowing session and return the mower to base."""
-        device = await asyncio.to_thread(self._ensure_device)
-        initial_state = _lower_enum_name(getattr(device.status, "state", None))
+        snapshot = await self.async_refresh()
+        initial_state = snapshot_session_control_state(snapshot)
 
         async def async_refresh_state() -> str | None:
-            return (await self.async_refresh()).state
+            return snapshot_session_control_state(await self.async_refresh())
 
         await async_stop_then_dock(
             initial_state=initial_state,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -43,6 +43,7 @@ from .debug_ota_catalog import (
     build_debug_ota_catalog_url,
     normalize_debug_ota_catalog_payload,
 )
+from .docking import async_stop_then_dock
 from .exceptions import DeviceException, InvalidActionException
 from .maintenance import (
     CMS_GET_REQUEST,
@@ -95,12 +96,19 @@ from .schedule import (
     encode_schedule_payload_text,
     schedule_task_summary,
 )
+from .runtime_state import (
+    RESUME_MOWING_REQUEST,
+    snapshot_with_cloud_presence,
+    snapshot_with_heartbeat_task_state,
+)
 from .vector_map import (
     parse_batch_vector_map,
     render_vector_map_png,
     vector_map_to_details,
     vector_map_to_summary,
 )
+
+_CLOUD_PRESENCE_REFRESH_INTERVAL = 60.0
 
 REMOTE_CONTROL_MAX_ROTATION = 1000
 REMOTE_CONTROL_MAX_VELOCITY = 1000
@@ -204,6 +212,8 @@ class DreameLawnMowerClient:
             ...,
         ] = ()
         self._last_runtime_track_blob_hex: str | None = None
+        self._latest_cloud_device_info: Mapping[str, Any] | None = None
+        self._cloud_device_info_refreshed_at = 0.0
 
     @property
     def descriptor(self) -> DreameLawnMowerDescriptor:
@@ -293,10 +303,40 @@ class DreameLawnMowerClient:
             token=getattr(device, "token", None) or self._descriptor.token,
             raw=self._descriptor.raw,
         )
-        return snapshot_from_device(self._descriptor, device)
+        snapshot = snapshot_from_device(self._descriptor, device)
+        try:
+            status_blob = await asyncio.to_thread(
+                self._sync_get_status_blob,
+                False,
+                True,
+            )
+        except DreameLawnMowerConnectionError:
+            status_blob = None
+        if status_blob is not None and status_blob.task_status is not None:
+            snapshot = snapshot_with_heartbeat_task_state(snapshot, status_blob)
+
+        try:
+            cloud_device_info = await asyncio.to_thread(
+                self._sync_get_cached_cloud_device_info,
+            )
+        except DreameLawnMowerConnectionError:
+            cloud_device_info = self._latest_cloud_device_info
+        if isinstance(cloud_device_info, Mapping):
+            snapshot = snapshot_with_cloud_presence(snapshot, cloud_device_info)
+        return snapshot
 
     async def async_start_mowing(self) -> None:
-        """Start or resume mowing."""
+        """Start a new task or resume the heartbeat-confirmed paused task."""
+        try:
+            status_blob = await self.async_get_status_blob(
+                refresh=False,
+                include_cloud=True,
+            )
+        except DreameLawnMowerConnectionError:
+            status_blob = None
+        if status_blob is not None and status_blob.task_resumable:
+            await asyncio.to_thread(self._sync_resume_mowing)
+            return
         await self._async_call_device_method("start_mowing")
 
     async def async_pause(self) -> None:
@@ -304,7 +344,22 @@ class DreameLawnMowerClient:
         await self._async_call_device_method("pause")
 
     async def async_dock(self) -> None:
-        """Return the mower to base."""
+        """End an active mowing session and return the mower to base."""
+        device = await asyncio.to_thread(self._ensure_device)
+        initial_state = _lower_enum_name(getattr(device.status, "state", None))
+
+        async def async_refresh_state() -> str | None:
+            return (await self.async_refresh()).state
+
+        await async_stop_then_dock(
+            initial_state=initial_state,
+            stop=lambda: self._async_call_device_method("stop"),
+            dock=lambda: self._async_call_device_method("dock"),
+            refresh_state=async_refresh_state,
+        )
+
+    async def async_dock_without_stopping(self) -> None:
+        """Return to base while preserving a resumable mowing session."""
         await self._async_call_device_method("dock")
 
     async def async_clean_segments(self, segment_ids: Sequence[int]) -> Any:
@@ -2123,6 +2178,26 @@ class DreameLawnMowerClient:
             return cloud.get_device_info()
         except DeviceException as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
+
+    def _sync_get_cached_cloud_device_info(self) -> Mapping[str, Any] | None:
+        """Refresh cloud presence at a bounded rate and retain last-known state."""
+        now = time.monotonic()
+        if (
+            self._latest_cloud_device_info is not None
+            and now - self._cloud_device_info_refreshed_at
+            < _CLOUD_PRESENCE_REFRESH_INTERVAL
+        ):
+            return self._latest_cloud_device_info
+
+        info = self._sync_get_cloud_device_info("en")
+        if isinstance(info, Mapping):
+            self._latest_cloud_device_info = dict(info)
+            self._cloud_device_info_refreshed_at = now
+        return self._latest_cloud_device_info
+
+    def _sync_resume_mowing(self) -> Any:
+        """Resume a paused mower task through the app task-control protocol."""
+        return self._sync_call_app_action(RESUME_MOWING_REQUEST)
 
     @staticmethod
     def _with_fallback_app_maps(
@@ -5363,6 +5438,9 @@ def _operation_snapshot_summary(snapshot: DreameLawnMowerSnapshot) -> dict[str, 
         "activity": snapshot.activity,
         "task_status": snapshot.task_status,
         "task_status_name": snapshot.task_status_name,
+        "task_status_source": snapshot.task_status_source,
+        "mowing_session_active": snapshot.mowing_session_active,
+        "task_resumable": snapshot.task_resumable,
         "battery_level": snapshot.battery_level,
         "charging": snapshot.charging,
         "raw_charging": snapshot.raw_charging,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -346,7 +346,11 @@ class DreameLawnMowerClient:
 
     async def async_dock(self) -> None:
         """End an active mowing session and return the mower to base."""
-        snapshot = await self.async_refresh()
+        try:
+            snapshot = await self.async_refresh()
+        except DreameLawnMowerConnectionError:
+            await self._async_call_device_method("dock")
+            return
         initial_state = snapshot_session_control_state(snapshot)
 
         async def async_refresh_state() -> str | None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -2184,16 +2184,16 @@ class DreameLawnMowerClient:
         """Refresh cloud presence at a bounded rate and retain last-known state."""
         now = time.monotonic()
         if (
-            self._latest_cloud_device_info is not None
+            self._cloud_device_info_refreshed_at > 0
             and now - self._cloud_device_info_refreshed_at
             < _CLOUD_PRESENCE_REFRESH_INTERVAL
         ):
             return self._latest_cloud_device_info
 
+        self._cloud_device_info_refreshed_at = now
         info = self._sync_get_cloud_device_info("en")
         if isinstance(info, Mapping):
             self._latest_cloud_device_info = dict(info)
-            self._cloud_device_info_refreshed_at = now
         return self._latest_cloud_device_info
 
     def _sync_resume_mowing(self) -> Any:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/docking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/docking.py
@@ -1,0 +1,76 @@
+"""Safe docking orchestration for Dreame lawn mowers."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import Awaitable, Callable
+
+_LOGGER = logging.getLogger(__name__)
+
+ACTIVE_DOCKING_STATES = frozenset(
+    {
+        "mowing",
+        "remote_control",
+        "clean_summon",
+        "second_cleaning",
+        "human_following",
+        "spot_cleaning",
+        "shortcut",
+        "monitoring",
+    }
+)
+
+AsyncCommand = Callable[[], Awaitable[object]]
+AsyncStateReader = Callable[[], Awaitable[str | None]]
+
+
+async def async_stop_then_dock(
+    *,
+    initial_state: str | None,
+    stop: AsyncCommand,
+    dock: AsyncCommand,
+    refresh_state: AsyncStateReader,
+    timeout: float = 20.0,
+    initial_delay: float = 0.6,
+    poll_interval: float = 2.0,
+) -> bool:
+    """End an active mowing session before sending the mower to its dock.
+
+    Returns whether an active session was observed to stop. A timeout does not
+    prevent docking because returning the mower remains the safer final action.
+    """
+
+    state = _normalize_state(initial_state)
+    if state not in ACTIVE_DOCKING_STATES:
+        await dock()
+        return True
+
+    await stop()
+    stopped = False
+    try:
+        async with asyncio.timeout(timeout):
+            if initial_delay > 0:
+                await asyncio.sleep(initial_delay)
+            while True:
+                state = _normalize_state(await refresh_state())
+                if state not in ACTIVE_DOCKING_STATES:
+                    stopped = True
+                    break
+                await asyncio.sleep(max(poll_interval, 0))
+    except TimeoutError:
+        _LOGGER.warning(
+            "Timed out waiting for mower session state %s to stop; docking anyway.",
+            initial_state,
+        )
+
+    await dock()
+    return stopped
+
+
+def _normalize_state(value: object) -> str | None:
+    if value is None:
+        return None
+    name = getattr(value, "name", value)
+    text = str(name).strip().lower()
+    return text or None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/docking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/docking.py
@@ -49,7 +49,13 @@ async def async_stop_then_dock(
         await dock()
         return True
 
-    await stop()
+    try:
+        await stop()
+    except Exception as err:  # noqa: BLE001 - dock despite stop race/unavailability
+        _LOGGER.warning("Failed to stop mower session: %s; docking anyway.", err)
+        await dock()
+        return False
+
     stopped = False
     try:
         async with asyncio.timeout(timeout):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/docking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/docking.py
@@ -8,9 +8,11 @@ from collections.abc import Awaitable, Callable
 
 _LOGGER = logging.getLogger(__name__)
 
-ACTIVE_DOCKING_STATES = frozenset(
+SESSION_STATES_TO_END = frozenset(
     {
         "mowing",
+        "paused",
+        "returning",
         "remote_control",
         "clean_summon",
         "second_cleaning",
@@ -18,6 +20,7 @@ ACTIVE_DOCKING_STATES = frozenset(
         "spot_cleaning",
         "shortcut",
         "monitoring",
+        "monitoring_paused",
     }
 )
 
@@ -42,7 +45,7 @@ async def async_stop_then_dock(
     """
 
     state = _normalize_state(initial_state)
-    if state not in ACTIVE_DOCKING_STATES:
+    if state not in SESSION_STATES_TO_END:
         await dock()
         return True
 
@@ -53,8 +56,16 @@ async def async_stop_then_dock(
             if initial_delay > 0:
                 await asyncio.sleep(initial_delay)
             while True:
-                state = _normalize_state(await refresh_state())
-                if state not in ACTIVE_DOCKING_STATES:
+                try:
+                    state = _normalize_state(await refresh_state())
+                except Exception as err:  # noqa: BLE001 - dock despite refresh failure
+                    _LOGGER.warning(
+                        "Failed to refresh mower state after stopping: %s; "
+                        "docking anyway.",
+                        err,
+                    )
+                    break
+                if state not in SESSION_STATES_TO_END:
                     stopped = True
                     break
                 await asyncio.sleep(max(poll_interval, 0))

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -645,11 +645,14 @@ def snapshot_from_device(
         or has_only_bare_error_flag
     )
     error_source: str | None = "status" if has_error else None
-    status_reports_no_error = _status_explicitly_reports_no_error(
-        status_has_error=status_has_error,
-        error_code=error_code,
-        error_name=error_name,
-        error_text=error_text,
+    status_reports_no_error = (
+        raw_error_code in MOWER_NON_ERROR_EVENT_CODES
+        or _status_explicitly_reports_no_error(
+            status_has_error=status_has_error,
+            error_code=error_code,
+            error_name=error_name,
+            error_text=error_text,
+        )
     )
     if (
         not has_error

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -12,6 +12,15 @@ MIN_REMOTE_CONTROL_BATTERY_LEVEL = 20
 REMOTE_CONTROL_STATES = {"remote_control"}
 REALTIME_ERROR_PROPERTY_KEY = "2.2"
 
+# User-confirmed mower meanings differ from the inherited vacuum error table.
+MOWER_ERROR_CODE_NAMES = {
+    2: "mower_stuck",
+    23: "emergency_stop_pressed",
+    53: "rain_detected",
+    54: "low_battery",
+}
+MOWER_NON_ERROR_EVENT_CODES = frozenset({61, 70})
+
 MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
@@ -89,6 +98,8 @@ def _error_name_from_code(value: int | None) -> str | None:
     """Return the bundled vendor error name for a numeric code, if known."""
     if value in (None, -1, 0):
         return None
+    if value in MOWER_ERROR_CODE_NAMES:
+        return MOWER_ERROR_CODE_NAMES[value]
     try:
         from .const import ERROR_CODE_TO_ERROR_NAME
         from .types import DreameMowerErrorCode
@@ -111,7 +122,7 @@ def _error_code_from_raw(value: Any) -> int | None:
 def _active_error_code_from_raw(value: Any) -> int | None:
     """Return a numeric active error code from raw app/status values."""
     code = _error_code_from_raw(value)
-    return None if code in (-1, 0) else code
+    return None if code in (-1, 0) or code in MOWER_NON_ERROR_EVENT_CODES else code
 
 
 def _realtime_error_code_from_device(device: Any) -> int | None:
@@ -119,7 +130,21 @@ def _realtime_error_code_from_device(device: Any) -> int | None:
     realtime_properties = getattr(device, "realtime_properties", {}) or {}
     entry = realtime_properties.get(REALTIME_ERROR_PROPERTY_KEY)
     value = entry.get("value") if isinstance(entry, Mapping) else entry
-    return _active_error_code_from_raw(value)
+    code = _error_code_from_raw(value)
+    return None if code in (None, -1, 0) else code
+
+
+def _raw_error_code_from_device(device: Any, error_obj: Any) -> int | None:
+    """Return the unmodified error property before enum normalization."""
+    try:
+        from .types import DreameMowerProperty
+
+        value = device.get_property(DreameMowerProperty.ERROR)
+    except (AttributeError, ImportError, TypeError, ValueError):
+        value = None
+    if value is not None:
+        return _error_code_from_raw(value)
+    return _error_code_from_raw(getattr(error_obj, "value", None))
 
 
 def _status_explicitly_reports_no_error(
@@ -147,7 +172,8 @@ def _friendly_error_display(
     """Return the best user-facing error while preserving raw text elsewhere."""
     if error_code not in (None, -1, 0):
         return (
-            _friendly_error_name(error_name)
+            _friendly_error_name(MOWER_ERROR_CODE_NAMES.get(error_code))
+            or _friendly_error_name(error_name)
             or _friendly_error_name(_error_name_from_code(error_code))
             or (None if _is_no_error_text(error_text) else error_text)
             or f"Error {error_code}"
@@ -196,6 +222,9 @@ class DreameLawnMowerSnapshot:
     battery_level: int | None = None
     task_status: str | None = None
     task_status_name: str | None = None
+    task_status_source: str | None = None
+    mowing_session_active: bool | None = None
+    task_resumable: bool | None = None
     error_code: int | None = None
     error_name: str | None = None
     error_text: str | None = None
@@ -254,6 +283,12 @@ class DreameLawnMowerStatusBlob:
     payload: tuple[int, ...] = field(default_factory=tuple)
     bytes_by_index: Mapping[str, int] = field(default_factory=dict)
     candidate_battery_level: int | None = None
+    heartbeat_charging: bool | None = None
+    main_state: int | None = None
+    sub_state: int | None = None
+    task_status: str | None = None
+    mowing_session_active: bool | None = None
+    task_resumable: bool | None = None
     candidate_runtime_region_id: int | None = None
     candidate_runtime_task_id: int | None = None
     candidate_runtime_progress_percent: float | None = None
@@ -582,10 +617,18 @@ def snapshot_from_device(
     last_realtime_method = _as_optional_str(last_realtime_payload.get("method"))
     error_name = _as_optional_str(getattr(device.status, "error_name", None))
     error_text = _as_optional_str(status_attributes.get("error"))
-    raw_error_code = _error_code_from_raw(getattr(error_obj, "value", None))
+    raw_error_code = _raw_error_code_from_device(device, error_obj)
     realtime_error_code = _realtime_error_code_from_device(device)
     error_code = raw_error_code
     status_has_error = bool(getattr(device.status, "has_error", False))
+    if raw_error_code in MOWER_NON_ERROR_EVENT_CODES:
+        # Codes 61 and 70 are DND start/end notifications on mower firmware,
+        # despite their inherited vacuum labels. Preserve the raw code for
+        # diagnostics without turning the Home Assistant entity into an error.
+        error_name = None
+        error_text = None
+        error_code = None
+        status_has_error = False
     error_code_active = _active_error_code_from_raw(error_code) is not None
     error_name_active = not _is_no_error_text(error_name)
     error_text_active = not _is_no_error_text(error_text)
@@ -608,7 +651,11 @@ def snapshot_from_device(
         error_name=error_name,
         error_text=error_text,
     )
-    if not has_error and not status_reports_no_error and realtime_error_code is not None:
+    if (
+        not has_error
+        and not status_reports_no_error
+        and _active_error_code_from_raw(realtime_error_code) is not None
+    ):
         error_code = realtime_error_code
         has_error = True
         error_source = f"realtime_property_{REALTIME_ERROR_PROPERTY_KEY}"

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -10,6 +10,13 @@ from .models import DreameLawnMowerSnapshot, DreameLawnMowerStatusBlob
 
 RESUME_MOWING_REQUEST = {"m": "a", "p": 0, "o": 5}
 
+_ACTIVE_TASK_CONTROL_STATES = {
+    "starting": "mowing",
+    "mowing": "mowing",
+    "paused": "paused",
+    "returning_to_dock": "returning",
+}
+
 
 def snapshot_with_heartbeat_task_state(
     snapshot: DreameLawnMowerSnapshot,
@@ -42,6 +49,16 @@ def snapshot_with_cloud_presence(
         online=online,
         available=snapshot.available and online,
     )
+
+
+def snapshot_session_control_state(snapshot: DreameLawnMowerSnapshot) -> str:
+    """Return the authoritative state used for session-ending commands."""
+    session_active = snapshot.mowing_session_active
+    if session_active is False:
+        return "idle"
+    if session_active is True:
+        return _ACTIVE_TASK_CONTROL_STATES.get(snapshot.task_status or "", "mowing")
+    return snapshot.state
 
 
 def _optional_bool(value: Any) -> bool | None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -1,0 +1,57 @@
+"""Normalize live mower task and cloud-presence evidence."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from dataclasses import replace
+from typing import Any
+
+from .models import DreameLawnMowerSnapshot, DreameLawnMowerStatusBlob
+
+RESUME_MOWING_REQUEST = {"m": "a", "p": 0, "o": 5}
+
+
+def snapshot_with_heartbeat_task_state(
+    snapshot: DreameLawnMowerSnapshot,
+    status_blob: DreameLawnMowerStatusBlob,
+) -> DreameLawnMowerSnapshot:
+    """Apply heartbeat-confirmed mowing-session state to a snapshot."""
+    task_status = status_blob.task_status
+    if task_status is None:
+        return snapshot
+    return replace(
+        snapshot,
+        task_status=task_status,
+        task_status_name=task_status.replace("_", " ").title(),
+        task_status_source=f"heartbeat_{status_blob.source or 'unknown'}",
+        mowing_session_active=status_blob.mowing_session_active,
+        task_resumable=status_blob.task_resumable,
+    )
+
+
+def snapshot_with_cloud_presence(
+    snapshot: DreameLawnMowerSnapshot,
+    cloud_device_info: Mapping[str, Any],
+) -> DreameLawnMowerSnapshot:
+    """Apply authoritative cloud presence without exposing cached state as live."""
+    online = _optional_bool(cloud_device_info.get("online"))
+    if online is None:
+        return snapshot
+    return replace(
+        snapshot,
+        online=online,
+        available=snapshot.available and online,
+    )
+
+
+def _optional_bool(value: Any) -> bool | None:
+    if value is None:
+        return None
+    if isinstance(value, str):
+        normalized = value.strip().lower()
+        if normalized in {"true", "on", "yes", "1"}:
+            return True
+        if normalized in {"false", "off", "no", "0"}:
+            return False
+        return None
+    return bool(value)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -16,6 +16,9 @@ from PIL import Image, ImageDraw, ImageFont
 from .models import DreameLawnMowerMapSummary
 
 _PATH_SENTINEL = (32767, -32768)
+_SHAPE_RECTANGLE = 2
+_SHAPE_CIRCLE = 3
+_CIRCLE_SEGMENTS = 36
 _MAX_IMAGE_SIDE = 2048
 _MIN_IMAGE_SIDE = 400
 _PADDING = 40
@@ -73,6 +76,7 @@ class DreameLawnMowerVectorZone:
     name: str = ""
     zone_type: int = 0
     shape_type: int = 0
+    angle: float = 0
     area: float = 0
     time_minutes: int = 0
     estimated_minutes: int = 0
@@ -598,19 +602,75 @@ def _parse_zone_collection(value: Any) -> tuple[DreameLawnMowerVectorZone, ...]:
     for zone_id, zone_data in _parse_map_entries(value):
         if not isinstance(zone_data, Mapping):
             continue
+        shape_type = int(zone_data.get("shapeType") or 0)
+        angle = float(zone_data.get("angle") or 0)
         result.append(
             DreameLawnMowerVectorZone(
                 zone_id=zone_id,
-                points=_extract_path_coords(zone_data.get("path")),
+                points=_resolve_zone_points(
+                    _extract_path_coords(zone_data.get("path")),
+                    shape_type=shape_type,
+                    angle=angle,
+                ),
                 name=str(zone_data.get("name") or ""),
                 zone_type=int(zone_data.get("type") or 0),
-                shape_type=int(zone_data.get("shapeType") or 0),
+                shape_type=shape_type,
+                angle=angle,
                 area=float(zone_data.get("area") or 0),
                 time_minutes=int(zone_data.get("time") or 0),
                 estimated_minutes=int(zone_data.get("etime") or 0),
             )
         )
     return tuple(result)
+
+
+def _resolve_zone_points(
+    points: tuple[tuple[int, int], ...],
+    *,
+    shape_type: int,
+    angle: float,
+) -> tuple[tuple[int, int], ...]:
+    """Expand compact circle and rotated-rectangle mower map shapes."""
+    if shape_type == _SHAPE_CIRCLE and len(points) >= 2:
+        (x1, y1), (x2, y2) = points[:2]
+        center_x = (x1 + x2) / 2
+        center_y = (y1 + y2) / 2
+        radius_x = abs(x2 - x1) / 2
+        radius_y = abs(y2 - y1) / 2
+        return tuple(
+            (
+                round(center_x + radius_x * math.cos(theta)),
+                round(center_y + radius_y * math.sin(theta)),
+            )
+            for theta in (
+                2 * math.pi * index / _CIRCLE_SEGMENTS
+                for index in range(_CIRCLE_SEGMENTS)
+            )
+        )
+
+    if shape_type == _SHAPE_RECTANGLE and angle and points:
+        center_x = sum(point[0] for point in points) / len(points)
+        center_y = sum(point[1] for point in points) / len(points)
+        theta = math.radians(-angle)
+        cosine = math.cos(theta)
+        sine = math.sin(theta)
+        return tuple(
+            (
+                round(
+                    center_x
+                    + (x - center_x) * cosine
+                    - (y - center_y) * sine
+                ),
+                round(
+                    center_y
+                    + (x - center_x) * sine
+                    + (y - center_y) * cosine
+                ),
+            )
+            for x, y in points
+        )
+
+    return points
 
 
 def _parse_path_collection(value: Any) -> tuple[DreameLawnMowerVectorPath, ...]:

--- a/custom_components/dreame_lawn_mower/entity.py
+++ b/custom_components/dreame_lawn_mower/entity.py
@@ -8,6 +8,10 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .coordinator import DreameLawnMowerCoordinator
 
+_OFFLINE_REPORTING_ENTITY_KEYS = frozenset(
+    {"online", "device_connected", "cloud_connected"}
+)
+
 
 class DreameLawnMowerEntity(CoordinatorEntity[DreameLawnMowerCoordinator]):
     """Shared base entity for Dreame lawn mower entities."""
@@ -24,7 +28,18 @@ class DreameLawnMowerEntity(CoordinatorEntity[DreameLawnMowerCoordinator]):
             else:
                 snapshot = getattr(coordinator, "data", None)
                 if snapshot is not None and not getattr(snapshot, "available", True):
-                    return False
+                    try:
+                        description = object.__getattribute__(
+                            self,
+                            "entity_description",
+                        )
+                    except AttributeError:
+                        return False
+                    if (
+                        getattr(description, "key", None)
+                        not in _OFFLINE_REPORTING_ENTITY_KEYS
+                    ):
+                        return False
         return super().__getattribute__(name)
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:

--- a/custom_components/dreame_lawn_mower/entity.py
+++ b/custom_components/dreame_lawn_mower/entity.py
@@ -14,6 +14,19 @@ class DreameLawnMowerEntity(CoordinatorEntity[DreameLawnMowerCoordinator]):
 
     _attr_has_entity_name = True
 
+    def __getattribute__(self, name: str) -> Any:
+        """Enforce cloud-offline availability across specialized entities."""
+        if name == "available":
+            try:
+                coordinator = object.__getattribute__(self, "coordinator")
+            except AttributeError:
+                pass
+            else:
+                snapshot = getattr(coordinator, "data", None)
+                if snapshot is not None and not getattr(snapshot, "available", True):
+                    return False
+        return super().__getattribute__(name)
+
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
         self._descriptor = coordinator.client.descriptor

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -238,6 +238,13 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             "state_name": snapshot.state_name,
             "task_status": snapshot.task_status,
             "task_status_name": snapshot.task_status_name,
+            "task_status_source": getattr(snapshot, "task_status_source", None),
+            "mowing_session_active": getattr(
+                snapshot,
+                "mowing_session_active",
+                None,
+            ),
+            "task_resumable": getattr(snapshot, "task_resumable", None),
             "unknown_property_count": len(
                 getattr(device, "unknown_properties", {}) or {}
             ),

--- a/custom_components/dreame_lawn_mower/map_cache.py
+++ b/custom_components/dreame_lawn_mower/map_cache.py
@@ -13,10 +13,17 @@ from .dreame_lawn_mower_client.models import DreameLawnMowerMapView
 MapViewRefresh = Callable[[], Awaitable[DreameLawnMowerMapView]]
 
 
-def map_camera_available(snapshot: Any, *, image_cached: bool) -> bool:
+def map_camera_available(
+    snapshot: Any,
+    *,
+    image_cached: bool,
+    requires_map_capability: bool = True,
+) -> bool:
     """Return whether a map camera may expose live or cached map data."""
     if snapshot is None or not getattr(snapshot, "available", False):
         return False
+    if not requires_map_capability:
+        return True
     return bool(
         image_cached
         or getattr(snapshot, "mapping_available", False)

--- a/custom_components/dreame_lawn_mower/map_cache.py
+++ b/custom_components/dreame_lawn_mower/map_cache.py
@@ -6,10 +6,22 @@ import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime, timedelta
+from typing import Any
 
 from .dreame_lawn_mower_client.models import DreameLawnMowerMapView
 
 MapViewRefresh = Callable[[], Awaitable[DreameLawnMowerMapView]]
+
+
+def map_camera_available(snapshot: Any, *, image_cached: bool) -> bool:
+    """Return whether a map camera may expose live or cached map data."""
+    if snapshot is None or not getattr(snapshot, "available", False):
+        return False
+    return bool(
+        image_cached
+        or getattr(snapshot, "mapping_available", False)
+        or "map" in getattr(snapshot, "capabilities", ())
+    )
 
 
 @dataclass(slots=True)

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -62,6 +62,8 @@ async def main() -> None:
         print(snapshot.descriptor.title)
         print(snapshot.state_name)
         print(snapshot.battery_level)
+        print(snapshot.task_status_name)
+        print(snapshot.task_resumable)
     finally:
         await client.async_close()
 
@@ -75,7 +77,9 @@ The same flow is available as `examples/python_client.py`.
 
 - account discovery for Dreamehome and MOVAhome accounts
 - normalized mower snapshots with state, activity, battery, errors, firmware,
-  and capability data
+  capability, cloud presence, and heartbeat-backed task data
+- automatic resume of a heartbeat-confirmed paused session while ordinary
+  starts continue to create a fresh mower task
 - read-only schedule retrieval and calendar-friendly task summaries
 - dry-run schedule enable/disable planning, with explicit gates required before
   live writes
@@ -127,4 +131,5 @@ service, config-flow, and registry behavior in `custom_components`.
 - `examples/weather_probe.py`
 - `examples/preference_probe.py`
 - `examples/task_status_probe.py`
+- `examples/status_blob_probe.py`
 - `examples/remote_control_probe.py`

--- a/examples/status_blob_probe.py
+++ b/examples/status_blob_probe.py
@@ -36,6 +36,27 @@ def _summarize_samples(samples: list[dict[str, object]]) -> dict[str, object]:
             if isinstance(sample.get("status_blob"), dict)
         ]
     )
+    task_statuses = _unique_values(
+        [
+            (sample.get("status_blob") or {}).get("task_status")
+            for sample in samples
+            if isinstance(sample.get("status_blob"), dict)
+        ]
+    )
+    session_active_flags = _unique_values(
+        [
+            (sample.get("status_blob") or {}).get("mowing_session_active")
+            for sample in samples
+            if isinstance(sample.get("status_blob"), dict)
+        ]
+    )
+    resumable_flags = _unique_values(
+        [
+            (sample.get("status_blob") or {}).get("task_resumable")
+            for sample in samples
+            if isinstance(sample.get("status_blob"), dict)
+        ]
+    )
     compared_candidates = [
         (
             sample.get("battery_level"),
@@ -84,6 +105,9 @@ def _summarize_samples(samples: list[dict[str, object]]) -> dict[str, object]:
         "docked_flags": docked_flags,
         "battery_levels": battery_levels,
         "candidate_battery_levels": candidate_battery_levels,
+        "task_statuses": task_statuses,
+        "mowing_session_active_flags": session_active_flags,
+        "task_resumable_flags": resumable_flags,
         "candidate_battery_matches_snapshot": (
             all(snapshot == candidate for snapshot, candidate in compared_candidates)
             if compared_candidates

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -263,6 +263,39 @@ def test_status_blob_decoder_reports_idle_outside_mowing_main_state() -> None:
     assert decoded.task_resumable is False
 
 
+def test_status_blob_decoder_marks_terminal_task_states_inactive() -> None:
+    for sub_state, expected_status in ((37, "finished"), (38, "failed")):
+        decoded = decode_mower_status_blob(
+            [
+                206,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                0,
+                128,
+                0,
+                128,
+                100,
+                21,
+                sub_state,
+                0,
+                0,
+                128,
+                211,
+                196,
+                206,
+            ]
+        )
+
+        assert decoded is not None
+        assert decoded.task_status == expected_status
+        assert decoded.mowing_session_active is False
+        assert decoded.task_resumable is False
+
+
 def test_property_annotations_mark_runtime_status_blob_frame() -> None:
     entry = DreameLawnMowerClient._annotate_cloud_property_entry(
         {

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -221,6 +221,46 @@ def test_status_blob_decoder_exposes_candidate_battery_byte() -> None:
 
     assert decoded is not None
     assert decoded.candidate_battery_level == 93
+    assert decoded.main_state == 4
+    assert decoded.sub_state == 35
+    assert decoded.task_status == "mowing"
+    assert decoded.mowing_session_active is True
+    assert decoded.task_resumable is False
+
+
+def test_status_blob_decoder_exposes_paused_resumable_session_at_dock() -> None:
+    decoded = decode_mower_status_blob(
+        [206, 0, 0, 0, 0, 0, 0, 0, 128, 0, 128, 100, 21, 36, 0, 0, 128, 211, 196, 206]
+    )
+
+    assert decoded is not None
+    assert decoded.main_state == 4
+    assert decoded.sub_state == 36
+    assert decoded.task_status == "paused"
+    assert decoded.mowing_session_active is True
+    assert decoded.task_resumable is True
+
+
+def test_status_blob_decoder_removes_charging_flag_from_battery_byte() -> None:
+    decoded = decode_mower_status_blob(
+        [206, 0, 0, 0, 0, 0, 0, 0, 128, 0, 128, 227, 149, 36, 0, 0, 128, 212, 186, 206]
+    )
+
+    assert decoded is not None
+    assert decoded.candidate_battery_level == 99
+    assert decoded.heartbeat_charging is True
+
+
+def test_status_blob_decoder_reports_idle_outside_mowing_main_state() -> None:
+    decoded = decode_mower_status_blob(
+        [206, 0, 0, 0, 0, 0, 0, 0, 128, 0, 128, 100, 4, 36, 0, 0, 128, 211, 196, 206]
+    )
+
+    assert decoded is not None
+    assert decoded.main_state == 3
+    assert decoded.task_status == "idle"
+    assert decoded.mowing_session_active is False
+    assert decoded.task_resumable is False
 
 
 def test_property_annotations_mark_runtime_status_blob_frame() -> None:

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import ssl
+from dataclasses import replace
 from types import SimpleNamespace
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import protocol
@@ -10,6 +11,7 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import 
     _normalize_cloud_firmware_check,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.runtime_state import (
+    snapshot_session_control_state,
     snapshot_with_cloud_presence,
 )
 from dreame_lawn_mower_client import DreameLawnMowerClient
@@ -70,6 +72,36 @@ def test_cloud_online_presence_keeps_successful_snapshot_available() -> None:
 
     assert snapshot.online is True
     assert snapshot.available is True
+
+
+def test_session_control_state_uses_active_heartbeat_at_dock() -> None:
+    snapshot = replace(
+        _snapshot(),
+        task_status="paused",
+        mowing_session_active=True,
+    )
+
+    assert snapshot_session_control_state(snapshot) == "paused"
+
+
+def test_session_control_state_respects_explicit_inactive_heartbeat() -> None:
+    snapshot = replace(
+        _snapshot(),
+        state="paused",
+        mowing_session_active=False,
+    )
+
+    assert snapshot_session_control_state(snapshot) == "idle"
+
+
+def test_session_control_state_falls_back_without_heartbeat_evidence() -> None:
+    snapshot = replace(
+        _snapshot(),
+        state="returning",
+        mowing_session_active=None,
+    )
+
+    assert snapshot_session_control_state(snapshot) == "returning"
 
 
 def test_cloud_mqtt_client_requires_verified_tls(monkeypatch) -> None:

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -9,9 +9,15 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import protoco
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     _normalize_cloud_firmware_check,
 )
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.runtime_state import (
+    snapshot_with_cloud_presence,
+)
 from dreame_lawn_mower_client import DreameLawnMowerClient
 from dreame_lawn_mower_client.client import DreameLawnMowerConnectionError
-from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
+from dreame_lawn_mower_client.models import (
+    DreameLawnMowerDescriptor,
+    DreameLawnMowerSnapshot,
+)
 
 
 def _client() -> DreameLawnMowerClient:
@@ -40,6 +46,30 @@ def _firmware_device() -> SimpleNamespace:
         status=SimpleNamespace(),
         data={},
     )
+
+
+def _snapshot(*, available: bool = True) -> DreameLawnMowerSnapshot:
+    return DreameLawnMowerSnapshot(
+        descriptor=_client().descriptor,
+        available=available,
+        state="charging_completed",
+        state_name="Charging complete",
+        activity="docked",
+    )
+
+
+def test_cloud_offline_presence_marks_cached_snapshot_unavailable() -> None:
+    snapshot = snapshot_with_cloud_presence(_snapshot(), {"online": False})
+
+    assert snapshot.online is False
+    assert snapshot.available is False
+
+
+def test_cloud_online_presence_keeps_successful_snapshot_available() -> None:
+    snapshot = snapshot_with_cloud_presence(_snapshot(), {"online": True})
+
+    assert snapshot.online is True
+    assert snapshot.available is True
 
 
 def test_cloud_mqtt_client_requires_verified_tls(monkeypatch) -> None:

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -104,6 +104,63 @@ def test_session_control_state_falls_back_without_heartbeat_evidence() -> None:
     assert snapshot_session_control_state(snapshot) == "returning"
 
 
+def test_cloud_presence_throttles_empty_refresh_after_cached_success(
+    monkeypatch,
+) -> None:
+    client = _client()
+    calls = 0
+
+    def empty_refresh(language: str | None = None):
+        nonlocal calls
+        calls += 1
+        return None
+
+    client._latest_cloud_device_info = {"online": True}
+    client._cloud_device_info_refreshed_at = 0.0
+    client._sync_get_cloud_device_info = empty_refresh
+    monkeypatch.setattr(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client."
+        "time.monotonic",
+        lambda: 100.0,
+    )
+
+    first = client._sync_get_cached_cloud_device_info()
+    second = client._sync_get_cached_cloud_device_info()
+
+    assert first == {"online": True}
+    assert second == {"online": True}
+    assert calls == 1
+    assert client._cloud_device_info_refreshed_at == 100.0
+
+
+def test_cloud_presence_throttles_failed_refresh_attempt(monkeypatch) -> None:
+    client = _client()
+    calls = 0
+
+    def failed_refresh(language: str | None = None):
+        nonlocal calls
+        calls += 1
+        raise DreameLawnMowerConnectionError("presence unavailable")
+
+    client._sync_get_cloud_device_info = failed_refresh
+    monkeypatch.setattr(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client."
+        "time.monotonic",
+        lambda: 100.0,
+    )
+
+    try:
+        client._sync_get_cached_cloud_device_info()
+    except DreameLawnMowerConnectionError:
+        pass
+    else:
+        raise AssertionError("Expected the first presence refresh to fail")
+
+    assert client._sync_get_cached_cloud_device_info() is None
+    assert calls == 1
+    assert client._cloud_device_info_refreshed_at == 100.0
+
+
 def test_cloud_mqtt_client_requires_verified_tls(monkeypatch) -> None:
     mqtt_clients = []
 

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -14,14 +14,21 @@ from custom_components.dreame_lawn_mower.coordinator import (
 def test_offline_snapshot_returns_normally_so_entities_remain_loaded() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.data = SimpleNamespace(state="stale")
+    coordinator.runtime_status_blob = {"status": "stale"}
     offline_snapshot = SimpleNamespace(available=False)
+    tracking_updates: list[tuple[object, bool]] = []
     coordinator.client = SimpleNamespace(
         async_refresh=lambda: _offline_snapshot(offline_snapshot),
+        update_runtime_live_tracking=lambda value, *, active: tracking_updates.append(
+            (value, active)
+        ),
     )
 
     result = asyncio.run(coordinator._async_update_data())
 
     assert result is offline_snapshot
+    assert coordinator.runtime_status_blob is None
+    assert tracking_updates == [(None, False)]
 
 
 async def _offline_snapshot(snapshot: SimpleNamespace) -> SimpleNamespace:

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -10,6 +10,7 @@ from homeassistant.helpers.update_coordinator import UpdateFailed
 
 from custom_components.dreame_lawn_mower.coordinator import (
     DreameLawnMowerCoordinator,
+    _runtime_tracking_active,
 )
 
 
@@ -28,3 +29,21 @@ def test_offline_snapshot_discards_stale_coordinator_data() -> None:
 
 async def _offline_snapshot() -> SimpleNamespace:
     return SimpleNamespace(available=False)
+
+
+def test_runtime_tracking_respects_explicit_inactive_heartbeat() -> None:
+    snapshot = SimpleNamespace(
+        mowing_session_active=False,
+        activity="mowing",
+    )
+
+    assert _runtime_tracking_active(snapshot) is False
+
+
+def test_runtime_tracking_falls_back_when_heartbeat_state_is_unknown() -> None:
+    snapshot = SimpleNamespace(
+        mowing_session_active=None,
+        activity="paused",
+    )
+
+    assert _runtime_tracking_active(snapshot) is True

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -1,0 +1,30 @@
+"""Coordinator availability regression checks."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+import pytest
+from homeassistant.helpers.update_coordinator import UpdateFailed
+
+from custom_components.dreame_lawn_mower.coordinator import (
+    DreameLawnMowerCoordinator,
+)
+
+
+def test_offline_snapshot_discards_stale_coordinator_data() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.data = SimpleNamespace(state="stale")
+    coordinator.client = SimpleNamespace(
+        async_refresh=lambda: _offline_snapshot(),
+    )
+
+    with pytest.raises(UpdateFailed, match="Mower is offline"):
+        asyncio.run(coordinator._async_update_data())
+
+    assert coordinator.data is None
+
+
+async def _offline_snapshot() -> SimpleNamespace:
+    return SimpleNamespace(available=False)

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -5,30 +5,27 @@ from __future__ import annotations
 import asyncio
 from types import SimpleNamespace
 
-import pytest
-from homeassistant.helpers.update_coordinator import UpdateFailed
-
 from custom_components.dreame_lawn_mower.coordinator import (
     DreameLawnMowerCoordinator,
     _runtime_tracking_active,
 )
 
 
-def test_offline_snapshot_discards_stale_coordinator_data() -> None:
+def test_offline_snapshot_returns_normally_so_entities_remain_loaded() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.data = SimpleNamespace(state="stale")
+    offline_snapshot = SimpleNamespace(available=False)
     coordinator.client = SimpleNamespace(
-        async_refresh=lambda: _offline_snapshot(),
+        async_refresh=lambda: _offline_snapshot(offline_snapshot),
     )
 
-    with pytest.raises(UpdateFailed, match="Mower is offline"):
-        asyncio.run(coordinator._async_update_data())
+    result = asyncio.run(coordinator._async_update_data())
 
-    assert coordinator.data is None
+    assert result is offline_snapshot
 
 
-async def _offline_snapshot() -> SimpleNamespace:
-    return SimpleNamespace(available=False)
+async def _offline_snapshot(snapshot: SimpleNamespace) -> SimpleNamespace:
+    return snapshot
 
 
 def test_runtime_tracking_respects_explicit_inactive_heartbeat() -> None:

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -2,10 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
-
-import pytest
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     DreameLawnMowerClient,
@@ -15,8 +14,7 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.docking import
 )
 
 
-@pytest.mark.asyncio
-async def test_active_mowing_session_stops_before_docking() -> None:
+def test_active_mowing_session_stops_before_docking() -> None:
     calls: list[str] = []
     states = iter(("mowing", "idle"))
 
@@ -30,32 +28,35 @@ async def test_active_mowing_session_stops_before_docking() -> None:
     async def dock() -> None:
         calls.append("dock")
 
-    stopped = await async_stop_then_dock(
-        initial_state="mowing",
-        stop=stop,
-        dock=dock,
-        refresh_state=refresh_state,
-        initial_delay=0,
-        poll_interval=0,
+    stopped = asyncio.run(
+        async_stop_then_dock(
+            initial_state="mowing",
+            stop=stop,
+            dock=dock,
+            refresh_state=refresh_state,
+            initial_delay=0,
+            poll_interval=0,
+        )
     )
 
     assert stopped is True
     assert calls == ["stop", "refresh", "refresh", "dock"]
 
 
-@pytest.mark.asyncio
-async def test_idle_mower_docks_without_stop_or_polling() -> None:
+def test_idle_mower_docks_without_stop_or_polling() -> None:
     stop = AsyncMock()
     refresh_state = AsyncMock()
     dock = AsyncMock()
 
-    stopped = await async_stop_then_dock(
-        initial_state="idle",
-        stop=stop,
-        dock=dock,
-        refresh_state=refresh_state,
-        initial_delay=0,
-        poll_interval=0,
+    stopped = asyncio.run(
+        async_stop_then_dock(
+            initial_state="idle",
+            stop=stop,
+            dock=dock,
+            refresh_state=refresh_state,
+            initial_delay=0,
+            poll_interval=0,
+        )
     )
 
     assert stopped is True
@@ -64,20 +65,21 @@ async def test_idle_mower_docks_without_stop_or_polling() -> None:
     dock.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_docking_continues_when_stop_state_times_out() -> None:
+def test_docking_continues_when_stop_state_times_out() -> None:
     stop = AsyncMock()
     refresh_state = AsyncMock(return_value="mowing")
     dock = AsyncMock()
 
-    stopped = await async_stop_then_dock(
-        initial_state="mowing",
-        stop=stop,
-        dock=dock,
-        refresh_state=refresh_state,
-        timeout=0,
-        initial_delay=0,
-        poll_interval=0,
+    stopped = asyncio.run(
+        async_stop_then_dock(
+            initial_state="mowing",
+            stop=stop,
+            dock=dock,
+            refresh_state=refresh_state,
+            timeout=0,
+            initial_delay=0,
+            poll_interval=0,
+        )
     )
 
     assert stopped is False
@@ -85,18 +87,16 @@ async def test_docking_continues_when_stop_state_times_out() -> None:
     dock.assert_awaited_once()
 
 
-@pytest.mark.asyncio
-async def test_dock_without_stopping_preserves_session_by_docking_directly() -> None:
+def test_dock_without_stopping_preserves_session_by_docking_directly() -> None:
     client = object.__new__(DreameLawnMowerClient)
     client._async_call_device_method = AsyncMock()
 
-    await client.async_dock_without_stopping()
+    asyncio.run(client.async_dock_without_stopping())
 
     client._async_call_device_method.assert_awaited_once_with("dock")
 
 
-@pytest.mark.asyncio
-async def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
+def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
     client = object.__new__(DreameLawnMowerClient)
     client.async_get_status_blob = AsyncMock(
         return_value=SimpleNamespace(task_resumable=True)
@@ -104,14 +104,13 @@ async def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
     client._sync_resume_mowing = Mock(return_value={"r": 0})
     client._async_call_device_method = AsyncMock()
 
-    await client.async_start_mowing()
+    asyncio.run(client.async_start_mowing())
 
     client._sync_resume_mowing.assert_called_once_with()
     client._async_call_device_method.assert_not_awaited()
 
 
-@pytest.mark.asyncio
-async def test_start_uses_fresh_action_without_resumable_session() -> None:
+def test_start_uses_fresh_action_without_resumable_session() -> None:
     client = object.__new__(DreameLawnMowerClient)
     client.async_get_status_blob = AsyncMock(
         return_value=SimpleNamespace(task_resumable=False)
@@ -119,7 +118,7 @@ async def test_start_uses_fresh_action_without_resumable_session() -> None:
     client._sync_resume_mowing = Mock()
     client._async_call_device_method = AsyncMock()
 
-    await client.async_start_mowing()
+    asyncio.run(client.async_start_mowing())
 
     client._sync_resume_mowing.assert_not_called()
     client._async_call_device_method.assert_awaited_once_with("start_mowing")

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -132,6 +132,28 @@ def test_docking_continues_when_stop_state_refresh_fails() -> None:
     dock.assert_awaited_once()
 
 
+def test_docking_continues_when_stop_action_fails() -> None:
+    stop = AsyncMock(side_effect=RuntimeError("stop unavailable"))
+    refresh_state = AsyncMock()
+    dock = AsyncMock()
+
+    stopped = asyncio.run(
+        async_stop_then_dock(
+            initial_state="paused",
+            stop=stop,
+            dock=dock,
+            refresh_state=refresh_state,
+            initial_delay=0,
+            poll_interval=0,
+        )
+    )
+
+    assert stopped is False
+    stop.assert_awaited_once()
+    refresh_state.assert_not_awaited()
+    dock.assert_awaited_once()
+
+
 def test_dock_without_stopping_preserves_session_by_docking_directly() -> None:
     client = object.__new__(DreameLawnMowerClient)
     client._async_call_device_method = AsyncMock()

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -1,0 +1,125 @@
+"""Regression tests for safe mower docking orchestration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
+    DreameLawnMowerClient,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.docking import (
+    async_stop_then_dock,
+)
+
+
+@pytest.mark.asyncio
+async def test_active_mowing_session_stops_before_docking() -> None:
+    calls: list[str] = []
+    states = iter(("mowing", "idle"))
+
+    async def stop() -> None:
+        calls.append("stop")
+
+    async def refresh_state() -> str:
+        calls.append("refresh")
+        return next(states)
+
+    async def dock() -> None:
+        calls.append("dock")
+
+    stopped = await async_stop_then_dock(
+        initial_state="mowing",
+        stop=stop,
+        dock=dock,
+        refresh_state=refresh_state,
+        initial_delay=0,
+        poll_interval=0,
+    )
+
+    assert stopped is True
+    assert calls == ["stop", "refresh", "refresh", "dock"]
+
+
+@pytest.mark.asyncio
+async def test_idle_mower_docks_without_stop_or_polling() -> None:
+    stop = AsyncMock()
+    refresh_state = AsyncMock()
+    dock = AsyncMock()
+
+    stopped = await async_stop_then_dock(
+        initial_state="idle",
+        stop=stop,
+        dock=dock,
+        refresh_state=refresh_state,
+        initial_delay=0,
+        poll_interval=0,
+    )
+
+    assert stopped is True
+    stop.assert_not_awaited()
+    refresh_state.assert_not_awaited()
+    dock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_docking_continues_when_stop_state_times_out() -> None:
+    stop = AsyncMock()
+    refresh_state = AsyncMock(return_value="mowing")
+    dock = AsyncMock()
+
+    stopped = await async_stop_then_dock(
+        initial_state="mowing",
+        stop=stop,
+        dock=dock,
+        refresh_state=refresh_state,
+        timeout=0,
+        initial_delay=0,
+        poll_interval=0,
+    )
+
+    assert stopped is False
+    stop.assert_awaited_once()
+    dock.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dock_without_stopping_preserves_session_by_docking_directly() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client._async_call_device_method = AsyncMock()
+
+    await client.async_dock_without_stopping()
+
+    client._async_call_device_method.assert_awaited_once_with("dock")
+
+
+@pytest.mark.asyncio
+async def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(task_resumable=True)
+    )
+    client._sync_resume_mowing = Mock(return_value={"r": 0})
+    client._async_call_device_method = AsyncMock()
+
+    await client.async_start_mowing()
+
+    client._sync_resume_mowing.assert_called_once_with()
+    client._async_call_device_method.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_start_uses_fresh_action_without_resumable_session() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(task_resumable=False)
+    )
+    client._sync_resume_mowing = Mock()
+    client._async_call_device_method = AsyncMock()
+
+    await client.async_start_mowing()
+
+    client._sync_resume_mowing.assert_not_called()
+    client._async_call_device_method.assert_awaited_once_with("start_mowing")

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     DreameLawnMowerClient,
+    DreameLawnMowerConnectionError,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.docking import (
     async_stop_then_dock,
@@ -222,3 +223,16 @@ def test_normal_dock_uses_heartbeat_session_state_at_base() -> None:
     refresh_state = orchestrator.await_args.kwargs["refresh_state"]
     assert asyncio.run(refresh_state()) == "paused"
     assert client.async_refresh.await_count == 2
+
+
+def test_normal_dock_falls_back_when_preflight_refresh_fails() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_refresh = AsyncMock(
+        side_effect=DreameLawnMowerConnectionError("status unavailable")
+    )
+    client._async_call_device_method = AsyncMock()
+
+    asyncio.run(client.async_dock())
+
+    client.async_refresh.assert_awaited_once()
+    client._async_call_device_method.assert_awaited_once_with("dock")

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
     DreameLawnMowerClient,
@@ -151,6 +151,10 @@ def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
 
     asyncio.run(client.async_start_mowing())
 
+    client.async_get_status_blob.assert_awaited_once_with(
+        refresh=True,
+        include_cloud=True,
+    )
     client._sync_resume_mowing.assert_called_once_with()
     client._async_call_device_method.assert_not_awaited()
 
@@ -165,5 +169,34 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
 
     asyncio.run(client.async_start_mowing())
 
+    client.async_get_status_blob.assert_awaited_once_with(
+        refresh=True,
+        include_cloud=True,
+    )
     client._sync_resume_mowing.assert_not_called()
     client._async_call_device_method.assert_awaited_once_with("start_mowing")
+
+
+def test_normal_dock_uses_heartbeat_session_state_at_base() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_refresh = AsyncMock(
+        return_value=SimpleNamespace(
+            state="charging_completed",
+            task_status="paused",
+            mowing_session_active=True,
+        )
+    )
+    client._async_call_device_method = AsyncMock()
+    orchestrator = AsyncMock()
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client."
+        "async_stop_then_dock",
+        orchestrator,
+    ):
+        asyncio.run(client.async_dock())
+
+    assert orchestrator.await_args.kwargs["initial_state"] == "paused"
+    refresh_state = orchestrator.await_args.kwargs["refresh_state"]
+    assert asyncio.run(refresh_state()) == "paused"
+    assert client.async_refresh.await_count == 2

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -65,6 +65,29 @@ def test_idle_mower_docks_without_stop_or_polling() -> None:
     dock.assert_awaited_once()
 
 
+def test_interrupted_session_stops_before_normal_docking() -> None:
+    for initial_state in ("paused", "monitoring_paused", "returning"):
+        stop = AsyncMock()
+        refresh_state = AsyncMock(return_value="idle")
+        dock = AsyncMock()
+
+        stopped = asyncio.run(
+            async_stop_then_dock(
+                initial_state=initial_state,
+                stop=stop,
+                dock=dock,
+                refresh_state=refresh_state,
+                initial_delay=0,
+                poll_interval=0,
+            )
+        )
+
+        assert stopped is True
+        stop.assert_awaited_once()
+        refresh_state.assert_awaited_once()
+        dock.assert_awaited_once()
+
+
 def test_docking_continues_when_stop_state_times_out() -> None:
     stop = AsyncMock()
     refresh_state = AsyncMock(return_value="mowing")
@@ -84,6 +107,28 @@ def test_docking_continues_when_stop_state_times_out() -> None:
 
     assert stopped is False
     stop.assert_awaited_once()
+    dock.assert_awaited_once()
+
+
+def test_docking_continues_when_stop_state_refresh_fails() -> None:
+    stop = AsyncMock()
+    refresh_state = AsyncMock(side_effect=OSError("cloud unavailable"))
+    dock = AsyncMock()
+
+    stopped = asyncio.run(
+        async_stop_then_dock(
+            initial_state="mowing",
+            stop=stop,
+            dock=dock,
+            refresh_state=refresh_state,
+            initial_delay=0,
+            poll_interval=0,
+        )
+    )
+
+    assert stopped is False
+    stop.assert_awaited_once()
+    refresh_state.assert_awaited_once()
     dock.assert_awaited_once()
 
 

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -18,6 +18,7 @@ from custom_components.dreame_lawn_mower.binary_sensor import (
     DreameLawnMowerRainProtectionEnabledBinarySensor,
 )
 from custom_components.dreame_lawn_mower.button import (
+    DreameLawnMowerDockWithoutStoppingButton,
     DreameLawnMowerResetMaintenanceButton,
 )
 from custom_components.dreame_lawn_mower.coordinator import _app_map_index_hints
@@ -352,6 +353,34 @@ def test_task_active_binary_sensor_uses_effective_started_flag() -> None:
     assert entity.is_on is False
 
 
+def test_task_active_binary_sensor_prefers_heartbeat_session_state() -> None:
+    entity = object.__new__(DreameLawnMowerBinarySensor)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            started=False,
+            mowing_session_active=True,
+            raw_attributes={},
+        )
+    )
+    entity.entity_description = _binary_sensor_description("task_active")
+
+    assert entity.is_on is True
+
+
+def test_task_resumable_binary_sensor_uses_heartbeat_state() -> None:
+    entity = object.__new__(DreameLawnMowerBinarySensor)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            task_resumable=True,
+            raw_attributes={},
+        )
+    )
+    entity.entity_description = _binary_sensor_description("task_resumable")
+
+    assert entity.available is True
+    assert entity.is_on is True
+
+
 def test_raw_started_binary_sensor_preserves_vendor_flag() -> None:
     entity = object.__new__(DreameLawnMowerBinarySensor)
     entity.coordinator = SimpleNamespace(
@@ -532,6 +561,32 @@ def test_reset_maintenance_button_executes_confirmed_reset(monkeypatch) -> None:
     assert coordinator.last_maintenance_reset_result["executed"] is True
     assert notifications[0]["title"] == "Dreame Lawn Mower Maintenance Reset"
     assert notifications[0]["notification_id"].endswith("_reset_maintenance_blade")
+
+
+def test_dock_without_stopping_button_calls_session_preserving_client_action() -> None:
+    class _FakeClient:
+        def __init__(self) -> None:
+            self.called = False
+
+        async def async_dock_without_stopping(self) -> None:
+            self.called = True
+
+    class _FakeCoordinator:
+        def __init__(self) -> None:
+            self.client = _FakeClient()
+            self.refreshed = False
+
+        async def async_request_refresh(self) -> None:
+            self.refreshed = True
+
+    coordinator = _FakeCoordinator()
+    entity = object.__new__(DreameLawnMowerDockWithoutStoppingButton)
+    entity.coordinator = coordinator
+
+    asyncio.run(entity.async_press())
+
+    assert coordinator.client.called is True
+    assert coordinator.refreshed is True
 
 
 def test_raw_returning_binary_sensor_preserves_vendor_flag() -> None:

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -396,6 +396,25 @@ def test_cloud_offline_snapshot_overrides_specialized_entity_availability() -> N
     assert entity.is_on is None
 
 
+def test_connectivity_binary_sensors_report_off_while_mower_is_offline() -> None:
+    for key, field in (
+        ("online", "online"),
+        ("device_connected", "device_connected"),
+        ("cloud_connected", "cloud_connected"),
+    ):
+        entity = object.__new__(DreameLawnMowerBinarySensor)
+        snapshot_values = {
+            "available": False,
+            "raw_attributes": {},
+            field: False,
+        }
+        entity.coordinator = SimpleNamespace(data=SimpleNamespace(**snapshot_values))
+        entity.entity_description = _binary_sensor_description(key)
+
+        assert entity.available is True
+        assert entity.is_on is False
+
+
 def test_raw_started_binary_sensor_preserves_vendor_flag() -> None:
     entity = object.__new__(DreameLawnMowerBinarySensor)
     entity.coordinator = SimpleNamespace(

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -381,6 +381,21 @@ def test_task_resumable_binary_sensor_uses_heartbeat_state() -> None:
     assert entity.is_on is True
 
 
+def test_cloud_offline_snapshot_overrides_specialized_entity_availability() -> None:
+    entity = object.__new__(DreameLawnMowerBinarySensor)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            available=False,
+            task_resumable=True,
+            raw_attributes={},
+        )
+    )
+    entity.entity_description = _binary_sensor_description("task_resumable")
+
+    assert entity.available is False
+    assert entity.is_on is None
+
+
 def test_raw_started_binary_sensor_preserves_vendor_flag() -> None:
     entity = object.__new__(DreameLawnMowerBinarySensor)
     entity.coordinator = SimpleNamespace(

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -77,6 +77,40 @@ def test_offline_map_camera_does_not_expose_cached_image() -> None:
     assert map_camera_available(snapshot, image_cached=True) is False
 
 
+def test_online_diagnostic_map_camera_does_not_require_map_capability() -> None:
+    snapshot = SimpleNamespace(
+        available=True,
+        mapping_available=False,
+        capabilities=(),
+    )
+
+    assert (
+        map_camera_available(
+            snapshot,
+            image_cached=False,
+            requires_map_capability=False,
+        )
+        is True
+    )
+
+
+def test_offline_diagnostic_map_camera_remains_unavailable() -> None:
+    snapshot = SimpleNamespace(
+        available=False,
+        mapping_available=False,
+        capabilities=(),
+    )
+
+    assert (
+        map_camera_available(
+            snapshot,
+            image_cached=False,
+            requires_map_capability=False,
+        )
+        is False
+    )
+
+
 def test_map_camera_attributes_include_all_app_map_metadata() -> None:
     """Camera attributes expose all app maps, not only the rendered map."""
     view = DreameLawnMowerMapView(

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -4,9 +4,13 @@ from __future__ import annotations
 
 import asyncio
 from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
 
 from custom_components.dreame_lawn_mower.map_attributes import map_camera_attributes
-from custom_components.dreame_lawn_mower.map_cache import DreameLawnMowerMapCameraCache
+from custom_components.dreame_lawn_mower.map_cache import (
+    DreameLawnMowerMapCameraCache,
+    map_camera_available,
+)
 from dreame_lawn_mower_client.models import (
     DreameLawnMowerMapSummary,
     DreameLawnMowerMapView,
@@ -61,6 +65,16 @@ def test_map_camera_attributes_include_app_map_summary_counts() -> None:
     assert attributes["app_maps"] is None
     assert attributes["app_map_object_count"] is None
     assert attributes["app_map_objects"] is None
+
+
+def test_offline_map_camera_does_not_expose_cached_image() -> None:
+    snapshot = SimpleNamespace(
+        available=False,
+        mapping_available=True,
+        capabilities=("map",),
+    )
+
+    assert map_camera_available(snapshot, image_cached=True) is False
 
 
 def test_map_camera_attributes_include_all_app_map_metadata() -> None:

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -1,0 +1,94 @@
+"""Regression tests for mower-specific error meanings."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    descriptor_from_cloud_record,
+    snapshot_from_device,
+)
+
+
+class _ErrorDevice:
+    def __init__(self, code: int, inherited_name: str) -> None:
+        self.available = True
+        self.device_connected = True
+        self.cloud_connected = True
+        self.status = SimpleNamespace(
+            state=SimpleNamespace(name="PAUSED"),
+            state_name="paused",
+            task_status=None,
+            task_status_name="unknown",
+            error=SimpleNamespace(value=code),
+            error_name=inherited_name,
+            has_error=True,
+            battery_level=80,
+            paused=True,
+            returning=False,
+            docked=False,
+            running=False,
+            scheduled_clean=False,
+            shortcut_task=False,
+            cleaning_mode=None,
+            cleaning_mode_name="unknown",
+            attributes={"error": inherited_name, "started": True},
+        )
+        self.info = SimpleNamespace(
+            firmware_version="test",
+            hardware_version="test",
+            raw={},
+        )
+        self.capability = SimpleNamespace(list=[])
+        self.unknown_properties = {}
+        self.realtime_properties = {}
+        self.last_realtime_message = None
+        self._error_code = code
+
+    def get_property(self, property_key: object) -> int | None:
+        if getattr(property_key, "name", None) == "ERROR":
+            return self._error_code
+        return None
+
+
+def _snapshot(code: int, inherited_name: str):
+    descriptor = descriptor_from_cloud_record(
+        {"did": "test", "model": "dreame.mower.g2408", "name": "Mower"},
+        account_type="dreame",
+        country="eu",
+    )
+    assert descriptor is not None
+    return snapshot_from_device(descriptor, _ErrorDevice(code, inherited_name))
+
+
+@pytest.mark.parametrize(
+    ("code", "inherited_name", "expected"),
+    [
+        (2, "cliff", "Mower stuck"),
+        (23, "heart", "Emergency stop pressed"),
+        (53, "unknown", "Rain detected"),
+        (54, "edge", "Low battery"),
+    ],
+)
+def test_mower_error_codes_override_vacuum_labels(
+    code: int,
+    inherited_name: str,
+    expected: str,
+) -> None:
+    snapshot = _snapshot(code, inherited_name)
+
+    assert snapshot.activity == "error"
+    assert snapshot.error_code == code
+    assert snapshot.error_display == expected
+
+
+@pytest.mark.parametrize("code", [61, 70])
+def test_dnd_transition_codes_are_not_active_errors(code: int) -> None:
+    snapshot = _snapshot(code, "route")
+
+    assert snapshot.activity == "paused"
+    assert snapshot.raw_error_code == code
+    assert snapshot.error_source is None
+    assert snapshot.error_display is None

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -53,14 +53,22 @@ class _ErrorDevice:
         return None
 
 
-def _snapshot(code: int, inherited_name: str):
+def _snapshot(
+    code: int,
+    inherited_name: str,
+    *,
+    realtime_error_code: int | None = None,
+):
     descriptor = descriptor_from_cloud_record(
         {"did": "test", "model": "dreame.mower.g2408", "name": "Mower"},
         account_type="dreame",
         country="eu",
     )
     assert descriptor is not None
-    return snapshot_from_device(descriptor, _ErrorDevice(code, inherited_name))
+    device = _ErrorDevice(code, inherited_name)
+    if realtime_error_code is not None:
+        device.realtime_properties = {"2.2": {"value": realtime_error_code}}
+    return snapshot_from_device(descriptor, device)
 
 
 @pytest.mark.parametrize(
@@ -90,5 +98,17 @@ def test_dnd_transition_codes_are_not_active_errors(code: int) -> None:
 
     assert snapshot.activity == "paused"
     assert snapshot.raw_error_code == code
+    assert snapshot.error_source is None
+    assert snapshot.error_display is None
+
+
+@pytest.mark.parametrize("code", [61, 70])
+def test_dnd_transition_suppresses_stale_realtime_error(code: int) -> None:
+    snapshot = _snapshot(code, "route", realtime_error_code=23)
+
+    assert snapshot.activity == "paused"
+    assert snapshot.raw_error_code == code
+    assert snapshot.realtime_error_code == 23
+    assert snapshot.error_code is None
     assert snapshot.error_source is None
     assert snapshot.error_display is None

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -73,7 +73,32 @@ def _batch_payload() -> dict[str, str]:
                             {"x": 20, "y": 30},
                         ],
                     },
-                ]
+                ],
+                [
+                    9,
+                    {
+                        "type": 2,
+                        "shapeType": 3,
+                        "path": [
+                            {"x": 40, "y": 40},
+                            {"x": 60, "y": 60},
+                        ],
+                    },
+                ],
+                [
+                    10,
+                    {
+                        "type": 2,
+                        "shapeType": 2,
+                        "angle": 45,
+                        "path": [
+                            {"x": 40, "y": 40},
+                            {"x": 50, "y": 40},
+                            {"x": 50, "y": 50},
+                            {"x": 40, "y": 50},
+                        ],
+                    },
+                ],
             ],
         },
         "spotAreas": {
@@ -207,7 +232,16 @@ def test_parse_batch_vector_map_handles_map_info_split_and_mow_paths() -> None:
     assert vector_map.boundary.width == 130
     assert len(vector_map.zones) == 1
     assert vector_map.zones[0].name == "Front Yard"
-    assert len(vector_map.forbidden_areas) == 1
+    assert len(vector_map.forbidden_areas) == 3
+    circle = vector_map.forbidden_areas[1]
+    assert circle.shape_type == 3
+    assert len(circle.points) == 36
+    assert circle.points[0] == (60, 50)
+    assert circle.points[9] == (50, 60)
+    rotated_rectangle = vector_map.forbidden_areas[2]
+    assert rotated_rectangle.shape_type == 2
+    assert rotated_rectangle.angle == 45
+    assert rotated_rectangle.points == ((38, 45), (45, 38), (52, 45), (45, 52))
     assert len(vector_map.spot_areas) == 1
     assert len(vector_map.paths) == 1
     assert len(vector_map.contours) == 1
@@ -255,7 +289,7 @@ def test_vector_map_summary_and_renderer_return_drawable_output() -> None:
     assert summary.width == 130
     assert summary.height == 120
     assert summary.segment_count == 1
-    assert summary.no_go_area_count == 1
+    assert summary.no_go_area_count == 3
     assert summary.spot_area_count == 1
     assert summary.active_point_count == 1
     assert summary.pathway_count == 1
@@ -384,7 +418,7 @@ def test_map_view_uses_batch_vector_map_when_app_map_fails() -> None:
     assert view.image_png.startswith(b"\x89PNG")
     assert view.summary is not None
     assert view.summary.segment_count == 1
-    assert view.summary.no_go_area_count == 1
+    assert view.summary.no_go_area_count == 3
     assert view.summary.spot_area_count == 1
     assert view.details is not None
     assert view.details["mow_path_point_count"] == 4


### PR DESCRIPTION
## Summary

- distinguish normal docking, which ends the active mowing session, from direct docking that keeps it resumable
- decode heartbeat-backed task state and charging-aware battery data, then resume paused sessions through the mower task protocol
- mark Home Assistant state unavailable when cloud presence reports the mower offline
- render circular and rotated rectangular forbidden areas correctly
- normalize confirmed mower error and notification codes

## User-facing behavior

The normal lawn mower dock action now stops an active task before returning to base. A separate **Dock Without Ending Session** button returns directly, allowing the regular start action to resume that paused session later.

Task Status, Task Active, and Task Resumable now follow the live heartbeat even while the mower is charging. Cached entities no longer continue presenting old values when cloud presence reports the mower offline.

Map rendering now honors compact circle and rotated-rectangle exclusion geometry.

## Validation

- Ruff and the repository test suite
- Home Assistant config flow under WSL
- supervised A2 transition: paused at dock, resume, mowing, pause, return, charging
- guarded per-zone safe-edge dry run without a settings write