### PR TITLE
Improve diagnostics for issue reporting

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -1,0 +1,104 @@
+name: Bug report
+description: Report a reproducible integration, entity, service, map, schedule, or video problem.
+title: "[Bug]: "
+labels:
+  - bug
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Reproduce the problem once, then download diagnostics before reloading Home Assistant. The report includes sanitized version, host, coordinator, entity, and recent failure information.
+
+        Do not paste credentials, tokens, serial numbers, exact coordinates, or broad raw debug logs.
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      description: The installed Dreame Lawn Mower version shown by HACS.
+      placeholder: 0.2.9
+    validations:
+      required: true
+  - type: textarea
+    id: home_assistant_system
+    attributes:
+      label: Home Assistant system
+      description: Include Home Assistant Core version, installation type, host operating system, and CPU architecture from System information.
+      placeholder: Home Assistant 2026.7.x, Home Assistant OS, Linux, x86_64
+    validations:
+      required: true
+  - type: input
+    id: model
+    attributes:
+      label: Mower model
+      description: Include both the retail name and raw model identifier when known.
+      placeholder: Dreame A2 1200 - dreame.mower.g2568a
+    validations:
+      required: true
+  - type: dropdown
+    id: feature
+    attributes:
+      label: Affected area
+      options:
+        - Setup or authentication
+        - Device availability or state
+        - Mowing controls or services
+        - Maps or zones
+        - Schedules or calendar
+        - Live video or camera
+        - Sensors or diagnostics
+        - Firmware update
+        - Other
+    validations:
+      required: true
+  - type: textarea
+    id: expected
+    attributes:
+      label: Expected behavior
+      placeholder: What should have happened?
+    validations:
+      required: true
+  - type: textarea
+    id: actual
+    attributes:
+      label: Actual behavior
+      placeholder: What happened instead, including the visible error?
+    validations:
+      required: true
+  - type: textarea
+    id: reproduction
+    attributes:
+      label: Reproduction steps and mower state
+      description: Include the exact steps, whether the mower was docked/charging/mowing/paused/returning, and whether the problem is consistent.
+      placeholder: |
+        1. Start ...
+        2. Open ...
+        3. The mower is ...
+    validations:
+      required: true
+  - type: textarea
+    id: vendor_app_comparison
+    attributes:
+      label: Dreamehome or MOVAhome comparison
+      description: Say whether the same operation works in the vendor app at the same time.
+      placeholder: Works in Dreamehome / also fails in Dreamehome / not available in the app.
+    validations:
+      required: true
+  - type: textarea
+    id: diagnostics
+    attributes:
+      label: Downloaded diagnostics
+      description: Drag the diagnostics JSON downloaded immediately after reproducing the problem. Add only short, sanitized log excerpts if they provide information not present in the file.
+      placeholder: Drag the downloaded diagnostics JSON here.
+    validations:
+      required: true
+  - type: checkboxes
+    id: safety
+    attributes:
+      label: Safety and privacy checks
+      options:
+        - label: I reproduced the problem immediately before downloading diagnostics.
+          required: true
+        - label: I removed credentials, tokens, serial numbers, exact coordinates, and other private data from anything added manually.
+          required: true
+        - label: I did not run movement or write tests without supervising the mower.
+          required: true

--- a/.github/ISSUE_TEMPLATE/model-support-report.yml
+++ b/.github/ISSUE_TEMPLATE/model-support-report.yml
@@ -44,6 +44,22 @@ body:
       placeholder: eu / pl
     validations:
       required: true
+  - type: input
+    id: integration_version
+    attributes:
+      label: Integration version
+      description: The installed Dreame Lawn Mower version shown by HACS.
+      placeholder: 0.2.9
+    validations:
+      required: true
+  - type: textarea
+    id: home_assistant_system
+    attributes:
+      label: Home Assistant system
+      description: Include Home Assistant Core version, installation type, host operating system, and CPU architecture from System information.
+      placeholder: Home Assistant 2026.7.x, Home Assistant OS, Linux, aarch64
+    validations:
+      required: true
   - type: textarea
     id: works
     attributes:
@@ -57,11 +73,27 @@ body:
       description: Tell us what does not work yet or looks wrong.
       placeholder: Map camera empty, schedule not shown, unknown sensors...
   - type: textarea
+    id: reproduction_context
+    attributes:
+      label: Reproduction context
+      description: Describe the steps and the mower state when the problem happens. For video, say whether the mower is active and away from its station.
+      placeholder: Steps, mower activity, dock/charging state, network context, and whether the problem happens every time.
+    validations:
+      required: true
+  - type: textarea
+    id: vendor_app_comparison
+    attributes:
+      label: Dreamehome or MOVAhome comparison
+      description: Say whether the same feature works in the vendor app at the same time.
+      placeholder: Works in Dreamehome / also fails in Dreamehome / not available in the app.
+    validations:
+      required: true
+  - type: textarea
     id: diagnostics
     attributes:
       label: Sanitized diagnostics or debug notes
-      description: Paste sanitized details or describe attached files/screenshots.
-      placeholder: Attached Home Assistant diagnostics and screenshots with tokens removed.
+      description: Reproduce once, then download diagnostics from the integration before reloading Home Assistant. Attach the JSON file and any relevant screenshot. Do not enable broad debug logging unless a maintainer asks for it.
+      placeholder: Drag the downloaded diagnostics JSON here, then add any short notes needed to identify the failed feature.
     validations:
       required: true
   - type: checkboxes
@@ -70,6 +102,8 @@ body:
       label: Safety checks
       options:
         - label: I removed credentials, tokens, serial numbers, and other secrets.
+          required: true
+        - label: I reproduced the problem immediately before downloading diagnostics.
           required: true
         - label: I understand write and drive features may need careful supervision on unvalidated models.
           required: true

--- a/README.md
+++ b/README.md
@@ -428,19 +428,36 @@ device rejection responses are surfaced as failed actions.
 
 ## Troubleshooting
 
-Start with Home Assistant diagnostics:
+Start with a fresh Home Assistant diagnostics capture:
 
-1. Open the device page.
-2. Download diagnostics.
-3. Check the `triage`, `state_reconciliation`, schedule, and map sections.
+1. Reproduce the problem once.
+2. Before reloading or restarting Home Assistant, open the integration or device
+   page and download diagnostics.
+3. Attach the downloaded JSON to the issue. Add screenshots or short log excerpts
+   only when they show something that is not already in the diagnostics.
+
+The report is sanitized by the integration and includes:
+
+- the installed integration, Home Assistant, Python, operating-system, and CPU
+  architecture versions
+- config-entry and coordinator health
+- current state and diagnostic attributes for every entity belonging to the
+  config entry, including the Live Video camera's last failure stage
+- a bounded list of recent coordinator, map, schedule, and video failures with
+  repeated failures coalesced
+- the existing `triage`, `state_reconciliation`, schedule, map, firmware, and raw
+  property summaries
+
+Do not enable broad debug logging unless a maintainer asks for a specific logger.
+Cloud protocol debug output can contain data that needs additional review before
+it is posted publicly.
 
 For issue reports, include:
 
-- mower model and app/account type
-- firmware version
-- normalized activity/state/error values
-- relevant diagnostic payload sections with secrets redacted
-- whether the issue happens while docked, mowing, returning, raining, or charging
+- the downloaded diagnostics captured immediately after the failure
+- what you expected and the exact steps that failed
+- whether the same operation worked in Dreamehome or MOVAhome at that time
+- screenshots only when the visible result matters
 
 Home Assistant log lines that start with `Captured Dreame lawn mower ...` can be
 converted to JSON with:

--- a/custom_components/dreame_lawn_mower/calendar.py
+++ b/custom_components/dreame_lawn_mower/calendar.py
@@ -16,6 +16,8 @@ from homeassistant.util import dt as dt_util
 
 from .const import DOMAIN
 from .coordinator import DreameLawnMowerCoordinator
+from .debug import sanitize_diagnostic_text
+from .diagnostic_events import record_diagnostic_event
 from .entity import DreameLawnMowerEntity
 
 _LOGGER = logging.getLogger(__name__)
@@ -93,10 +95,16 @@ class DreameLawnMowerScheduleCalendar(DreameLawnMowerEntity, CalendarEntity):
         try:
             payload = await self.coordinator.client.async_get_app_schedules()
         except Exception as err:  # noqa: BLE001 - calendar should stay read-only
-            self._last_error = str(err)
+            self._last_error = sanitize_diagnostic_text(err)
             self._cached_event_count = 0
             self._cached_selection = None
