### PR TITLE
Reduce live-video startup latency

### DIFF
--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -20,5 +20,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.2.1"
+  "version": "0.2.2"
 }

--- a/custom_components/dreame_lawn_mower/video_cached_xp2p.py
+++ b/custom_components/dreame_lawn_mower/video_cached_xp2p.py
@@ -2,63 +2,43 @@
 
 from __future__ import annotations
 
-import asyncio
 from collections.abc import Awaitable, Callable
 from dataclasses import dataclass
-from typing import Any
 
 from .dreame_lawn_mower_client.models import (
     DreameLawnMowerCameraStreamRuntimeInputs,
 )
-from .dreame_lawn_mower_client.stream_health import (
-    DreameLawnMowerStreamUrlProbeResult,
-)
 from .dreame_lawn_mower_client.video_runtime import (
     DreameLawnMowerXp2pLiveStreamSession,
-)
-from .video_stream_helpers import (
-    probe_stream_health_and_route,
-    stream_health_error,
 )
 
 
 @dataclass(slots=True, frozen=True)
 class DreameLawnMowerCachedXp2pStartResult:
-    """One health-checked cached startup result."""
+    """One cached startup result reserved for Home Assistant's sole consumer."""
 
     session: DreameLawnMowerXp2pLiveStreamSession | None = None
-    health: DreameLawnMowerStreamUrlProbeResult | None = None
     error: str | None = None
 
 
 async def async_start_cached_xp2p(
-    runtime: Any,
+    runtime: object,
     inputs: DreameLawnMowerCameraStreamRuntimeInputs,
     *,
     start_session: Callable[..., Awaitable[DreameLawnMowerXp2pLiveStreamSession]],
-    stop_session: Callable[..., Awaitable[None]],
-    executor: Callable[..., Awaitable[Any]],
 ) -> DreameLawnMowerCachedXp2pStartResult:
-    """Start cached XP2P, health-check it, and own failed-session cleanup."""
-    session: DreameLawnMowerXp2pLiveStreamSession | None = None
+    """Start cached XP2P without consuming its single-reader FLV endpoint.
+
+    Home Assistant must be the first and only reader of the returned endpoint.
+    Playback verification therefore happens after the session is adopted by the
+    camera stream instead of through a throwaway preflight connection.
+    """
     try:
         session = await start_session(
             runtime,
             inputs,
             camera_toggle_managed=False,
         )
-        health = await executor(probe_stream_health_and_route, runtime, session)
-    except asyncio.CancelledError:
-        if session is not None:
-            await stop_session(runtime, session)
-        raise
     except Exception as err:  # noqa: BLE001 - Auto falls back to cloud.
-        if session is not None:
-            await stop_session(runtime, session)
         return DreameLawnMowerCachedXp2pStartResult(error=str(err))
