### PR TITLE
Switch the mower when selecting a map

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ region/account details are especially helpful for moving a device from
 - button to dock without ending the current mowing session
 - heartbeat-backed task status and automatic resume of a paused mowing session
 - battery, activity, state, task, firmware, and error sensors
-- current-map selector entities for map, mowing action, edge, zone, and spot scope
+- active-map selector that switches the mower, plus mowing action, edge, zone,
+  and spot selectors that follow the selected map
 - current-map services for switching maps and starting explicit zone, spot, or edge runs
 - binary sensors for docked, charging, mowing, paused, returning, and error state
 - binary sensors for active and resumable mowing sessions
@@ -373,7 +374,9 @@ Current map support now includes:
 
 - a read-only `Map` camera for the active map
 - a read-only `All Maps` contact sheet for quick map inventory
-- `select` entities for map, mowing action, edge, zone, and spot scope
+- a `Map` select that switches the mower's active map and refreshes the map,
+  zone, spot, and edge controls
+- `select` entities for mowing action, edge, zone, and spot scope
 - services for switching the active mower map and starting explicit zone, spot,
   or edge jobs
 - runtime live-track telemetry surfaced through sensors and map-camera attributes

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -452,6 +452,24 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         self.voice_settings_refreshed_at = now
         return payload
 
+    async def async_switch_current_map(self, map_index: int) -> None:
+        """Switch the active mower map and refresh all map-scoped state."""
+        await self.client.async_switch_current_map(map_index)
+        self.selected_map_index = map_index
+        self.selected_contour_id = None
+        self.selected_zone_id = None
+        self.selected_spot_id = None
+        await self.async_request_refresh()
+        await self.async_refresh_app_maps(
+            force=True,
+            source="app_maps_switch_current_map",
+        )
+        await self.async_refresh_vector_map_details(
+            force=True,
+            source="vector_map_switch_current_map",
+        )
+        self.async_update_listeners()
+
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""
         await self.client.async_close()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -97,6 +97,12 @@ from .mowing_tasks import (
     build_zone_mowing_request,
     ensure_mowing_task_succeeded,
 )