-            _LOGGER.debug("Failed to fetch mower schedules: %s", err)
+            record_diagnostic_event(
+                self.coordinator,
+                code="schedule_calendar_refresh_failed",
+                source="schedule_calendar",
+                message=self._last_error,
+            )
+            _LOGGER.debug("Failed to fetch mower schedules: %s", self._last_error)
             return []
         self._last_error = None
         self._cached_selection = schedule_calendar_selection(

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -23,6 +23,8 @@ from .const import (
     DOMAIN,
 )
 from .coordinator import DreameLawnMowerCoordinator
+from .debug import sanitize_diagnostic_text
+from .diagnostic_events import record_diagnostic_event
 from .dreame_lawn_mower_client.client import render_app_map_payload_png
 from .dreame_lawn_mower_client.models import DreameLawnMowerMapView
 from .image import (
@@ -213,8 +215,17 @@ class DreameLawnMowerMapCamera(
                 self.async_write_ha_state()
                 return image
             except Exception as err:
-                _LOGGER.warning("Failed to convert Dreame mower map image: %s", err)
-                self._map_cache.last_error = str(err)
+                safe_error = sanitize_diagnostic_text(err)
+                _LOGGER.warning(
+                    "Failed to convert Dreame mower map image: %s", safe_error
+                )
+                record_diagnostic_event(
+                    self.coordinator,
+                    code="map_image_conversion_failed",
+                    source="map_camera",
+                    message=safe_error,
+                )
+                self._map_cache.last_error = safe_error
                 self.async_write_ha_state()
 
         if self._map_cache.last_image is not None:
@@ -239,8 +250,15 @@ class DreameLawnMowerMapCamera(
             self.async_write_ha_state()
             return view
         except Exception as err:
-            _LOGGER.warning("Failed to refresh Dreame mower map image: %s", err)
-            view = self._map_cache.store_error(str(err))
+            safe_error = sanitize_diagnostic_text(err)
+            _LOGGER.warning("Failed to refresh Dreame mower map image: %s", safe_error)
+            record_diagnostic_event(
+                self.coordinator,
+                code="map_refresh_failed",
+                source="map_camera",
+                message=safe_error,
+            )
+            view = self._map_cache.store_error(safe_error)
             self.async_write_ha_state()
             return view
 
@@ -290,10 +308,17 @@ class DreameLawnMowerLivePathMapCamera(DreameLawnMowerMapCamera):
             self.async_write_ha_state()
             return view
         except Exception as err:
+            safe_error = sanitize_diagnostic_text(err)
             _LOGGER.warning(
-                "Failed to refresh Dreame mower live-path map image: %s", err
+                "Failed to refresh Dreame mower live-path map image: %s", safe_error
             )
-            view = self._map_cache.store_error(str(err), source="batch_vector_map")
+            record_diagnostic_event(
+                self.coordinator,
+                code="live_path_map_refresh_failed",
+                source="map_camera",
+                message=safe_error,
+            )
+            view = self._map_cache.store_error(safe_error, source="batch_vector_map")
             self.async_write_ha_state()
             return view
 
@@ -413,12 +438,21 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
                 )
             )
         except Exception as err:
-            _LOGGER.warning("Failed to refresh Dreame mower all-map image: %s", err)
+            safe_error = sanitize_diagnostic_text(err)
+            _LOGGER.warning(
+                "Failed to refresh Dreame mower all-map image: %s", safe_error
+            )
+            record_diagnostic_event(
+                self.coordinator,
+                code="all_maps_refresh_failed",
+                source="map_camera",
+                message=safe_error,
+            )
             return await self.hass.async_add_executor_job(
                 partial(
                     map_placeholder_jpeg,
                     title="Dreame all maps unavailable",
-                    detail=str(err),
+                    detail=safe_error,
                 )
             )
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -33,6 +33,11 @@ from .const import (
     DEFAULT_SCAN_INTERVAL_SECONDS,
     DOMAIN,
 )
+from .debug import sanitize_diagnostic_text
+from .diagnostic_events import (
+    DreameLawnMowerDiagnosticEventStore,
+    record_diagnostic_event,
+)
 from .dreame_lawn_mower_client.models import (
     DreameLawnMowerStatusBlob,
     display_name_for_model,
@@ -110,6 +115,7 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         self.bluetooth_connected: bool | None = None
         self.runtime_status_blob: DreameLawnMowerStatusBlob | None = None
         self.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+        self.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
         self.last_batch_device_data_probe_result: dict[str, Any] | None = None
         self.last_preference_probe_result: dict[str, Any] | None = None
         self.last_preference_write_result: dict[str, Any] | None = None
@@ -136,7 +142,15 @@ class DreameLawnMowerCoordinator(DataUpdateCoordinator[DreameLawnMowerSnapshot])
         try:
             snapshot = await self.client.async_refresh()
         except DreameLawnMowerConnectionError as err:
-            raise UpdateFailed(str(err)) from err
+            safe_error = sanitize_diagnostic_text(err)
+            record_diagnostic_event(
+                self,
+                code="coordinator_update_failed",
+                source="coordinator",
+                message=safe_error,
+                context={"exception_type": type(err).__name__},
+            )
+            raise UpdateFailed(safe_error) from err
         if not snapshot.available:
             self.runtime_status_blob = None
             self.client.update_runtime_live_tracking(None, active=False)

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from collections.abc import Mapping
 from dataclasses import asdict, is_dataclass
 from datetime import UTC, datetime
@@ -24,27 +25,80 @@ from .dreame_lawn_mower_client.models import (
     remote_control_state_safe,
 )
 
-DIAGNOSTIC_SCHEMA_VERSION = 5
+DIAGNOSTIC_SCHEMA_VERSION = 6
 UNKNOWN_REALTIME_PREFIX = "UNKNOWN_REALTIME_"
 
 REDACT_KEYS = {
     CONF_PASSWORD,
     CONF_TOKEN,
     CONF_USERNAME,
+    "access_token",
+    "api_key",
+    "app_id",
+    "app_key",
+    "app_secret",
+    "authorization",
     "bindDomain",
+    "client_id",
+    "client_secret",
+    "cookie",
+    "coordinates",
+    "device_id",
+    "device_name",
     "did",
+    "entity_picture",
+    "family_id",
+    "gps",
     "host",
+    "lan_client_token",
+    "latitude",
+    "library_path",
     "localip",
+    "longitude",
     "mac",
     "masterName",
     "masterUid",
     "masterUid2UUID",
+    "p2p_info",
+    "pose_x",
+    "pose_y",
+    "position_x",
+    "position_y",
+    "refresh_token",
+    "runtime_pose_x",
+    "runtime_pose_y",
+    "secret_id",
+    "secret_key",
     "serial_number",
+    "session_token",
+    "signature",
     "sn",
     "token",
     "uid",
     "username",
+    "uuid",
+    "xp2p_key",
+    "xp2p_library_path",
+    "xp2p_runner_command",
+    "xp2p_secretKey",
+    "candidate_runtime_pose_x",
+    "candidate_runtime_pose_y",
 }
+
+_NORMALIZED_REDACT_KEYS = {
+    re.sub(r"[^a-z0-9]", "", str(key).casefold()) for key in REDACT_KEYS
+}
+_SENSITIVE_TEXT_VALUE = re.compile(
+    r"(?i)\b(access[_-]?token|app[_-]?(?:id|key|secret)|client[_-]?secret|"
+    r"password|refresh[_-]?token|secret[_-]?(?:id|key)|session[_-]?token|token|"
+    r"xp2p[_-]?(?:key|secretkey))\b(\s*(?:[:=]\s*|\s+))([\"']?)"
+    r"[^\s,;&\"'}]+"
+)
+_BEARER_VALUE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
+_LOCAL_PATH_VALUE = re.compile(
+    r"(?i)(?<![\w])(?:[a-z]:[\\/]|(?<![:/])/(?:config|home|users|usr|tmp|"
+    r"var|opt|mnt|data|share|addons|ssl|media)/)[^\s,;\"']+"
+)
 
 STATUS_FIELDS = (
     "state_name",
@@ -215,19 +269,33 @@ def _redact_debug_data(value: Any) -> Any:
         return {
             str(key): (
                 "**REDACTED**"
-                if str(key) in REDACT_KEYS
+                if re.sub(r"[^a-z0-9]", "", str(key).casefold())
+                in _NORMALIZED_REDACT_KEYS
                 else _redact_debug_data(item)
             )
             for key, item in value.items()
         }
     if isinstance(value, list):
         return [_redact_debug_data(item) for item in value]
+    if isinstance(value, str):
+        return sanitize_diagnostic_text(value)
     return value
 
 
 def sanitize_debug_data(value: Any) -> Any:
     """Return JSON-friendly debug data with sensitive fields redacted."""
     return _redact_debug_data(_normalize_debug_value(value))
+
+
+def sanitize_diagnostic_text(value: object) -> str:
+    """Redact common credential and local-path forms from a message."""
+    text = str(value)
+    text = _BEARER_VALUE.sub("Bearer **REDACTED**", text)
+    text = _SENSITIVE_TEXT_VALUE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}**REDACTED**",
+        text,
+    )
+    return _LOCAL_PATH_VALUE.sub("**REDACTED_PATH**", text)
 
 
 def _collect_status_values(device: Any) -> dict[str, Any]:
@@ -554,8 +622,13 @@ def _collect_triage_summary(
 def build_debug_payload(
     *,
     entry_data: Mapping[str, Any] | None,
+    entry_options: Mapping[str, Any] | None = None,
     snapshot: Any,
     device: Any,
+    report_context: Mapping[str, Any] | None = None,
+    coordinator_diagnostics: Mapping[str, Any] | None = None,
+    entity_diagnostics: list[Mapping[str, Any]] | None = None,
+    recent_events: list[Mapping[str, Any]] | None = None,
 ) -> dict[str, Any]:
     """Build a sanitized structured debug payload for diagnostics or logs."""
     descriptor = getattr(snapshot, "descriptor", None)
@@ -568,7 +641,12 @@ def build_debug_payload(
     payload = {
         "diagnostic_schema_version": DIAGNOSTIC_SCHEMA_VERSION,
         "captured_at": datetime.now(UTC).isoformat(),
+        "report_context": _normalize_debug_value(dict(report_context or {})),
         "entry": _normalize_debug_value(dict(entry_data or {})),
+        "entry_options": _normalize_debug_value(dict(entry_options or {})),
+        "coordinator": _normalize_debug_value(dict(coordinator_diagnostics or {})),
+        "entities": _normalize_debug_value(list(entity_diagnostics or [])),
+        "recent_events": _normalize_debug_value(list(recent_events or [])),
         "descriptor": _normalize_debug_value(descriptor),
         "snapshot": _normalize_debug_value(snapshot),
         "triage": _collect_triage_summary(

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -91,8 +91,14 @@ _NORMALIZED_REDACT_KEYS = {
 _SENSITIVE_TEXT_VALUE = re.compile(
     r"(?i)\b(access[_-]?token|app[_-]?(?:id|key|secret)|client[_-]?secret|"
     r"password|refresh[_-]?token|secret[_-]?(?:id|key)|session[_-]?token|token|"
-    r"xp2p[_-]?(?:key|secretkey))\b(\s*(?:[:=]\s*|\s+))([\"']?)"
+    r"xp2p[_-]?(?:key|secretkey))\b([\"']?)(\s*(?:[:=]\s*|\s+))([\"']?)"
     r"[^\s,;&\"'}]+"
+)
+_SENSITIVE_IDENTIFIER_TEXT_VALUE = re.compile(
+    r"(?i)\b(bind[_-]?domain|client[_-]?id|coordinates|device[_-]?(?:id|name)|"
+    r"did|family[_-]?id|gps|host|latitude|localip|longitude|mac|master[_-]?name|"
+    r"master[_-]?uid(?:2uuid)?|p2p[_-]?info|serial[_-]?number|sn|uid|username|"
+    r"uuid)\b([\"']?)(\s*[:=]\s*)([\"']?)[^\s,;&\"'}]+"
 )
 _BEARER_VALUE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
 _LOCAL_PATH_VALUE = re.compile(
@@ -292,7 +298,17 @@ def sanitize_diagnostic_text(value: object) -> str:
     text = str(value)
     text = _BEARER_VALUE.sub("Bearer **REDACTED**", text)
     text = _SENSITIVE_TEXT_VALUE.sub(
-        lambda match: f"{match.group(1)}{match.group(2)}**REDACTED**",
+        lambda match: (
+            f"{match.group(1)}{match.group(2)}{match.group(3)}{match.group(4)}"
+            "**REDACTED**"
+        ),
+        text,
+    )
+    text = _SENSITIVE_IDENTIFIER_TEXT_VALUE.sub(
+        lambda match: (
+            f"{match.group(1)}{match.group(2)}{match.group(3)}{match.group(4)}"
+            "**REDACTED**"
+        ),
         text,
     )
     return _LOCAL_PATH_VALUE.sub("**REDACTED_PATH**", text)

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -100,6 +100,10 @@ _SENSITIVE_IDENTIFIER_TEXT_VALUE = re.compile(
     r"master[_-]?uid(?:2uuid)?|p2p[_-]?info|serial[_-]?number|sn|uid|username|"
     r"uuid)\b([\"']?)(\s*[:=]\s*)([\"']?)[^\s,;&\"'}]+"
 )
+_SENSITIVE_HEADER_VALUE = re.compile(
+    r"(?im)\b(authorization|proxy-authorization|cookie|set-cookie)"
+    r"(\s*:\s*)[^\r\n]+"
+)
 _BEARER_VALUE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
 _LOCAL_PATH_VALUE = re.compile(
     r"(?i)(?<![\w])(?:[a-z]:[\\/]|(?<![:/])/(?:config|home|users|usr|tmp|"
@@ -296,6 +300,10 @@ def sanitize_debug_data(value: Any) -> Any:
 def sanitize_diagnostic_text(value: object) -> str:
     """Redact common credential and local-path forms from a message."""
     text = str(value)
+    text = _SENSITIVE_HEADER_VALUE.sub(
+        lambda match: f"{match.group(1)}{match.group(2)}**REDACTED**",
+        text,
+    )
     text = _BEARER_VALUE.sub("Bearer **REDACTED**", text)
     text = _SENSITIVE_TEXT_VALUE.sub(
         lambda match: (

--- a/custom_components/dreame_lawn_mower/diagnostic_events.py
+++ b/custom_components/dreame_lawn_mower/diagnostic_events.py
@@ -1,0 +1,84 @@
+"""Sanitized recent-event diagnostics for the Home Assistant integration."""
+
+from __future__ import annotations
+
+from collections import deque
+from collections.abc import Mapping
+from datetime import UTC, datetime
+from typing import Any
+
+from .debug import sanitize_debug_data, sanitize_diagnostic_text
+
+DEFAULT_DIAGNOSTIC_EVENT_LIMIT = 25
+
+
+class DreameLawnMowerDiagnosticEventStore:
+    """Keep a bounded, deduplicated record of recent integration events."""
+
+    def __init__(self, *, limit: int = DEFAULT_DIAGNOSTIC_EVENT_LIMIT) -> None:
+        self._events: deque[dict[str, Any]] = deque(maxlen=max(1, limit))
+
+    def record(
+        self,
+        *,
+        code: str,
+        source: str,
+        message: object,
+        severity: str = "warning",
+        context: Mapping[str, Any] | None = None,
+    ) -> dict[str, Any]:
+        """Record one safe event, coalescing consecutive duplicates."""
+        captured_at = datetime.now(UTC).isoformat()
+        safe_message = sanitize_diagnostic_text(message)
+        safe_context = sanitize_debug_data(dict(context or {}))
+        fingerprint = (code, source, safe_message, repr(safe_context))
+
+        if self._events and self._events[-1]["_fingerprint"] == fingerprint:
+            event = self._events[-1]
+            event["last_seen"] = captured_at
+            event["count"] += 1
+            return self._public_event(event)
+
+        event = {
+            "_fingerprint": fingerprint,
+            "code": code,
+            "source": source,
+            "severity": severity,
+            "message": safe_message,
+            "context": safe_context,
+            "first_seen": captured_at,
+            "last_seen": captured_at,
+            "count": 1,
+        }
+        self._events.append(event)
+        return self._public_event(event)
+
+    def as_list(self) -> list[dict[str, Any]]:
+        """Return JSON-safe events without internal bookkeeping."""
+        return [self._public_event(event) for event in self._events]
+
+    @staticmethod
+    def _public_event(event: Mapping[str, Any]) -> dict[str, Any]:
+        return {key: value for key, value in event.items() if not key.startswith("_")}
+
+
+def record_diagnostic_event(
+    coordinator: object,
+    *,
+    code: str,
+    source: str,
+    message: object,
+    severity: str = "warning",
+    context: Mapping[str, Any] | None = None,
+) -> dict[str, Any] | None:
+    """Record an event when the coordinator exposes the shared store."""
+    store = getattr(coordinator, "diagnostic_events", None)
+    if not isinstance(store, DreameLawnMowerDiagnosticEventStore):
+        return None
+    return store.record(
+        code=code,
+        source=source,
+        message=message,
+        severity=severity,
+        context=context,
+    )

--- a/custom_components/dreame_lawn_mower/diagnostics.py
+++ b/custom_components/dreame_lawn_mower/diagnostics.py
@@ -2,16 +2,41 @@
 
 from __future__ import annotations
 
+from homeassistant.helpers import entity_registry as er
+from homeassistant.helpers import system_info
+from homeassistant.loader import async_get_loaded_integration
+
 from .const import DOMAIN
 from .debug import build_debug_payload
+from .reporting import (
+    build_coordinator_diagnostics,
+    build_entity_diagnostics,
+    build_report_context,
+)
 
 
 async def async_get_config_entry_diagnostics(hass, entry):
     """Return diagnostics for a config entry."""
     coordinator = hass.data[DOMAIN][entry.entry_id]
     await coordinator.async_request_refresh()
+    integration = async_get_loaded_integration(hass, DOMAIN)
+    registry = er.async_get(hass)
+    registry_entries = er.async_entries_for_config_entry(registry, entry.entry_id)
+    recent_events = getattr(coordinator, "diagnostic_events", None)
     return build_debug_payload(
         entry_data=entry.data,
+        entry_options=entry.options,
         snapshot=coordinator.data,
         device=coordinator.client._device,
+        report_context=build_report_context(
+            system_info=await system_info.async_get_system_info(hass),
+            integration_version=integration.version,
+            config_entry=entry,
+        ),
+        coordinator_diagnostics=build_coordinator_diagnostics(coordinator),
+        entity_diagnostics=build_entity_diagnostics(
+            registry_entries,
+            hass.states.get,
+        ),
+        recent_events=recent_events.as_list() if recent_events is not None else [],
     )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/video_runtime.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/video_runtime.py
@@ -114,9 +114,9 @@ class DreameLawnMowerXp2pRuntimeDiagnostics:
     error: str | None = None
 
     def as_dict(self) -> dict[str, Any]:
-        """Return a JSON-safe diagnostics payload."""
+        """Return a JSON-safe diagnostics payload without the local path."""
         return {
-            "library_path": self.library_path,
+            "library_path_configured": bool(self.library_path),
             "loadable": self.loadable,
             "ready": self.ready,
             "required_symbols": self.required_symbols,
@@ -421,7 +421,8 @@ class DreameLawnMowerXp2pExternalRunner:
             )
         except OSError as err:
             raise DreameLawnMowerVideoRuntimeError(
-                f"Could not start XP2P external runner: {err}"
+                "Could not start the configured XP2P external runner "
+                f"({type(err).__name__})."
             ) from err
         except subprocess.TimeoutExpired as err:
             raise DreameLawnMowerVideoRuntimeError(
@@ -489,7 +490,8 @@ class DreameLawnMowerXp2pProcessRunner:
             )
         except OSError as err:
             raise DreameLawnMowerVideoRuntimeError(
-                f"Could not start XP2P process runner: {err}"
+                "Could not start the configured XP2P process runner "
+                f"({type(err).__name__})."
             ) from err
 
         stderr_tail: list[str] = []
@@ -602,7 +604,8 @@ class DreameLawnMowerNativeXp2pRuntime:
             self._library = library if library is not None else CDLL(self.library_path)
         except OSError as err:
             raise DreameLawnMowerVideoRuntimeError(
-                f"Could not load XP2P native library {self.library_path!r}: {err}"
+                "Could not load the configured XP2P native library "
+                f"({type(err).__name__})."
             ) from err
         self._start_service = self._bind(
             "startService",
@@ -963,7 +966,10 @@ def diagnose_native_xp2p_runtime(
     try:
         loaded_library = library if library is not None else CDLL(path)
     except OSError as err:
-        error = f"Could not load XP2P native library {path!r}: {err}"
+        error = (
+            "Could not load the configured XP2P native library "
+            f"({type(err).__name__})."
+        )
         if inspection.get("platform_hint") == "android_jni":
             error += (
                 " The file looks like Dreamehome's Android JNI XP2P library; "

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -29,6 +29,7 @@ _SENSITIVE_ENTITY_STATE_NAMES = frozenset(
     {
         "runtimepositionx",
         "runtimepositiony",
+        "serialnumber",
     }
 )
 
@@ -90,7 +91,8 @@ def build_entity_diagnostics(
         attributes = getattr(state, "attributes", {}) if state is not None else {}
         original_name = getattr(registry_entry, "original_name", None)
         translation_key = getattr(registry_entry, "translation_key", None)
-        if _entity_state_is_sensitive(original_name, translation_key):
+        unique_id = getattr(registry_entry, "unique_id", None)
+        if _entity_state_is_sensitive(original_name, translation_key, unique_id):
             state_value = "**REDACTED**" if state_value is not None else None
         entities.append(
             {
@@ -126,11 +128,16 @@ def _enum_value(value: object) -> object:
 def _entity_state_is_sensitive(
     original_name: object,
     translation_key: object,
+    unique_id: object,
 ) -> bool:
-    """Return whether an entity's scalar state contains private location data."""
-    return any(
+    """Return whether an entity's scalar state contains private report data."""
+    normalized_values = (
         "".join(character for character in str(value).casefold() if character.isalnum())
-        in _SENSITIVE_ENTITY_STATE_NAMES
-        for value in (original_name, translation_key)
+        for value in (original_name, translation_key, unique_id)
         if value is not None
+    )
+    return any(
+        value.endswith(sensitive_name)
+        for value in normalized_values
+        for sensitive_name in _SENSITIVE_ENTITY_STATE_NAMES
     )

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -1,0 +1,136 @@
+"""Build privacy-aware integration report sections."""
+
+from __future__ import annotations
+
+from collections.abc import Callable, Iterable, Mapping
+from typing import Any
+
+from .debug import sanitize_debug_data, sanitize_diagnostic_text
+
+_SYSTEM_INFO_KEYS = (
+    "installation_type",
+    "version",
+    "dev",
+    "hassio",
+    "virtualenv",
+    "python_version",
+    "docker",
+    "arch",
+    "container_arch",
+    "os_name",
+    "os_version",
+    "host_os",
+    "supervisor",
+    "docker_version",
+    "chassis",
+)
+
+_SENSITIVE_ENTITY_STATE_NAMES = frozenset(
+    {
+        "runtimepositionx",
+        "runtimepositiony",
+    }
+)
+
+
+def build_report_context(
+    *,
+    system_info: Mapping[str, Any],
+    integration_version: object,
+    config_entry: object,
+) -> dict[str, Any]:
+    """Return version and host facts needed to reproduce integration issues."""
+    return {
+        "integration_version": str(integration_version),
+        "home_assistant": {
+            key: system_info[key] for key in _SYSTEM_INFO_KEYS if key in system_info
+        },
+        "config_entry": {
+            "state": _enum_value(getattr(config_entry, "state", None)),
+            "disabled_by": _enum_value(getattr(config_entry, "disabled_by", None)),
+            "version": getattr(config_entry, "version", None),
+            "minor_version": getattr(config_entry, "minor_version", None),
+        },
+    }
+
+
+def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
+    """Return the latest coordinator health without exposing account data."""
+    update_interval = getattr(coordinator, "update_interval", None)
+    last_exception = getattr(coordinator, "last_exception", None)
+    return {
+        "last_update_success": getattr(coordinator, "last_update_success", None),
+        "last_exception_type": (
+            type(last_exception).__name__ if last_exception is not None else None
+        ),
+        "last_exception": (
+            sanitize_diagnostic_text(last_exception)
+            if last_exception is not None
+            else None
+        ),
+        "update_interval_seconds": (
+            update_interval.total_seconds()
+            if hasattr(update_interval, "total_seconds")
+            else None
+        ),
+    }
+
+
+def build_entity_diagnostics(
+    registry_entries: Iterable[object],
+    state_getter: Callable[[str], object | None],
+) -> list[dict[str, Any]]:
+    """Return sanitized state for every entity owned by one config entry."""
+    entities: list[dict[str, Any]] = []
+    for registry_entry in registry_entries:
+        entity_id = str(getattr(registry_entry, "entity_id", ""))
+        domain = entity_id.partition(".")[0] or None
+        state = state_getter(entity_id) if entity_id else None
+        state_value = getattr(state, "state", None)
+        attributes = getattr(state, "attributes", {}) if state is not None else {}
+        original_name = getattr(registry_entry, "original_name", None)
+        translation_key = getattr(registry_entry, "translation_key", None)
+        if _entity_state_is_sensitive(original_name, translation_key):
+            state_value = "**REDACTED**" if state_value is not None else None
+        entities.append(
+            {
+                "domain": domain,
+                "original_name": original_name,
+                "translation_key": translation_key,
+                "entity_category": _enum_value(
+                    getattr(registry_entry, "entity_category", None)
+                ),
+                "disabled_by": _enum_value(
+                    getattr(registry_entry, "disabled_by", None)
+                ),
+                "loaded": state is not None,
+                "available": state_value not in {None, "unavailable"},
+                "state": state_value,
+                "attributes": sanitize_debug_data(attributes),
+            }
+        )
+
+    entities.sort(
+        key=lambda item: (
+            str(item.get("domain") or ""),
+            str(item.get("original_name") or item.get("translation_key") or ""),
+        )
+    )
+    return entities
+
+
+def _enum_value(value: object) -> object:
+    return getattr(value, "value", value)
+
+
+def _entity_state_is_sensitive(
+    original_name: object,
+    translation_key: object,
+) -> bool:
+    """Return whether an entity's scalar state contains private location data."""
+    return any(
+        "".join(character for character in str(value).casefold() if character.isalnum())
+        in _SENSITIVE_ENTITY_STATE_NAMES
+        for value in (original_name, translation_key)
+        if value is not None
+    )

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Protocol
 from urllib.parse import urljoin
@@ -37,6 +38,8 @@ from .const import (
     XP2P_RUNNER_MODE_PROCESS,
 )
 from .coordinator import DreameLawnMowerCoordinator
+from .debug import sanitize_debug_data, sanitize_diagnostic_text
+from .diagnostic_events import record_diagnostic_event
 from .dreame_lawn_mower_client.models import (
     DreameLawnMowerCameraStreamRuntimeInputs,
     camera_stream_block_reason,
@@ -131,6 +134,9 @@ class DreameLawnMowerVideoCamera(
             stop_active=self._async_stop_active_session,
         )
         self._last_error: str | None = None
+        self._last_error_at: str | None = None
+        self._last_error_code: str | None = None
+        self._last_error_stage: str | None = None
         self._last_runtime_inputs_ready: bool | None = None
         self._last_runtime_inputs_source: str | None = None
         self._last_runtime_inputs_missing: tuple[str, ...] = ()
@@ -171,16 +177,18 @@ class DreameLawnMowerVideoCamera(
             try:
                 await self._lan_cache.async_load()
             except Exception as err:  # noqa: BLE001 - Auto/cloud remain available.
-                self._lan_cache_error = str(err)
-                _LOGGER.warning("Failed to load Dreame LAN video cache: %s", err)
+                self._lan_cache_error = sanitize_diagnostic_text(err)
+                _LOGGER.warning(
+                    "Failed to load Dreame LAN video cache: %s", self._lan_cache_error
+                )
         if not self._provisioning_cache.loaded:
             try:
                 await self._provisioning_cache.async_load()
             except Exception as err:  # noqa: BLE001 - cloud remains available.
-                self._provisioning_cache_error = str(err)
+                self._provisioning_cache_error = sanitize_diagnostic_text(err)
                 _LOGGER.warning(
                     "Failed to load Dreame video provisioning cache: %s",
-                    err,
+                    self._provisioning_cache_error,
                 )
         snapshot = self.coordinator.data
         if not self._runtime_configured or (
@@ -200,8 +208,11 @@ class DreameLawnMowerVideoCamera(
         except asyncio.CancelledError:
             raise
         except Exception as err:  # noqa: BLE001 - retry remains available on play.
-            self._runtime_preparation_error = str(err)
-            _LOGGER.warning("Failed to prepare Dreame mower live video: %s", err)
+            self._runtime_preparation_error = sanitize_diagnostic_text(err)
+            _LOGGER.warning(
+                "Failed to prepare Dreame mower live video: %s",
+                self._runtime_preparation_error,
+            )
         else:
             self._runtime_preparation_error = None
 
@@ -282,6 +293,9 @@ class DreameLawnMowerVideoCamera(
             "video_runtime_preparation_error": self._runtime_preparation_error,
             "stream_session_active": self._session is not None,
             "last_stream_error": self._last_error,
+            "last_stream_error_at": getattr(self, "_last_error_at", None),
+            "last_stream_error_code": getattr(self, "_last_error_code", None),
+            "last_stream_error_stage": getattr(self, "_last_error_stage", None),
             "last_runtime_inputs_ready": self._last_runtime_inputs_ready,
             "last_runtime_inputs_source": self._last_runtime_inputs_source,
             "last_runtime_inputs_missing": self._last_runtime_inputs_missing,
@@ -310,7 +324,8 @@ class DreameLawnMowerVideoCamera(
                 return urljoin(f"{get_url(self.hass)}/", endpoint)
             except Exception as err:  # noqa: BLE001 - expose a clean source miss.
                 self._set_stream_error(
-                    f"Home Assistant could not expose the verified video stream: {err}"
+                    f"Home Assistant could not expose the verified video stream: {err}",
+                    stage="ha_proxy",
                 )
                 if owns_stream:
                     await self._async_stop_owned_stream(ha_stream)
@@ -437,7 +452,8 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - expose a clean camera miss.
             await self._async_cleanup_failed_stream_setup(session)
             self._set_stream_error(
-                f"Qualified XP2P video could not verify its playback session: {err}"
+                f"Qualified XP2P video could not verify its playback session: {err}",
+                stage="playback_verification",
             )
             return False
 
@@ -506,7 +522,7 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - snapshots may be transient.
             _LOGGER.debug(
                 "Failed to start Dreame mower video for a still image: %s",
-                err,
+                sanitize_diagnostic_text(err),
             )
             return self._last_image
         if ha_stream is None:
@@ -523,7 +539,10 @@ class DreameLawnMowerVideoCamera(
             _LOGGER.debug("Timed out reading Dreame mower still image")
             return self._last_image
         except Exception as err:  # noqa: BLE001 - snapshots may be transient.
-            _LOGGER.debug("Failed to read Dreame mower still image: %s", err)
+            _LOGGER.debug(
+                "Failed to read Dreame mower still image: %s",
+                sanitize_diagnostic_text(err),
+            )
             return self._last_image
         finally:
             if snapshot_only_stream:
@@ -557,11 +576,12 @@ class DreameLawnMowerVideoCamera(
         )
         if not self._runtime_configured:
             self._set_stream_error(
-                "Configure a native XP2P library path or XP2P runner command."
+                "Configure a native XP2P library path or XP2P runner command.",
+                stage="runtime_configuration",
             )
             return None
         if reason := camera_stream_block_reason(self.coordinator.data):
-            self._set_stream_error(reason)
+            self._set_stream_error(reason, stage="mower_state_gate")
             return None
         if (
             self._video_transport == VIDEO_TRANSPORT_AUTO
@@ -574,7 +594,7 @@ class DreameLawnMowerVideoCamera(
             runtime = await self._async_get_runtime()
             self._runtime_preparation_error = None
         except Exception as err:  # noqa: BLE001 - HA should receive a clean miss.
-            self._set_stream_error(str(err))
+            self._set_stream_error(str(err), stage="runtime_preparation")
             return None
 
         if (
@@ -588,7 +608,10 @@ class DreameLawnMowerVideoCamera(
                     cached_xp2p_inputs,
                 )
             except DreameLawnMowerVideoRuntimeError as err:
-                self._set_stream_error(self._with_lan_failure(str(err)))
+                self._set_stream_error(
+                    self._with_lan_failure(str(err)),
+                    stage="cached_xp2p_start",
+                )
                 return None
             if cached_source is not None:
                 return cached_source
@@ -618,7 +641,7 @@ class DreameLawnMowerVideoCamera(
                 try:
                     lan_source = await self._async_try_lan_stream(runtime, lan_inputs)
                 except DreameLawnMowerVideoRuntimeError as err:
-                    self._set_stream_error(str(err))
+                    self._set_stream_error(str(err), stage="lan_start")
                     return None
                 if lan_source is not None:
                     return lan_source
@@ -631,9 +654,10 @@ class DreameLawnMowerVideoCamera(
                         await self._lan_cache.async_clear_endpoint()
                         self._lan_cache_error = None
                     except Exception as err:  # noqa: BLE001 - retry in memory.
-                        self._lan_cache_error = str(err)
+                        self._lan_cache_error = sanitize_diagnostic_text(err)
                         _LOGGER.warning(
-                            "Failed to clear stale Dreame LAN endpoint: %s", err
+                            "Failed to clear stale Dreame LAN endpoint: %s",
+                            self._lan_cache_error,
                         )
                     try:
                         cloud_inputs = await self._async_get_runtime_inputs()
@@ -652,7 +676,7 @@ class DreameLawnMowerVideoCamera(
                                     cloud_inputs,
                                 )
                             except DreameLawnMowerVideoRuntimeError as err:
-                                self._set_stream_error(str(err))
+                                self._set_stream_error(str(err), stage="lan_start")
                                 return None
                             if lan_source is not None:
                                 return lan_source
@@ -687,8 +711,10 @@ class DreameLawnMowerVideoCamera(
                     + ", ".join(cloud_inputs.missing_required)
                 )
             stream_enable_attempted = True
-            self._last_stream_enable_result = video_helpers.safe_state_attribute(
-                await self.coordinator.client.async_set_camera_stream_enabled(True)
+            self._last_stream_enable_result = sanitize_debug_data(
+                video_helpers.safe_state_attribute(
+                    await self.coordinator.client.async_set_camera_stream_enabled(True)
+                )
             )
             self._last_stream_disable_error = None
             session = await self._async_start_runtime_session(runtime, cloud_inputs)
@@ -703,15 +729,21 @@ class DreameLawnMowerVideoCamera(
                 await self._async_stop_session(runtime, session)
             if stream_enable_attempted:
                 await self._async_disable_camera_stream()
-            self._set_stream_error(self._with_lan_failure(str(err)))
+            self._set_stream_error(
+                self._with_lan_failure(str(err)),
+                stage="cloud_start",
+            )
             return None
         except Exception as err:  # noqa: BLE001 - HA should receive a clean miss.
             if runtime is not None and session is not None:
                 await self._async_stop_session(runtime, session)
             if stream_enable_attempted:
                 await self._async_disable_camera_stream()
-            _LOGGER.warning("Failed to start Dreame mower live video: %s", err)
-            self._set_stream_error(self._with_lan_failure(str(err)))
+            safe_error = sanitize_diagnostic_text(err)
+            self._set_stream_error(
+                self._with_lan_failure(safe_error),
+                stage="cloud_start",
+            )
             return None
 
         return self._adopt_stream_session(
@@ -727,24 +759,30 @@ class DreameLawnMowerVideoCamera(
         try:
             await self.coordinator.async_refresh()
         except Exception as err:  # noqa: BLE001 - fail closed before video startup.
-            _LOGGER.debug("Failed to refresh mower state before Auto video: %s", err)
+            _LOGGER.debug(
+                "Failed to refresh mower state before Auto video: %s",
+                sanitize_diagnostic_text(err),
+            )
             self._set_stream_error(
-                "Could not refresh mower state before starting Auto video."
+                "Could not refresh mower state before starting Auto video.",
+                stage="state_refresh",
             )
             return False
         if not self.coordinator.last_update_success:
             self._set_stream_error(
-                "Could not refresh mower state before starting Auto video."
+                "Could not refresh mower state before starting Auto video.",
+                stage="state_refresh",
             )
             return False
         snapshot = self.coordinator.data
         if snapshot is None or not getattr(snapshot, "available", True):
             self._set_stream_error(
-                "The mower is unavailable after refreshing video safety state."
+                "The mower is unavailable after refreshing video safety state.",
+                stage="state_refresh",
             )
             return False
         if reason := camera_stream_block_reason(snapshot):
-            self._set_stream_error(reason)
+            self._set_stream_error(reason, stage="mower_state_gate")
             return False
         return True
 
@@ -769,7 +807,7 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - Auto may fall back to cloud.
             if session is not None:
                 await self._async_stop_session(runtime, session)
-            self._last_lan_error = str(err)
+            self._last_lan_error = sanitize_diagnostic_text(err)
             return None
         if not stream_health.flv_header_present:
             await self._async_stop_session(runtime, session)
@@ -779,8 +817,11 @@ class DreameLawnMowerVideoCamera(
             await self._lan_cache.async_save_session(session)
             self._lan_cache_error = None
         except Exception as err:  # noqa: BLE001 - a live stream remains usable.
-            self._lan_cache_error = str(err)
-            _LOGGER.warning("Failed to save Dreame LAN video endpoint: %s", err)
+            self._lan_cache_error = sanitize_diagnostic_text(err)
+            _LOGGER.warning(
+                "Failed to save Dreame LAN video endpoint: %s",
+                self._lan_cache_error,
+            )
         if not await self._async_stop_session_for_handoff(runtime, session):
             self._last_lan_error = (
                 "Qualified same-LAN probe session could not stop before "
@@ -794,7 +835,8 @@ class DreameLawnMowerVideoCamera(
             raise
         except Exception as err:  # noqa: BLE001 - Auto may fall back to cloud.
             self._last_lan_error = (
-                f"Qualified same-LAN video could not open a playback session: {err}"
+                "Qualified same-LAN video could not open a playback session: "
+                f"{sanitize_diagnostic_text(err)}"
             )
             return None
         return self._adopt_stream_session(
@@ -816,7 +858,11 @@ class DreameLawnMowerVideoCamera(
             start_session=self._async_start_runtime_session,
         )
         if result.session is None:
-            self._last_cached_xp2p_error = result.error
+            self._last_cached_xp2p_error = (
+                sanitize_diagnostic_text(result.error)
+                if result.error is not None
+                else None
+            )
             return None
         return self._adopt_stream_session(
             runtime,
@@ -838,8 +884,11 @@ class DreameLawnMowerVideoCamera(
                 await self._lan_cache.async_save_identity(inputs)
                 self._lan_cache_error = None
             except Exception as err:  # noqa: BLE001 - cloud transport still works.
-                self._lan_cache_error = str(err)
-                _LOGGER.warning("Failed to save Dreame LAN video identity: %s", err)
+                self._lan_cache_error = sanitize_diagnostic_text(err)
+                _LOGGER.warning(
+                    "Failed to save Dreame LAN video identity: %s",
+                    self._lan_cache_error,
+                )
         if inputs.ready:
             await self.hass.async_add_executor_job(
                 self._provisioning_cache.stage_fresh_device_config,
@@ -862,10 +911,10 @@ class DreameLawnMowerVideoCamera(
             await self._provisioning_cache.async_save(inputs, config)
             self._provisioning_cache_error = None
         except Exception as err:  # noqa: BLE001 - current stream can continue.
-            self._provisioning_cache_error = str(err)
+            self._provisioning_cache_error = sanitize_diagnostic_text(err)
             _LOGGER.warning(
                 "Failed to save Dreame video provisioning cache: %s",
-                err,
+                self._provisioning_cache_error,
             )
 
     async def _async_start_lan_runtime_session(
@@ -922,6 +971,9 @@ class DreameLawnMowerVideoCamera(
             "playback_session_verified": False,
         }
         self._last_error = None
+        self._last_error_at = None
+        self._last_error_code = None
+        self._last_error_stage = None
         self._last_video_transport = transport
         self._attr_is_on = True
         self._attr_is_streaming = True
@@ -1046,7 +1098,10 @@ class DreameLawnMowerVideoCamera(
             try:
                 await ha_stream.stop()
             except Exception as err:  # noqa: BLE001 - continue XP2P cleanup.
-                _LOGGER.debug("Failed to stop Home Assistant camera stream: %s", err)
+                _LOGGER.debug(
+                    "Failed to stop Home Assistant camera stream: %s",
+                    sanitize_diagnostic_text(err),
+                )
             finally:
                 self._unregister_ha_stream(ha_stream)
         if runtime is None or session is None:
@@ -1088,7 +1143,10 @@ class DreameLawnMowerVideoCamera(
             await self.hass.async_add_executor_job(runtime.stop_live_stream, session)
             return True
         except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
-            _LOGGER.debug("Failed to stop Dreame mower live video: %s", err)
+            _LOGGER.debug(
+                "Failed to stop Dreame mower live video: %s",
+                sanitize_diagnostic_text(err),
+            )
             return False
 
     async def _async_stop_session_for_handoff(
@@ -1110,8 +1168,11 @@ class DreameLawnMowerVideoCamera(
             await self.coordinator.client.async_set_camera_stream_enabled(False)
             self._last_stream_disable_error = None
         except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
-            self._last_stream_disable_error = str(err)
-            _LOGGER.debug("Failed to disable Dreame mower app video mode: %s", err)
+            self._last_stream_disable_error = sanitize_diagnostic_text(err)
+            _LOGGER.debug(
+                "Failed to disable Dreame mower app video mode: %s",
+                self._last_stream_disable_error,
+            )
 
     def _create_runtime(self) -> _DreameVideoRuntime:
         """Create the configured runtime adapter."""
@@ -1207,7 +1268,42 @@ class DreameLawnMowerVideoCamera(
     def _runner_command(self) -> str | None:
         return video_helpers.option_text(self._entry, CONF_XP2P_RUNNER_COMMAND)
 
-    def _set_stream_error(self, error: str) -> None:
-        self._last_error = error
+    def _set_stream_error(
+        self,
+        error: str,
+        *,
+        stage: str = "stream_start",
+    ) -> None:
+        safe_error = sanitize_diagnostic_text(error)
+        code = f"video_{stage}_failed"
+        changed = (
+            safe_error != getattr(self, "_last_error", None)
+            or stage != getattr(self, "_last_error_stage", None)
+        )
+        self._last_error = safe_error
+        self._last_error_at = datetime.now(UTC).isoformat()
+        self._last_error_code = code
+        self._last_error_stage = stage
         self._attr_is_streaming = False
+        snapshot = getattr(self.coordinator, "data", None)
+        record_diagnostic_event(
+            self.coordinator,
+            code=code,
+            source="video_camera",
+            message=safe_error,
+            context={
+                "model": getattr(getattr(self, "_descriptor", None), "model", None),
+                "firmware_version": getattr(snapshot, "firmware_version", None),
+                "transport": self._video_transport,
+                "runtime_mode": self._runtime_mode,
+                "managed_runtime_supported": video_helpers.managed_runtime_supported(),
+            },
+        )
+        if changed:
+            _LOGGER.warning(
+                "Dreame mower live video failed [%s]: %s. Reproduce once, then "
+                "download integration diagnostics before reloading Home Assistant.",
+                code,
+                safe_error,
+            )
         self.async_write_ha_state()

--- a/docs/development.md
+++ b/docs/development.md
@@ -149,6 +149,26 @@ Keep long probe recipes, protocol notes, app decompilation notes, and live test
 history in `docs/agent-handoff.md`, `docs/dreamehome-research.md`, or focused
 docs like this one.
 
+## Diagnostics Contract
+
+Downloaded diagnostics are the primary public issue-report artifact. Keep the
+collection path safe enough that a user can attach the file without enabling a
+broad protocol logger.
+
+- `debug.py` owns JSON normalization and recursive redaction.
+- `reporting.py` owns version, host, coordinator, and entity report sections.
+- `diagnostic_events.py` owns the bounded in-memory failure history.
+- entities and coordinators should record a concise stable code, safe message,
+  source, and non-secret context at a meaningful failure boundary.
+- repeated identical failures should be coalesced instead of filling the report.
+- do not record raw cloud responses, credentials, tokens, serial numbers, local
+  addresses, exact coordinates, runner commands, or local library paths.
+- when a new entity keeps a useful `last_*` error or health attribute, verify that
+  the generic entity diagnostics collector includes it after sanitization.
+
+Increment `DIAGNOSTIC_SCHEMA_VERSION` when the public report structure changes,
+and add contract tests for both the useful evidence and its redaction.
+
 ## Before Committing
 
 Run at least:

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -390,6 +390,21 @@ def test_sanitize_diagnostic_text_redacts_json_credentials_and_identifiers() -> 
     )
 
 
+def test_sanitize_diagnostic_text_redacts_sensitive_http_headers() -> None:
+    message = sanitize_diagnostic_text(
+        "request failed\n"
+        "Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==\n"
+        "Cookie: session=secret; device=private\n"
+        "Content-Type: application/json"
+    )
+
+    assert message == (
+        "request failed\n"
+        "Authorization: **REDACTED**\n"
+        "Cookie: **REDACTED**\n"
+        "Content-Type: application/json"
+    )
+
 def test_sanitize_diagnostic_text_redacts_local_paths_but_keeps_urls() -> None:
     message = sanitize_diagnostic_text(
         "failed at C:\\config\\custom_components\\private\\runner.exe and "

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -377,6 +377,19 @@ def test_sanitize_diagnostic_text_redacts_bearer_and_query_credentials() -> None
     )
 
 
+def test_sanitize_diagnostic_text_redacts_json_credentials_and_identifiers() -> None:
+    message = sanitize_diagnostic_text(
+        'cloud failed: {"token":"secret", "accessToken": "other", '
+        '"serialNumber":"serial-123", "did": 456}'
+    )
+
+    assert message == (
+        'cloud failed: {"token":"**REDACTED**", '
+        '"accessToken": "**REDACTED**", '
+        '"serialNumber":"**REDACTED**", "did": **REDACTED**}'
+    )
+
+
 def test_sanitize_diagnostic_text_redacts_local_paths_but_keeps_urls() -> None:
     message = sanitize_diagnostic_text(
         "failed at C:\\config\\custom_components\\private\\runner.exe and "

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from custom_components.dreame_lawn_mower.debug import (
     build_debug_payload,
     sanitize_debug_data,
+    sanitize_diagnostic_text,
 )
 from dreame_lawn_mower_client.models import (
     DreameLawnMowerDescriptor,
@@ -163,7 +164,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
         device=device,
     )
 
-    assert payload["diagnostic_schema_version"] == 5
+    assert payload["diagnostic_schema_version"] == 6
     assert payload["entry"]["username"] == "**REDACTED**"
     assert payload["entry"]["password"] == "**REDACTED**"
     assert payload["entry"]["token"] == "**REDACTED**"
@@ -271,7 +272,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
     }
     assert payload["state_reconciliation"]["warnings"] == []
     assert payload["triage"] == {
-        "schema_version": 5,
+        "schema_version": 6,
         "known_model": True,
         "model": "dreame.mower.g2408",
         "display_model": "A2",
@@ -315,6 +316,78 @@ def test_sanitize_debug_data_redacts_operation_snapshot_identifiers() -> None:
     assert payload["snapshot"]["descriptor"]["host"] == "**REDACTED**"
     assert payload["snapshot"]["serial_number"] == "**REDACTED**"
     assert payload["status_blob"]["hex"] == "ce00ce"
+
+
+def test_sanitize_debug_data_redacts_mixed_case_runtime_credentials() -> None:
+    payload = sanitize_debug_data(
+        {
+            "appKey": "app-key-value",
+            "appSecret": "app-secret-value",
+            "accessToken": "access-token-value",
+            "p2pInfo": "private-p2p-material",
+            "entity_picture": "/api/camera_proxy/camera.mower?token=secret",
+            "token_present": True,
+            "message": "request failed: accessToken=secret-value",
+        }
+    )
+
+    assert payload == {
+        "appKey": "**REDACTED**",
+        "appSecret": "**REDACTED**",
+        "accessToken": "**REDACTED**",
+        "p2pInfo": "**REDACTED**",
+        "entity_picture": "**REDACTED**",
+        "token_present": True,
+        "message": "request failed: accessToken=**REDACTED**",
+    }
+
+
+def test_sanitize_debug_data_redacts_paths_and_map_coordinates() -> None:
+    payload = sanitize_debug_data(
+        {
+            "libraryPath": "/config/custom_components/private/libxp2p.so",
+            "pose_x": 5910,
+            "pose_y": 12400,
+            "runtime_pose_x": 5910,
+            "candidateRuntimePoseY": 12400,
+            "runtime_heading_deg": 63.5,
+        }
+    )
+
+    assert payload == {
+        "libraryPath": "**REDACTED**",
+        "pose_x": "**REDACTED**",
+        "pose_y": "**REDACTED**",
+        "runtime_pose_x": "**REDACTED**",
+        "candidateRuntimePoseY": "**REDACTED**",
+        "runtime_heading_deg": 63.5,
+    }
+
+
+def test_sanitize_diagnostic_text_redacts_bearer_and_query_credentials() -> None:
+    message = sanitize_diagnostic_text(
+        "Bearer secret-token failed at /video?token=url-token&mode=auto "
+        "using --app-secret cli-secret"
+    )
+
+    assert message == (
+        "Bearer **REDACTED** failed at "
+        "/video?token=**REDACTED**&mode=auto "
+        "using --app-secret **REDACTED**"
+    )
+
+
+def test_sanitize_diagnostic_text_redacts_local_paths_but_keeps_urls() -> None:
+    message = sanitize_diagnostic_text(
+        "failed at C:\\config\\custom_components\\private\\runner.exe and "
+        "/config/custom_components/private/libxp2p.so; "
+        "stream=http://127.0.0.1:5544/ipc.flv"
+    )
+
+    assert message == (
+        "failed at **REDACTED_PATH** and **REDACTED_PATH**; "
+        "stream=http://127.0.0.1:5544/ipc.flv"
+    )
 
 
 def test_build_debug_payload_highlights_state_disagreements() -> None:
@@ -406,7 +479,7 @@ def test_build_debug_payload_highlights_state_disagreements() -> None:
         "raw_mower_state_looks_docked_but_raw_docked_false",
         "raw_mower_state_differs_from_state_name",
     ]
-    assert payload["triage"]["schema_version"] == 5
+    assert payload["triage"]["schema_version"] == 6
     assert payload["triage"]["error"] == {
         "active": True,
         "code": 73,

--- a/tests/test_diagnostic_events.py
+++ b/tests/test_diagnostic_events.py
@@ -1,0 +1,45 @@
+"""Contract tests for sanitized recent diagnostic events."""
+
+from custom_components.dreame_lawn_mower.diagnostic_events import (
+    DreameLawnMowerDiagnosticEventStore,
+)
+
+
+def test_diagnostic_event_store_redacts_and_coalesces_duplicates() -> None:
+    store = DreameLawnMowerDiagnosticEventStore(limit=3)
+
+    store.record(
+        code="video_cloud_start_failed",
+        source="video_camera",
+        message="request failed token=secret-value",
+        context={"appSecret": "secret", "transport": "cloud"},
+    )
+    store.record(
+        code="video_cloud_start_failed",
+        source="video_camera",
+        message="request failed token=secret-value",
+        context={"appSecret": "secret", "transport": "cloud"},
+    )
+
+    events = store.as_list()
+    assert len(events) == 1
+    assert events[0]["count"] == 2
+    assert events[0]["message"] == "request failed token=**REDACTED**"
+    assert events[0]["context"] == {
+        "appSecret": "**REDACTED**",
+        "transport": "cloud",
+    }
+    assert "_fingerprint" not in events[0]
+
+
+def test_diagnostic_event_store_keeps_only_the_recent_bounded_history() -> None:
+    store = DreameLawnMowerDiagnosticEventStore(limit=2)
+
+    for index in range(3):
+        store.record(
+            code=f"event_{index}",
+            source="test",
+            message=f"failure {index}",
+        )
+
+    assert [event["code"] for event in store.as_list()] == ["event_1", "event_2"]

--- a/tests/test_diagnostics_download.py
+++ b/tests/test_diagnostics_download.py
@@ -1,0 +1,145 @@
+"""Integration-surface test for the downloaded diagnostics bundle."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import timedelta
+from types import SimpleNamespace
+
+from custom_components.dreame_lawn_mower import diagnostics as diagnostics_module
+from custom_components.dreame_lawn_mower.const import DOMAIN
+from custom_components.dreame_lawn_mower.diagnostic_events import (
+    DreameLawnMowerDiagnosticEventStore,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    DreameLawnMowerDescriptor,
+    DreameLawnMowerSnapshot,
+)
+
+
+def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
+    monkeypatch,
+) -> None:
+    descriptor = DreameLawnMowerDescriptor(
+        did="device-1",
+        name="Garden Mower",
+        model="dreame.mower.g2568a",
+        display_model="A2 1200",
+        account_type="dreame",
+        country="eu",
+    )
+    snapshot = DreameLawnMowerSnapshot(
+        descriptor=descriptor,
+        available=True,
+        state="mowing",
+        state_name="mowing",
+        activity="mowing",
+        capabilities=("camera_streaming",),
+        raw_attributes={},
+    )
+    device = SimpleNamespace(
+        name="Garden Mower",
+        available=True,
+        host=None,
+        token=None,
+        unknown_properties={},
+        realtime_properties={},
+        last_realtime_message=None,
+        status=None,
+        capability=None,
+        info=None,
+    )
+
+    async def _refresh() -> None:
+        return None
+
+    event_store = DreameLawnMowerDiagnosticEventStore()
+    event_store.record(
+        code="video_cloud_start_failed",
+        source="video_camera",
+        message="accessToken=secret failed",
+    )
+    coordinator = SimpleNamespace(
+        data=snapshot,
+        client=SimpleNamespace(_device=device),
+        diagnostic_events=event_store,
+        last_update_success=True,
+        last_exception=None,
+        update_interval=timedelta(seconds=30),
+        async_request_refresh=_refresh,
+    )
+    state = SimpleNamespace(
+        state="idle",
+        attributes={
+            "last_stream_error_code": "video_cloud_start_failed",
+            "last_stream_error": "accessToken=secret failed",
+        },
+    )
+    hass = SimpleNamespace(
+        data={DOMAIN: {"entry-1": coordinator}},
+        states=SimpleNamespace(get=lambda _entity_id: state),
+    )
+    entry = SimpleNamespace(
+        entry_id="entry-1",
+        data={"did": "device-1", "token": "secret"},
+        options={
+            "video_transport": "cloud",
+            "xp2p_runner_command": "runner --token=secret",
+        },
+        state=SimpleNamespace(value="loaded"),
+        disabled_by=None,
+        version=1,
+        minor_version=2,
+    )
+    registry_entry = SimpleNamespace(
+        entity_id="camera.garden_live_video",
+        original_name="Live Video",
+        translation_key=None,
+        entity_category=None,
+        disabled_by=None,
+    )
+
+    async def _system_info(_hass):
+        return {
+            "installation_type": "Home Assistant OS",
+            "version": "2026.7.1",
+            "python_version": "3.13.5",
+            "arch": "aarch64",
+            "user": "private-user",
+        }
+
+    monkeypatch.setattr(
+        diagnostics_module.system_info,
+        "async_get_system_info",
+        _system_info,
+    )
+    monkeypatch.setattr(
+        diagnostics_module,
+        "async_get_loaded_integration",
+        lambda _hass, _domain: SimpleNamespace(version="0.3.0"),
+    )
+    monkeypatch.setattr(diagnostics_module.er, "async_get", lambda _hass: object())
+    monkeypatch.setattr(
+        diagnostics_module.er,
+        "async_entries_for_config_entry",
+        lambda _registry, _entry_id: [registry_entry],
+    )
+
+    payload = asyncio.run(
+        diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
+    )
+
+    assert payload["diagnostic_schema_version"] == 6
+    assert payload["report_context"]["integration_version"] == "0.3.0"
+    assert payload["report_context"]["home_assistant"]["arch"] == "aarch64"
+    assert "user" not in payload["report_context"]["home_assistant"]
+    assert payload["entry"]["did"] == "**REDACTED**"
+    assert payload["entry_options"]["xp2p_runner_command"] == "**REDACTED**"
+    assert payload["entities"][0]["original_name"] == "Live Video"
+    assert payload["entities"][0]["attributes"]["last_stream_error"] == (
+        "accessToken=**REDACTED** failed"
+    )
+    assert payload["recent_events"][0]["code"] == "video_cloud_start_failed"
+    assert payload["recent_events"][0]["message"] == (
+        "accessToken=**REDACTED** failed"
+    )

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -165,3 +165,20 @@ def test_entity_diagnostics_redact_runtime_map_coordinates() -> None:
         "position_y": "**REDACTED**",
         "runtime_heading_deg": 63.5,
     }
+
+
+def test_entity_diagnostics_redact_identifier_sensor_state() -> None:
+    entry = SimpleNamespace(
+        entity_id="sensor.garden_mower_serial",
+        unique_id="device-1_serial_number",
+        original_name="Serial Number",
+        translation_key=None,
+        entity_category=SimpleNamespace(value="diagnostic"),
+        disabled_by=None,
+    )
+    state = SimpleNamespace(state="SERIAL-123", attributes={"icon": "mdi:barcode"})
+
+    entities = build_entity_diagnostics([entry], lambda _entity_id: state)
+
+    assert entities[0]["state"] == "**REDACTED**"
+    assert "SERIAL-123" not in repr(entities)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,0 +1,167 @@
+"""Contract tests for downloaded issue-report context."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+from custom_components.dreame_lawn_mower.reporting import (
+    build_coordinator_diagnostics,
+    build_entity_diagnostics,
+    build_report_context,
+)
+
+
+def test_report_context_keeps_reproduction_facts_and_drops_local_user() -> None:
+    context = build_report_context(
+        system_info={
+            "installation_type": "Home Assistant OS",
+            "version": "2026.7.1",
+            "python_version": "3.13.5",
+            "arch": "x86_64",
+            "os_name": "Linux",
+            "user": "private-user",
+            "timezone": "Europe/Warsaw",
+        },
+        integration_version="0.3.0",
+        config_entry=SimpleNamespace(
+            state=SimpleNamespace(value="loaded"),
+            disabled_by=None,
+            version=2,
+            minor_version=1,
+        ),
+    )
+
+    assert context["integration_version"] == "0.3.0"
+    assert context["home_assistant"] == {
+        "installation_type": "Home Assistant OS",
+        "version": "2026.7.1",
+        "python_version": "3.13.5",
+        "arch": "x86_64",
+        "os_name": "Linux",
+    }
+    assert context["config_entry"] == {
+        "state": "loaded",
+        "disabled_by": None,
+        "version": 2,
+        "minor_version": 1,
+    }
+
+
+def test_entity_diagnostics_capture_runtime_failure_without_identifiers() -> None:
+    entries = [
+        SimpleNamespace(
+            entity_id="camera.garden_live_video",
+            original_name="Live Video",
+            translation_key=None,
+            entity_category=None,
+            disabled_by=None,
+        )
+    ]
+    state = SimpleNamespace(
+        state="idle",
+        attributes={
+            "last_stream_error": "accessToken=secret failed",
+            "last_stream_error_code": "video_cloud_start_failed",
+            "managed_xp2p_runtime_supported": True,
+            "entity_picture": "/api/camera_proxy/camera.garden?token=secret",
+        },
+    )
+
+    entities = build_entity_diagnostics(entries, lambda _entity_id: state)
+
+    assert entities == [
+        {
+            "domain": "camera",
+            "original_name": "Live Video",
+            "translation_key": None,
+            "entity_category": None,
+            "disabled_by": None,
+            "loaded": True,
+            "available": True,
+            "state": "idle",
+            "attributes": {
+                "last_stream_error": "accessToken=**REDACTED** failed",
+                "last_stream_error_code": "video_cloud_start_failed",
+                "managed_xp2p_runtime_supported": True,
+                "entity_picture": "**REDACTED**",
+            },
+        }
+    ]
+    assert "garden_live_video" not in repr(entities)
+
+
+def test_coordinator_diagnostics_sanitize_last_failure() -> None:
+    diagnostics = build_coordinator_diagnostics(
+        SimpleNamespace(
+            last_update_success=False,
+            last_exception=RuntimeError("refresh failed token=secret"),
+            update_interval=timedelta(seconds=30),
+        )
+    )
+
+    assert diagnostics == {
+        "last_update_success": False,
+        "last_exception_type": "RuntimeError",
+        "last_exception": "refresh failed token=**REDACTED**",
+        "update_interval_seconds": 30.0,
+    }
+
+
+def test_entity_diagnostics_redact_runtime_map_coordinates() -> None:
+    entries = [
+        SimpleNamespace(
+            entity_id="sensor.garden_runtime_position_x",
+            original_name="Runtime Position X",
+            translation_key=None,
+            entity_category=SimpleNamespace(value="diagnostic"),
+            disabled_by=SimpleNamespace(value="integration"),
+        ),
+        SimpleNamespace(
+            entity_id="camera.garden_map",
+            original_name="Map",
+            translation_key=None,
+            entity_category=None,
+            disabled_by=None,
+        ),
+    ]
+    states = {
+        "sensor.garden_runtime_position_x": SimpleNamespace(
+            state="5910",
+            attributes={
+                "source": "cloud",
+                "pose_x": 5910,
+                "pose_y": 12400,
+                "heading_deg": 63.5,
+                "track_point_count": 17,
+            },
+        ),
+        "camera.garden_map": SimpleNamespace(
+            state="idle",
+            attributes={
+                "runtime_pose_x": 5910,
+                "runtime_pose_y": 12400,
+                "position_x": 5910,
+                "position_y": 12400,
+                "runtime_heading_deg": 63.5,
+            },
+        ),
+    }
+
+    entities = build_entity_diagnostics(entries, states.get)
+
+    map_entity = next(item for item in entities if item["domain"] == "camera")
+    position_entity = next(item for item in entities if item["domain"] == "sensor")
+    assert position_entity["state"] == "**REDACTED**"
+    assert position_entity["attributes"] == {
+        "source": "cloud",
+        "pose_x": "**REDACTED**",
+        "pose_y": "**REDACTED**",
+        "heading_deg": 63.5,
+        "track_point_count": 17,
+    }
+    assert map_entity["attributes"] == {
+        "runtime_pose_x": "**REDACTED**",
+        "runtime_pose_y": "**REDACTED**",
+        "position_x": "**REDACTED**",
+        "position_y": "**REDACTED**",
+        "runtime_heading_deg": 63.5,
+    }

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -39,6 +39,9 @@ from custom_components.dreame_lawn_mower.const import (
     VIDEO_TRANSPORT_CLOUD,
     VIDEO_TRANSPORT_LAN,
 )
+from custom_components.dreame_lawn_mower.diagnostic_events import (
+    DreameLawnMowerDiagnosticEventStore,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
     DreameLawnMowerCameraStreamRuntimeInputs,
 )
@@ -161,6 +164,29 @@ def test_video_camera_advertises_stop_control() -> None:
     assert features & CameraEntityFeature.ON_OFF
     assert "async_turn_on" in DreameLawnMowerVideoCamera.__dict__
     assert "async_turn_off" in DreameLawnMowerVideoCamera.__dict__
+
+
+def test_video_failure_is_sanitized_logged_once_and_preserved(caplog) -> None:
+    entity = _uninitialized_entity(
+        snapshot=SimpleNamespace(firmware_version="4.3.6_0625")
+    )
+    entity._descriptor = SimpleNamespace(model="dreame.mower.g2568a")
+    entity.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+    entity.async_write_ha_state = lambda: None
+
+    entity._set_stream_error("accessToken=secret failed", stage="cloud_start")
+    entity._set_stream_error("accessToken=secret failed", stage="cloud_start")
+
+    assert entity._last_error == "accessToken=**REDACTED** failed"
+    assert entity._last_error_code == "video_cloud_start_failed"
+    assert entity._last_error_stage == "cloud_start"
+    assert entity._last_error_at is not None
+    events = entity.coordinator.diagnostic_events.as_list()
+    assert len(events) == 1
+    assert events[0]["count"] == 2
+    assert events[0]["context"]["model"] == "dreame.mower.g2568a"
+    assert caplog.text.count("video_cloud_start_failed") == 1
+    assert "secret" not in caplog.text
 
 
 def test_video_camera_auto_policy_prefers_direct_capable_sdk_negotiation() -> None:
@@ -374,7 +400,7 @@ def test_video_camera_does_not_start_while_turned_off() -> None:
             return "http://127.0.0.1/live.flv"
 
         entity._async_start_stream = _start
-        entity._set_stream_error = lambda _error: None
+        entity._set_stream_error = lambda _error, **_kwargs: None
         return await entity._async_start_raw_source(), starts
 
     source, starts = asyncio.run(_run())
@@ -1345,7 +1371,7 @@ def test_video_camera_disables_video_when_enable_attempt_raises() -> None:
         entity._last_stream_disable_error = None
         entity._async_stop_active_session = lambda: asyncio.sleep(0)
         entity._create_runtime = lambda: object()
-        entity._set_stream_error = lambda _error: None
+        entity._set_stream_error = lambda _error, **_kwargs: None
         entity.hass = SimpleNamespace(
             async_add_executor_job=lambda function, *args: asyncio.sleep(
                 0,
@@ -1840,7 +1866,7 @@ def test_video_camera_auto_refresh_blocks_cached_start_after_mower_docks() -> No
             )
 
         entity.coordinator.async_refresh = _async_refresh
-        entity._set_stream_error = errors.append
+        entity._set_stream_error = lambda error, **_kwargs: errors.append(error)
         entity._create_runtime = lambda: (_ for _ in ()).throw(
             AssertionError("Unsafe cached startup must stop before runtime creation")
         )

--- a/tests/test_video_runtime.py
+++ b/tests/test_video_runtime.py
@@ -435,7 +435,8 @@ def test_native_xp2p_runtime_reports_loader_errors() -> None:
     try:
         DreameLawnMowerNativeXp2pRuntime("missing-xp2p-runtime.so")
     except DreameLawnMowerVideoRuntimeError as err:
-        assert "Could not load XP2P native library" in str(err)
+        assert "Could not load the configured XP2P native library" in str(err)
+        assert "missing-xp2p-runtime.so" not in str(err)
     else:
         raise AssertionError("Expected missing native library to fail")
 
@@ -496,7 +497,12 @@ def test_native_xp2p_runtime_diagnostics_report_loader_errors() -> None:
     assert diagnostics.ready is False
     assert diagnostics.loadable is False
     assert diagnostics.missing_required_symbols == ()
-    assert "Could not load XP2P native library" in str(diagnostics.error)
+    assert "Could not load the configured XP2P native library" in str(
+        diagnostics.error
+    )
+    assert "missing-xp2p-runtime.so" not in str(diagnostics.error)
+    assert diagnostics.as_dict()["library_path_configured"] is True
+    assert "library_path" not in diagnostics.as_dict()
 
 
 def test_native_xp2p_runtime_diagnostics_identify_android_jni_library(
@@ -661,6 +667,24 @@ def test_external_runner_requires_stream_url(tmp_path) -> None:
         assert "stream_url" in str(err)
     else:
         raise AssertionError("Expected missing stream_url to fail")
+
+
+def test_runner_start_errors_do_not_expose_configured_executable_path(
+    tmp_path,
+) -> None:
+    missing_command = tmp_path / "private" / "xp2p-runner"
+    for runner in (
+        DreameLawnMowerXp2pExternalRunner((missing_command,)),
+        DreameLawnMowerXp2pProcessRunner((missing_command,)),
+    ):
+        try:
+            runner.start_live_stream(_runtime_inputs())
+        except DreameLawnMowerVideoRuntimeError as err:
+            message = str(err)
+            assert "configured XP2P" in message
+            assert str(missing_command) not in message
+        else:
+            raise AssertionError("Expected missing runner executable to fail")
 
 
 def test_external_runner_reports_process_failures_without_secret(tmp_path) -> None:


### PR DESCRIPTION
## Summary

- make downloaded diagnostics the primary issue-report artifact, including Home Assistant and integration versions, coordinator health, sanitized entity state, and a bounded history of recent failures
- record stable error codes and stages across coordinator updates, maps, schedules, and live video while coalescing repeated failures and emitting actionable warnings
- expand privacy redaction for credentials, device identifiers, exact mower coordinates, runner commands, and local paths
- add a general bug-report form, improve the model-support form, and document the diagnostics workflow for users and contributors

This gives reports such as #48 enough runtime evidence to distinguish configuration, mower-state, transport, provisioning, and playback failures without asking users to enable broad protocol logging.

## Validation

- `ruff check .`
- Python compile check for integration, client, tests, and examples
- issue-template YAML parsing
- full test suite excluding the separately configured Home Assistant config-flow harness