### PR TITLE
Support multiple mowers during setup

### DIFF
--- a/custom_components/dreame_lawn_mower/config_flow.py
+++ b/custom_components/dreame_lawn_mower/config_flow.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+from collections import Counter
 from typing import Any
 
 import voluptuous as vol
 from homeassistant.config_entries import ConfigFlow, OptionsFlow
 from homeassistant.data_entry_flow import FlowResult
+from homeassistant.helpers import selector
 
 from .api import (
     DreameLawnMowerAuthError,
@@ -50,6 +52,8 @@ from .const import (
     XP2P_RUNNER_MODE_OPTIONS,
     XP2P_RUNNER_MODE_PROCESS,
 )
+
+CONF_DEVICE = "device"
 
 
 async def async_discover_devices(
@@ -139,10 +143,19 @@ class DreameLawnMowerConfigFlow(ConfigFlow, domain=DOMAIN):
             else:
                 if not devices:
                     self._errors["base"] = "no_devices"
-                elif len(devices) == 1:
-                    return await self._async_create_entry(devices[0])
                 else:
-                    self._devices = {device.title: device for device in devices}
+                    configured_ids = self._async_current_ids()
+                    self._devices = {
+                        device.unique_id: device
+                        for device in devices
+                        if device.unique_id not in configured_ids
+                    }
+                    if not self._devices:
+                        return self.async_abort(reason="already_configured")
+                    if len(self._devices) == 1:
+                        return await self._async_create_entry(
+                            next(iter(self._devices.values()))
+                        )
                     return await self.async_step_device()
 
         return self.async_show_form(
@@ -168,11 +181,32 @@ class DreameLawnMowerConfigFlow(ConfigFlow, domain=DOMAIN):
     ) -> FlowResult:
         """Handle selection when multiple mowers are discovered."""
         if user_input is not None:
-            return await self._async_create_entry(self._devices[user_input["device"]])
+            return await self._async_create_entry(
+                self._devices[user_input[CONF_DEVICE]]
+            )
+
+        title_counts = Counter(device.title for device in self._devices.values())
+        options = [
+            selector.SelectOptionDict(
+                value=unique_id,
+                label=(
+                    device.title
+                    if title_counts[device.title] == 1
+                    else f"{device.title} - {unique_id}"
+                ),
+            )
+            for unique_id, device in self._devices.items()
+        ]
 
         return self.async_show_form(
             step_id="device",
-            data_schema=vol.Schema({vol.Required("device"): vol.In(self._devices)}),
+            data_schema=vol.Schema(
+                {
+                    vol.Required(CONF_DEVICE): selector.SelectSelector(
+                        selector.SelectSelectorConfig(options=options)
+                    )
+                }
+            ),
         )
 
     async def async_step_reauth(

--- a/custom_components/dreame_lawn_mower/strings.json
+++ b/custom_components/dreame_lawn_mower/strings.json
@@ -13,6 +13,7 @@
       },
       "device": {
         "title": "Select mower",
+        "description": "Choose one mower to add. Run setup again to add another mower from the same account.",
         "data": {
           "device": "Discovered mower"
         }
@@ -34,6 +35,9 @@
       "invalid_account_type": "The selected account type is not supported by this integration.",
       "invalid_region": "The selected region was rejected by the cloud. Check the account region used in the vendor app.",
       "no_devices": "No supported lawn mower devices were found for this account. Check that the selected region and account type match the vendor app."
+    },
+    "abort": {
+      "already_configured": "All supported mowers on this account are already configured."
     }
   },
   "options": {

--- a/custom_components/dreame_lawn_mower/translations/en.json
+++ b/custom_components/dreame_lawn_mower/translations/en.json
@@ -13,6 +13,7 @@
       },
       "device": {
         "title": "Select mower",
+        "description": "Choose one mower to add. Run setup again to add another mower from the same account.",
         "data": {
           "device": "Discovered mower"
         }
@@ -34,6 +35,9 @@
       "invalid_account_type": "The selected account type is not supported by this integration.",
       "invalid_region": "The selected region was rejected by the cloud. Check the account region used in the vendor app.",
       "no_devices": "No supported lawn mower devices were found for this account. Check that the selected region and account type match the vendor app."
+    },
+    "abort": {
+      "already_configured": "All supported mowers on this account are already configured."
     }
   },
   "options": {

--- a/tests/components/dreame_lawn_mower/test_config_flow.py
+++ b/tests/components/dreame_lawn_mower/test_config_flow.py
@@ -6,8 +6,11 @@ import asyncio
 from types import SimpleNamespace
 
 import pytest
+import voluptuous_serialize
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
+from homeassistant.helpers import config_validation as cv
+from pytest_homeassistant_custom_component.common import MockConfigEntry
 
 from custom_components.dreame_lawn_mower.config_flow import DreameLawnMowerOptionsFlow
 from custom_components.dreame_lawn_mower.const import (
@@ -34,9 +37,14 @@ from custom_components.dreame_lawn_mower.const import (
 
 
 class _FakeDevice:
-    def __init__(self) -> None:
-        self.did = "device-1"
-        self.name = "Garage Mower"
+    def __init__(
+        self,
+        *,
+        did: str = "device-1",
+        name: str = "Garage Mower",
+    ) -> None:
+        self.did = did
+        self.name = name
         self.model = "dreame.mower.g3255"
         self.display_model = "A3 AWD Pro"
         self.account_type = ACCOUNT_TYPE_DREAME
@@ -47,11 +55,24 @@ class _FakeDevice:
 
     @property
     def title(self) -> str:
-        return "Garage Mower (A3 AWD Pro)"
+        return f"{self.name} ({self.display_model})"
 
     @property
     def unique_id(self) -> str:
         return self.did
+
+
+async def _start_user_flow(hass):
+    return await hass.config_entries.flow.async_init(
+        DOMAIN,
+        context={"source": config_entries.SOURCE_USER},
+        data={
+            CONF_ACCOUNT_TYPE: ACCOUNT_TYPE_DREAME,
+            CONF_COUNTRY: "eu",
+            CONF_PASSWORD: "secret",
+            CONF_USERNAME: "user@example.com",
+        },
+    )
 
 
 @pytest.mark.asyncio
@@ -64,22 +85,133 @@ async def test_user_flow_creates_entry(hass, monkeypatch) -> None:
         _fake_discover,
     )
 
-    result = await hass.config_entries.flow.async_init(
-        DOMAIN,
-        context={"source": config_entries.SOURCE_USER},
-        data={
-            CONF_ACCOUNT_TYPE: ACCOUNT_TYPE_DREAME,
-            CONF_COUNTRY: "eu",
-            CONF_PASSWORD: "secret",
-            CONF_USERNAME: "user@example.com",
-        },
-    )
+    result = await _start_user_flow(hass)
 
     assert result["type"] is FlowResultType.CREATE_ENTRY
     assert result["title"] == "Garage Mower (A3 AWD Pro)"
     assert result["data"][CONF_DID] == "device-1"
     assert result["data"][CONF_MODEL] == "dreame.mower.g3255"
     assert result["data"][CONF_NAME] == "Garage Mower"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_lists_multiple_mowers_by_name(hass, monkeypatch) -> None:
+    async def _fake_discover(**kwargs):
+        return [
+            _FakeDevice(did="device-1", name="Garden Mower"),
+            _FakeDevice(did="device-2", name="Parents' Mower"),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.dreame_lawn_mower.config_flow.async_discover_devices",
+        _fake_discover,
+    )
+
+    result = await _start_user_flow(hass)
+
+    assert result["type"] is FlowResultType.FORM
+    assert result["step_id"] == "device"
+    serialized_schema = voluptuous_serialize.convert(
+        result["data_schema"], custom_serializer=cv.custom_serializer
+    )
+    assert serialized_schema[0]["selector"]["select"]["options"] == [
+        {"value": "device-1", "label": "Garden Mower (A3 AWD Pro)"},
+        {"value": "device-2", "label": "Parents' Mower (A3 AWD Pro)"},
+    ]
+
+    result = await hass.config_entries.flow.async_configure(
+        result["flow_id"], {"device": "device-2"}
+    )
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Parents' Mower (A3 AWD Pro)"
+    assert result["data"][CONF_DID] == "device-2"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_keeps_mowers_with_the_same_name_distinct(
+    hass, monkeypatch
+) -> None:
+    async def _fake_discover(**kwargs):
+        return [
+            _FakeDevice(did="device-1", name="Garden Mower"),
+            _FakeDevice(did="device-2", name="Garden Mower"),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.dreame_lawn_mower.config_flow.async_discover_devices",
+        _fake_discover,
+    )
+
+    result = await _start_user_flow(hass)
+
+    serialized_schema = voluptuous_serialize.convert(
+        result["data_schema"], custom_serializer=cv.custom_serializer
+    )
+    assert serialized_schema[0]["selector"]["select"]["options"] == [
+        {
+            "value": "device-1",
+            "label": "Garden Mower (A3 AWD Pro) - device-1",
+        },
+        {
+            "value": "device-2",
+            "label": "Garden Mower (A3 AWD Pro) - device-2",
+        },
+    ]
+
+
+@pytest.mark.asyncio
+async def test_user_flow_only_offers_unconfigured_mowers(hass, monkeypatch) -> None:
+    MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="device-1",
+        data={CONF_DID: "device-1"},
+    ).add_to_hass(hass)
+
+    async def _fake_discover(**kwargs):
+        return [
+            _FakeDevice(did="device-1", name="Garden Mower"),
+            _FakeDevice(did="device-2", name="Parents' Mower"),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.dreame_lawn_mower.config_flow.async_discover_devices",
+        _fake_discover,
+    )
+
+    result = await _start_user_flow(hass)
+
+    assert result["type"] is FlowResultType.CREATE_ENTRY
+    assert result["title"] == "Parents' Mower (A3 AWD Pro)"
+    assert result["data"][CONF_DID] == "device-2"
+
+
+@pytest.mark.asyncio
+async def test_user_flow_aborts_when_all_mowers_are_configured(
+    hass, monkeypatch
+) -> None:
+    for did in ("device-1", "device-2"):
+        MockConfigEntry(
+            domain=DOMAIN,
+            unique_id=did,
+            data={CONF_DID: did},
+        ).add_to_hass(hass)
+
+    async def _fake_discover(**kwargs):
+        return [
+            _FakeDevice(did="device-1", name="Garden Mower"),
+            _FakeDevice(did="device-2", name="Parents' Mower"),
+        ]
+
+    monkeypatch.setattr(
+        "custom_components.dreame_lawn_mower.config_flow.async_discover_devices",
+        _fake_discover,
+    )
+
+    result = await _start_user_flow(hass)
+
+    assert result["type"] is FlowResultType.ABORT
+    assert result["reason"] == "already_configured"
 
 
 def test_options_flow_accepts_map_label_scale() -> None:


### PR DESCRIPTION
## Summary

- show discovered mowers by their name and model while using stable device IDs as selection values
- keep identically named mowers distinct and hide mowers that already have config entries
- explain repeated setup for additional mowers and report when every mower is already configured

Fixes #51