### PR TITLE
Keep zone mowing startup out of the error state

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -20,7 +20,10 @@ MOWER_ERROR_CODE_NAMES = {
     53: "rain_detected",
     54: "low_battery",
 }
-MOWER_NON_ERROR_EVENT_CODES = frozenset({61, 70})
+# Mower firmware also sends transient lifecycle notifications through the error
+# property. Code 50 is emitted while an accepted zone-mowing task starts; 61
+# and 70 are DND start/end notifications.
+MOWER_NON_ERROR_EVENT_CODES = frozenset({50, 61, 70})
 
 MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
@@ -213,7 +216,9 @@ def _friendly_error_display(
             or _friendly_error_name(_error_name_from_code(error_code))
             or (None if _is_no_error_text(error_text) else error_text)
         )
-        return f"Unverified {inherited.casefold()}" if inherited else f"Error {error_code}"
+        return (
+            f"Unverified {inherited.casefold()}" if inherited else f"Error {error_code}"
+        )
 
     return _friendly_error_name(error_name) or error_text
 
@@ -941,9 +946,8 @@ def snapshot_from_device(
     error_code = raw_error_code
     status_has_error = bool(getattr(device.status, "has_error", False))
     if raw_error_code in MOWER_NON_ERROR_EVENT_CODES:
-        # Codes 61 and 70 are DND start/end notifications on mower firmware,
-        # despite their inherited vacuum labels. Preserve the raw code for
-        # diagnostics without turning the Home Assistant entity into an error.
+        # Preserve lifecycle notifications for diagnostics without turning the
+        # Home Assistant entity into an error.
         error_name = None
         error_text = None
         error_code = None

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -100,8 +100,8 @@ def test_unconfirmed_vacuum_error_name_is_marked_unverified() -> None:
     assert snapshot.error_display == "Unverified drop"
 
 
-@pytest.mark.parametrize("code", [61, 70])
-def test_dnd_transition_codes_are_not_active_errors(code: int) -> None:
+@pytest.mark.parametrize("code", [50, 61, 70])
+def test_mower_lifecycle_event_codes_are_not_active_errors(code: int) -> None:
     snapshot = _snapshot(code, "route")
 
     assert snapshot.activity == "paused"
@@ -110,8 +110,8 @@ def test_dnd_transition_codes_are_not_active_errors(code: int) -> None:
     assert snapshot.error_display is None
 
 
-@pytest.mark.parametrize("code", [61, 70])
-def test_dnd_transition_suppresses_stale_realtime_error(code: int) -> None:
+@pytest.mark.parametrize("code", [50, 61, 70])
+def test_mower_lifecycle_event_suppresses_stale_realtime_error(code: int) -> None:
     snapshot = _snapshot(code, "route", realtime_error_code=23)
 
     assert snapshot.activity == "paused"


### PR DESCRIPTION
Zone mowing no longer changes the Home Assistant entity to `Error` while the mower is starting the accepted task.

Dreame firmware emits code `50` through the error property during this transition even though the mower simultaneously reports no error. The reusable client now treats it as a lifecycle notification, while preserving the raw value for diagnostics. Existing confirmed mower faults remain unchanged.

Follow-up to #31.