-    if not health.flv_header_present:
-        await stop_session(runtime, session)
-        return DreameLawnMowerCachedXp2pStartResult(
-            error=stream_health_error(health)
-        )
-    return DreameLawnMowerCachedXp2pStartResult(session=session, health=health)
+    return DreameLawnMowerCachedXp2pStartResult(session=session)

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -117,6 +117,9 @@ class DreameLawnMowerVideoCamera(
         self._unverified_playback_session: (
             DreameLawnMowerXp2pLiveStreamSession | None
         ) = None
+        self._pending_provisioning_inputs: (
+            DreameLawnMowerCameraStreamRuntimeInputs | None
+        ) = None
         self._stream_lock = asyncio.Lock()
         self._snapshot_lock = asyncio.Lock()
         self._stream_idle_monitor = DreameLawnMowerHaStreamIdleMonitor(
@@ -223,8 +226,7 @@ class DreameLawnMowerVideoCamera(
         if snapshot is not None and not getattr(snapshot, "available", True):
             return False
         cached_lan_ready = (
-            self._lan_cache.inputs is not None
-            and self._lan_cache.endpoint is not None
+            self._lan_cache.inputs is not None and self._lan_cache.endpoint is not None
         )
         cached_xp2p_ready = (
             self._provisioning_cache.inputs is not None
@@ -308,14 +310,17 @@ class DreameLawnMowerVideoCamera(
                 return urljoin(f"{get_url(self.hass)}/", endpoint)
             except Exception as err:  # noqa: BLE001 - expose a clean source miss.
                 self._set_stream_error(
-                    "Home Assistant could not expose the verified video stream: "
-                    f"{err}"
+                    f"Home Assistant could not expose the verified video stream: {err}"
                 )
                 if owns_stream:
                     await self._async_stop_owned_stream(ha_stream)
                 return None
 
-    async def _async_start_raw_source(self) -> str | None:
+    async def _async_start_raw_source(
+        self,
+        *,
+        skip_cached_xp2p: bool = False,
+    ) -> str | None:
         """Start live video and return its private single-consumer FLV URL."""
         async with self._stream_lock:
             if not getattr(self, "_attr_is_on", True):
@@ -325,6 +330,8 @@ class DreameLawnMowerVideoCamera(
                 if self._session_is_usable(self._session):
                     return self._session.stream_url
                 await self._async_stop_active_session()
+            if skip_cached_xp2p:
+                return await self._async_start_stream(skip_cached_xp2p=True)
             return await self._async_start_stream()
 
     async def async_create_stream(self) -> Any | None:
@@ -344,15 +351,40 @@ class DreameLawnMowerVideoCamera(
                     return self.stream
                 await self._async_stop_active_session()
 
+        ha_stream, attempted_transport = await self._async_create_stream_attempt_locked(
+            skip_cached_xp2p=False
+        )
+        if ha_stream is not None:
+            return ha_stream
+        if (
+            attempted_transport == "cached_xp2p"
+            and self._video_transport == VIDEO_TRANSPORT_AUTO
+        ):
+            ha_stream, _ = await self._async_create_stream_attempt_locked(
+                skip_cached_xp2p=True
+            )
+        return ha_stream
+
+    async def _async_create_stream_attempt_locked(
+        self,
+        *,
+        skip_cached_xp2p: bool,
+    ) -> tuple[Any | None, str | None]:
+        """Create and verify one HA stream attempt while creation is serialized."""
         previous_session = self._session
         session: DreameLawnMowerXp2pLiveStreamSession | None = None
         owns_session = False
         try:
             async with asyncio.timeout(_HA_STREAM_START_TIMEOUT):
-                source = await self._async_start_raw_source()
+                source = (
+                    await self._async_start_raw_source(skip_cached_xp2p=True)
+                    if skip_cached_xp2p
+                    else await self._async_start_raw_source()
+                )
             if not source:
-                return None
+                return None, None
             session = self._session
+            attempted_transport = self._last_video_transport
             owns_session = session is not None and session is not previous_session
             dynamic_settings = await self.hass.data[
                 DATA_CAMERA_PREFS
@@ -366,7 +398,7 @@ class DreameLawnMowerVideoCamera(
                 ):
                     if self._session is session:
                         await self._async_stop_active_session()
-                    return None
+                    return None, attempted_transport
                 ha_stream = create_stream(
                     self.hass,
                     source,
@@ -380,8 +412,8 @@ class DreameLawnMowerVideoCamera(
 
             if getattr(self, "_unverified_playback_session", None) is session:
                 if not await self._async_verify_playback_stream(ha_stream, session):
-                    return None
-            return ha_stream
+                    return None, attempted_transport
+            return ha_stream, attempted_transport
         except BaseException:
             if owns_session and session is not None:
                 await self._async_cleanup_failed_stream_setup(session)
@@ -405,18 +437,24 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - expose a clean camera miss.
             await self._async_cleanup_failed_stream_setup(session)
             self._set_stream_error(
-                "Qualified XP2P video could not verify its playback session: "
-                f"{err}"
+                f"Qualified XP2P video could not verify its playback session: {err}"
             )
             return False
 
+        provisioning_inputs: DreameLawnMowerCameraStreamRuntimeInputs | None = None
         async with self._stream_lock:
             if self.stream is not ha_stream or self._session is not session:
                 return False
             self._unverified_playback_session = None
+            provisioning_inputs = self._pending_provisioning_inputs
+            self._pending_provisioning_inputs = None
             if getattr(self, "_last_stream_health", None) is not None:
+                self._last_stream_health["available"] = True
+                self._last_stream_health["flv_header_present"] = True
                 self._last_stream_health["playback_session_verified"] = True
             self._last_image = image
+        if provisioning_inputs is not None:
+            await self._async_cache_healthy_provisioning(provisioning_inputs)
         return True
 
     async def _async_cleanup_failed_stream_setup(
@@ -503,7 +541,11 @@ class DreameLawnMowerVideoCamera(
             # so no live viewer can adopt this stream before it is stopped.
             await self._async_stop_active_session()
 
-    async def _async_start_stream(self) -> str | None:
+    async def _async_start_stream(
+        self,
+        *,
+        skip_cached_xp2p: bool = False,
+    ) -> str | None:
         """Start one serialized XP2P stream session."""
         self._last_stream_health = None
         self._last_lan_error = None
@@ -534,6 +576,22 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - HA should receive a clean miss.
             self._set_stream_error(str(err))
             return None
+
+        if (
+            not skip_cached_xp2p
+            and cached_xp2p_inputs is not None
+            and cached_xp2p_inputs.ready
+        ):
+            try:
+                cached_source = await self._async_try_cached_xp2p_stream(
+                    runtime,
+                    cached_xp2p_inputs,
+                )
+            except DreameLawnMowerVideoRuntimeError as err:
+                self._set_stream_error(self._with_lan_failure(str(err)))
+                return None
+            if cached_source is not None:
+                return cached_source
 
         cloud_inputs: DreameLawnMowerCameraStreamRuntimeInputs | None = None
         cloud_inputs_error: Exception | None = None
@@ -616,18 +674,6 @@ class DreameLawnMowerVideoCamera(
                     "once while the video cloud is reachable to provision it."
                 )
 
-        if cached_xp2p_inputs is not None and cached_xp2p_inputs.ready:
-            try:
-                cached_source = await self._async_try_cached_xp2p_stream(
-                    runtime,
-                    cached_xp2p_inputs,
-                )
-            except DreameLawnMowerVideoRuntimeError as err:
-                self._set_stream_error(self._with_lan_failure(str(err)))
-                return None
-            if cached_source is not None:
-                return cached_source
-
         stream_enable_attempted = False
         session: DreameLawnMowerXp2pLiveStreamSession | None = None
         try:
@@ -646,11 +692,6 @@ class DreameLawnMowerVideoCamera(
             )
             self._last_stream_disable_error = None
             session = await self._async_start_runtime_session(runtime, cloud_inputs)
-            stream_health = await self.hass.async_add_executor_job(
-                video_helpers.probe_stream_health_and_route,
-                runtime,
-                session,
-            )
         except asyncio.CancelledError:
             if runtime is not None and session is not None:
                 await self._async_stop_session(runtime, session)
@@ -673,53 +714,12 @@ class DreameLawnMowerVideoCamera(
             self._set_stream_error(self._with_lan_failure(str(err)))
             return None
 
-        self._last_stream_health = stream_health.as_dict()
-        if not stream_health.flv_header_present:
-            await self._async_stop_session(runtime, session)
-            await self._async_disable_camera_stream()
-            self._set_stream_error(
-                self._with_lan_failure(video_helpers.stream_health_error(stream_health))
-            )
-            return None
-
-        try:
-            try:
-                await self._async_cache_healthy_provisioning(cloud_inputs)
-            except asyncio.CancelledError:
-                await self._async_stop_session_for_handoff(runtime, session)
-                raise
-
-            # Tencent's delegated HTTP-FLV endpoint is session-scoped and is not a
-            # safe multi-consumer source. The health check intentionally consumes
-            # the qualified session; hand Home Assistant a fresh, untouched one.
-            if not await self._async_stop_session_for_handoff(runtime, session):
-                await self._async_disable_camera_stream()
-                self._set_stream_error(
-                    self._with_lan_failure(
-                        "Qualified XP2P probe session could not stop before "
-                        "playback handoff."
-                    )
-                )
-                return None
-            session = None
-            session = await self._async_start_runtime_session(runtime, cloud_inputs)
-        except asyncio.CancelledError:
-            await self._async_disable_camera_stream()
-            raise
-        except Exception as err:  # noqa: BLE001 - HA should receive a clean miss.
-            await self._async_disable_camera_stream()
-            self._set_stream_error(
-                self._with_lan_failure(
-                    f"Qualified XP2P video could not open a playback session: {err}"
-                )
-            )
-            return None
-
         return self._adopt_stream_session(
             runtime,
             session,
-            stream_health,
+            None,
             transport=VIDEO_TRANSPORT_CLOUD,
+            provisioning_inputs=cloud_inputs,
         )
 
     async def _async_refresh_auto_start_state(self) -> bool:
@@ -794,8 +794,7 @@ class DreameLawnMowerVideoCamera(
             raise
         except Exception as err:  # noqa: BLE001 - Auto may fall back to cloud.
             self._last_lan_error = (
-                "Qualified same-LAN video could not open a playback session: "
-                f"{err}"
+                f"Qualified same-LAN video could not open a playback session: {err}"
             )
             return None
         return self._adopt_stream_session(
@@ -815,36 +814,14 @@ class DreameLawnMowerVideoCamera(
             runtime,
             inputs,
             start_session=self._async_start_runtime_session,
-            stop_session=self._async_stop_session,
-            executor=self.hass.async_add_executor_job,
         )
-        if result.session is None or result.health is None:
+        if result.session is None:
             self._last_cached_xp2p_error = result.error
-            return None
-        if not await self._async_stop_session_for_handoff(runtime, result.session):
-            self._last_cached_xp2p_error = (
-                "Qualified cached XP2P probe session could not stop before "
-                "playback handoff."
-            )
-            raise DreameLawnMowerVideoRuntimeError(self._last_cached_xp2p_error)
-        try:
-            session = await self._async_start_runtime_session(
-                runtime,
-                inputs,
-                camera_toggle_managed=False,
-            )
-        except asyncio.CancelledError:
-            raise
-        except Exception as err:  # noqa: BLE001 - Auto may fall back to cloud.
-            self._last_cached_xp2p_error = (
-                "Qualified cached XP2P video could not open a playback session: "
-                f"{err}"
-            )
             return None
         return self._adopt_stream_session(
             runtime,
-            session,
-            result.health,
+            result.session,
+            None,
             transport="cached_xp2p",
         )
 
@@ -929,16 +906,19 @@ class DreameLawnMowerVideoCamera(
         self,
         runtime: _DreameVideoRuntime,
         session: DreameLawnMowerXp2pLiveStreamSession,
-        stream_health: DreameLawnMowerStreamUrlProbeResult,
+        stream_health: DreameLawnMowerStreamUrlProbeResult | None,
         *,
         transport: str,
+        provisioning_inputs: DreameLawnMowerCameraStreamRuntimeInputs | None = None,
     ) -> str:
-        """Adopt one health-checked session as the active HA camera source."""
+        """Reserve one untouched session for Home Assistant's sole consumer."""
         self._runtime = runtime
         self._session = session
         self._unverified_playback_session = session
+        self._pending_provisioning_inputs = provisioning_inputs
         self._last_stream_health = {
-            **stream_health.as_dict(),
+            **(stream_health.as_dict() if stream_health is not None else {}),
+            "verification_source": "home_assistant",
             "playback_session_verified": False,
         }
         self._last_error = None
@@ -1060,6 +1040,7 @@ class DreameLawnMowerVideoCamera(
         self._runtime = None
         self._session = None
         self._unverified_playback_session = None
+        self._pending_provisioning_inputs = None
         self._attr_is_streaming = False
         if ha_stream is not None:
             try:
@@ -1074,8 +1055,7 @@ class DreameLawnMowerVideoCamera(
         camera_toggle_managed = getattr(
             session,
             "camera_toggle_managed",
-            getattr(session, "transport", VIDEO_TRANSPORT_CLOUD)
-            != VIDEO_TRANSPORT_LAN,
+            getattr(session, "transport", VIDEO_TRANSPORT_CLOUD) != VIDEO_TRANSPORT_LAN,
         )
         if camera_toggle_managed:
             await self._async_disable_camera_stream()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.2.1"
+version = "0.2.2"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -26,7 +26,6 @@ except ModuleNotFoundError:
 
 from homeassistant.components.camera import CameraEntityFeature
 
-import custom_components.dreame_lawn_mower.video_cached_xp2p as cached_xp2p_module
 import custom_components.dreame_lawn_mower.video_camera as video_camera_module
 import custom_components.dreame_lawn_mower.video_stream_helpers as video_helpers_module
 from custom_components.dreame_lawn_mower import (
@@ -134,6 +133,7 @@ def _uninitialized_entity(*, snapshot: object | None = None):
         async_refresh=_async_refresh,
     )
     entity._session = None
+    entity._pending_provisioning_inputs = None
     entity._runtime = None
     entity._prepared_runtime = None
     entity._runtime_prepare_task = None
@@ -1359,8 +1359,8 @@ def test_video_camera_disables_video_when_enable_attempt_raises() -> None:
     assert asyncio.run(_run()) == (None, [True, False])
 
 
-def test_video_camera_caches_provisioning_only_after_healthy_flv() -> None:
-    async def _attempt(*, healthy: bool) -> tuple[str | None, int, int, int]:
+def test_video_camera_caches_provisioning_only_after_ha_decodes_frame() -> None:
+    async def _run() -> tuple[str | None, int, int, int, int, dict[str, object]]:
         entity = _uninitialized_entity()
         inputs = DreameLawnMowerCameraStreamRuntimeInputs(
             source="dreame_third_video_tx",
@@ -1458,30 +1458,47 @@ def test_video_camera_caches_provisioning_only_after_healthy_flv() -> None:
             return function(*args)
 
         entity.hass = SimpleNamespace(async_add_executor_job=_executor)
-        health = DreameLawnMowerStreamUrlProbeResult(
-            available=healthy,
-            flv_header_present=healthy,
-            error_category=None if healthy else "invalid_header",
+        source = await entity._async_start_stream()
+        saves_before_playback = cache.saves
+        session = entity._session
+
+        class _Stream:
+            async def async_get_image(self, **kwargs: object) -> bytes:
+                assert kwargs == {"wait_for_next_keyframe": True}
+                return b"\xff\xd8cloud-frame\xff\xd9"
+
+        stream = _Stream()
+        entity.stream = stream
+        assert session is not None
+        assert await entity._async_verify_playback_stream(stream, session)
+        return (
+            source,
+            saves_before_playback,
+            cache.saves,
+            runtime.starts,
+            runtime.stops,
+            entity._last_stream_health,
         )
-        with patch.object(
-            video_camera_module.video_helpers,
-            "probe_stream_health_and_route",
-            return_value=health,
-        ):
-            source = await entity._async_start_stream()
-        return source, cache.saves, runtime.starts, runtime.stops
 
-    assert asyncio.run(_attempt(healthy=False)) == (None, 0, 1, 1)
-    assert asyncio.run(_attempt(healthy=True)) == (
-        "http://127.0.0.1/cloud-2.flv",
+    source, before, after, starts, stops, health = asyncio.run(_run())
+
+    assert (source, before, after, starts, stops) == (
+        "http://127.0.0.1/cloud-1.flv",
+        0,
         1,
-        2,
         1,
+        0,
     )
+    assert health == {
+        "verification_source": "home_assistant",
+        "playback_session_verified": True,
+        "available": True,
+        "flv_header_present": True,
+    }
 
 
-def test_video_camera_cloud_handoff_cancellation_disables_video() -> None:
-    async def _run() -> tuple[list[bool], int, int, bool]:
+def test_video_camera_cloud_start_cancellation_cleans_late_session() -> None:
+    async def _run() -> tuple[list[bool], int, int]:
         entity = _uninitialized_entity()
         inputs = DreameLawnMowerCameraStreamRuntimeInputs(
             source="dreame_third_video_tx",
@@ -1491,8 +1508,9 @@ def test_video_camera_cloud_handoff_cancellation_disables_video() -> None:
             p2p_info="p2p-info-1",
         )
         stream_enabled_calls: list[bool] = []
-        stop_started = asyncio.Event()
-        release_stop = asyncio.Event()
+        start_started = asyncio.Event()
+        release_start = asyncio.Event()
+        stop_completed = asyncio.Event()
 
         class _Client:
             async def async_set_camera_stream_enabled(self, enabled: bool) -> None:
@@ -1515,6 +1533,7 @@ def test_video_camera_cloud_handoff_cancellation_disables_video() -> None:
 
             def stop_live_stream(self, _session: object) -> None:
                 self.stops += 1
+                stop_completed.set()
 
         runtime = _Runtime()
         entity.coordinator = SimpleNamespace(client=_Client(), data=object())
@@ -1527,38 +1546,35 @@ def test_video_camera_cloud_handoff_cancellation_disables_video() -> None:
         async def _runtime_inputs() -> object:
             return inputs
 
-        async def _cache_inputs(_inputs: object) -> None:
-            return None
+        def _executor(function, *args):
+            async def _run_executor_job():
+                if function == runtime.start_live_stream:
+                    start_started.set()
+                    await release_start.wait()
+                return function(*args)
 
-        async def _executor(function, *args):
-            if function == runtime.stop_live_stream:
-                stop_started.set()
-                await release_stop.wait()
-            return function(*args)
+            return asyncio.create_task(_run_executor_job())
 
         entity._async_get_runtime_inputs = _runtime_inputs
-        entity._async_cache_healthy_provisioning = _cache_inputs
-        entity.hass = SimpleNamespace(async_add_executor_job=_executor)
-        health = DreameLawnMowerStreamUrlProbeResult(
-            available=True,
-            flv_header_present=True,
+        entity.hass = SimpleNamespace(
+            async_add_executor_job=_executor,
+            async_create_task=asyncio.create_task,
         )
-        with patch.object(
-            video_camera_module.video_helpers,
-            "probe_stream_health_and_route",
-            return_value=health,
-        ):
-            task = asyncio.create_task(entity._async_start_stream())
-            await stop_started.wait()
-            task.cancel()
-            await asyncio.sleep(0)
-            waiting_for_stop = not task.done()
-            release_stop.set()
-            with suppress(asyncio.CancelledError):
-                await task
-        return stream_enabled_calls, runtime.starts, runtime.stops, waiting_for_stop
 
-    assert asyncio.run(_run()) == ([True, False], 1, 1, True)
+        task = asyncio.create_task(entity._async_start_stream())
+        await start_started.wait()
+        task.cancel()
+        with suppress(asyncio.CancelledError):
+            await task
+        release_start.set()
+        await asyncio.wait_for(stop_completed.wait(), timeout=1)
+        return stream_enabled_calls, runtime.starts, runtime.stops
+
+    assert asyncio.run(_run()) == (
+        [True, False],
+        1,
+        1,
+    )
 
 
 def test_video_camera_lan_handoff_raises_when_probe_stop_fails() -> None:
@@ -1719,13 +1735,6 @@ def test_video_camera_auto_uses_cached_xp2p_without_video_cloud_calls() -> None:
             def stop_live_stream(self, _session: object) -> None:
                 return None
 
-        class _Health:
-            flv_header_present = True
-
-            @staticmethod
-            def as_dict() -> dict[str, object]:
-                return {"flv_header_present": True}
-
         runtime = _Runtime()
         snapshot = SimpleNamespace(available=True, raw_attributes={})
 
@@ -1750,13 +1759,9 @@ def test_video_camera_auto_uses_cached_xp2p_without_video_cloud_calls() -> None:
             return function(*args)
 
         entity.hass = SimpleNamespace(async_add_executor_job=_executor)
-        with patch.object(
-                cached_xp2p_module,
-                "probe_stream_health_and_route",
-            return_value=_Health(),
-        ):
-            source = await entity._async_start_stream()
+        source = await entity._async_start_stream()
         session = entity._session
+        assert entity._unverified_playback_session is session
         await entity._async_stop_active_session()
         return (
             source,
@@ -1767,68 +1772,33 @@ def test_video_camera_auto_uses_cached_xp2p_without_video_cloud_calls() -> None:
 
     assert asyncio.run(_run()) == (
         "http://127.0.0.1/cached.flv",
-        2,
+        1,
         "cached_xp2p",
         False,
     )
 
 
-def test_video_camera_cached_probe_stop_failure_aborts_cloud_fallback() -> None:
-    async def _run() -> tuple[str | None, str | None]:
-        entity = _uninitialized_entity(
-            snapshot=SimpleNamespace(available=True, raw_attributes={})
-        )
+def test_video_camera_cached_playback_failure_retries_without_cached_xp2p() -> None:
+    async def _run() -> tuple[object | None, list[bool]]:
+        entity = _uninitialized_entity()
         entity._entry.options[CONF_VIDEO_TRANSPORT] = VIDEO_TRANSPORT_AUTO
-        inputs = DreameLawnMowerCameraStreamRuntimeInputs(
-            source="video_provisioning_cache",
-            did="did-1",
-            product_id="product-1",
-            device_name="device-1",
-            p2p_info="p2p-info-1",
-        )
-        entity._provisioning_cache.inputs = inputs
-        entity._prepared_runtime = object()
-        entity._runtime_preparation_error = None
-        entity._last_stream_health = None
-        entity._last_error = None
-        entity._attr_is_streaming = False
-        entity.async_write_ha_state = lambda: None
+        entity.stream = None
+        calls: list[bool] = []
+        fallback_stream = object()
 
-        class _Client:
-            async def async_get_camera_stream_runtime_inputs(self) -> object:
-                raise AssertionError("Stop failure must not fall through to cloud")
+        async def _attempt(*, skip_cached_xp2p: bool) -> tuple[object | None, str]:
+            calls.append(skip_cached_xp2p)
+            if not skip_cached_xp2p:
+                return None, "cached_xp2p"
+            return fallback_stream, VIDEO_TRANSPORT_CLOUD
 
-            async def async_set_camera_stream_enabled(self, _enabled: bool) -> None:
-                raise AssertionError("Stop failure must not enable cloud video")
+        entity._async_create_stream_attempt_locked = _attempt
+        return await entity._async_create_stream_locked(), calls
 
-        entity.coordinator.client = _Client()
-        entity.hass = SimpleNamespace(async_add_executor_job=object())
-        session = DreameLawnMowerXp2pLiveStreamSession(
-            service_id="product-1/device-1",
-            stream_url="http://127.0.0.1/cached.flv",
-        )
-        health = DreameLawnMowerStreamUrlProbeResult(
-            available=True,
-            flv_header_present=True,
-        )
+    stream, calls = asyncio.run(_run())
 
-        async def _failed_stop(_runtime: object, _session: object) -> bool:
-            return False
-
-        entity._async_stop_session_for_handoff = _failed_stop
-        with patch.object(
-            video_camera_module,
-            "async_start_cached_xp2p",
-            return_value=SimpleNamespace(session=session, health=health, error=None),
-        ):
-            source = await entity._async_start_stream()
-        return source, entity._last_error
-
-    source, error = asyncio.run(_run())
-
-    assert source is None
-    assert error is not None
-    assert "cached XP2P probe session could not stop" in error
+    assert stream is not None
+    assert calls == [False, True]
 
 
 def test_video_camera_auto_refresh_blocks_cached_start_after_mower_docks() -> None:


### PR DESCRIPTION
## Summary

- hand the first Cloud or cached XP2P session directly to Home Assistant instead of probing, stopping, and negotiating a second playback session
- keep Home Assistant as the sole FLV consumer and verify startup by decoding the first frame
- save refreshed XP2P provisioning only after playback verification succeeds
- retry Auto mode without cached XP2P when the cached playback session cannot be decoded
- prepare integration version 0.2.2

## Why

On the current v0.2.1 installation, the live camera took about 27.6 seconds from click to the first HLS segment even though the relay exposed an FLV header in about 1.14 seconds. The previous safety handoff consumed that qualified single-reader session and repeated native startup before Home Assistant could begin its own decode and HLS buffering.

## Validation

- focused video-camera suite
- full Windows test suite outside the Linux-only Home Assistant plugin-fixture lane
- Ruff checks and formatting for the changed Python files

Linux CI remains the authoritative gate for the Home Assistant config-flow plugin tests.