### PR TITLE
Fix A3 AWD 1000 diagnostics and video triage

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ Support levels in this table mean:
 | Dreame A2 (`dreame.mower.g2408`) | Validated | Primary live development device, including schedules, maps, remote control, guarded preference writes, and diagnostics |
 | MOVA LiDAX Ultra 1000 (`mova.mower.g2529c`) | Recognized | Added from a MOVAhome EU diagnostics report; commands and battery are reported working, state handling now accepts model-specific cloud property ids |
 | Dreame A3 AWD Pro 3500 (`dreame.mower.g2541e`) | Recognized | Added from a Dreamehome EU diagnostics report; needs broader live confirmation before it is considered validated |
+| Dreame A3 AWD 1000 (`dreame.mower.q2501a`) | Recognized | Core entities, maps, and mower state are field-confirmed on firmware `4.3.6_0418`; live video still needs model-specific runtime proof |
 | Newer A-series mower (`dreame.mower.g3255`) | Recognized | Raw model has been observed in code mapping, but the public retail name is still unverified |
 | Dreame A1 (`dreame.mower.p2255`) | Recognized | Model mapping is present; needs fixtures and live validation |
 | Dreame A1 Pro (`dreame.mower.g2422`) | Recognized | Model mapping is present; needs fixtures and live validation |

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -155,7 +155,15 @@ def _normalize_debug_value(value: Any) -> Any:
     if is_dataclass(value):
         return _normalize_debug_value(asdict(value))
     if isinstance(value, Enum):
