### PR TITLE
Fix mower-native zone mowing and zone names

### DIFF
--- a/README.md
+++ b/README.md
@@ -402,6 +402,26 @@ the real active mower map, while zone, spot, and edge starts target explicit
 current-map ids rather than relying only on the generic Home Assistant
 `start_mowing` action.
 
+For example, this starts the saved zone with ID `1` on the mower's active map:
+
+```yaml
+action: dreame_lawn_mower.start_zone_mowing
+target:
+  entity_id: lawn_mower.a3_awd_pro_3500
+data:
+  zone_ids: [1]
+```
+
+Use `entity_id` when the value starts with `lawn_mower.`. A Home Assistant
+`device_id` is a separate device-registry identifier and must not contain an
+entity ID. The lawn mower entity exposes `available_zone_ids`, and zone selects
+use names saved in the Dreame app when vector-map metadata provides them. An
+unnamed zone retains the stable `Zone #<id>` fallback.
+
+Zone, spot, and edge actions are acknowledged by the mower before Home
+Assistant reports success. Unknown current-map IDs, map-scope mismatches, and
+device rejection responses are surfaced as failed actions.
+
 ## Troubleshooting
 
 Start with Home Assistant diagnostics:

--- a/custom_components/dreame_lawn_mower/control_options.py
+++ b/custom_components/dreame_lawn_mower/control_options.py
@@ -78,6 +78,7 @@ def current_app_map_entry(
 def current_zone_entries(
     batch_device_data: Mapping[str, Any] | None,
     app_maps: Mapping[str, Any] | None = None,
+    vector_map_details: Mapping[str, Any] | None = None,
     selected_map_index: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return selectable zone entries for the current map."""
@@ -86,6 +87,7 @@ def current_zone_entries(
         batch_device_data,
         selected_map_index=selected_map_index,
     )
+    preferences_by_id: dict[int, dict[str, Any]] = {}
     for entry in _batch_preference_maps(batch_device_data):
         if entry.get("idx") != current_idx:
             continue
@@ -94,8 +96,7 @@ def current_zone_entries(
             preferences,
             str | bytes | bytearray,
         ):
-            return []
-        zones: list[dict[str, Any]] = []
+            break
         for item in preferences:
             if not isinstance(item, Mapping):
                 continue
@@ -103,18 +104,89 @@ def current_zone_entries(
             if not isinstance(area_id, int):
                 continue
             # Area 0 is the whole-lawn/global entry; 200+ looks like edge metadata.
-            if area_id <= 0 or area_id >= 200:
-                continue
-            zones.append(
-                {
-                    "area_id": area_id,
-                    "label": f"Zone #{area_id}",
-                    "map_index": current_idx,
-                    "preference": dict(item),
-                }
-            )
-        return zones
-    return []
+            if 0 < area_id < 200:
+                preferences_by_id[area_id] = dict(item)
+        break
+
+    vector_zones = _current_vector_zones(vector_map_details, current_idx)
+    zone_ids = list(preferences_by_id)
+    zone_ids.extend(zone_id for zone_id in vector_zones if zone_id not in zone_ids)
+
+    return [
+        {
+            "area_id": area_id,
+            "label": _zone_display_label(area_id, vector_zones.get(area_id)),
+            "map_index": current_idx,
+            "preference": preferences_by_id.get(area_id, {}),
+        }
+        for area_id in zone_ids
+    ]
+
+
+def _current_vector_zones(
+    vector_map_details: Mapping[str, Any] | None,
+    map_index: int,
+) -> dict[int, str | None]:
+    """Return zone names keyed by id without losing unnamed entries."""
+    if not isinstance(vector_map_details, Mapping):
+        return {}
+
+    candidates: list[Mapping[str, Any]] = []
+    maps = vector_map_details.get("maps")
+    if isinstance(maps, Sequence) and not isinstance(
+        maps,
+        str | bytes | bytearray,
+    ):
+        candidates.extend(
+            entry
+            for entry in maps
+            if isinstance(entry, Mapping) and entry.get("map_index") == map_index
+        )
+    if vector_map_details.get("map_index") == map_index:
+        candidates.append(vector_map_details)
+
+    for candidate in candidates:
+        zones = candidate.get("zones")
+        if isinstance(zones, Sequence) and not isinstance(
+            zones,
+            str | bytes | bytearray,
+        ):
+            result: dict[int, str | None] = {}
+            for zone in zones:
+                if not isinstance(zone, Mapping):
+                    continue
+                zone_id = zone.get("zone_id")
+                if not isinstance(zone_id, int) or zone_id <= 0:
+                    continue
+                name = zone.get("name")
+                result[zone_id] = (
+                    name.strip() if isinstance(name, str) and name.strip() else None
+                )
+            if result:
+                return result
+
+        zone_ids = candidate.get("zone_ids")
+        zone_names = candidate.get("zone_names")
+        if (
+            isinstance(zone_ids, Sequence)
+            and not isinstance(zone_ids, str | bytes | bytearray)
+            and isinstance(zone_names, Sequence)
+            and not isinstance(zone_names, str | bytes | bytearray)
+            and len(zone_ids) == len(zone_names)
+        ):
+            return {
+                zone_id: name.strip()
+                if isinstance(name, str) and name.strip()
+                else None
+                for zone_id, name in zip(zone_ids, zone_names, strict=True)
+                if isinstance(zone_id, int) and zone_id > 0
+            }
+    return {}
+
+
+def _zone_display_label(zone_id: int, name: str | None) -> str:
+    """Return an unambiguous display label with a stable id fallback."""
+    return f"{name} (#{zone_id})" if name else f"Zone #{zone_id}"
 
 
 def current_contour_entries(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -121,6 +121,13 @@ from .mowing_preferences import (
     normalize_mowing_preference_mode,
     summarize_mowing_preference_info,
 )
+from .mowing_tasks import (
+    MowingTaskResponseError,
+    build_edge_mowing_request,
+    build_spot_mowing_request,
+    build_zone_mowing_request,
+    ensure_mowing_task_succeeded,
+)
 from .schedule import (
     EMPTY_SCHEDULE_VERSION,
     SCHEDULE_CHUNK_SIZE,
@@ -177,6 +184,7 @@ __all__ = [
     "DreameLawnMowerMapDiagnostics",
     "DreameLawnMowerMapSummary",
     "DreameLawnMowerMapView",
+    "MowingTaskResponseError",
     "DreameLawnMowerRemoteControlSupport",
     "DreameLawnMowerSnapshot",
     "DreameLawnMowerStatusBlob",
@@ -249,8 +257,11 @@ __all__ = [
     "build_cloud_property_summary",
     "build_map_probe_payload",
     "build_cms_set_request",
+    "build_edge_mowing_request",
     "build_schedule_enable_status_request",
     "build_schedule_upload_requests",
+    "build_spot_mowing_request",
+    "build_zone_mowing_request",
     "decode_batch_mowing_preferences",
     "decode_batch_ota_info",
     "decode_batch_schedule_payload",
@@ -265,6 +276,7 @@ __all__ = [
     "encode_schedule_payload_text",
     "encode_schedule_plans",
     "encode_schedule_week_payload",
+    "ensure_mowing_task_succeeded",
     "key_definition_label",
     "find_jadx_executable",
     "display_name_for_model",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -90,6 +90,13 @@ from .mowing_preferences import (
     normalize_mowing_preference_mode,
     summarize_mowing_preference_info,
 )
+from .mowing_tasks import (
+    MowingTaskResponseError,
+    build_edge_mowing_request,
+    build_spot_mowing_request,
+    build_zone_mowing_request,
+    ensure_mowing_task_succeeded,
+)
 from .schedule import (
     EMPTY_SCHEDULE_VERSION,
     SCHEDULE_CHUNK_SIZE,
@@ -371,31 +378,23 @@ class DreameLawnMowerClient:
         """Return to base while preserving a resumable mowing session."""
         await self._async_call_device_method("dock")
 
-    async def async_clean_segments(self, segment_ids: Sequence[int]) -> Any:
-        """Start segment or zone mowing for explicit map area ids."""
-        return await asyncio.to_thread(self._sync_clean_segments, list(segment_ids))
+    async def async_start_zone_mowing(self, zone_ids: Sequence[int]) -> Any:
+        """Start mower-native zone mowing for explicit map area ids."""
+        return await asyncio.to_thread(self._sync_start_zone_mowing, list(zone_ids))
 
     async def async_start_edge_mowing(
         self,
         contour_ids: Sequence[Sequence[int]],
     ) -> Any:
         """Start edge mowing for one or more contour id pairs."""
-        normalized = [
-            [int(contour_id[0]), int(contour_id[1])]
-            for contour_id in contour_ids
-            if len(contour_id) >= 2
-        ]
-        return await asyncio.to_thread(self._sync_start_edge_mowing, normalized)
+        return await asyncio.to_thread(
+            self._sync_start_edge_mowing,
+            [list(contour_id) for contour_id in contour_ids],
+        )
 
-    async def async_clean_spots(
-        self,
-        points: Sequence[tuple[int, int] | list[int]],
-    ) -> Any:
-        """Start spot mowing for one or more center points."""
-        normalized = [
-            [int(point[0]), int(point[1])] for point in points if len(point) >= 2
-        ]
-        return await asyncio.to_thread(self._sync_clean_spots, normalized)
+    async def async_start_spot_mowing(self, spot_ids: Sequence[int]) -> Any:
+        """Start mower-native spot mowing for explicit saved spot area ids."""
+        return await asyncio.to_thread(self._sync_start_spot_mowing, list(spot_ids))
 
     async def async_switch_current_map(self, map_index: int) -> Any:
         """Switch the active mower map through the app task path."""
@@ -1534,44 +1533,32 @@ class DreameLawnMowerClient:
 
         return payload
 
-    def _sync_clean_segments(self, segment_ids: Sequence[int]) -> Any:
-        """Start segment or zone mowing for the provided area ids."""
-        if not segment_ids:
-            raise ValueError("At least one segment id is required.")
-        device = self._ensure_device()
+    def _sync_start_zone_mowing(self, zone_ids: Sequence[int]) -> Any:
+        """Start mower-native zone mowing for the provided area ids."""
         try:
-            return device.clean_segment([int(segment_id) for segment_id in segment_ids])
-        except (DeviceException, InvalidActionException, ValueError) as err:
+            response = self._sync_call_app_action(build_zone_mowing_request(zone_ids))
+            return ensure_mowing_task_succeeded(response, task_name="zone mowing")
+        except (DeviceException, MowingTaskResponseError) as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
 
     def _sync_start_edge_mowing(self, contour_ids: Sequence[Sequence[int]]) -> Any:
         """Start edge mowing for the provided contour id pairs."""
-        normalized = _normalize_contour_ids(contour_ids)
-        if not normalized:
-            raise ValueError("At least one contour id pair is required.")
         try:
-            return self._sync_call_app_action(
-                {
-                    "m": "a",
-                    "p": 0,
-                    "o": 101,
-                    "d": {"edge": normalized},
-                }
+            response = self._sync_call_app_action(
+                build_edge_mowing_request(contour_ids)
             )
-        except DeviceException as err:
+            return ensure_mowing_task_succeeded(response, task_name="edge mowing")
+        except (DeviceException, MowingTaskResponseError) as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
 
-    def _sync_clean_spots(self, points: Sequence[Sequence[int]]) -> Any:
-        """Start spot mowing for the provided center points."""
-        if not points:
-            raise ValueError("At least one spot point is required.")
-        device = self._ensure_device()
+    def _sync_start_spot_mowing(self, spot_ids: Sequence[int]) -> Any:
+        """Start mower-native spot mowing for the provided saved area ids."""
         try:
-            return device.clean_spot(
-                [[int(point[0]), int(point[1])] for point in points],
-                1,
+            response = self._sync_call_app_action(
+                build_spot_mowing_request(spot_ids)
             )
-        except (DeviceException, InvalidActionException, ValueError) as err:
+            return ensure_mowing_task_succeeded(response, task_name="spot mowing")
+        except (DeviceException, MowingTaskResponseError) as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
 
     def _sync_switch_current_map(self, map_index: int) -> Any:
@@ -5848,17 +5835,6 @@ def _map_view_has_live_path(map_view: DreameLawnMowerMapView) -> bool:
         return False
 
     return bool(details.get("has_live_path"))
-
-
-def _normalize_contour_ids(
-    contour_ids: Sequence[Sequence[int]],
-) -> list[list[int]]:
-    result: list[list[int]] = []
-    for contour_id in contour_ids:
-        if len(contour_id) < 2:
-            continue
-        result.append([int(contour_id[0]), int(contour_id[1])])
-    return result
 
 
 def _json_safe(value: Any, *, max_depth: int = 4) -> Any:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_tasks.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_tasks.py
@@ -1,0 +1,110 @@
+"""Mower-native app task requests and response validation."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+MOWING_TASK_EDGE = 101
+MOWING_TASK_ZONE = 102
+MOWING_TASK_SPOT = 103
+
+
+class MowingTaskResponseError(ValueError):
+    """Raised when the mower rejects or does not acknowledge a task request."""
+
+
+def build_zone_mowing_request(zone_ids: Sequence[int]) -> dict[str, Any]:
+    """Build the Dreame app action used to mow one or more saved zones."""
+    return _build_mowing_task_request(
+        MOWING_TASK_ZONE,
+        "region",
+        _normalize_area_ids(zone_ids, area_type="zone"),
+    )
+
+
+def build_spot_mowing_request(spot_ids: Sequence[int]) -> dict[str, Any]:
+    """Build the Dreame app action used to mow one or more saved spot areas."""
+    return _build_mowing_task_request(
+        MOWING_TASK_SPOT,
+        "area",
+        _normalize_area_ids(spot_ids, area_type="spot"),
+    )
+
+
+def build_edge_mowing_request(
+    contour_ids: Sequence[Sequence[int]],
+) -> dict[str, Any]:
+    """Build the Dreame app action used to mow saved map edges."""
+    normalized: list[list[int]] = []
+    for contour_id in contour_ids:
+        if len(contour_id) < 2:
+            raise ValueError("Each contour id must contain two integer values.")
+        normalized.append([int(contour_id[0]), int(contour_id[1])])
+    if not normalized:
+        raise ValueError("At least one contour id pair is required.")
+    return _build_mowing_task_request(MOWING_TASK_EDGE, "edge", normalized)
+
+
+def ensure_mowing_task_succeeded(
+    response: Any,
+    *,
+    task_name: str,
+) -> Any:
+    """Return a successful app response or raise for missing/rejected replies."""
+    if not isinstance(response, Mapping):
+        raise MowingTaskResponseError(
+            f"The mower did not acknowledge the {task_name} request."
+        )
+
+    result = response.get("r")
+    response_data = response.get("d")
+    nested_result = (
+        response_data.get("r") if isinstance(response_data, Mapping) else None
+    )
+    if result != 0 or nested_result not in (None, 0):
+        detail = response.get("msg") or response.get("message") or response.get("d")
+        suffix = f": {detail}" if detail not in (None, "", {}, []) else ""
+        failure_result = result if result != 0 else nested_result
+        raise MowingTaskResponseError(
+            f"The mower rejected the {task_name} request "
+            f"(result {failure_result!r}){suffix}."
+        )
+    return response
+
+
+def _normalize_area_ids(
+    area_ids: Sequence[int],
+    *,
+    area_type: str,
+) -> list[int]:
+    normalized: list[int] = []
+    for area_id in area_ids:
+        if isinstance(area_id, bool):
+            raise ValueError(f"{area_type.capitalize()} ids must be positive integers.")
+        try:
+            value = int(area_id)
+        except (TypeError, ValueError) as err:
+            raise ValueError(
+                f"{area_type.capitalize()} ids must be positive integers."
+            ) from err
+        if value <= 0:
+            raise ValueError(f"{area_type.capitalize()} ids must be positive integers.")
+        normalized.append(value)
+
+    if not normalized:
+        raise ValueError(f"At least one {area_type} id is required.")
+    return normalized
+
+
+def _build_mowing_task_request(
+    operation: int,
+    target_key: str,
+    target_ids: Sequence[Any],
+) -> dict[str, Any]:
+    return {
+        "m": "a",
+        "p": 0,
+        "o": operation,
+        "d": {target_key: list(target_ids)},
+    }

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -440,6 +440,10 @@ def vector_map_to_details(
         for zone in vector_map.zones
         if zone.name
     ]
+    zones = [
+        {"zone_id": zone.zone_id, "name": zone.name or None}
+        for zone in vector_map.zones
+    ]
     contour_ids = [list(contour.contour_id) for contour in vector_map.contours]
     available_maps = [
         {
@@ -463,6 +467,10 @@ def vector_map_to_details(
             "total_area": parsed_map.total_area or None,
             "zone_ids": [zone.zone_id for zone in parsed_map.zones],
             "zone_names": [zone.name for zone in parsed_map.zones if zone.name],
+            "zones": [
+                {"zone_id": zone.zone_id, "name": zone.name or None}
+                for zone in parsed_map.zones
+            ],
             "spot_ids": [spot.zone_id for spot in parsed_map.spot_areas],
             "contour_ids": [
                 list(contour.contour_id) for contour in parsed_map.contours
@@ -501,6 +509,7 @@ def vector_map_to_details(
         "total_area": vector_map.total_area or None,
         "zone_count": len(vector_map.zones),
         "zone_names": zone_names,
+        "zones": zones,
         "forbidden_area_count": len(vector_map.forbidden_areas),
         "spot_area_count": len(vector_map.spot_areas),
         "pathway_count": len(vector_map.paths),

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -38,7 +38,6 @@ from .control_options import (
     current_map_index,
     current_spot_entries,
     current_zone_entries,
-    find_spot_center,
     map_entries,
     mowing_action_label,
 )
@@ -195,6 +194,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         zone_entries = current_zone_entries(
             self.coordinator.batch_device_data,
             self.coordinator.app_maps,
+            getattr(self.coordinator, "vector_map_details", None),
             selected_map_index=self.coordinator.selected_map_index,
         )
         contour_entries = current_contour_entries(
@@ -398,12 +398,13 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             zone_entries = current_zone_entries(
                 self.coordinator.batch_device_data,
                 self.coordinator.app_maps,
+                getattr(self.coordinator, "vector_map_details", None),
                 selected_map_index=self.coordinator.selected_map_index,
             )
             zone_id = self._selected_zone_id(zone_entries)
             if zone_id is None:
                 raise HomeAssistantError("No current-map zone is available to start.")
-            await self.coordinator.client.async_clean_segments([zone_id])
+            await self.coordinator.client.async_start_zone_mowing([zone_id])
         elif action == MOWING_ACTION_SPOT:
             self._ensure_selected_map_matches_active()
             spot_entries = current_spot_entries(
@@ -414,17 +415,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             spot_id = self._selected_spot_id(spot_entries)
             if spot_id is None:
                 raise HomeAssistantError("No current-map spot is available to start.")
-            center = find_spot_center(
-                self.coordinator.app_maps,
-                spot_id,
-                self.coordinator.batch_device_data,
-                selected_map_index=self.coordinator.selected_map_index,
-            )
-            if center is None:
-                raise HomeAssistantError(
-                    f"Spot #{spot_id} does not expose a valid center point."
-                )
-            await self.coordinator.client.async_clean_spots([center])
+            await self.coordinator.client.async_start_spot_mowing([spot_id])
         else:
             await self.coordinator.client.async_start_mowing()
         await self.coordinator.async_request_refresh()
@@ -433,33 +424,70 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         """Start mowing for one or more explicit current-map zones."""
         if not zone_ids:
             raise HomeAssistantError("At least one zone id is required.")
-        await self.coordinator.client.async_clean_segments(zone_ids)
+        self._ensure_selected_map_matches_active()
+        zone_entries = current_zone_entries(
+            self.coordinator.batch_device_data,
+            self.coordinator.app_maps,
+            getattr(self.coordinator, "vector_map_details", None),
+            selected_map_index=self.coordinator.selected_map_index,
+        )
+        normalized = [int(zone_id) for zone_id in zone_ids]
+        self._ensure_requested_ids_available(
+            normalized,
+            available_ids=[int(entry["area_id"]) for entry in zone_entries],
+            target_name="Zone",
+        )
+        await self.coordinator.client.async_start_zone_mowing(normalized)
         await self.coordinator.async_request_refresh()
 
     async def async_start_spot_mowing(self, spot_ids: list[int]) -> None:
         """Start mowing for one or more explicit current-map spot ids."""
         if not spot_ids:
             raise HomeAssistantError("At least one spot id is required.")
-
-        points = []
-        for spot_id in spot_ids:
-            center = find_spot_center(
-                self.coordinator.app_maps,
-                int(spot_id),
-                self.coordinator.batch_device_data,
-            )
-            if center is None:
-                raise HomeAssistantError(
-                    f"Spot #{spot_id} does not expose a valid center point."
-                )
-            points.append(center)
-
-        await self.coordinator.client.async_clean_spots(points)
+        self._ensure_selected_map_matches_active()
+        spot_entries = current_spot_entries(
+            self.coordinator.app_maps,
+            self.coordinator.batch_device_data,
+            selected_map_index=self.coordinator.selected_map_index,
+        )
+        normalized = [int(spot_id) for spot_id in spot_ids]
+        self._ensure_requested_ids_available(
+            normalized,
+            available_ids=[int(entry["spot_id"]) for entry in spot_entries],
+            target_name="Spot",
+        )
+        await self.coordinator.client.async_start_spot_mowing(normalized)
         await self.coordinator.async_request_refresh()
 
     async def async_start_edge_mowing(self, contour_ids: list[list[int]]) -> None:
         """Start mowing for one or more explicit current-map edge contour ids."""
         normalized = _normalize_contour_ids(contour_ids)
+        self._ensure_selected_map_matches_active()
+        contour_entries = current_contour_entries(
+            getattr(self.coordinator, "vector_map_details", None),
+            self.coordinator.app_maps,
+            self.coordinator.batch_device_data,
+            selected_map_index=self.coordinator.selected_map_index,
+        )
+        available = {
+            tuple(entry["contour_id"])
+            for entry in contour_entries
+            if isinstance(entry.get("contour_id"), tuple)
+        }
+        missing = [
+            tuple(contour_id)
+            for contour_id in normalized
+            if tuple(contour_id) not in available
+        ]
+        if missing:
+            missing_text = ", ".join(str(contour_id) for contour_id in missing)
+            available_text = ", ".join(
+                str(contour_id) for contour_id in sorted(available)
+            )
+            raise HomeAssistantError(
+                f"Edge contour {missing_text} is not available on the active map. "
+                f"Available contour ids: {available_text or 'none'}."
+            )
         await self.coordinator.client.async_start_edge_mowing(normalized)
         await self.coordinator.async_request_refresh()
 
@@ -511,6 +539,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             zone_entries = current_zone_entries(
                 self.coordinator.batch_device_data,
                 self.coordinator.app_maps,
+                getattr(self.coordinator, "vector_map_details", None),
                 selected_map_index=self.coordinator.selected_map_index,
             )
             target_zone_id = self._resolve_zone_id(zone_entries, zone_id=zone_id)
@@ -675,6 +704,30 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         if any(entry["map_index"] == map_index for entry in known_maps):
             return
         raise HomeAssistantError(f"Map index {map_index} is not available.")
+
+    @staticmethod
+    def _ensure_requested_ids_available(
+        requested_ids: list[int],
+        *,
+        available_ids: list[int],
+        target_name: str,
+    ) -> None:
+        """Reject explicit scoped ids that are absent from current-map metadata."""
+        missing = [
+            target_id for target_id in requested_ids if target_id not in available_ids
+        ]
+        if not missing:
+            return
+        missing_text = ", ".join(f"#{target_id}" for target_id in missing)
+        available_text = ", ".join(f"#{target_id}" for target_id in available_ids)
+        if not available_text:
+            available_text = "none"
+        subject = target_name if len(missing) == 1 else f"{target_name}s"
+        verb = "is" if len(missing) == 1 else "are"
+        raise HomeAssistantError(
+            f"{subject} {missing_text} {verb} not available on the active map. "
+            f"Available {target_name.lower()} ids: {available_text}."
+        )
 
     def _reset_current_map_scope(self, map_index: int) -> None:
         """Align local selection state with a successful active-map switch."""

--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -20,5 +20,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.2.3"
+  "version": "0.2.4"
 }

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -212,7 +212,7 @@ class DreameLawnMowerEdgeSelect(DreameLawnMowerSelectEntity):
         return bool(
             self.coordinator.data is not None
             and current_contour_entries(
-                self.coordinator.vector_map_details,
+                getattr(self.coordinator, "vector_map_details", None),
                 self.coordinator.app_maps,
                 self.coordinator.batch_device_data,
                 selected_map_index=self.coordinator.selected_map_index,
@@ -225,7 +225,7 @@ class DreameLawnMowerEdgeSelect(DreameLawnMowerSelectEntity):
         return [
             entry["label"]
             for entry in current_contour_entries(
-                self.coordinator.vector_map_details,
+                getattr(self.coordinator, "vector_map_details", None),
                 self.coordinator.app_maps,
                 self.coordinator.batch_device_data,
                 selected_map_index=self.coordinator.selected_map_index,
@@ -238,7 +238,7 @@ class DreameLawnMowerEdgeSelect(DreameLawnMowerSelectEntity):
         contour_id = self.coordinator.selected_contour_id
         if contour_id is None:
             options = current_contour_entries(
-                self.coordinator.vector_map_details,
+                getattr(self.coordinator, "vector_map_details", None),
                 self.coordinator.app_maps,
                 self.coordinator.batch_device_data,
                 selected_map_index=self.coordinator.selected_map_index,
@@ -249,7 +249,7 @@ class DreameLawnMowerEdgeSelect(DreameLawnMowerSelectEntity):
     async def async_select_option(self, option: str) -> None:
         """Persist the selected contour in coordinator state."""
         for entry in current_contour_entries(
-            self.coordinator.vector_map_details,
+            getattr(self.coordinator, "vector_map_details", None),
             self.coordinator.app_maps,
             self.coordinator.batch_device_data,
             selected_map_index=self.coordinator.selected_map_index,
@@ -280,6 +280,7 @@ class DreameLawnMowerZoneSelect(DreameLawnMowerSelectEntity):
             and current_zone_entries(
                 self.coordinator.batch_device_data,
                 self.coordinator.app_maps,
+                self.coordinator.vector_map_details,
                 selected_map_index=self.coordinator.selected_map_index,
             )
         )
@@ -292,6 +293,7 @@ class DreameLawnMowerZoneSelect(DreameLawnMowerSelectEntity):
             for entry in current_zone_entries(
                 self.coordinator.batch_device_data,
                 self.coordinator.app_maps,
+                self.coordinator.vector_map_details,
                 selected_map_index=self.coordinator.selected_map_index,
             )
         ]
@@ -304,9 +306,18 @@ class DreameLawnMowerZoneSelect(DreameLawnMowerSelectEntity):
             options = current_zone_entries(
                 self.coordinator.batch_device_data,
                 self.coordinator.app_maps,
+                self.coordinator.vector_map_details,
                 selected_map_index=self.coordinator.selected_map_index,
             )
             return options[0]["label"] if options else None
+        for entry in current_zone_entries(
+            self.coordinator.batch_device_data,
+            self.coordinator.app_maps,
+            getattr(self.coordinator, "vector_map_details", None),
+            selected_map_index=self.coordinator.selected_map_index,
+        ):
+            if entry["area_id"] == zone_id:
+                return str(entry["label"])
         return zone_label(zone_id)
 
     async def async_select_option(self, option: str) -> None:
@@ -314,6 +325,7 @@ class DreameLawnMowerZoneSelect(DreameLawnMowerSelectEntity):
         for entry in current_zone_entries(
             self.coordinator.batch_device_data,
             self.coordinator.app_maps,
+            self.coordinator.vector_map_details,
             selected_map_index=self.coordinator.selected_map_index,
         ):
             if entry["label"] == option:

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -213,8 +213,7 @@ SENSORS = [
         name="Mowing Mode",
         value_fn=lambda snapshot: snapshot.mowing_mode_name,
         exists_fn=lambda snapshot: (
-            bool(snapshot.mowing_mode_name)
-            and snapshot.mowing_mode_name != "unknown"
+            bool(snapshot.mowing_mode_name) and snapshot.mowing_mode_name != "unknown"
         ),
         icon="mdi:grass",
         entity_registry_enabled_default=False,
@@ -2787,6 +2786,7 @@ def _selected_target_summary(coordinator: Any) -> dict[str, Any]:
         entries = current_zone_entries(
             getattr(coordinator, "batch_device_data", None),
             getattr(coordinator, "app_maps", None),
+            getattr(coordinator, "vector_map_details", None),
             selected_map_index=selected_map_index,
         )
         selected_zone_id = getattr(coordinator, "selected_zone_id", None)
@@ -2806,7 +2806,7 @@ def _selected_target_summary(coordinator: Any) -> dict[str, Any]:
             return {
                 "target_type": "zone",
                 "target_id": fallback,
-                "target_label": zone_label(fallback),
+                "target_label": str(entries[0]["label"]),
                 "available_target_count": len(entries),
                 "selected_map_index": selected_map_index,
                 "selected_map_label": selected_map,
@@ -2952,6 +2952,7 @@ def _selected_zone_preference_summary(coordinator: Any) -> dict[str, Any]:
     zone_entries = current_zone_entries(
         getattr(coordinator, "batch_device_data", None),
         getattr(coordinator, "app_maps", None),
+        getattr(coordinator, "vector_map_details", None),
         selected_map_index=getattr(coordinator, "selected_map_index", None),
     )
     selected_zone_id = getattr(coordinator, "selected_zone_id", None)

--- a/custom_components/dreame_lawn_mower/services.yaml
+++ b/custom_components/dreame_lawn_mower/services.yaml
@@ -1,6 +1,7 @@
 start_zone_mowing:
   name: Start zone mowing
-  description: Start mowing for one or more explicit current-map zone IDs.
+  description: >-
+    Start mower-native mowing for one or more saved zones on the active map.
   target:
     entity:
       integration: dreame_lawn_mower
@@ -8,13 +9,14 @@ start_zone_mowing:
   fields:
     zone_ids:
       name: Zone IDs
-      description: List of zone IDs to mow, for example [1, 3].
+      description: List of saved Dreame zone IDs to mow, for example [1, 3].
       required: true
       example: [1, 3]
 
 start_spot_mowing:
   name: Start spot mowing
-  description: Start mowing for one or more explicit current-map spot IDs.
+  description: >-
+    Start mower-native mowing for one or more saved spot areas on the active map.
   target:
     entity:
       integration: dreame_lawn_mower
@@ -22,7 +24,7 @@ start_spot_mowing:
   fields:
     spot_ids:
       name: Spot IDs
-      description: List of spot IDs to mow, for example [2, 4].
+      description: List of saved Dreame spot area IDs to mow, for example [2, 4].
       required: true
       example: [2, 4]
 

--- a/dreame_lawn_mower_client/mowing_tasks.py
+++ b/dreame_lawn_mower_client/mowing_tasks.py
@@ -1,0 +1,8 @@
+"""Wrapper module for mower-native task helpers."""
+
+from ._loader import load_internal_module
+
+_internal = load_internal_module("mowing_tasks")
+
+__all__ = [name for name in dir(_internal) if not name.startswith("_")]
+globals().update({name: getattr(_internal, name) for name in __all__})

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.2.3"
+version = "0.2.4"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -167,6 +167,10 @@ def _vector_map_details() -> dict:
                 "map_id": 1,
                 "map_index": 0,
                 "map_name": "Front Lawn Map",
+                "zones": [
+                    {"zone_id": 1, "name": "Front Garden"},
+                    {"zone_id": 3, "name": None},
+                ],
                 "contour_ids": [[1, 0], [3, 0]],
                 "contour_count": 2,
                 "mow_path_count": 0,
@@ -178,6 +182,7 @@ def _vector_map_details() -> dict:
                 "map_id": 2,
                 "map_index": 1,
                 "map_name": "Back Lawn Map",
+                "zones": [{"zone_id": 5, "name": "Back Orchard"}],
                 "contour_ids": [[5, 0]],
                 "contour_count": 1,
                 "mow_path_count": 1,
@@ -304,6 +309,19 @@ def test_current_zone_entries_filter_global_and_edge_area_ids() -> None:
     ]
 
 
+def test_current_zone_entries_use_vector_names_by_id_with_safe_fallback() -> None:
+    entries = current_zone_entries(
+        _batch_device_data(),
+        _app_maps(),
+        _vector_map_details(),
+    )
+
+    assert [entry["label"] for entry in entries] == [
+        "Front Garden (#1)",
+        "Zone #3",
+    ]
+
+
 def test_current_spot_entries_expose_spot_ids_and_centers() -> None:
     entries = current_spot_entries(_app_maps(), _batch_device_data())
 
@@ -424,14 +442,15 @@ def test_zone_select_sets_zone_and_switches_action() -> None:
         data=SimpleNamespace(),
         batch_device_data=_batch_device_data(),
         app_maps=_app_maps(),
+        vector_map_details=_vector_map_details(),
         selected_map_index=None,
         selected_zone_id=None,
         selected_mowing_action="all_area",
         async_update_listeners=lambda: None,
     )
 
-    assert entity.options == ["Zone #1", "Zone #3"]
-    assert entity.current_option == "Zone #1"
+    assert entity.options == ["Front Garden (#1)", "Zone #3"]
+    assert entity.current_option == "Front Garden (#1)"
 
     asyncio.run(entity.async_select_option("Zone #3"))
 
@@ -503,14 +522,15 @@ def test_zone_select_uses_selected_map_scope() -> None:
         data=SimpleNamespace(),
         batch_device_data=_batch_device_data(),
         app_maps=_app_maps(current_map_index=0),
+        vector_map_details=_vector_map_details(),
         selected_map_index=1,
         selected_zone_id=None,
         selected_mowing_action="all_area",
         async_update_listeners=lambda: None,
     )
 
-    assert entity.options == ["Zone #5"]
-    assert entity.current_option == "Zone #5"
+    assert entity.options == ["Back Orchard (#5)"]
+    assert entity.current_option == "Back Orchard (#5)"
 
 
 def test_spot_select_uses_selected_map_scope() -> None:
@@ -585,7 +605,7 @@ def test_lawn_mower_attributes_include_current_vector_map_state() -> None:
     assert attributes["selected_zone_preference"] == {
         "map_index": 1,
         "area_id": 5,
-        "label": "Zone #5",
+        "label": "Back Orchard (#5)",
         "mode": 0,
         "mode_name": "global",
         "reported_version": 10,
@@ -650,8 +670,8 @@ def test_lawn_mower_attributes_fallback_to_vector_map_ids_for_names() -> None:
 def test_lawn_mower_start_uses_selected_edge() -> None:
     client = SimpleNamespace(
         async_start_edge_mowing=AsyncMock(),
-        async_clean_segments=AsyncMock(),
-        async_clean_spots=AsyncMock(),
+        async_start_zone_mowing=AsyncMock(),
+        async_start_spot_mowing=AsyncMock(),
         async_start_mowing=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
@@ -671,8 +691,8 @@ def test_lawn_mower_start_uses_selected_edge() -> None:
     asyncio.run(entity.async_start_mowing())
 
     client.async_start_edge_mowing.assert_awaited_once_with([[3, 0]])
-    client.async_clean_segments.assert_not_called()
-    client.async_clean_spots.assert_not_called()
+    client.async_start_zone_mowing.assert_not_called()
+    client.async_start_spot_mowing.assert_not_called()
     client.async_start_mowing.assert_not_called()
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
@@ -684,12 +704,16 @@ def test_lawn_mower_start_edge_service_uses_explicit_contours() -> None:
     entity = object.__new__(DreameLawnMower)
     entity.coordinator = SimpleNamespace(
         client=client,
+        app_maps=_app_maps(),
+        batch_device_data=_batch_device_data(),
+        vector_map_details=_vector_map_details(),
+        selected_map_index=None,
         async_request_refresh=AsyncMock(),
     )
 
-    asyncio.run(entity.async_start_edge_mowing([[7, 1], ("9", "0")]))
+    asyncio.run(entity.async_start_edge_mowing([[1, 0], ("3", "0")]))
 
-    client.async_start_edge_mowing.assert_awaited_once_with([[7, 1], [9, 0]])
+    client.async_start_edge_mowing.assert_awaited_once_with([[1, 0], [3, 0]])
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
@@ -707,6 +731,25 @@ def test_lawn_mower_start_edge_service_requires_valid_pairs() -> None:
         asyncio.run(entity.async_start_edge_mowing([[7]]))
 
     client.async_start_edge_mowing.assert_not_called()
+
+
+def test_lawn_mower_start_edge_service_rejects_unknown_active_map_contour() -> None:
+    client = SimpleNamespace(async_start_edge_mowing=AsyncMock())
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        app_maps=_app_maps(),
+        batch_device_data=_batch_device_data(),
+        vector_map_details=_vector_map_details(),
+        selected_map_index=None,
+        async_request_refresh=AsyncMock(),
+    )
+
+    with pytest.raises(HomeAssistantError, match=r"Edge contour \(7, 1\)"):
+        asyncio.run(entity.async_start_edge_mowing([[7, 1]]))
+
+    client.async_start_edge_mowing.assert_not_called()
+    entity.coordinator.async_request_refresh.assert_not_awaited()
 
 
 def test_lawn_mower_switch_current_map_service_updates_scope_and_refreshes() -> None:
@@ -1108,8 +1151,8 @@ def test_lawn_mower_plan_map_preference_mode_update_blocks_unconfirmed_write() -
 
 def test_lawn_mower_start_uses_selected_zone() -> None:
     client = SimpleNamespace(
-        async_clean_segments=AsyncMock(),
-        async_clean_spots=AsyncMock(),
+        async_start_zone_mowing=AsyncMock(),
+        async_start_spot_mowing=AsyncMock(),
         async_start_mowing=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
@@ -1128,15 +1171,15 @@ def test_lawn_mower_start_uses_selected_zone() -> None:
 
     asyncio.run(entity.async_start_mowing())
 
-    client.async_clean_segments.assert_awaited_once_with([3])
+    client.async_start_zone_mowing.assert_awaited_once_with([3])
     client.async_start_mowing.assert_not_called()
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
-def test_lawn_mower_start_uses_selected_spot_center() -> None:
+def test_lawn_mower_start_uses_selected_spot_area_id() -> None:
     client = SimpleNamespace(
-        async_clean_segments=AsyncMock(),
-        async_clean_spots=AsyncMock(),
+        async_start_zone_mowing=AsyncMock(),
+        async_start_spot_mowing=AsyncMock(),
         async_start_mowing=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
@@ -1155,7 +1198,7 @@ def test_lawn_mower_start_uses_selected_spot_center() -> None:
 
     asyncio.run(entity.async_start_mowing())
 
-    client.async_clean_spots.assert_awaited_once_with([(120, 120)])
+    client.async_start_spot_mowing.assert_awaited_once_with([2])
     client.async_start_mowing.assert_not_called()
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
@@ -1163,8 +1206,8 @@ def test_lawn_mower_start_uses_selected_spot_center() -> None:
 def test_lawn_mower_start_zone_requires_available_zone() -> None:
     client = SimpleNamespace(
         async_start_edge_mowing=AsyncMock(),
-        async_clean_segments=AsyncMock(),
-        async_clean_spots=AsyncMock(),
+        async_start_zone_mowing=AsyncMock(),
+        async_start_spot_mowing=AsyncMock(),
         async_start_mowing=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
@@ -1175,7 +1218,7 @@ def test_lawn_mower_start_zone_requires_available_zone() -> None:
         selected_contour_id=None,
         selected_zone_id=None,
         selected_spot_id=None,
-        vector_map_details=_vector_map_details(),
+        vector_map_details={},
         batch_device_data={"batch_mowing_preferences": {"maps": []}},
         app_maps=_app_maps(),
         async_request_refresh=AsyncMock(),
@@ -1188,8 +1231,8 @@ def test_lawn_mower_start_zone_requires_available_zone() -> None:
 def test_lawn_mower_start_blocks_map_scope_mismatch() -> None:
     client = SimpleNamespace(
         async_start_edge_mowing=AsyncMock(),
-        async_clean_segments=AsyncMock(),
-        async_clean_spots=AsyncMock(),
+        async_start_zone_mowing=AsyncMock(),
+        async_start_spot_mowing=AsyncMock(),
         async_start_mowing=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
@@ -1212,4 +1255,59 @@ def test_lawn_mower_start_blocks_map_scope_mismatch() -> None:
     ):
         asyncio.run(entity.async_start_mowing())
 
-    client.async_clean_segments.assert_not_called()
+    client.async_start_zone_mowing.assert_not_called()
+
+
+def test_lawn_mower_zone_service_uses_validated_current_map_ids() -> None:
+    client = SimpleNamespace(async_start_zone_mowing=AsyncMock())
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        selected_map_index=None,
+        vector_map_details=_vector_map_details(),
+        batch_device_data=_batch_device_data(),
+        app_maps=_app_maps(),
+        async_request_refresh=AsyncMock(),
+    )
+
+    asyncio.run(entity.async_start_zone_mowing([1, 3]))
+
+    client.async_start_zone_mowing.assert_awaited_once_with([1, 3])
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_lawn_mower_zone_service_rejects_unknown_active_map_id() -> None:
+    client = SimpleNamespace(async_start_zone_mowing=AsyncMock())
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        selected_map_index=None,
+        vector_map_details=_vector_map_details(),
+        batch_device_data=_batch_device_data(),
+        app_maps=_app_maps(),
+        async_request_refresh=AsyncMock(),
+    )
+
+    with pytest.raises(HomeAssistantError, match="Zone #9 is not available"):
+        asyncio.run(entity.async_start_zone_mowing([9]))
+
+    client.async_start_zone_mowing.assert_not_called()
+    entity.coordinator.async_request_refresh.assert_not_awaited()
+
+
+def test_lawn_mower_spot_service_sends_saved_area_ids_not_coordinates() -> None:
+    client = SimpleNamespace(async_start_spot_mowing=AsyncMock())
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        selected_map_index=None,
+        vector_map_details=_vector_map_details(),
+        batch_device_data=_batch_device_data(),
+        app_maps=_app_maps(),
+        async_request_refresh=AsyncMock(),
+    )
+
+    asyncio.run(entity.async_start_spot_mowing([2]))
+
+    client.async_start_spot_mowing.assert_awaited_once_with([2])
+    entity.coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_mowing_tasks.py
+++ b/tests/test_mowing_tasks.py
@@ -1,0 +1,55 @@
+"""Contract tests for mower-native task requests."""
+
+from __future__ import annotations
+
+import pytest
+
+from dreame_lawn_mower_client.mowing_tasks import (
+    MowingTaskResponseError,
+    build_spot_mowing_request,
+    build_zone_mowing_request,
+    ensure_mowing_task_succeeded,
+)
+
+
+def test_zone_mowing_request_uses_saved_region_ids() -> None:
+    assert build_zone_mowing_request([1, 3]) == {
+        "m": "a",
+        "p": 0,
+        "o": 102,
+        "d": {"region": [1, 3]},
+    }
+
+
+def test_spot_mowing_request_uses_saved_area_ids() -> None:
+    assert build_spot_mowing_request([2, 4]) == {
+        "m": "a",
+        "p": 0,
+        "o": 103,
+        "d": {"area": [2, 4]},
+    }
+
+
+@pytest.mark.parametrize("zone_ids", [[], [0], [-1], [True]])
+def test_zone_mowing_request_rejects_invalid_ids(zone_ids: list[int]) -> None:
+    with pytest.raises(ValueError, match="(?i)zone id"):
+        build_zone_mowing_request(zone_ids)
+
+
+def test_mowing_task_response_requires_explicit_vendor_success() -> None:
+    response = {"m": "r", "r": 0, "d": {}}
+
+    assert ensure_mowing_task_succeeded(response, task_name="zone mowing") is response
+
+    with pytest.raises(MowingTaskResponseError, match="did not acknowledge"):
+        ensure_mowing_task_succeeded(None, task_name="zone mowing")
+    with pytest.raises(MowingTaskResponseError, match="result 5"):
+        ensure_mowing_task_succeeded(
+            {"m": "r", "r": 5, "d": {"reason": "busy"}},
+            task_name="zone mowing",
+        )
+    with pytest.raises(MowingTaskResponseError, match="result 9"):
+        ensure_mowing_task_succeeded(
+            {"m": "r", "r": 0, "d": {"r": 9}},
+            task_name="zone mowing",
+        )

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -6,6 +6,7 @@ import json
 from io import BytesIO
 from types import SimpleNamespace
 
+import pytest
 from PIL import Image
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.vector_map import (
@@ -14,7 +15,10 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.vector_map imp
     vector_map_to_details,
     vector_map_to_summary,
 )
-from dreame_lawn_mower_client import DreameLawnMowerClient
+from dreame_lawn_mower_client import (
+    DreameLawnMowerClient,
+    DreameLawnMowerConnectionError,
+)
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 
 
@@ -323,6 +327,7 @@ def test_vector_map_details_report_live_path_counts() -> None:
     assert details["total_area"] == 10
     assert details["zone_count"] == 1
     assert details["zone_names"] == ["Front Yard"]
+    assert details["zones"] == [{"zone_id": 1, "name": "Front Yard"}]
     assert details["contour_count"] == 1
     assert details["contour_ids"] == [[1, 0]]
     assert details["available_map_count"] == 2
@@ -338,6 +343,7 @@ def test_vector_map_details_report_live_path_counts() -> None:
             "total_area": 10,
             "zone_ids": [1],
             "zone_names": ["Front Yard"],
+            "zones": [{"zone_id": 1, "name": "Front Yard"}],
             "spot_ids": [9],
             "contour_ids": [[1, 0]],
             "contour_count": 1,
@@ -356,6 +362,7 @@ def test_vector_map_details_report_live_path_counts() -> None:
             "total_area": None,
             "zone_ids": [2],
             "zone_names": ["Back Yard"],
+            "zones": [{"zone_id": 2, "name": "Back Yard"}],
             "spot_ids": [],
             "contour_ids": [[5, 0]],
             "contour_count": 1,
@@ -377,23 +384,40 @@ def test_vector_map_details_report_live_path_counts() -> None:
     assert details["has_live_path"] is True
 
 
-def test_client_edge_and_map_actions_use_expected_app_task_payloads() -> None:
+def test_client_mowing_and_map_actions_use_expected_app_task_payloads() -> None:
     client = _client()
     recorded_payloads: list[dict] = []
     client._sync_call_app_action = lambda payload, **kwargs: (
         recorded_payloads.append(  # type: ignore[method-assign]  # noqa: ARG005
             payload
         )
-        or {"ok": True}
+        or {"m": "r", "r": 0, "d": {}}
     )
 
-    assert client._sync_start_edge_mowing([[1, 0]]) == {"ok": True}
-    assert client._sync_switch_current_map(1) == {"ok": True}
+    success = {"m": "r", "r": 0, "d": {}}
+    assert client._sync_start_edge_mowing([[1, 0]]) == success
+    assert client._sync_start_zone_mowing([1, 3]) == success
+    assert client._sync_start_spot_mowing([9]) == success
+    assert client._sync_switch_current_map(1) == success
 
     assert recorded_payloads == [
         {"m": "a", "p": 0, "o": 101, "d": {"edge": [[1, 0]]}},
+        {"m": "a", "p": 0, "o": 102, "d": {"region": [1, 3]}},
+        {"m": "a", "p": 0, "o": 103, "d": {"area": [9]}},
         {"m": "a", "p": 0, "o": 200, "d": {"idx": 1}},
     ]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [None, {"m": "r", "r": 7, "d": {"reason": "busy"}}],
+)
+def test_client_zone_mowing_rejects_missing_or_failed_reply(response: object) -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload, **kwargs: response  # type: ignore[method-assign]  # noqa: ARG005
+
+    with pytest.raises(DreameLawnMowerConnectionError, match="zone mowing"):
+        client._sync_start_zone_mowing([1])
 
 
 def test_map_view_uses_batch_vector_map_when_app_map_fails() -> None:


### PR DESCRIPTION
## Summary

- route zone and spot starts through Dreame's mower-native task protocol, and require an explicit successful mower acknowledgement
- validate zone, spot, and edge targets against the active map before starting
- preserve Dreame zone names by ID with a stable fallback for unnamed zones
- document the correct Home Assistant entity target syntax from the issue report
- prepare integration and Python package metadata for release 0.2.4

Fixes #31

## Validation

- `python -m ruff check .`
- `python -m compileall -q custom_components/dreame_lawn_mower dreame_lawn_mower_client`
- `pytest tests --ignore=tests/components/dreame_lawn_mower/test_config_flow.py` (708 passed)
- built the 0.2.4 wheel and verified its package metadata, embedded integration manifest, mower task modules, and contract tests