### PR TITLE
Release 0.2.0

### DIFF
--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -20,5 +20,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.1.10"
+  "version": "0.2.0"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.1.10"
+version = "0.2.0"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- bump the integration manifest and Python package version to `0.2.0`
- prepare the first release with Home Assistant live video, improved mower session handling, and mower-native terminology

## Release highlights

- add an A2-validated Home Assistant camera with HLS playback and JPEG snapshots through a Python-managed Tencent XP2P runtime
- support health-checked cached XP2P restart, redacted diagnostics, and deterministic camera/process cleanup
- distinguish normal docking from **Dock Without Ending Session**, allowing paused tasks to remain resumable
- improve offline availability, heartbeat-backed task state, docking behavior, stale-fault suppression, and exclusion-zone rendering
- add mower-native state/task/mode/area/duration fields and labels while preserving compatibility aliases and existing entity registry identifiers

## Notes

- same-LAN delivery may be selected by Tencent automatically, but the tested A2 production firmware does not expose the separate LAN-only service; this release does not claim cloud-independent startup
- new automations should use the mower-native fields documented in the integration; inherited fields remain available during the compatibility window

## Validation

- `python -m ruff check .`
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 python -m pytest tests --ignore=tests/components/dreame_lawn_mower/test_config_flow.py` (672 passed)
- manifest and package versions both resolve to `0.2.0`