### PR TITLE
Adopt PowerForge release automation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -26,7 +26,7 @@ jobs:
       checks: read
       contents: write
       pull-requests: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@PowerForge-v1.0.2
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@e88d91b6c4e7347b8daadbbc54428a6191bddb7a # PowerForge-v1.0.2 with receiver trust hardening
     with:
       pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
       merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Release
 
 on:
-  pull_request:
+  pull_request_target:
     types: [closed]
   workflow_dispatch:
     inputs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,36 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: Merged pull request number to release or recover
+        required: true
+        type: number
+      merge_commit_sha:
+        description: Expected merge commit SHA
+        required: false
+        type: string
+      increment:
+        description: auto, none, patch, minor, or major
+        required: false
+        default: auto
+        type: string
+
+jobs:
+  release:
+    if: github.event_name == 'workflow_dispatch' || github.event.pull_request.merged == true
+    permissions:
+      checks: read
+      contents: write
+      pull-requests: read
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@PowerForge-v1.0.2
+    with:
+      pr_number: ${{ github.event.pull_request.number || inputs.pr_number }}
+      merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}
+      default_branch: ${{ github.event.repository.default_branch }}
+      increment: ${{ inputs.increment || 'auto' }}
+    secrets:
+      github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- add the thin PowerForge receiver for merged-pull-request releases
- use a trusted closed-PR trigger so fork and Dependabot merges can release
- pin the shared workflow to the immutable reviewed PowerForge commit
- support manual recovery by pull request number and merge SHA

Release labels select the version increment; versioning and GitHub release behavior remain owned by PowerForge.