### PR TITLE
Release 0.2.6

### DIFF
--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -20,5 +20,5 @@
     "py-mini-racer",
     "paho-mqtt"
   ],
-  "version": "0.2.5"
+  "version": "0.2.6"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "homeassistant-dreame-lawn-mower"
-version = "0.2.5"
+version = "0.2.6"
 description = "HACS-ready Dreame and MOVA lawn mower integration for Home Assistant"
 readme = "README.md"
 requires-python = ">=3.13"


### PR DESCRIPTION
## Summary

- set the integration and Python package version to `0.2.6`
- release active-map switching and validation
- prevent accepted zone-mowing starts from briefly appearing as errors
- add longer live-path support, live mower position attributes, map display rotation, and additional status-frame compatibility

No migration is required.