-        return value.name.lower()
+        name = value.name
+        if isinstance(name, str):
+            return name.lower()
+        enum_value = value.value
+        return (
+            str(value)
+            if enum_value is value
+            else _normalize_debug_value(enum_value)
+        )
     if isinstance(value, Mapping):
         return {
             str(key): _normalize_debug_value(item)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -26,6 +26,7 @@ MODEL_NAME_MAP = {
     "dreame.mower.g2422": "A1 Pro",
     "dreame.mower.g2408": "A2",
     "dreame.mower.g2541e": "A3 AWD Pro 3500",
+    "dreame.mower.q2501a": "A3 AWD 1000",
     "mova.mower.g2529c": "LiDAX Ultra 1000",
 }
 
@@ -33,6 +34,7 @@ DISPLAY_NAME_ALIASES = {
     "a1": "A1",
     "a1 pro": "A1 Pro",
     "a2": "A2",
+    "a3 awd 1000": "A3 AWD 1000",
     "a3 awd pro 3500": "A3 AWD Pro 3500",
     "awd 1000": "AWD 1000",
     "lidax ultra 800": "LiDAX Ultra 800",

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -169,6 +169,7 @@ class DreameLawnMowerVideoCamera(
         self._provisioning_cache_error: str | None = None
         self._last_cached_xp2p_error: str | None = None
         self._last_video_transport: str | None = None
+        self._last_video_transport_attempted: str | None = None
 
     async def async_added_to_hass(self) -> None:
         """Schedule managed runtime preparation without blocking entity setup."""
@@ -277,6 +278,7 @@ class DreameLawnMowerVideoCamera(
             "video_transport_policy": self._video_transport,
             "video_block_reason": camera_stream_block_reason(self.coordinator.data),
             "last_video_transport": self._last_video_transport,
+            "last_video_transport_attempted": self._last_video_transport_attempted,
             "lan_video_identity_cached": self._lan_cache.inputs is not None,
             "lan_video_endpoint_cached": self._lan_cache.endpoint is not None,
             "lan_video_cache_error": self._lan_cache_error,
@@ -569,6 +571,7 @@ class DreameLawnMowerVideoCamera(
         self._last_stream_health = None
         self._last_lan_error = None
         self._last_cached_xp2p_error = None
+        self._last_video_transport_attempted = None
         cached_xp2p_inputs = (
             self._provisioning_cache.inputs
             if self._video_transport == VIDEO_TRANSPORT_AUTO
@@ -602,6 +605,7 @@ class DreameLawnMowerVideoCamera(
             and cached_xp2p_inputs is not None
             and cached_xp2p_inputs.ready
         ):
+            self._last_video_transport_attempted = "cached_xp2p"
             try:
                 cached_source = await self._async_try_cached_xp2p_stream(
                     runtime,
@@ -638,6 +642,7 @@ class DreameLawnMowerVideoCamera(
                     lan_inputs = self._lan_cache.inputs
 
             if lan_inputs is not None:
+                self._last_video_transport_attempted = VIDEO_TRANSPORT_LAN
                 try:
                     lan_source = await self._async_try_lan_stream(runtime, lan_inputs)
                 except DreameLawnMowerVideoRuntimeError as err:
@@ -670,6 +675,7 @@ class DreameLawnMowerVideoCamera(
                         )
                     else:
                         if cloud_inputs.lan_identity_ready:
+                            self._last_video_transport_attempted = VIDEO_TRANSPORT_LAN
                             try:
                                 lan_source = await self._async_try_lan_stream(
                                     runtime,
@@ -700,6 +706,7 @@ class DreameLawnMowerVideoCamera(
 
         stream_enable_attempted = False
         session: DreameLawnMowerXp2pLiveStreamSession | None = None
+        self._last_video_transport_attempted = VIDEO_TRANSPORT_CLOUD
         try:
             if cloud_inputs is None:
                 if cloud_inputs_error is not None:

--- a/tests/test_diagnostics_download.py
+++ b/tests/test_diagnostics_download.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from datetime import timedelta
+from enum import IntFlag
 from types import SimpleNamespace
 
 from custom_components.dreame_lawn_mower import diagnostics as diagnostics_module
@@ -15,6 +16,12 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import 
     DreameLawnMowerDescriptor,
     DreameLawnMowerSnapshot,
 )
+
+
+class _AnonymousFeature(IntFlag):
+    """Feature flag with no named zero member, matching Home Assistant enums."""
+
+    ENABLED = 1
 
 
 def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
@@ -71,6 +78,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
     state = SimpleNamespace(
         state="idle",
         attributes={
+            "anonymous_feature": _AnonymousFeature(0),
             "last_stream_error_code": "video_cloud_start_failed",
             "last_stream_error": "accessToken=secret failed",
         },
@@ -139,6 +147,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
     assert payload["entities"][0]["attributes"]["last_stream_error"] == (
         "accessToken=**REDACTED** failed"
     )
+    assert payload["entities"][0]["attributes"]["anonymous_feature"] == 0
     assert payload["recent_events"][0]["code"] == "video_cloud_start_failed"
     assert payload["recent_events"][0]["message"] == (
         "accessToken=**REDACTED** failed"

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -207,6 +207,23 @@ def test_descriptor_maps_a3_awd_pro_3500_model_name() -> None:
     assert descriptor.title == "Back Garden (A3 AWD Pro 3500)"
 
 
+def test_descriptor_maps_a3_awd_1000_model_name() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-7",
+            "model": "dreame.mower.q2501a",
+            "customName": "Front Garden",
+            "deviceInfo": {"displayName": "A3 AWD 1000"},
+        },
+        account_type="dreame",
+        country="ru",
+    )
+
+    assert descriptor is not None
+    assert descriptor.display_model == "A3 AWD 1000"
+    assert descriptor.title == "Front Garden (A3 AWD 1000)"
+
+
 def test_snapshot_uses_state_name_before_boolean_helpers() -> None:
     descriptor = descriptor_from_cloud_record(
         {

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -154,6 +154,7 @@ def _uninitialized_entity(*, snapshot: object | None = None):
     entity._runtime_input_config = None
     entity._last_lan_error = None
     entity._last_video_transport = None
+    entity._last_video_transport_attempted = None
     return entity
 
 
@@ -1345,7 +1346,7 @@ def test_video_camera_auto_refreshes_after_stale_cached_lan_endpoint() -> None:
 
 
 def test_video_camera_disables_video_when_enable_attempt_raises() -> None:
-    async def _run() -> tuple[str | None, list[bool]]:
+    async def _run() -> tuple[str | None, list[bool], str | None, str | None]:
         entity = _uninitialized_entity()
         calls: list[bool] = []
 
@@ -1380,9 +1381,14 @@ def test_video_camera_disables_video_when_enable_attempt_raises() -> None:
         )
 
         result = await entity._async_start_stream()
-        return result, calls
+        return (
+            result,
+            calls,
+            entity._last_video_transport,
+            entity._last_video_transport_attempted,
+        )
 
-    assert asyncio.run(_run()) == (None, [True, False])
+    assert asyncio.run(_run()) == (None, [True, False], None, VIDEO_TRANSPORT_CLOUD)
 
 
 def test_video_camera_caches_provisioning_only_after_ha_decodes_frame() -> None:


### PR DESCRIPTION
## Summary

- handle unnamed Home Assistant `Enum` and `IntFlag` values during diagnostics serialization, preventing the reported diagnostics download failure
- recognize `dreame.mower.q2501a` as the Dreame A3 AWD 1000 and document the field-confirmed core support
- distinguish the last attempted video transport from the last successfully negotiated transport

## A3 live-video follow-up

Live video on `q2501a` still needs a real post-fix capture. After reproducing the stream failure once, the downloaded diagnostics will now retain the failure stage and attempted transport without exposing credentials. This PR intentionally does not close #53 until playback is proven or the model-specific blocker is identified.

## Validation

- `python -m ruff check .`
- `python -m pytest tests --ignore=tests/components/dreame_lawn_mower/test_config_flow.py -q`

Relates to #53.
