### PR TITLE
Fix live video playback and streamline mower entities

### DIFF
--- a/custom_components/dreame_lawn_mower/binary_sensor.py
+++ b/custom_components/dreame_lawn_mower/binary_sensor.py
@@ -324,6 +324,7 @@ class DreameLawnMowerFirmwareUpdateAvailableBinarySensor(
     _attr_name = "Firmware Update Available"
     _attr_icon = "mdi:update"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)

--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -80,6 +80,7 @@ class DreameLawnMowerCaptureDebugSnapshotButton(
     _attr_name = "Capture Debug Snapshot"
     _attr_icon = "mdi:file-document-refresh-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)
@@ -121,6 +122,7 @@ class DreameLawnMowerCaptureOperationSnapshotButton(
     _attr_name = "Capture Operation Snapshot"
     _attr_icon = "mdi:clipboard-pulse-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)

--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -20,5 +20,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.2.0"
+  "version": "0.2.1"
 }

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -345,6 +345,12 @@ class DreameLawnMowerSensor(DreameLawnMowerEntity, SensorEntity):
         self._attr_native_unit_of_measurement = description.native_unit_of_measurement
         self._attr_icon = description.icon
         self._attr_entity_category = description.entity_category
+        self._attr_entity_registry_enabled_default = (
+            description.entity_registry_enabled_default
+        )
+        self._attr_entity_registry_visible_default = (
+            description.entity_registry_visible_default
+        )
 
     @property
     def native_value(self) -> Any:

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -131,6 +131,7 @@ SENSORS = [
         ),
         icon="mdi:numeric",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     DreameSensorDescription(
         key="raw_error",
@@ -138,6 +139,7 @@ SENSORS = [
         value_fn=lambda snapshot: getattr(snapshot, "error_text", None) or "none",
         icon="mdi:text-box-search-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     DreameSensorDescription(
         key="firmware_version",
@@ -145,6 +147,7 @@ SENSORS = [
         value_fn=lambda snapshot: snapshot.firmware_version,
         icon="mdi:package-up",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     DreameSensorDescription(
         key="hardware_version",
@@ -152,6 +155,7 @@ SENSORS = [
         value_fn=lambda snapshot: snapshot.hardware_version,
         icon="mdi:chip",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     DreameSensorDescription(
         key="serial_number",
@@ -160,6 +164,7 @@ SENSORS = [
         exists_fn=lambda snapshot: bool(snapshot.serial_number),
         icon="mdi:barcode",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     DreameSensorDescription(
         key="cloud_update_time",
@@ -168,6 +173,7 @@ SENSORS = [
         exists_fn=lambda snapshot: bool(snapshot.cloud_update_time),
         icon="mdi:clock-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
+        entity_registry_enabled_default=False,
     ),
     DreameSensorDescription(
         key="unknown_property_count",
@@ -642,6 +648,7 @@ class DreameLawnMowerFirmwareUpdateStatusSensor(
     _attr_name = "Firmware Update Status"
     _attr_icon = "mdi:update"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
+    _attr_entity_registry_enabled_default = False
 
     def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
         super().__init__(coordinator)

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -71,6 +71,8 @@ class DreameLawnMowerFirmwareUpdateEntity(
         support = self.coordinator.firmware_update_support
         if support is not None and support.latest_version:
             return support.latest_version
+        if support is not None and getattr(support, "update_available", False) is True:
+            return None
         # HA renders an update entity as Unknown when latest_version is None.
         # No available update means the installed release is also the latest
         # known release, not an unknown firmware state.

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -71,11 +71,14 @@ class DreameLawnMowerFirmwareUpdateEntity(
         support = self.coordinator.firmware_update_support
         if support is not None and support.latest_version:
             return support.latest_version
-        if support is not None and getattr(support, "update_available", False) is True:
+        if (
+            support is not None
+            and getattr(support, "update_available", None) is not False
+        ):
             return None
         # HA renders an update entity as Unknown when latest_version is None.
-        # No available update means the installed release is also the latest
-        # known release, not an unknown firmware state.
+        # Only an explicit no-update result proves the installed release is
+        # also the latest known release.
         return self.installed_version
 
     @property

--- a/custom_components/dreame_lawn_mower/update.py
+++ b/custom_components/dreame_lawn_mower/update.py
@@ -69,7 +69,12 @@ class DreameLawnMowerFirmwareUpdateEntity(
     def latest_version(self) -> str | None:
         """Return the app-approved target firmware version."""
         support = self.coordinator.firmware_update_support
-        return None if support is None else support.latest_version
+        if support is not None and support.latest_version:
+            return support.latest_version
+        # HA renders an update entity as Unknown when latest_version is None.
+        # No available update means the installed release is also the latest
+        # known release, not an unknown firmware state.
+        return self.installed_version
 
     @property
     def in_progress(self) -> bool | int | None:

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -294,18 +294,26 @@ class DreameLawnMowerVideoCamera(
 
     async def stream_source(self) -> str | None:
         """Return HA's verified HLS proxy instead of the single-consumer FLV URL."""
-        ha_stream = await self.async_create_stream()
-        if ha_stream is None:
-            return None
-        try:
-            ha_stream.add_provider(HLS_PROVIDER)
-            endpoint = ha_stream.endpoint_url(HLS_PROVIDER)
-            return urljoin(f"{get_url(self.hass)}/", endpoint)
-        except Exception as err:  # noqa: BLE001 - expose a clean source miss.
-            self._set_stream_error(
-                f"Home Assistant could not expose the verified video stream: {err}"
-            )
-            return None
+        if not getattr(self, "_create_stream_lock", None):
+            self._create_stream_lock = asyncio.Lock()
+        async with self._create_stream_lock:
+            previous_stream = getattr(self, "stream", None)
+            ha_stream = await self._async_create_stream_locked()
+            if ha_stream is None:
+                return None
+            owns_stream = ha_stream is not previous_stream
+            try:
+                ha_stream.add_provider(HLS_PROVIDER)
+                endpoint = ha_stream.endpoint_url(HLS_PROVIDER)
+                return urljoin(f"{get_url(self.hass)}/", endpoint)
+            except Exception as err:  # noqa: BLE001 - expose a clean source miss.
+                self._set_stream_error(
+                    "Home Assistant could not expose the verified video stream: "
+                    f"{err}"
+                )
+                if owns_stream:
+                    await self._async_stop_owned_stream(ha_stream)
+                return None
 
     async def _async_start_raw_source(self) -> str | None:
         """Start live video and return its private single-consumer FLV URL."""
@@ -481,13 +489,13 @@ class DreameLawnMowerVideoCamera(
             return self._last_image
         finally:
             if snapshot_only_stream:
-                await self._async_stop_snapshot_stream(ha_stream)
+                await self._async_stop_owned_stream(ha_stream)
         if image is not None:
             self._last_image = image
         return image or self._last_image
 
-    async def _async_stop_snapshot_stream(self, ha_stream: Any) -> None:
-        """Stop an HA stream created only to serve one still image."""
+    async def _async_stop_owned_stream(self, ha_stream: Any) -> None:
+        """Stop an HA stream created only for the current one-shot operation."""
         async with self._stream_lock:
             if self.stream is not ha_stream:
                 return

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -64,6 +64,7 @@ from .video_session_lifecycle import DreameLawnMowerHaStreamIdleMonitor
 
 _LOGGER = logging.getLogger(__name__)
 _HA_STREAM_START_TIMEOUT = DEFAULT_XP2P_HOST_STARTUP_TIMEOUT + 30.0
+_HA_PLAYBACK_VERIFY_TIMEOUT = 15.0
 _SNAPSHOT_STREAM_START_TIMEOUT = 15.0
 _SNAPSHOT_IMAGE_TIMEOUT = 15.0
 
@@ -111,6 +112,9 @@ class DreameLawnMowerVideoCamera(
         self._prepared_runtime: _DreameVideoRuntime | None = None
         self._runtime_prepare_task: asyncio.Task[None] | None = None
         self._session: DreameLawnMowerXp2pLiveStreamSession | None = None
+        self._unverified_playback_session: (
+            DreameLawnMowerXp2pLiveStreamSession | None
+        ) = None
         self._stream_lock = asyncio.Lock()
         self._snapshot_lock = asyncio.Lock()
         self._stream_idle_monitor = DreameLawnMowerHaStreamIdleMonitor(
@@ -344,19 +348,55 @@ class DreameLawnMowerVideoCamera(
                     ha_stream.set_update_callback(self.async_write_ha_state)
                     self.stream = ha_stream
                     self._stream_idle_monitor.schedule(ha_stream, session)
-                    return ha_stream
+
+                if getattr(self, "_unverified_playback_session", None) is session:
+                    if not await self._async_verify_playback_stream(ha_stream, session):
+                        return None
+                return ha_stream
             except BaseException:
                 if owns_session and session is not None:
                     await self._async_cleanup_failed_stream_setup(session)
                 raise
 
+    async def _async_verify_playback_stream(
+        self,
+        ha_stream: Any,
+        session: DreameLawnMowerXp2pLiveStreamSession,
+    ) -> bool:
+        """Verify the adopted session through HA's sole stream consumer."""
+        try:
+            async with asyncio.timeout(_HA_PLAYBACK_VERIFY_TIMEOUT):
+                image = await ha_stream.async_get_image(wait_for_next_keyframe=True)
+            if image is None:
+                raise DreameLawnMowerVideoRuntimeError(
+                    "Home Assistant did not decode a frame from the playback session."
+                )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 - expose a clean camera miss.
+            await self._async_cleanup_failed_stream_setup(session)
+            self._set_stream_error(
+                "Qualified XP2P video could not verify its playback session: "
+                f"{err}"
+            )
+            return False
+
+        async with self._stream_lock:
+            if self.stream is not ha_stream or self._session is not session:
+                return False
+            self._unverified_playback_session = None
+            if getattr(self, "_last_stream_health", None) is not None:
+                self._last_stream_health["playback_session_verified"] = True
+            self._last_image = image
+        return True
+
     async def _async_cleanup_failed_stream_setup(
         self,
         session: DreameLawnMowerXp2pLiveStreamSession,
     ) -> None:
-        """Stop a session started for an HA stream that was never adopted."""
+        """Stop a session whose HA stream setup or verification failed."""
         async with self._stream_lock:
-            if self._session is session and self.stream is None:
+            if self._session is session:
                 await self._async_stop_active_session()
 
     @staticmethod
@@ -429,8 +469,12 @@ class DreameLawnMowerVideoCamera(
     async def _async_stop_snapshot_stream(self, ha_stream: Any) -> None:
         """Stop an HA stream created only to serve one still image."""
         async with self._stream_lock:
-            if self.stream is ha_stream:
-                await self._async_stop_active_session()
+            if self.stream is not ha_stream:
+                return
+            outputs = getattr(ha_stream, "outputs", None)
+            if callable(outputs) and outputs():
+                return
+            await self._async_stop_active_session()
 
     async def _async_start_stream(self) -> str | None:
         """Start one serialized XP2P stream session."""
@@ -853,7 +897,11 @@ class DreameLawnMowerVideoCamera(
         """Adopt one health-checked session as the active HA camera source."""
         self._runtime = runtime
         self._session = session
-        self._last_stream_health = stream_health.as_dict()
+        self._unverified_playback_session = session
+        self._last_stream_health = {
+            **stream_health.as_dict(),
+            "playback_session_verified": False,
+        }
         self._last_error = None
         self._last_video_transport = transport
         self._attr_is_on = True
@@ -972,6 +1020,7 @@ class DreameLawnMowerVideoCamera(
         session = self._session
         self._runtime = None
         self._session = None
+        self._unverified_playback_session = None
         self._attr_is_streaming = False
         if ha_stream is not None:
             try:

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -6,13 +6,14 @@ import asyncio
 import logging
 from pathlib import Path
 from typing import Any, Protocol
+from urllib.parse import urljoin
 
 from homeassistant.components.camera import (
     DATA_CAMERA_PREFS,
     Camera,
     CameraEntityFeature,
 )
-from homeassistant.components.stream import create_stream
+from homeassistant.components.stream import HLS_PROVIDER, create_stream
 from homeassistant.components.stream.const import (
     ATTR_STREAMS,
 )
@@ -20,6 +21,7 @@ from homeassistant.components.stream.const import (
     DOMAIN as STREAM_DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.helpers.network import get_url
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import video_stream_helpers as video_helpers
@@ -291,7 +293,22 @@ class DreameLawnMowerVideoCamera(
         }
 
     async def stream_source(self) -> str | None:
-        """Start live video and return the local FLV source URL for HA stream."""
+        """Return HA's verified HLS proxy instead of the single-consumer FLV URL."""
+        ha_stream = await self.async_create_stream()
+        if ha_stream is None:
+            return None
+        try:
+            ha_stream.add_provider(HLS_PROVIDER)
+            endpoint = ha_stream.endpoint_url(HLS_PROVIDER)
+            return urljoin(f"{get_url(self.hass)}/", endpoint)
+        except Exception as err:  # noqa: BLE001 - expose a clean source miss.
+            self._set_stream_error(
+                f"Home Assistant could not expose the verified video stream: {err}"
+            )
+            return None
+
+    async def _async_start_raw_source(self) -> str | None:
+        """Start live video and return its private single-consumer FLV URL."""
         async with self._stream_lock:
             if not getattr(self, "_attr_is_on", True):
                 self._set_stream_error("Dreame mower live video is turned off.")
@@ -304,59 +321,63 @@ class DreameLawnMowerVideoCamera(
 
     async def async_create_stream(self) -> Any | None:
         """Create HA's stream with enough time for native XP2P startup."""
-        if not self._create_stream_lock:
+        if not getattr(self, "_create_stream_lock", None):
             self._create_stream_lock = asyncio.Lock()
         async with self._create_stream_lock:
+            return await self._async_create_stream_locked()
+
+    async def _async_create_stream_locked(self) -> Any | None:
+        """Create or reuse one HA stream while the creation lock is held."""
+        async with self._stream_lock:
+            if self.stream is not None:
+                if getattr(self, "_attr_is_on", True) and self._session_is_usable(
+                    self._session
+                ):
+                    return self.stream
+                await self._async_stop_active_session()
+
+        previous_session = self._session
+        session: DreameLawnMowerXp2pLiveStreamSession | None = None
+        owns_session = False
+        try:
+            async with asyncio.timeout(_HA_STREAM_START_TIMEOUT):
+                source = await self._async_start_raw_source()
+            if not source:
+                return None
+            session = self._session
+            owns_session = session is not None and session is not previous_session
+            dynamic_settings = await self.hass.data[
+                DATA_CAMERA_PREFS
+            ].get_dynamic_stream_settings(self.entity_id)
+
             async with self._stream_lock:
-                if self.stream is not None:
-                    if getattr(self, "_attr_is_on", True) and self._session_is_usable(
-                        self._session
-                    ):
-                        return self.stream
-                    await self._async_stop_active_session()
-
-            previous_session = self._session
-            session: DreameLawnMowerXp2pLiveStreamSession | None = None
-            owns_session = False
-            try:
-                async with asyncio.timeout(_HA_STREAM_START_TIMEOUT):
-                    source = await self.stream_source()
-                if not source:
+                if (
+                    not getattr(self, "_attr_is_on", True)
+                    or self._session is not session
+                    or not self._session_is_usable(session)
+                ):
+                    if self._session is session:
+                        await self._async_stop_active_session()
                     return None
-                session = self._session
-                owns_session = session is not None and session is not previous_session
-                dynamic_settings = await self.hass.data[
-                    DATA_CAMERA_PREFS
-                ].get_dynamic_stream_settings(self.entity_id)
+                ha_stream = create_stream(
+                    self.hass,
+                    source,
+                    options=self.stream_options,
+                    dynamic_stream_settings=dynamic_settings,
+                    stream_label=self.entity_id,
+                )
+                ha_stream.set_update_callback(self.async_write_ha_state)
+                self.stream = ha_stream
+                self._stream_idle_monitor.schedule(ha_stream, session)
 
-                async with self._stream_lock:
-                    if (
-                        not getattr(self, "_attr_is_on", True)
-                        or self._session is not session
-                        or not self._session_is_usable(session)
-                    ):
-                        if self._session is session:
-                            await self._async_stop_active_session()
-                        return None
-                    ha_stream = create_stream(
-                        self.hass,
-                        source,
-                        options=self.stream_options,
-                        dynamic_stream_settings=dynamic_settings,
-                        stream_label=self.entity_id,
-                    )
-                    ha_stream.set_update_callback(self.async_write_ha_state)
-                    self.stream = ha_stream
-                    self._stream_idle_monitor.schedule(ha_stream, session)
-
-                if getattr(self, "_unverified_playback_session", None) is session:
-                    if not await self._async_verify_playback_stream(ha_stream, session):
-                        return None
-                return ha_stream
-            except BaseException:
-                if owns_session and session is not None:
-                    await self._async_cleanup_failed_stream_setup(session)
-                raise
+            if getattr(self, "_unverified_playback_session", None) is session:
+                if not await self._async_verify_playback_stream(ha_stream, session):
+                    return None
+            return ha_stream
+        except BaseException:
+            if owns_session and session is not None:
+                await self._async_cleanup_failed_stream_setup(session)
+            raise
 
     async def _async_verify_playback_stream(
         self,
@@ -418,7 +439,10 @@ class DreameLawnMowerVideoCamera(
         if not getattr(self, "_attr_is_on", True):
             return None
         async with self._snapshot_lock:
-            return await self._async_camera_image_locked(width, height)
+            if not getattr(self, "_create_stream_lock", None):
+                self._create_stream_lock = asyncio.Lock()
+            async with self._create_stream_lock:
+                return await self._async_camera_image_locked(width, height)
 
     async def _async_camera_image_locked(
         self,
@@ -429,7 +453,7 @@ class DreameLawnMowerVideoCamera(
         previous_stream = getattr(self, "stream", None)
         try:
             async with asyncio.timeout(_SNAPSHOT_STREAM_START_TIMEOUT):
-                ha_stream = await self.async_create_stream()
+                ha_stream = await self._async_create_stream_locked()
         except TimeoutError:
             _LOGGER.debug("Timed out starting Dreame mower video for a still image")
             return self._last_image
@@ -441,11 +465,7 @@ class DreameLawnMowerVideoCamera(
             return self._last_image
         if ha_stream is None:
             return self._last_image
-        outputs = getattr(ha_stream, "outputs", None)
-        has_existing_output = bool(outputs()) if callable(outputs) else False
-        snapshot_only_stream = (
-            ha_stream is not previous_stream and not has_existing_output
-        )
+        snapshot_only_stream = ha_stream is not previous_stream
         try:
             async with asyncio.timeout(_SNAPSHOT_IMAGE_TIMEOUT):
                 image = await ha_stream.async_get_image(
@@ -471,9 +491,8 @@ class DreameLawnMowerVideoCamera(
         async with self._stream_lock:
             if self.stream is not ha_stream:
                 return
-            outputs = getattr(ha_stream, "outputs", None)
-            if callable(outputs) and outputs():
-                return
+            # The creation lock remains held across the image read and cleanup,
+            # so no live viewer can adopt this stream before it is stopped.
             await self._async_stop_active_session()
 
     async def _async_start_stream(self) -> str | None:
@@ -582,10 +601,14 @@ class DreameLawnMowerVideoCamera(
                 )
 
         if cached_xp2p_inputs is not None and cached_xp2p_inputs.ready:
-            cached_source = await self._async_try_cached_xp2p_stream(
-                runtime,
-                cached_xp2p_inputs,
-            )
+            try:
+                cached_source = await self._async_try_cached_xp2p_stream(
+                    runtime,
+                    cached_xp2p_inputs,
+                )
+            except DreameLawnMowerVideoRuntimeError as err:
+                self._set_stream_error(self._with_lan_failure(str(err)))
+                return None
             if cached_source is not None:
                 return cached_source
 
@@ -787,7 +810,7 @@ class DreameLawnMowerVideoCamera(
                 "Qualified cached XP2P probe session could not stop before "
                 "playback handoff."
             )
-            return None
+            raise DreameLawnMowerVideoRuntimeError(self._last_cached_xp2p_error)
         try:
             session = await self._async_start_runtime_session(
                 runtime,

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -65,6 +65,7 @@ from .video_session_lifecycle import DreameLawnMowerHaStreamIdleMonitor
 _LOGGER = logging.getLogger(__name__)
 _HA_STREAM_START_TIMEOUT = DEFAULT_XP2P_HOST_STARTUP_TIMEOUT + 30.0
 _SNAPSHOT_STREAM_START_TIMEOUT = 15.0
+_SNAPSHOT_IMAGE_TIMEOUT = 15.0
 
 
 class _DreameVideoRuntime(Protocol):
@@ -400,11 +401,15 @@ class DreameLawnMowerVideoCamera(
         if ha_stream is None:
             return self._last_image
         try:
-            image = await ha_stream.async_get_image(
-                width=width,
-                height=height,
-                wait_for_next_keyframe=True,
-            )
+            async with asyncio.timeout(_SNAPSHOT_IMAGE_TIMEOUT):
+                image = await ha_stream.async_get_image(
+                    width=width,
+                    height=height,
+                    wait_for_next_keyframe=True,
+                )
+        except TimeoutError:
+            _LOGGER.debug("Timed out reading Dreame mower still image")
+            return self._last_image
         except Exception as err:  # noqa: BLE001 - snapshots may be transient.
             _LOGGER.debug("Failed to read Dreame mower still image: %s", err)
             return self._last_image
@@ -579,14 +584,26 @@ class DreameLawnMowerVideoCamera(
             )
             return None
 
-        await self._async_cache_healthy_provisioning(cloud_inputs)
-
-        # Tencent's delegated HTTP-FLV endpoint is session-scoped and is not a
-        # safe multi-consumer source. The health check intentionally consumes
-        # the qualified session; hand Home Assistant a fresh, untouched one.
-        await self._async_stop_session(runtime, session)
-        session = None
         try:
+            try:
+                await self._async_cache_healthy_provisioning(cloud_inputs)
+            except asyncio.CancelledError:
+                await self._async_stop_session_for_handoff(runtime, session)
+                raise
+
+            # Tencent's delegated HTTP-FLV endpoint is session-scoped and is not a
+            # safe multi-consumer source. The health check intentionally consumes
+            # the qualified session; hand Home Assistant a fresh, untouched one.
+            if not await self._async_stop_session_for_handoff(runtime, session):
+                await self._async_disable_camera_stream()
+                self._set_stream_error(
+                    self._with_lan_failure(
+                        "Qualified XP2P probe session could not stop before "
+                        "playback handoff."
+                    )
+                )
+                return None
+            session = None
             session = await self._async_start_runtime_session(runtime, cloud_inputs)
         except asyncio.CancelledError:
             await self._async_disable_camera_stream()
@@ -666,7 +683,13 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - a live stream remains usable.
             self._lan_cache_error = str(err)
             _LOGGER.warning("Failed to save Dreame LAN video endpoint: %s", err)
-        await self._async_stop_session(runtime, session)
+        if not await self._async_stop_session_for_handoff(runtime, session):
+            self._last_lan_error = (
+                "Qualified same-LAN probe session could not stop before "
+                "playback handoff."
+            )
+            return None
+        session = None
         try:
             session = await self._async_start_lan_runtime_session(runtime, inputs)
         except asyncio.CancelledError:
@@ -700,7 +723,12 @@ class DreameLawnMowerVideoCamera(
         if result.session is None or result.health is None:
             self._last_cached_xp2p_error = result.error
             return None
-        await self._async_stop_session(runtime, result.session)
+        if not await self._async_stop_session_for_handoff(runtime, result.session):
+            self._last_cached_xp2p_error = (
+                "Qualified cached XP2P probe session could not stop before "
+                "playback handoff."
+            )
+            return None
         try:
             session = await self._async_start_runtime_session(
                 runtime,
@@ -971,12 +999,27 @@ class DreameLawnMowerVideoCamera(
         self,
         runtime: _DreameVideoRuntime,
         session: DreameLawnMowerXp2pLiveStreamSession,
-    ) -> None:
+    ) -> bool:
         """Stop a runtime session without changing entity state bookkeeping."""
         try:
             await self.hass.async_add_executor_job(runtime.stop_live_stream, session)
+            return True
         except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
             _LOGGER.debug("Failed to stop Dreame mower live video: %s", err)
+            return False
+
+    async def _async_stop_session_for_handoff(
+        self,
+        runtime: _DreameVideoRuntime,
+        session: DreameLawnMowerXp2pLiveStreamSession,
+    ) -> bool:
+        """Finish probe cleanup before cancellation or a replacement session."""
+        stop_task = asyncio.create_task(self._async_stop_session(runtime, session))
+        try:
+            return await asyncio.shield(stop_task)
+        except asyncio.CancelledError:
+            await stop_task
+            raise
 
     async def _async_disable_camera_stream(self) -> None:
         """Best-effort app-side video cleanup."""

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -384,52 +384,33 @@ class DreameLawnMowerVideoCamera(
         width: int | None,
         height: int | None,
     ) -> bytes | None:
-        """Decode one JPEG while serializing snapshot-only session ownership."""
-        existing_session = self._session
-        snapshot_session: DreameLawnMowerXp2pLiveStreamSession | None = None
+        """Return one JPEG from Home Assistant's single FLV consumer."""
         try:
             async with asyncio.timeout(_SNAPSHOT_STREAM_START_TIMEOUT):
-                source = await self.stream_source()
+                ha_stream = await self.async_create_stream()
         except TimeoutError:
             _LOGGER.debug("Timed out starting Dreame mower video for a still image")
             return self._last_image
-        if source is None:
+        except Exception as err:  # noqa: BLE001 - snapshots may be transient.
+            _LOGGER.debug(
+                "Failed to start Dreame mower video for a still image: %s",
+                err,
+            )
+            return self._last_image
+        if ha_stream is None:
             return self._last_image
         try:
-            current_session = self._session
-            if current_session is not None and current_session is not existing_session:
-                snapshot_session = current_session
-            image = await self.hass.async_add_executor_job(
-                video_helpers.decode_flv_jpeg,
-                source,
-                width,
-                height,
+            image = await ha_stream.async_get_image(
+                width=width,
+                height=height,
+                wait_for_next_keyframe=True,
             )
         except Exception as err:  # noqa: BLE001 - snapshots may be transient.
-            _LOGGER.debug("Failed to decode Dreame mower still image: %s", err)
+            _LOGGER.debug("Failed to read Dreame mower still image: %s", err)
             return self._last_image
-        finally:
-            if snapshot_session is not None:
-                await self._async_stop_snapshot_session(snapshot_session)
         if image is not None:
             self._last_image = image
         return image or self._last_image
-
-    async def _async_stop_snapshot_session(
-        self,
-        snapshot_session: DreameLawnMowerXp2pLiveStreamSession,
-    ) -> None:
-        """Stop a session created only for a still unless HLS adopted it."""
-        while True:
-            async with self._stream_lock:
-                if self._session is not snapshot_session or self.stream is not None:
-                    return
-                create_stream_lock = self._create_stream_lock
-                if create_stream_lock is None or not create_stream_lock.locked():
-                    await self._async_stop_active_session()
-                    return
-            async with create_stream_lock:
-                pass
 
     async def _async_start_stream(self) -> str | None:
         """Start one serialized XP2P stream session."""
@@ -600,6 +581,25 @@ class DreameLawnMowerVideoCamera(
 
         await self._async_cache_healthy_provisioning(cloud_inputs)
 
+        # Tencent's delegated HTTP-FLV endpoint is session-scoped and is not a
+        # safe multi-consumer source. The health check intentionally consumes
+        # the qualified session; hand Home Assistant a fresh, untouched one.
+        await self._async_stop_session(runtime, session)
+        session = None
+        try:
+            session = await self._async_start_runtime_session(runtime, cloud_inputs)
+        except asyncio.CancelledError:
+            await self._async_disable_camera_stream()
+            raise
+        except Exception as err:  # noqa: BLE001 - HA should receive a clean miss.
+            await self._async_disable_camera_stream()
+            self._set_stream_error(
+                self._with_lan_failure(
+                    f"Qualified XP2P video could not open a playback session: {err}"
+                )
+            )
+            return None
+
         return self._adopt_stream_session(
             runtime,
             session,
@@ -666,6 +666,17 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - a live stream remains usable.
             self._lan_cache_error = str(err)
             _LOGGER.warning("Failed to save Dreame LAN video endpoint: %s", err)
+        await self._async_stop_session(runtime, session)
+        try:
+            session = await self._async_start_lan_runtime_session(runtime, inputs)
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 - Auto may fall back to cloud.
+            self._last_lan_error = (
+                "Qualified same-LAN video could not open a playback session: "
+                f"{err}"
+            )
+            return None
         return self._adopt_stream_session(
             runtime,
             session,
@@ -689,9 +700,24 @@ class DreameLawnMowerVideoCamera(
         if result.session is None or result.health is None:
             self._last_cached_xp2p_error = result.error
             return None
+        await self._async_stop_session(runtime, result.session)
+        try:
+            session = await self._async_start_runtime_session(
+                runtime,
+                inputs,
+                camera_toggle_managed=False,
+            )
+        except asyncio.CancelledError:
+            raise
+        except Exception as err:  # noqa: BLE001 - Auto may fall back to cloud.
+            self._last_cached_xp2p_error = (
+                "Qualified cached XP2P video could not open a playback session: "
+                f"{err}"
+            )
+            return None
         return self._adopt_stream_session(
             runtime,
-            result.session,
+            session,
             result.health,
             transport="cached_xp2p",
         )

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -386,6 +386,7 @@ class DreameLawnMowerVideoCamera(
         height: int | None,
     ) -> bytes | None:
         """Return one JPEG from Home Assistant's single FLV consumer."""
+        previous_stream = getattr(self, "stream", None)
         try:
             async with asyncio.timeout(_SNAPSHOT_STREAM_START_TIMEOUT):
                 ha_stream = await self.async_create_stream()
@@ -400,6 +401,11 @@ class DreameLawnMowerVideoCamera(
             return self._last_image
         if ha_stream is None:
             return self._last_image
+        outputs = getattr(ha_stream, "outputs", None)
+        has_existing_output = bool(outputs()) if callable(outputs) else False
+        snapshot_only_stream = (
+            ha_stream is not previous_stream and not has_existing_output
+        )
         try:
             async with asyncio.timeout(_SNAPSHOT_IMAGE_TIMEOUT):
                 image = await ha_stream.async_get_image(
@@ -413,9 +419,18 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - snapshots may be transient.
             _LOGGER.debug("Failed to read Dreame mower still image: %s", err)
             return self._last_image
+        finally:
+            if snapshot_only_stream:
+                await self._async_stop_snapshot_stream(ha_stream)
         if image is not None:
             self._last_image = image
         return image or self._last_image
+
+    async def _async_stop_snapshot_stream(self, ha_stream: Any) -> None:
+        """Stop an HA stream created only to serve one still image."""
+        async with self._stream_lock:
+            if self.stream is ha_stream:
+                await self._async_stop_active_session()
 
     async def _async_start_stream(self) -> str | None:
         """Start one serialized XP2P stream session."""

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -557,7 +557,11 @@ class DreameLawnMowerVideoCamera(
                     lan_inputs = self._lan_cache.inputs
 
             if lan_inputs is not None:
-                lan_source = await self._async_try_lan_stream(runtime, lan_inputs)
+                try:
+                    lan_source = await self._async_try_lan_stream(runtime, lan_inputs)
+                except DreameLawnMowerVideoRuntimeError as err:
+                    self._set_stream_error(str(err))
+                    return None
                 if lan_source is not None:
                     return lan_source
                 if (
@@ -584,10 +588,14 @@ class DreameLawnMowerVideoCamera(
                         )
                     else:
                         if cloud_inputs.lan_identity_ready:
-                            lan_source = await self._async_try_lan_stream(
-                                runtime,
-                                cloud_inputs,
-                            )
+                            try:
+                                lan_source = await self._async_try_lan_stream(
+                                    runtime,
+                                    cloud_inputs,
+                                )
+                            except DreameLawnMowerVideoRuntimeError as err:
+                                self._set_stream_error(str(err))
+                                return None
                             if lan_source is not None:
                                 return lan_source
                             self._last_lan_error = (
@@ -778,7 +786,7 @@ class DreameLawnMowerVideoCamera(
                 "Qualified same-LAN probe session could not stop before "
                 "playback handoff."
             )
-            return None
+            raise DreameLawnMowerVideoRuntimeError(self._last_lan_error)
         session = None
         try:
             session = await self._async_start_lan_runtime_session(runtime, inputs)

--- a/custom_components/dreame_lawn_mower/video_stream_helpers.py
+++ b/custom_components/dreame_lawn_mower/video_stream_helpers.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import io
 import platform
 import shlex
 from collections.abc import Callable
@@ -29,10 +28,6 @@ _STREAM_HEALTH_ATTEMPTS = 3
 _STREAM_HEALTH_RETRY_INTERVAL = 0.5
 _STREAM_HEALTH_TIMEOUT = 3.0
 _STREAM_HEALTH_BYTES = 16
-_STILL_CONNECT_TIMEOUT = 3.0
-_STILL_READ_TIMEOUT = 7.0
-
-
 def option_text(entry: ConfigEntry, key: str) -> str | None:
     """Return a trimmed non-empty string option."""
     value = entry.options.get(key)
@@ -69,34 +64,6 @@ def safe_state_attribute(value: Any, *, max_depth: int = 4) -> Any:
     if isinstance(value, (list, tuple)):
         return [safe_state_attribute(item, max_depth=max_depth - 1) for item in value]
     return repr(value)
-
-
-def decode_flv_jpeg(
-    stream_url: str,
-    width: int | None,
-    height: int | None,
-) -> bytes | None:
-    """Decode the first FLV video frame to JPEG without optional TurboJPEG."""
-    import av
-    from PIL import Image
-
-    with av.open(
-        stream_url,
-        timeout=(_STILL_CONNECT_TIMEOUT, _STILL_READ_TIMEOUT),
-    ) as container:
-        for frame in container.decode(video=0):
-            image = frame.to_image().convert("RGB")
-            if width or height:
-                target_width = max(int(width or image.width), 1)
-                target_height = max(int(height or image.height), 1)
-                image.thumbnail(
-                    (target_width, target_height),
-                    Image.Resampling.LANCZOS,
-                )
-            encoded = io.BytesIO()
-            image.save(encoded, format="JPEG", quality=90)
-            return encoded.getvalue()
-    return None
 
 
 def split_runner_command(command: str) -> tuple[str, ...]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.2.0"
+version = "0.2.1"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from io import BytesIO
+from types import SimpleNamespace
 from typing import Any
 
 from homeassistant.const import Platform
@@ -58,6 +59,7 @@ from custom_components.dreame_lawn_mower.sensor import (
     DreameLawnMowerRuntimeHeadingSensor,
     DreameLawnMowerRuntimePositionXSensor,
     DreameLawnMowerRuntimePositionYSensor,
+    DreameLawnMowerSensor,
     DreameLawnMowerWeatherProtectionStatusSensor,
     DreameSensorDescription,
     app_map_object_attributes,
@@ -99,6 +101,26 @@ def test_sensor_description_exposes_ha_compat_fields() -> None:
     assert description.state_class is None
     assert description.last_reset is None
     assert description.options is None
+
+
+def test_sensor_applies_description_registry_defaults() -> None:
+    description = DreameSensorDescription(
+        key="hidden_test",
+        name="Hidden Test",
+        value_fn=lambda _: None,
+        entity_registry_enabled_default=False,
+        entity_registry_visible_default=False,
+    )
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(
+            descriptor=SimpleNamespace(unique_id="mower-1"),
+        )
+    )
+
+    entity = DreameLawnMowerSensor(coordinator, description)
+
+    assert entity._attr_entity_registry_enabled_default is False
+    assert entity._attr_entity_registry_visible_default is False
 
 
 def test_binary_sensor_description_exposes_ha_compat_fields() -> None:

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -19,6 +19,8 @@ from custom_components.dreame_lawn_mower.binary_sensor import (
 )
 from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerCaptureBatchDeviceDataProbeButton,
+    DreameLawnMowerCaptureDebugSnapshotButton,
+    DreameLawnMowerCaptureOperationSnapshotButton,
     DreameLawnMowerCapturePreferenceProbeButton,
     DreameLawnMowerCaptureScheduleProbeButton,
     DreameLawnMowerCaptureTaskStatusProbeButton,
@@ -38,6 +40,7 @@ from custom_components.dreame_lawn_mower.image import (
     png_bytes_to_jpeg,
 )
 from custom_components.dreame_lawn_mower.sensor import (
+    SENSORS,
     DreameLawnMowerAppMapObjectCountSensor,
     DreameLawnMowerConfiguredScheduleCountSensor,
     DreameLawnMowerFirmwareUpdateStatusSensor,
@@ -285,6 +288,30 @@ def test_reset_maintenance_button_is_diagnostic_disabled_by_default() -> None:
         ]
         is False
     )
+
+
+def test_default_entity_surface_hides_duplicate_and_debug_entities() -> None:
+    descriptions = {description.key: description for description in SENSORS}
+    for key in (
+        "error_code",
+        "raw_error",
+        "firmware_version",
+        "hardware_version",
+        "serial_number",
+        "cloud_update_time",
+    ):
+        assert descriptions[key].entity_registry_enabled_default is False
+
+    for entity_class in (
+        DreameLawnMowerCaptureDebugSnapshotButton,
+        DreameLawnMowerCaptureOperationSnapshotButton,
+        DreameLawnMowerFirmwareUpdateAvailableBinarySensor,
+        DreameLawnMowerFirmwareUpdateStatusSensor,
+    ):
+        assert (
+            entity_class.__dict__["__attr_entity_registry_enabled_default"]
+            is False
+        )
 
 
 def test_maintenance_reset_result_attributes_are_compact() -> None:

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -94,6 +94,20 @@ def test_firmware_update_entity_uses_installed_version_when_no_target_exists() -
     assert entity.latest_version == "4.3.6_0625"
 
 
+def test_firmware_update_entity_keeps_unknown_target_for_reported_update() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(firmware_version="4.3.6_0625"),
+        firmware_update_support=SimpleNamespace(
+            latest_version=None,
+            update_available=True,
+        ),
+    )
+
+    assert entity.installed_version == "4.3.6_0625"
+    assert entity.latest_version is None
+
+
 def test_approve_firmware_update_treats_wrapper_success_as_accepted() -> None:
     client = object.__new__(DreameLawnMowerClient)
 

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -87,7 +87,10 @@ def test_firmware_update_entity_uses_installed_version_when_no_target_exists() -
     entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
     entity.coordinator = SimpleNamespace(
         data=SimpleNamespace(firmware_version="4.3.6_0625"),
-        firmware_update_support=SimpleNamespace(latest_version=None),
+        firmware_update_support=SimpleNamespace(
+            latest_version=None,
+            update_available=False,
+        ),
     )
 
     assert entity.installed_version == "4.3.6_0625"
@@ -101,6 +104,20 @@ def test_firmware_update_entity_keeps_unknown_target_for_reported_update() -> No
         firmware_update_support=SimpleNamespace(
             latest_version=None,
             update_available=True,
+        ),
+    )
+
+    assert entity.installed_version == "4.3.6_0625"
+    assert entity.latest_version is None
+
+
+def test_firmware_update_entity_keeps_unknown_target_for_uncertain_update() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(firmware_version="4.3.6_0625"),
+        firmware_update_support=SimpleNamespace(
+            latest_version=None,
+            update_available=None,
         ),
     )
 

--- a/tests/test_update_entity.py
+++ b/tests/test_update_entity.py
@@ -83,6 +83,17 @@ def test_firmware_update_entity_prefers_live_non_update_state() -> None:
     assert entity.in_progress is False
 
 
+def test_firmware_update_entity_uses_installed_version_when_no_target_exists() -> None:
+    entity = object.__new__(DreameLawnMowerFirmwareUpdateEntity)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(firmware_version="4.3.6_0625"),
+        firmware_update_support=SimpleNamespace(latest_version=None),
+    )
+
+    assert entity.installed_version == "4.3.6_0625"
+    assert entity.latest_version == "4.3.6_0625"
+
+
 def test_approve_firmware_update_treats_wrapper_success_as_accepted() -> None:
     client = object.__new__(DreameLawnMowerClient)
 

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -615,8 +615,11 @@ def test_video_camera_returns_jpeg_from_home_assistant_stream() -> None:
                 call.update(kwargs)
                 return b"\xff\xd8real-jpeg\xff\xd9"
 
+        stream = _Stream()
+        entity.stream = stream
+
         async def _create_stream() -> _Stream:
-            return _Stream()
+            return stream
 
         entity.async_create_stream = _create_stream
         image = await entity.async_camera_image(width=640, height=360)
@@ -630,6 +633,35 @@ def test_video_camera_returns_jpeg_from_home_assistant_stream() -> None:
         "height": 360,
         "wait_for_next_keyframe": True,
     }
+
+
+def test_video_camera_stops_stream_created_only_for_snapshot() -> None:
+    async def _run() -> tuple[bytes | None, int]:
+        entity = _uninitialized_entity()
+        entity._last_image = None
+        stops = 0
+
+        class _Stream:
+            async def async_get_image(self, **_kwargs) -> bytes:
+                return b"\xff\xd8snapshot-jpeg\xff\xd9"
+
+        stream = _Stream()
+
+        async def _create_stream() -> _Stream:
+            entity.stream = stream
+            return stream
+
+        async def _stop() -> None:
+            nonlocal stops
+            stops += 1
+            entity.stream = None
+
+        entity.async_create_stream = _create_stream
+        entity._async_stop_active_session = _stop
+        image = await entity.async_camera_image()
+        return image, stops
+
+    assert asyncio.run(_run()) == (b"\xff\xd8snapshot-jpeg\xff\xd9", 1)
 
 
 def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
@@ -659,10 +691,11 @@ def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
 
 
 def test_video_camera_snapshot_image_timeout_returns_last_image() -> None:
-    async def _run() -> tuple[bytes | None, bool]:
+    async def _run() -> tuple[bytes | None, bool, int]:
         entity = _uninitialized_entity()
         entity._last_image = b"\xff\xd8cached-jpeg\xff\xd9"
         cancelled = False
+        stops = 0
 
         class _Stream:
             async def async_get_image(self, **_kwargs) -> bytes:
@@ -673,15 +706,24 @@ def test_video_camera_snapshot_image_timeout_returns_last_image() -> None:
                     cancelled = True
                 raise AssertionError("unreachable")
 
+        stream = _Stream()
+
         async def _create_stream() -> _Stream:
-            return _Stream()
+            entity.stream = stream
+            return stream
+
+        async def _stop() -> None:
+            nonlocal stops
+            stops += 1
+            entity.stream = None
 
         entity.async_create_stream = _create_stream
+        entity._async_stop_active_session = _stop
         with patch.object(video_camera_module, "_SNAPSHOT_IMAGE_TIMEOUT", 0.01):
             image = await entity.async_camera_image()
-        return image, cancelled
+        return image, cancelled, stops
 
-    assert asyncio.run(_run()) == (b"\xff\xd8cached-jpeg\xff\xd9", True)
+    assert asyncio.run(_run()) == (b"\xff\xd8cached-jpeg\xff\xd9", True, 1)
 
 
 def test_video_camera_stop_unregisters_cached_home_assistant_stream() -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -10,6 +10,8 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 from unittest.mock import patch
 
+import pytest
+
 try:
     import turbojpeg  # noqa: F401
 except ModuleNotFoundError:
@@ -45,6 +47,7 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.stream_health 
     DreameLawnMowerStreamUrlProbeResult,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.video_runtime import (
+    DreameLawnMowerVideoRuntimeError,
     DreameLawnMowerXp2pLiveStreamSession,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.xp2p_config import (
@@ -1558,8 +1561,8 @@ def test_video_camera_cloud_handoff_cancellation_disables_video() -> None:
     assert asyncio.run(_run()) == ([True, False], 1, 1, True)
 
 
-def test_video_camera_lan_handoff_aborts_when_probe_stop_fails() -> None:
-    async def _run() -> tuple[str | None, int, int, str | None]:
+def test_video_camera_lan_handoff_raises_when_probe_stop_fails() -> None:
+    async def _run() -> tuple[int, int, str | None]:
         entity = _uninitialized_entity()
         inputs = DreameLawnMowerCameraStreamRuntimeInputs(
             source="lan_video_cache",
@@ -1610,14 +1613,65 @@ def test_video_camera_lan_handoff_aborts_when_probe_stop_fails() -> None:
             "probe_stream_health_and_route",
             return_value=health,
         ):
-            source = await entity._async_try_lan_stream(runtime, inputs)
-        return source, runtime.starts, runtime.stops, entity._last_lan_error
+            with pytest.raises(DreameLawnMowerVideoRuntimeError):
+                await entity._async_try_lan_stream(runtime, inputs)
+        return runtime.starts, runtime.stops, entity._last_lan_error
 
-    source, starts, stops, error = asyncio.run(_run())
+    starts, stops, error = asyncio.run(_run())
 
-    assert source is None
     assert starts == 1
     assert stops == 1
+    assert error == (
+        "Qualified same-LAN probe session could not stop before playback handoff."
+    )
+
+
+def test_video_camera_lan_probe_stop_failure_aborts_auto_fallback() -> None:
+    async def _run() -> tuple[str | None, str | None]:
+        entity = _uninitialized_entity(
+            snapshot=SimpleNamespace(available=True, raw_attributes={})
+        )
+        entity._entry.options[CONF_VIDEO_TRANSPORT] = VIDEO_TRANSPORT_AUTO
+        entity._prepared_runtime = object()
+        entity._runtime_preparation_error = None
+        entity._last_error = None
+        entity._attr_is_streaming = False
+        entity.async_write_ha_state = lambda: None
+        entity._lan_cache = SimpleNamespace(
+            inputs=DreameLawnMowerCameraStreamRuntimeInputs(
+                source="lan_video_cache",
+                did="did-1",
+                product_id="product-1",
+                device_name="device-1",
+            ),
+            endpoint=object(),
+        )
+
+        class _Client:
+            async def async_get_camera_stream_runtime_inputs(self) -> object:
+                raise AssertionError("Stop failure must not refresh LAN or use cloud")
+
+            async def async_set_camera_stream_enabled(self, _enabled: bool) -> None:
+                raise AssertionError("Stop failure must not enable cloud video")
+
+        entity.coordinator.client = _Client()
+
+        async def _failed_lan_start(
+            _runtime: object,
+            _inputs: object,
+        ) -> str | None:
+            raise DreameLawnMowerVideoRuntimeError(
+                "Qualified same-LAN probe session could not stop before "
+                "playback handoff."
+            )
+
+        entity._async_try_lan_stream = _failed_lan_start
+        source = await entity._async_start_stream()
+        return source, entity._last_error
+
+    source, error = asyncio.run(_run())
+
+    assert source is None
     assert error == (
         "Qualified same-LAN probe session could not stop before playback handoff."
     )

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -604,56 +604,32 @@ def test_video_camera_cancellation_cleans_unadopted_session() -> None:
     assert session is None
 
 
-def test_video_camera_returns_jpeg_from_managed_flv_source() -> None:
-    async def _run() -> tuple[
-        bytes | None,
-        tuple[object, object, object],
-        int,
-    ]:
+def test_video_camera_returns_jpeg_from_home_assistant_stream() -> None:
+    async def _run() -> tuple[bytes | None, dict[str, object]]:
         entity = _uninitialized_entity()
-        calls: list[tuple[object, object, object]] = []
         entity._last_image = None
-        entity.stream = None
-        entity._stream_lock = asyncio.Lock()
-        entity._create_stream_lock = None
-        snapshot_session = SimpleNamespace(stream_url="http://127.0.0.1/live.flv")
-        stops = 0
+        call: dict[str, object] = {}
 
-        async def _source() -> str:
-            entity._session = snapshot_session
-            return snapshot_session.stream_url
+        class _Stream:
+            async def async_get_image(self, **kwargs) -> bytes:
+                call.update(kwargs)
+                return b"\xff\xd8real-jpeg\xff\xd9"
 
-        async def _stop() -> None:
-            nonlocal stops
-            stops += 1
-            entity._session = None
+        async def _create_stream() -> _Stream:
+            return _Stream()
 
-        entity.stream_source = _source
-        entity._async_stop_active_session = _stop
-        entity.hass = SimpleNamespace(
-            async_add_executor_job=lambda function, *args: asyncio.sleep(
-                0,
-                result=function(*args),
-            )
-        )
+        entity.async_create_stream = _create_stream
+        image = await entity.async_camera_image(width=640, height=360)
+        return image, call
 
-        def _decode(source: str, width: int | None, height: int | None) -> bytes:
-            calls.append((source, width, height))
-            return b"\xff\xd8real-jpeg\xff\xd9"
-
-        with patch.object(
-            video_camera_module.video_helpers,
-            "decode_flv_jpeg",
-            _decode,
-        ):
-            image = await entity.async_camera_image(width=640, height=360)
-        return image, calls[0], stops
-
-    image, call, stops = asyncio.run(_run())
+    image, call = asyncio.run(_run())
 
     assert image == b"\xff\xd8real-jpeg\xff\xd9"
-    assert call == ("http://127.0.0.1/live.flv", 640, 360)
-    assert stops == 1
+    assert call == {
+        "width": 640,
+        "height": 360,
+        "wait_for_next_keyframe": True,
+    }
 
 
 def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
@@ -662,7 +638,7 @@ def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
         entity._last_image = b"\xff\xd8cached-jpeg\xff\xd9"
         cancelled = False
 
-        async def _source() -> str:
+        async def _create_stream() -> object:
             nonlocal cancelled
             try:
                 await asyncio.Future()
@@ -670,7 +646,7 @@ def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
                 cancelled = True
             raise AssertionError("unreachable")
 
-        entity.stream_source = _source
+        entity.async_create_stream = _create_stream
         with patch.object(
             video_camera_module,
             "_SNAPSHOT_STREAM_START_TIMEOUT",
@@ -680,110 +656,6 @@ def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
         return image, cancelled
 
     assert asyncio.run(_run()) == (b"\xff\xd8cached-jpeg\xff\xd9", True)
-
-
-def test_video_camera_snapshot_does_not_stop_session_adopted_by_hls() -> None:
-    async def _run() -> int:
-        entity = _uninitialized_entity()
-        session = SimpleNamespace(stream_url="http://127.0.0.1/live.flv")
-        entity._session = session
-        entity.stream = None
-        entity._stream_lock = asyncio.Lock()
-        entity._create_stream_lock = asyncio.Lock()
-        stops = 0
-
-        async def _stop() -> None:
-            nonlocal stops
-            stops += 1
-
-        entity._async_stop_active_session = _stop
-        await entity._create_stream_lock.acquire()
-        cleanup = asyncio.create_task(entity._async_stop_snapshot_session(session))
-        await asyncio.sleep(0)
-        entity.stream = object()
-        entity._create_stream_lock.release()
-        await cleanup
-        return stops
-
-    assert asyncio.run(_run()) == 0
-
-
-def test_video_camera_snapshot_stops_after_failed_hls_adoption() -> None:
-    async def _run() -> int:
-        entity = _uninitialized_entity()
-        session = SimpleNamespace(stream_url="http://127.0.0.1/live.flv")
-        entity._session = session
-        entity.stream = None
-        entity._stream_lock = asyncio.Lock()
-        entity._create_stream_lock = asyncio.Lock()
-        stops = 0
-
-        async def _stop() -> None:
-            nonlocal stops
-            stops += 1
-            entity._session = None
-
-        entity._async_stop_active_session = _stop
-        await entity._create_stream_lock.acquire()
-        cleanup = asyncio.create_task(entity._async_stop_snapshot_session(session))
-        await asyncio.sleep(0)
-        entity._create_stream_lock.release()
-        await cleanup
-        return stops
-
-    assert asyncio.run(_run()) == 1
-
-
-def test_video_camera_serializes_concurrent_snapshot_sessions() -> None:
-    async def _run() -> tuple[int, int, int]:
-        entity = _uninitialized_entity()
-        entity._last_image = None
-        entity.stream = None
-        entity._stream_lock = asyncio.Lock()
-        entity._create_stream_lock = None
-        first_decode_started = asyncio.Event()
-        release_first_decode = asyncio.Event()
-        source_calls = 0
-        decode_calls = 0
-        stops = 0
-
-        async def _source() -> str:
-            nonlocal source_calls
-            source_calls += 1
-            session = SimpleNamespace(
-                stream_url=f"http://127.0.0.1/live-{source_calls}.flv"
-            )
-            entity._session = session
-            return session.stream_url
-
-        async def _decode_job(_function, *_args) -> bytes:
-            nonlocal decode_calls
-            decode_calls += 1
-            if decode_calls == 1:
-                first_decode_started.set()
-                await release_first_decode.wait()
-            return b"\xff\xd8real-jpeg\xff\xd9"
-
-        async def _stop() -> None:
-            nonlocal stops
-            stops += 1
-            entity._session = None
-
-        entity.stream_source = _source
-        entity._async_stop_active_session = _stop
-        entity.hass = SimpleNamespace(async_add_executor_job=_decode_job)
-
-        first = asyncio.create_task(entity.async_camera_image())
-        await first_decode_started.wait()
-        second = asyncio.create_task(entity.async_camera_image())
-        await asyncio.sleep(0)
-        assert decode_calls == 1
-        assert stops == 0
-        release_first_decode.set()
-        await asyncio.gather(first, second)
-        return source_calls, decode_calls, stops
-
-    assert asyncio.run(_run()) == (2, 2, 2)
 
 
 def test_video_camera_stop_unregisters_cached_home_assistant_stream() -> None:
@@ -1183,7 +1055,7 @@ def test_video_camera_disables_video_when_enable_attempt_raises() -> None:
 
 
 def test_video_camera_caches_provisioning_only_after_healthy_flv() -> None:
-    async def _attempt(*, healthy: bool) -> tuple[str | None, int]:
+    async def _attempt(*, healthy: bool) -> tuple[str | None, int, int, int]:
         entity = _uninitialized_entity()
         inputs = DreameLawnMowerCameraStreamRuntimeInputs(
             source="dreame_third_video_tx",
@@ -1244,25 +1116,30 @@ def test_video_camera_caches_provisioning_only_after_healthy_flv() -> None:
                 return None
 
         class _Runtime:
-            @staticmethod
+            def __init__(self) -> None:
+                self.starts = 0
+                self.stops = 0
+
             def start_live_stream(
+                self,
                 actual_inputs: object,
             ) -> DreameLawnMowerXp2pLiveStreamSession:
                 assert actual_inputs is inputs
+                self.starts += 1
                 return DreameLawnMowerXp2pLiveStreamSession(
                     service_id="product-1/device-1",
-                    stream_url="http://127.0.0.1/cloud.flv",
+                    stream_url=f"http://127.0.0.1/cloud-{self.starts}.flv",
                 )
 
-            @staticmethod
-            def stop_live_stream(_session: object) -> None:
-                return None
+            def stop_live_stream(self, _session: object) -> None:
+                self.stops += 1
 
         cache = _ProvisioningCache()
         entity._provisioning_cache = cache
         entity._lan_cache = _LanCache()
         entity.coordinator = SimpleNamespace(client=_Client(), data=object())
-        entity._prepared_runtime = _Runtime()
+        runtime = _Runtime()
+        entity._prepared_runtime = runtime
         entity._runtime_preparation_error = None
         entity._last_stream_health = None
         entity._last_error = None
@@ -1287,11 +1164,13 @@ def test_video_camera_caches_provisioning_only_after_healthy_flv() -> None:
             return_value=health,
         ):
             source = await entity._async_start_stream()
-        return source, cache.saves
+        return source, cache.saves, runtime.starts, runtime.stops
 
-    assert asyncio.run(_attempt(healthy=False)) == (None, 0)
+    assert asyncio.run(_attempt(healthy=False)) == (None, 0, 1, 1)
     assert asyncio.run(_attempt(healthy=True)) == (
-        "http://127.0.0.1/cloud.flv",
+        "http://127.0.0.1/cloud-2.flv",
+        1,
+        2,
         1,
     )
 
@@ -1386,7 +1265,7 @@ def test_video_camera_auto_uses_cached_xp2p_without_video_cloud_calls() -> None:
 
     assert asyncio.run(_run()) == (
         "http://127.0.0.1/cached.flv",
-        1,
+        2,
         "cached_xp2p",
         False,
     )

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -343,8 +343,8 @@ def test_video_camera_serializes_concurrent_stream_starts() -> None:
 
         entity._async_start_stream = _start
         results = await asyncio.gather(
-            entity.stream_source(),
-            entity.stream_source(),
+            entity._async_start_raw_source(),
+            entity._async_start_raw_source(),
         )
         return results, maximum_active, start_count
 
@@ -372,7 +372,7 @@ def test_video_camera_does_not_start_while_turned_off() -> None:
 
         entity._async_start_stream = _start
         entity._set_stream_error = lambda _error: None
-        return await entity.stream_source(), starts
+        return await entity._async_start_raw_source(), starts
 
     source, starts = asyncio.run(_run())
 
@@ -403,13 +403,46 @@ def test_video_camera_restarts_a_dead_host_worker() -> None:
 
         entity._async_stop_active_session = _stop
         entity._async_start_stream = _start
-        return await entity.stream_source(), stops, starts
+        return await entity._async_start_raw_source(), stops, starts
 
     source, stops, starts = asyncio.run(_run())
 
     assert source == "http://127.0.0.1/fresh.flv"
     assert stops == 1
     assert starts == 1
+
+
+def test_video_camera_direct_stream_source_uses_verified_ha_proxy() -> None:
+    async def _run() -> tuple[str | None, list[str]]:
+        entity = _uninitialized_entity()
+        providers: list[str] = []
+
+        class _Stream:
+            def add_provider(self, provider: str) -> None:
+                providers.append(provider)
+
+            @staticmethod
+            def endpoint_url(provider: str) -> str:
+                assert provider == video_camera_module.HLS_PROVIDER
+                return "/api/hls/verified/playlist.m3u8"
+
+        async def _create_stream() -> _Stream:
+            return _Stream()
+
+        entity.async_create_stream = _create_stream
+        entity.hass = object()
+        with patch.object(
+            video_camera_module,
+            "get_url",
+            return_value="http://homeassistant.local:8123",
+        ):
+            source = await entity.stream_source()
+        return source, providers
+
+    assert asyncio.run(_run()) == (
+        "http://homeassistant.local:8123/api/hls/verified/playlist.m3u8",
+        [video_camera_module.HLS_PROVIDER],
+    )
 
 
 def test_video_camera_creates_home_assistant_stream_from_live_source() -> None:
@@ -426,7 +459,7 @@ def test_video_camera_creates_home_assistant_stream_from_live_source() -> None:
             entity._session = session
             return session.stream_url
 
-        entity.stream_source = _source
+        entity._async_start_raw_source = _source
 
         dynamic_settings = object()
 
@@ -471,7 +504,7 @@ def test_video_camera_verifies_the_adopted_playback_session_through_ha() -> None
             entity._unverified_playback_session = session
             return session.stream_url
 
-        entity.stream_source = _source
+        entity._async_start_raw_source = _source
 
         class _Preferences:
             async def get_dynamic_stream_settings(self, _entity_id: str) -> object:
@@ -524,7 +557,7 @@ def test_video_camera_rejects_an_unreadable_adopted_playback_session() -> None:
             entity._session = None
             entity._unverified_playback_session = None
 
-        entity.stream_source = _source
+        entity._async_start_raw_source = _source
         entity._async_stop_active_session = _stop
 
         class _Preferences:
@@ -588,7 +621,7 @@ def test_video_camera_replaces_cached_stream_after_worker_exit() -> None:
 
         fresh_stream = SimpleNamespace(set_update_callback=lambda _callback: None)
         entity._async_stop_active_session = _stop
-        entity.stream_source = _source
+        entity._async_start_raw_source = _source
         entity.hass = SimpleNamespace(
             data={video_camera_module.DATA_CAMERA_PREFS: _Preferences()}
         )
@@ -636,7 +669,7 @@ def test_video_camera_does_not_cache_stream_after_turn_off_race() -> None:
                 await release_preferences.wait()
                 return object()
 
-        entity.stream_source = _source
+        entity._async_start_raw_source = _source
         entity._async_stop_active_session = _stop
         entity.hass = SimpleNamespace(
             data={video_camera_module.DATA_CAMERA_PREFS: _Preferences()}
@@ -684,7 +717,7 @@ def test_video_camera_cancellation_cleans_unadopted_session() -> None:
                 preferences_started.set()
                 await asyncio.Future()
 
-        entity.stream_source = _source
+        entity._async_start_raw_source = _source
         entity._async_stop_active_session = _stop
         entity.hass = SimpleNamespace(
             data={video_camera_module.DATA_CAMERA_PREFS: _Preferences()}
@@ -719,7 +752,7 @@ def test_video_camera_returns_jpeg_from_home_assistant_stream() -> None:
         async def _create_stream() -> _Stream:
             return stream
 
-        entity.async_create_stream = _create_stream
+        entity._async_create_stream_locked = _create_stream
         image = await entity.async_camera_image(width=640, height=360)
         return image, call
 
@@ -740,6 +773,10 @@ def test_video_camera_stops_stream_created_only_for_snapshot() -> None:
         stops = 0
 
         class _Stream:
+            @staticmethod
+            def outputs() -> dict[str, object]:
+                return {"hls": object()}
+
             async def async_get_image(self, **_kwargs) -> bytes:
                 return b"\xff\xd8snapshot-jpeg\xff\xd9"
 
@@ -754,7 +791,7 @@ def test_video_camera_stops_stream_created_only_for_snapshot() -> None:
             stops += 1
             entity.stream = None
 
-        entity.async_create_stream = _create_stream
+        entity._async_create_stream_locked = _create_stream
         entity._async_stop_active_session = _stop
         image = await entity.async_camera_image()
         return image, stops
@@ -762,26 +799,29 @@ def test_video_camera_stops_stream_created_only_for_snapshot() -> None:
     assert asyncio.run(_run()) == (b"\xff\xd8snapshot-jpeg\xff\xd9", 1)
 
 
-def test_video_camera_keeps_snapshot_stream_when_a_viewer_attaches() -> None:
-    async def _run() -> tuple[bytes | None, int]:
+def test_video_camera_serializes_snapshot_cleanup_before_viewer_start() -> None:
+    async def _run() -> tuple[bytes | None, bool, bool, int, int]:
         entity = _uninitialized_entity()
         entity._last_image = None
+        entity._create_stream_lock = None
         stops = 0
+        creates = 0
+        image_started = asyncio.Event()
+        release_image = asyncio.Event()
 
-        class _Stream:
-            def __init__(self) -> None:
-                self.active_outputs: dict[str, object] = {}
-
-            def outputs(self) -> dict[str, object]:
-                return self.active_outputs
-
+        class _SnapshotStream:
             async def async_get_image(self, **_kwargs: object) -> bytes:
-                self.active_outputs["hls"] = object()
+                image_started.set()
+                await release_image.wait()
                 return b"\xff\xd8snapshot-jpeg\xff\xd9"
 
-        stream = _Stream()
+        snapshot_stream = _SnapshotStream()
+        viewer_stream = object()
 
-        async def _create_stream() -> _Stream:
+        async def _create_stream() -> object:
+            nonlocal creates
+            creates += 1
+            stream = snapshot_stream if creates == 1 else viewer_stream
             entity.stream = stream
             return stream
 
@@ -790,12 +830,25 @@ def test_video_camera_keeps_snapshot_stream_when_a_viewer_attaches() -> None:
             stops += 1
             entity.stream = None
 
-        entity.async_create_stream = _create_stream
+        entity._async_create_stream_locked = _create_stream
         entity._async_stop_active_session = _stop
-        image = await entity.async_camera_image()
-        return image, stops
+        snapshot_task = asyncio.create_task(entity.async_camera_image())
+        await image_started.wait()
+        viewer_task = asyncio.create_task(entity.async_create_stream())
+        await asyncio.sleep(0)
+        viewer_waited = not viewer_task.done()
+        release_image.set()
+        image = await snapshot_task
+        viewer = await viewer_task
+        return image, viewer_waited, viewer is viewer_stream, stops, creates
 
-    assert asyncio.run(_run()) == (b"\xff\xd8snapshot-jpeg\xff\xd9", 0)
+    assert asyncio.run(_run()) == (
+        b"\xff\xd8snapshot-jpeg\xff\xd9",
+        True,
+        True,
+        1,
+        2,
+    )
 
 
 def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
@@ -812,7 +865,7 @@ def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
                 cancelled = True
             raise AssertionError("unreachable")
 
-        entity.async_create_stream = _create_stream
+        entity._async_create_stream_locked = _create_stream
         with patch.object(
             video_camera_module,
             "_SNAPSHOT_STREAM_START_TIMEOUT",
@@ -851,7 +904,7 @@ def test_video_camera_snapshot_image_timeout_returns_last_image() -> None:
             stops += 1
             entity.stream = None
 
-        entity.async_create_stream = _create_stream
+        entity._async_create_stream_locked = _create_stream
         entity._async_stop_active_session = _stop
         with patch.object(video_camera_module, "_SNAPSHOT_IMAGE_TIMEOUT", 0.01):
             image = await entity.async_camera_image()
@@ -1617,6 +1670,64 @@ def test_video_camera_auto_uses_cached_xp2p_without_video_cloud_calls() -> None:
         "cached_xp2p",
         False,
     )
+
+
+def test_video_camera_cached_probe_stop_failure_aborts_cloud_fallback() -> None:
+    async def _run() -> tuple[str | None, str | None]:
+        entity = _uninitialized_entity(
+            snapshot=SimpleNamespace(available=True, raw_attributes={})
+        )
+        entity._entry.options[CONF_VIDEO_TRANSPORT] = VIDEO_TRANSPORT_AUTO
+        inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+            source="video_provisioning_cache",
+            did="did-1",
+            product_id="product-1",
+            device_name="device-1",
+            p2p_info="p2p-info-1",
+        )
+        entity._provisioning_cache.inputs = inputs
+        entity._prepared_runtime = object()
+        entity._runtime_preparation_error = None
+        entity._last_stream_health = None
+        entity._last_error = None
+        entity._attr_is_streaming = False
+        entity.async_write_ha_state = lambda: None
+
+        class _Client:
+            async def async_get_camera_stream_runtime_inputs(self) -> object:
+                raise AssertionError("Stop failure must not fall through to cloud")
+
+            async def async_set_camera_stream_enabled(self, _enabled: bool) -> None:
+                raise AssertionError("Stop failure must not enable cloud video")
+
+        entity.coordinator.client = _Client()
+        entity.hass = SimpleNamespace(async_add_executor_job=object())
+        session = DreameLawnMowerXp2pLiveStreamSession(
+            service_id="product-1/device-1",
+            stream_url="http://127.0.0.1/cached.flv",
+        )
+        health = DreameLawnMowerStreamUrlProbeResult(
+            available=True,
+            flv_header_present=True,
+        )
+
+        async def _failed_stop(_runtime: object, _session: object) -> bool:
+            return False
+
+        entity._async_stop_session_for_handoff = _failed_stop
+        with patch.object(
+            video_camera_module,
+            "async_start_cached_xp2p",
+            return_value=SimpleNamespace(session=session, health=health, error=None),
+        ):
+            source = await entity._async_start_stream()
+        return source, entity._last_error
+
+    source, error = asyncio.run(_run())
+
+    assert source is None
+    assert error is not None
+    assert "cached XP2P probe session could not stop" in error
 
 
 def test_video_camera_auto_refresh_blocks_cached_start_after_mower_docks() -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -415,6 +415,8 @@ def test_video_camera_restarts_a_dead_host_worker() -> None:
 def test_video_camera_direct_stream_source_uses_verified_ha_proxy() -> None:
     async def _run() -> tuple[str | None, list[str]]:
         entity = _uninitialized_entity()
+        entity._create_stream_lock = None
+        entity.stream = None
         providers: list[str] = []
 
         class _Stream:
@@ -427,9 +429,11 @@ def test_video_camera_direct_stream_source_uses_verified_ha_proxy() -> None:
                 return "/api/hls/verified/playlist.m3u8"
 
         async def _create_stream() -> _Stream:
-            return _Stream()
+            stream = _Stream()
+            entity.stream = stream
+            return stream
 
-        entity.async_create_stream = _create_stream
+        entity._async_create_stream_locked = _create_stream
         entity.hass = object()
         with patch.object(
             video_camera_module,
@@ -443,6 +447,49 @@ def test_video_camera_direct_stream_source_uses_verified_ha_proxy() -> None:
         "http://homeassistant.local:8123/api/hls/verified/playlist.m3u8",
         [video_camera_module.HLS_PROVIDER],
     )
+
+
+def test_video_camera_direct_stream_source_cleans_up_only_its_failed_stream() -> None:
+    async def _run(*, existing: bool) -> tuple[str | None, int, bool]:
+        entity = _uninitialized_entity()
+        entity._create_stream_lock = None
+        entity.async_write_ha_state = lambda: None
+        stops = 0
+
+        class _Stream:
+            @staticmethod
+            def add_provider(_provider: str) -> None:
+                return None
+
+            @staticmethod
+            def endpoint_url(_provider: str) -> str:
+                return "/api/hls/verified/playlist.m3u8"
+
+        stream = _Stream()
+        entity.stream = stream if existing else None
+
+        async def _create_stream() -> _Stream:
+            entity.stream = stream
+            return stream
+
+        async def _stop() -> None:
+            nonlocal stops
+            stops += 1
+            entity.stream = None
+
+        entity._async_create_stream_locked = _create_stream
+        entity._async_stop_active_session = _stop
+        entity.hass = object()
+        with patch.object(
+            video_camera_module,
+            "get_url",
+            side_effect=RuntimeError("no Home Assistant URL"),
+        ):
+            source = await entity.stream_source()
+        return source, stops, entity.stream is stream
+
+    assert asyncio.run(_run(existing=False)) == (None, 1, False)
+    assert asyncio.run(_run(existing=True)) == (None, 0, True)
 
 
 def test_video_camera_creates_home_assistant_stream_from_live_source() -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -454,6 +454,104 @@ def test_video_camera_creates_home_assistant_stream_from_live_source() -> None:
     assert call.kwargs["stream_label"] == "camera.dreame_live_video"
 
 
+def test_video_camera_verifies_the_adopted_playback_session_through_ha() -> None:
+    async def _run() -> tuple[object | None, dict[str, object], bytes | None]:
+        entity = _uninitialized_entity()
+        entity._create_stream_lock = None
+        entity.stream = None
+        entity.stream_options = {}
+        entity.entity_id = "camera.dreame_live_video"
+        entity.async_write_ha_state = lambda: None
+        entity._last_image = None
+        session = SimpleNamespace(stream_url="http://127.0.0.1/playback.flv")
+        entity._last_stream_health = {"flv_header_present": True}
+
+        async def _source() -> str:
+            entity._session = session
+            entity._unverified_playback_session = session
+            return session.stream_url
+
+        entity.stream_source = _source
+
+        class _Preferences:
+            async def get_dynamic_stream_settings(self, _entity_id: str) -> object:
+                return object()
+
+        class _Stream:
+            def set_update_callback(self, _callback: object) -> None:
+                return None
+
+            async def async_get_image(self, **kwargs: object) -> bytes:
+                assert kwargs == {"wait_for_next_keyframe": True}
+                assert entity._session is session
+                return b"\xff\xd8playback-frame\xff\xd9"
+
+        entity.hass = SimpleNamespace(
+            data={video_camera_module.DATA_CAMERA_PREFS: _Preferences()}
+        )
+        with patch.object(video_camera_module, "create_stream", return_value=_Stream()):
+            result = await entity.async_create_stream()
+        return result, entity._last_stream_health, entity._last_image
+
+    result, health, image = asyncio.run(_run())
+
+    assert result is not None
+    assert health["playback_session_verified"] is True
+    assert image == b"\xff\xd8playback-frame\xff\xd9"
+
+
+def test_video_camera_rejects_an_unreadable_adopted_playback_session() -> None:
+    async def _run() -> tuple[object | None, int, str | None]:
+        entity = _uninitialized_entity()
+        entity._create_stream_lock = None
+        entity.stream = None
+        entity.stream_options = {}
+        entity.entity_id = "camera.dreame_live_video"
+        entity.async_write_ha_state = lambda: None
+        session = SimpleNamespace(stream_url="http://127.0.0.1/playback.flv")
+        entity._last_stream_health = {"flv_header_present": True}
+        stops = 0
+
+        async def _source() -> str:
+            entity._session = session
+            entity._unverified_playback_session = session
+            return session.stream_url
+
+        async def _stop() -> None:
+            nonlocal stops
+            stops += 1
+            entity.stream = None
+            entity._session = None
+            entity._unverified_playback_session = None
+
+        entity.stream_source = _source
+        entity._async_stop_active_session = _stop
+
+        class _Preferences:
+            async def get_dynamic_stream_settings(self, _entity_id: str) -> object:
+                return object()
+
+        class _Stream:
+            def set_update_callback(self, _callback: object) -> None:
+                return None
+
+            async def async_get_image(self, **_kwargs: object) -> None:
+                return None
+
+        entity.hass = SimpleNamespace(
+            data={video_camera_module.DATA_CAMERA_PREFS: _Preferences()}
+        )
+        with patch.object(video_camera_module, "create_stream", return_value=_Stream()):
+            result = await entity.async_create_stream()
+        return result, stops, entity._last_error
+
+    result, stops, error = asyncio.run(_run())
+
+    assert result is None
+    assert stops == 1
+    assert error is not None and "did not decode a frame" in error
+
+
 def test_video_camera_replaces_cached_stream_after_worker_exit() -> None:
     async def _run() -> tuple[object, int]:
         entity = _uninitialized_entity()
@@ -662,6 +760,42 @@ def test_video_camera_stops_stream_created_only_for_snapshot() -> None:
         return image, stops
 
     assert asyncio.run(_run()) == (b"\xff\xd8snapshot-jpeg\xff\xd9", 1)
+
+
+def test_video_camera_keeps_snapshot_stream_when_a_viewer_attaches() -> None:
+    async def _run() -> tuple[bytes | None, int]:
+        entity = _uninitialized_entity()
+        entity._last_image = None
+        stops = 0
+
+        class _Stream:
+            def __init__(self) -> None:
+                self.active_outputs: dict[str, object] = {}
+
+            def outputs(self) -> dict[str, object]:
+                return self.active_outputs
+
+            async def async_get_image(self, **_kwargs: object) -> bytes:
+                self.active_outputs["hls"] = object()
+                return b"\xff\xd8snapshot-jpeg\xff\xd9"
+
+        stream = _Stream()
+
+        async def _create_stream() -> _Stream:
+            entity.stream = stream
+            return stream
+
+        async def _stop() -> None:
+            nonlocal stops
+            stops += 1
+            entity.stream = None
+
+        entity.async_create_stream = _create_stream
+        entity._async_stop_active_session = _stop
+        image = await entity.async_camera_image()
+        return image, stops
+
+    assert asyncio.run(_run()) == (b"\xff\xd8snapshot-jpeg\xff\xd9", 0)
 
 
 def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -658,6 +658,32 @@ def test_video_camera_snapshot_start_timeout_returns_last_image() -> None:
     assert asyncio.run(_run()) == (b"\xff\xd8cached-jpeg\xff\xd9", True)
 
 
+def test_video_camera_snapshot_image_timeout_returns_last_image() -> None:
+    async def _run() -> tuple[bytes | None, bool]:
+        entity = _uninitialized_entity()
+        entity._last_image = b"\xff\xd8cached-jpeg\xff\xd9"
+        cancelled = False
+
+        class _Stream:
+            async def async_get_image(self, **_kwargs) -> bytes:
+                nonlocal cancelled
+                try:
+                    await asyncio.Future()
+                finally:
+                    cancelled = True
+                raise AssertionError("unreachable")
+
+        async def _create_stream() -> _Stream:
+            return _Stream()
+
+        entity.async_create_stream = _create_stream
+        with patch.object(video_camera_module, "_SNAPSHOT_IMAGE_TIMEOUT", 0.01):
+            image = await entity.async_camera_image()
+        return image, cancelled
+
+    assert asyncio.run(_run()) == (b"\xff\xd8cached-jpeg\xff\xd9", True)
+
+
 def test_video_camera_stop_unregisters_cached_home_assistant_stream() -> None:
     async def _run() -> tuple[object | None, int, list[object]]:
         entity = _uninitialized_entity()
@@ -1172,6 +1198,152 @@ def test_video_camera_caches_provisioning_only_after_healthy_flv() -> None:
         1,
         2,
         1,
+    )
+
+
+def test_video_camera_cloud_handoff_cancellation_disables_video() -> None:
+    async def _run() -> tuple[list[bool], int, int, bool]:
+        entity = _uninitialized_entity()
+        inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+            source="dreame_third_video_tx",
+            did="did-1",
+            product_id="product-1",
+            device_name="device-1",
+            p2p_info="p2p-info-1",
+        )
+        stream_enabled_calls: list[bool] = []
+        stop_started = asyncio.Event()
+        release_stop = asyncio.Event()
+
+        class _Client:
+            async def async_set_camera_stream_enabled(self, enabled: bool) -> None:
+                stream_enabled_calls.append(enabled)
+
+        class _Runtime:
+            def __init__(self) -> None:
+                self.starts = 0
+                self.stops = 0
+
+            def start_live_stream(
+                self,
+                _inputs: object,
+            ) -> DreameLawnMowerXp2pLiveStreamSession:
+                self.starts += 1
+                return DreameLawnMowerXp2pLiveStreamSession(
+                    service_id="product-1/device-1",
+                    stream_url="http://127.0.0.1/cloud.flv",
+                )
+
+            def stop_live_stream(self, _session: object) -> None:
+                self.stops += 1
+
+        runtime = _Runtime()
+        entity.coordinator = SimpleNamespace(client=_Client(), data=object())
+        entity._prepared_runtime = runtime
+        entity._runtime_preparation_error = None
+        entity._last_stream_disable_error = None
+        entity._last_error = None
+        entity.async_write_ha_state = lambda: None
+
+        async def _runtime_inputs() -> object:
+            return inputs
+
+        async def _cache_inputs(_inputs: object) -> None:
+            return None
+
+        async def _executor(function, *args):
+            if function == runtime.stop_live_stream:
+                stop_started.set()
+                await release_stop.wait()
+            return function(*args)
+
+        entity._async_get_runtime_inputs = _runtime_inputs
+        entity._async_cache_healthy_provisioning = _cache_inputs
+        entity.hass = SimpleNamespace(async_add_executor_job=_executor)
+        health = DreameLawnMowerStreamUrlProbeResult(
+            available=True,
+            flv_header_present=True,
+        )
+        with patch.object(
+            video_camera_module.video_helpers,
+            "probe_stream_health_and_route",
+            return_value=health,
+        ):
+            task = asyncio.create_task(entity._async_start_stream())
+            await stop_started.wait()
+            task.cancel()
+            await asyncio.sleep(0)
+            waiting_for_stop = not task.done()
+            release_stop.set()
+            with suppress(asyncio.CancelledError):
+                await task
+        return stream_enabled_calls, runtime.starts, runtime.stops, waiting_for_stop
+
+    assert asyncio.run(_run()) == ([True, False], 1, 1, True)
+
+
+def test_video_camera_lan_handoff_aborts_when_probe_stop_fails() -> None:
+    async def _run() -> tuple[str | None, int, int, str | None]:
+        entity = _uninitialized_entity()
+        inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+            source="lan_video_cache",
+            did="did-1",
+            product_id="product-1",
+            device_name="device-1",
+        )
+
+        class _LanCache:
+            endpoint = None
+
+            @staticmethod
+            async def async_save_session(_session: object) -> None:
+                return None
+
+        class _Runtime:
+            def __init__(self) -> None:
+                self.starts = 0
+                self.stops = 0
+
+            def start_lan_stream(
+                self,
+                _inputs: object,
+            ) -> DreameLawnMowerXp2pLiveStreamSession:
+                self.starts += 1
+                return DreameLawnMowerXp2pLiveStreamSession(
+                    service_id="product-1/device-1",
+                    stream_url="http://127.0.0.1/lan.flv",
+                )
+
+            def stop_live_stream(self, _session: object) -> None:
+                self.stops += 1
+                raise RuntimeError("runner did not stop")
+
+        runtime = _Runtime()
+        entity._lan_cache = _LanCache()
+
+        async def _executor(function, *args):
+            return function(*args)
+
+        entity.hass = SimpleNamespace(async_add_executor_job=_executor)
+        health = DreameLawnMowerStreamUrlProbeResult(
+            available=True,
+            flv_header_present=True,
+        )
+        with patch.object(
+            video_camera_module.video_helpers,
+            "probe_stream_health_and_route",
+            return_value=health,
+        ):
+            source = await entity._async_try_lan_stream(runtime, inputs)
+        return source, runtime.starts, runtime.stops, entity._last_lan_error
+
+    source, starts, stops, error = asyncio.run(_run())
+
+    assert source is None
+    assert starts == 1
+    assert stops == 1
+    assert error == (
+        "Qualified same-LAN probe session could not stop before playback handoff."
     )
 
 


### PR DESCRIPTION
## Summary

- qualify XP2P routes without giving Home Assistant a probe-consumed session, then verify the fresh playback session through Home Assistant's own stream worker
- expose the verified Home Assistant HLS proxy to direct stream-source consumers instead of the private single-consumer FLV endpoint
- serialize one-shot stream ownership so snapshots and failed proxy exposure clean up promptly without tearing down an existing viewer
- abort probe handoffs and transport fallback when the previous worker cannot stop, and disable cloud video when startup is cancelled
- keep snapshot startup and image reads bounded so a stalled stream returns the last image instead of hanging
- show the installed firmware as current only when no update is reported; preserve an unknown target when an update has no version
- default duplicate firmware, raw diagnostic, and debug snapshot entities to disabled while keeping maintenance resets available as opt-in controls
- bump the integration to 0.2.1

## Validation

- Ruff
- 685 Python 3.13 tests outside the Linux-only Home Assistant plugin lane
- focused video, update, and entity-surface regressions