+from .runtime_state import (
+    RESUME_MOWING_REQUEST,
+    snapshot_session_control_state,
+    snapshot_with_cloud_presence,
+    snapshot_with_heartbeat_task_state,
+)
 from .schedule import (
     EMPTY_SCHEDULE_VERSION,
     SCHEDULE_CHUNK_SIZE,
@@ -105,12 +111,6 @@ from .schedule import (
     decode_schedule_payload_text,
     encode_schedule_payload_text,
     schedule_task_summary,
-)
-from .runtime_state import (
-    RESUME_MOWING_REQUEST,
-    snapshot_session_control_state,
-    snapshot_with_cloud_presence,
-    snapshot_with_heartbeat_task_state,
 )
 from .vector_map import (
     parse_batch_vector_map,
@@ -1566,7 +1566,7 @@ class DreameLawnMowerClient:
         if map_index < 0:
             raise ValueError("map_index must be zero or greater.")
         try:
-            return self._sync_call_app_action(
+            response = self._sync_call_app_action(
                 {
                     "m": "a",
                     "p": 0,
@@ -1574,7 +1574,8 @@ class DreameLawnMowerClient:
                     "d": {"idx": int(map_index)},
                 }
             )
-        except DeviceException as err:
+            return ensure_mowing_task_succeeded(response, task_name="map switch")
+        except (DeviceException, MowingTaskResponseError) as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
 
     def _sync_get_vector_map_details(self) -> dict[str, Any]:

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -495,19 +495,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         """Switch the mower's active app map."""
         normalized_map_index = int(map_index)
         self._ensure_known_map_index(normalized_map_index)
-
-        await self.coordinator.client.async_switch_current_map(normalized_map_index)
-        self._reset_current_map_scope(normalized_map_index)
-        await self.coordinator.async_request_refresh()
-        await self.coordinator.async_refresh_app_maps(
-            force=True,
-            source="app_maps_switch_current_map",
-        )
-        await self.coordinator.async_refresh_vector_map_details(
-            force=True,
-            source="vector_map_switch_current_map",
-        )
-        self.coordinator.async_update_listeners()
+        await self.coordinator.async_switch_current_map(normalized_map_index)
 
     async def async_plan_zone_mowing_preference_update(
         self,
@@ -728,13 +716,6 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             f"{subject} {missing_text} {verb} not available on the active map. "
             f"Available {target_name.lower()} ids: {available_text}."
         )
-
-    def _reset_current_map_scope(self, map_index: int) -> None:
-        """Align local selection state with a successful active-map switch."""
-        self.coordinator.selected_map_index = map_index
-        self.coordinator.selected_contour_id = None
-        self.coordinator.selected_zone_id = None
-        self.coordinator.selected_spot_id = None
 
     def _resolve_zone_id(
         self,

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -104,7 +104,7 @@ class DreameLawnMowerVoiceLanguageSelect(DreameLawnMowerSelectEntity):
 
 
 class DreameLawnMowerMapSelect(DreameLawnMowerSelectEntity):
-    """Choose which app map the zone and spot selectors should target."""
+    """Choose the mower's active app map."""
 
     _attr_name = "Map"
     _attr_icon = "mdi:map-search-outline"
@@ -154,14 +154,13 @@ class DreameLawnMowerMapSelect(DreameLawnMowerSelectEntity):
         return None
 
     async def async_select_option(self, option: str) -> None:
-        """Persist the selected app-map scope in coordinator state."""
+        """Switch the mower and all map-scoped controls to the selected map."""
         for entry in map_entries(
             self.coordinator.app_maps,
             self.coordinator.batch_device_data,
         ):
             if entry["label"] == option:
-                self.coordinator.selected_map_index = entry["map_index"]
-                self.coordinator.async_update_listeners()
+                await self.coordinator.async_switch_current_map(entry["map_index"])
                 return
         raise ValueError(f"Unknown map option: {option}")
 

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -18,6 +18,7 @@ from custom_components.dreame_lawn_mower.control_options import (
     current_spot_entries,
     current_zone_entries,
 )
+from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
 from custom_components.dreame_lawn_mower.lawn_mower import DreameLawnMower
 from custom_components.dreame_lawn_mower.select import (
     DreameLawnMowerEdgeSelect,
@@ -417,14 +418,14 @@ def test_current_contour_entries_can_follow_selected_map_override() -> None:
     ]
 
 
-def test_map_select_updates_selected_map_scope() -> None:
+def test_map_select_switches_active_mower_map() -> None:
     entity = object.__new__(DreameLawnMowerMapSelect)
     entity.coordinator = SimpleNamespace(
         data=SimpleNamespace(),
         batch_device_data=_batch_device_data(),
         app_maps=_app_maps(current_map_index=1),
         selected_map_index=None,
-        async_update_listeners=lambda: None,
+        async_switch_current_map=AsyncMock(),
     )
 
     assert entity.options == ["Front Lawn (#1)", "Back Lawn (#2)"]
@@ -432,8 +433,37 @@ def test_map_select_updates_selected_map_scope() -> None:
 
     asyncio.run(entity.async_select_option("Front Lawn (#1)"))
 
-    assert entity.coordinator.selected_map_index == 0
-    assert entity.current_option == "Front Lawn (#1)"
+    entity.coordinator.async_switch_current_map.assert_awaited_once_with(0)
+
+
+def test_coordinator_switch_current_map_updates_device_and_scoped_caches() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(async_switch_current_map=AsyncMock())
+    coordinator.selected_map_index = 0
+    coordinator.selected_contour_id = (3, 0)
+    coordinator.selected_zone_id = 3
+    coordinator.selected_spot_id = 2
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.async_refresh_app_maps = AsyncMock()
+    coordinator.async_refresh_vector_map_details = AsyncMock()
+    coordinator.async_update_listeners = lambda: None
+
+    asyncio.run(coordinator.async_switch_current_map(1))
+
+    coordinator.client.async_switch_current_map.assert_awaited_once_with(1)
+    coordinator.async_request_refresh.assert_awaited_once()
+    coordinator.async_refresh_app_maps.assert_awaited_once_with(
+        force=True,
+        source="app_maps_switch_current_map",
+    )
+    coordinator.async_refresh_vector_map_details.assert_awaited_once_with(
+        force=True,
+        source="vector_map_switch_current_map",
+    )
+    assert coordinator.selected_map_index == 1
+    assert coordinator.selected_contour_id is None
+    assert coordinator.selected_zone_id is None
+    assert coordinator.selected_spot_id is None
 
 
 def test_zone_select_sets_zone_and_switches_action() -> None:
@@ -753,41 +783,17 @@ def test_lawn_mower_start_edge_service_rejects_unknown_active_map_contour() -> N
 
 
 def test_lawn_mower_switch_current_map_service_updates_scope_and_refreshes() -> None:
-    client = SimpleNamespace(
-        async_switch_current_map=AsyncMock(),
-    )
     coordinator = SimpleNamespace(
-        client=client,
         app_maps=_app_maps(current_map_index=0),
         batch_device_data=_batch_device_data(),
-        selected_map_index=0,
-        selected_contour_id=(3, 0),
-        selected_zone_id=3,
-        selected_spot_id=2,
-        async_request_refresh=AsyncMock(),
-        async_refresh_app_maps=AsyncMock(),
-        async_refresh_vector_map_details=AsyncMock(),
-        async_update_listeners=lambda: None,
+        async_switch_current_map=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
     entity.coordinator = coordinator
 
     asyncio.run(entity.async_switch_current_map(1))
 
-    client.async_switch_current_map.assert_awaited_once_with(1)
-    coordinator.async_request_refresh.assert_awaited_once()
-    coordinator.async_refresh_app_maps.assert_awaited_once_with(
-        force=True,
-        source="app_maps_switch_current_map",
-    )
-    coordinator.async_refresh_vector_map_details.assert_awaited_once_with(
-        force=True,
-        source="vector_map_switch_current_map",
-    )
-    assert coordinator.selected_map_index == 1
-    assert coordinator.selected_contour_id is None
-    assert coordinator.selected_zone_id is None
-    assert coordinator.selected_spot_id is None
+    coordinator.async_switch_current_map.assert_awaited_once_with(1)
 
 
 def test_lawn_mower_switch_current_map_service_rejects_unknown_map_index() -> None:

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -420,6 +420,18 @@ def test_client_zone_mowing_rejects_missing_or_failed_reply(response: object) ->
         client._sync_start_zone_mowing([1])
 
 
+@pytest.mark.parametrize(
+    "response",
+    [None, {"m": "r", "r": 7, "d": {"reason": "busy"}}],
+)
+def test_client_map_switch_rejects_missing_or_failed_reply(response: object) -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload, **kwargs: response  # type: ignore[method-assign]  # noqa: ARG005
+
+    with pytest.raises(DreameLawnMowerConnectionError, match="map switch"):
+        client._sync_switch_current_map(1)
+
+
 def test_map_view_uses_batch_vector_map_when_app_map_fails() -> None:
     client = _client()
     client._sync_get_app_maps = lambda **kwargs: {  # noqa: ARG005


### PR DESCRIPTION
## Summary

- make the `Map` select switch the mower's real active map
- share one coordinator workflow between the select and `switch_current_map` service
- clear stale edge, zone, and spot selections and refresh map state after a switch
- clarify the selector behavior in the README

Closes #35

## Validation

- focused Home Assistant map-control tests
- Ruff and Git diff checks