### PR TITLE
Add privacy-safe staged telemetry for video failures

### DIFF
--- a/README.md
+++ b/README.md
@@ -443,7 +443,8 @@ The report is sanitized by the integration and includes:
   architecture versions
 - config-entry and coordinator health
 - current state and diagnostic attributes for every entity belonging to the
-  config entry, including the Live Video camera's last failure stage
+  config entry, including the Live Video camera's last failure stage and a
+  bounded, privacy-safe summary of each TX video cloud stage
 - a bounded list of recent coordinator, map, schedule, and video failures with
   repeated failures coalesced
 - the existing `triage`, `state_reconciliation`, schedule, map, firmware, and raw
@@ -452,6 +453,13 @@ The report is sanitized by the integration and includes:
 Do not enable broad debug logging unless a maintainer asks for a specific logger.
 Cloud protocol debug output can contain data that needs additional review before
 it is posted publicly.
+
+The staged cloud summaries retain field names, value types, safe status codes,
+required-field presence, and sanitized error messages. They do not retain raw
+response values, account or device identifiers, credentials, stream URLs, or
+unbounded payloads. This lets maintainers distinguish unsupported models,
+malformed vendor responses, and missing provisioning without asking users to
+share an account as the first debugging step.
 
 For issue reports, include:
 

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -25,7 +25,7 @@ from .dreame_lawn_mower_client.models import (
     remote_control_state_safe,
 )
 
-DIAGNOSTIC_SCHEMA_VERSION = 6
+DIAGNOSTIC_SCHEMA_VERSION = 7
 UNKNOWN_REALTIME_PREFIX = "UNKNOWN_REALTIME_"
 
 REDACT_KEYS = {

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -97,6 +97,7 @@ from .mowing_tasks import (
     build_zone_mowing_request,
     ensure_mowing_task_succeeded,
 )
+from .operation_diagnostics import build_operation_stage_diagnostics
 from .runtime_state import (
     RESUME_MOWING_REQUEST,
     snapshot_session_control_state,
@@ -226,6 +227,7 @@ class DreameLawnMowerClient:
         self._last_runtime_track_blob_hex: str | None = None
         self._latest_cloud_device_info: Mapping[str, Any] | None = None
         self._cloud_device_info_refreshed_at = 0.0
+        self._last_camera_stream_diagnostics: Mapping[str, Any] = {}
 
     @property
     def descriptor(self) -> DreameLawnMowerDescriptor:
@@ -236,6 +238,11 @@ class DreameLawnMowerClient:
     def device(self) -> Any | None:
         """Return the currently connected upstream device instance."""
         return self._device
+
+    @property
+    def last_camera_stream_diagnostics(self) -> Mapping[str, Any]:
+        """Return the latest privacy-safe TX video cloud operation summary."""
+        return self._last_camera_stream_diagnostics
 
     def update_runtime_live_tracking(
         self,
@@ -1808,23 +1815,78 @@ class DreameLawnMowerClient:
     def _sync_get_camera_stream_inputs(self) -> dict[str, Any]:
         """Fetch and normalize the cloud data used by TXVideoSdk video startup."""
         cloud = self._sync_get_cloud_protocol()
+        diagnostics: dict[str, Any] = {
+            "operation": "camera_stream_inputs",
+            "version": 1,
+            "stages": [],
+        }
+        self._last_camera_stream_diagnostics = diagnostics
         output: dict[str, Any] = {
             "source": "dreame_third_video_tx",
             "did": self._descriptor.did,
             "tx_rtc_info": {},
             "p2p_info": None,
             "raw": {},
+            "diagnostics": diagnostics,
         }
+        current_stage = "cloud_access_token"
+        current_request: Mapping[str, Any] = {"os": 1}
+        sensitive_values: list[object] = [self._descriptor.did]
+
+        def record_stage(
+            stage: str,
+            *,
+            request: Mapping[str, Any],
+            response: Any = None,
+            result: Mapping[str, Any] | None = None,
+            error: BaseException | None = None,
+            include_response: bool = True,
+        ) -> None:
+            arguments: dict[str, Any] = {
+                "request_context": request,
+                "result": result,
+                "error": error,
+                "sensitive_values": tuple(sensitive_values),
+            }
+            if include_response:
+                arguments["response"] = response
+            diagnostics["stages"].append(
+                build_operation_stage_diagnostics(stage, **arguments)
+            )
+
         try:
             access_token = None
             if hasattr(cloud, "get_tx_video_access_token"):
+                current_stage = "cloud_access_token"
+                current_request = {"os": 1}
                 access = cloud.get_tx_video_access_token(os=1)
                 output["raw"]["access_token"] = _json_safe(access, max_depth=4)
                 access_token = _find_text_by_key(
                     access,
                     ("accessToken", "accesstoken", "token"),
                 )
+                if access_token:
+                    sensitive_values.append(access_token)
+                record_stage(
+                    current_stage,
+                    request=current_request,
+                    response=access,
+                    result={"access_token_present": bool(access_token)},
+                )
+            else:
+                record_stage(
+                    current_stage,
+                    request=current_request,
+                    result={"available": False},
+                    include_response=False,
+                )
             if hasattr(cloud, "get_tx_video_device_identity"):
+                current_stage = "cloud_device_identity"
+                current_request = {
+                    "did_present": bool(self._descriptor.did),
+                    "access_token_present": bool(access_token),
+                    "os": 1,
+                }
                 identity = cloud.get_tx_video_device_identity(
                     access_token=access_token,
                     os=1,
@@ -1833,19 +1895,118 @@ class DreameLawnMowerClient:
                 output["tx_rtc_info"] = _normalize_tx_rtc_info(
                     identity,
                 )
+                record_stage(
+                    current_stage,
+                    request=current_request,
+                    response=identity,
+                    result={
+                        f"{field}_present": bool(output["tx_rtc_info"].get(field))
+                        for field in (
+                            "channel_id",
+                            "product_id",
+                            "device_name",
+                            "secret_id",
+                            "secret_key",
+                            "app_id",
+                            "app_secret",
+                        )
+                    },
+                )
             else:
                 output["tx_rtc_info"] = _normalize_tx_rtc_info({})
+                record_stage(
+                    "cloud_device_identity",
+                    request={
+                        "did_present": bool(self._descriptor.did),
+                        "access_token_present": bool(access_token),
+                        "os": 1,
+                    },
+                    result={"available": False},
+                    include_response=False,
+                )
             if hasattr(cloud, "get_tx_video_p2p_info"):
+                current_stage = "cloud_p2p_info"
+                current_request = {
+                    "did_present": bool(self._descriptor.did),
+                    "access_token_present": bool(access_token),
+                    "os": 1,
+                }
                 p2p_info = cloud.get_tx_video_p2p_info(
                     access_token=access_token,
                     os=1,
                 )
                 output["raw"]["p2p_info"] = _json_safe(p2p_info, max_depth=5)
                 output["p2p_info"] = _normalize_tx_p2p_info(p2p_info)
+                record_stage(
+                    current_stage,
+                    request=current_request,
+                    response=p2p_info,
+                    result={
+                        "p2p_info_present": bool(
+                            output["p2p_info"].get("p2p_info")
+                        ),
+                        "available": bool(output["p2p_info"].get("available")),
+                    },
+                )
             else:
                 output["p2p_info"] = {"available": False}
+                record_stage(
+                    "cloud_p2p_info",
+                    request={
+                        "did_present": bool(self._descriptor.did),
+                        "access_token_present": bool(access_token),
+                        "os": 1,
+                    },
+                    result={"available": False},
+                    include_response=False,
+                )
         except DeviceException as err:
+            record_stage(
+                current_stage,
+                request=current_request,
+                error=err,
+                include_response=False,
+            )
+            diagnostics["completed"] = False
             raise DreameLawnMowerConnectionError(str(err)) from err
+
+        runtime_inputs = _camera_stream_runtime_inputs_from_cloud_payload(output)
+        diagnostics["ready"] = runtime_inputs.ready
+        diagnostics["missing_required"] = runtime_inputs.missing_required
+        if runtime_inputs.missing_required and hasattr(
+            cloud,
+            "get_tx_video_user_eligibility",
+        ):
+            eligibility_request = {
+                "did_present": bool(self._descriptor.did),
+                "access_token_present": bool(access_token),
+                "os": 1,
+            }
+            try:
+                eligibility = cloud.get_tx_video_user_eligibility(
+                    access_token=access_token,
+                    os=1,
+                )
+            except DeviceException as err:
+                record_stage(
+                    "cloud_user_eligibility",
+                    request=eligibility_request,
+                    error=err,
+                    include_response=False,
+                )
+            else:
+                record_stage(
+                    "cloud_user_eligibility",
+                    request=eligibility_request,
+                    response=eligibility,
+                    result={
+                        "is_device_user": _find_text_by_key(
+                            eligibility,
+                            ("isDevUser", "devUser", "isUser"),
+                        )
+                    },
+                )
+        diagnostics["completed"] = True
         return output
 
     def _sync_get_camera_stream_runtime_inputs(
@@ -5636,6 +5797,11 @@ def _camera_stream_runtime_inputs_from_cloud_payload(
         lan_client_token=_find_text_by_key(
             raw.get("access_token"),
             ("accessToken", "accesstoken", "token"),
+        ),
+        diagnostics=(
+            value.get("diagnostics")
+            if isinstance(value.get("diagnostics"), Mapping)
+            else {}
         ),
         raw=_json_safe(value, max_depth=5),
     )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1814,7 +1814,6 @@ class DreameLawnMowerClient:
 
     def _sync_get_camera_stream_inputs(self) -> dict[str, Any]:
         """Fetch and normalize the cloud data used by TXVideoSdk video startup."""
-        cloud = self._sync_get_cloud_protocol()
         diagnostics: dict[str, Any] = {
             "operation": "camera_stream_inputs",
             "version": 1,
@@ -1853,6 +1852,28 @@ class DreameLawnMowerClient:
             diagnostics["stages"].append(
                 build_operation_stage_diagnostics(stage, **arguments)
             )
+
+        setup_request = {"device_initialized": self._device is not None}
+        try:
+            cloud = self._sync_get_cloud_protocol()
+        except Exception as err:
+            record_stage(
+                "cloud_setup",
+                request=setup_request,
+                error=err,
+                include_response=False,
+            )
+            diagnostics["completed"] = False
+            raise
+        record_stage(
+            "cloud_setup",
+            request=setup_request,
+            result={
+                "available": True,
+                "logged_in": bool(getattr(cloud, "logged_in", False)),
+            },
+            include_response=False,
+        )
 
         try:
             access_token = None
@@ -1987,7 +2008,7 @@ class DreameLawnMowerClient:
                     access_token=access_token,
                     os=1,
                 )
-            except DeviceException as err:
+            except Exception as err:
                 record_stage(
                     "cloud_user_eligibility",
                     request=eligibility_request,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1916,6 +1916,17 @@ class DreameLawnMowerClient:
                 output["tx_rtc_info"] = _normalize_tx_rtc_info(
                     identity,
                 )
+                for field in (
+                    "channel_id",
+                    "product_id",
+                    "device_name",
+                    "secret_id",
+                    "secret_key",
+                    "app_id",
+                    "app_secret",
+                ):
+                    if sensitive_value := output["tx_rtc_info"].get(field):
+                        sensitive_values.append(sensitive_value)
                 record_stage(
                     current_stage,
                     request=current_request,
@@ -1990,6 +2001,15 @@ class DreameLawnMowerClient:
             )
             diagnostics["completed"] = False
             raise DreameLawnMowerConnectionError(str(err)) from err
+        except Exception as err:
+            record_stage(
+                current_stage,
+                request=current_request,
+                error=err,
+                include_response=False,
+            )
+            diagnostics["completed"] = False
+            raise
 
         runtime_inputs = _camera_stream_runtime_inputs_from_cloud_payload(output)
         diagnostics["ready"] = runtime_inputs.ready

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -670,6 +670,7 @@ class DreameLawnMowerCameraStreamRuntimeInputs:
     flv_path_template: str = (
         "ipc.flv?action=live&channel={channel}&quality=high&_crypto=on"
     )
+    diagnostics: Mapping[str, Any] = field(default_factory=dict, repr=False)
     raw: Mapping[str, Any] = field(default_factory=dict, repr=False)
 
     @property

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import re
 from collections.abc import Mapping, Sequence
+from itertools import islice
 from typing import Any
 
 _MISSING = object()
@@ -11,7 +12,11 @@ _MAX_DEPTH = 5
 _MAX_FIELDS = 40
 _MAX_ITEMS = 4
 _MAX_MESSAGES = 4
+_MAX_CODES = 8
+_MAX_NODES = 256
 _MAX_MESSAGE_LENGTH = 240
+_MAX_REDACTIONS = 32
+_MAX_REDACTION_LENGTH = 512
 
 _SAFE_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]{0,63}$")
 _SENSITIVE_KEYS = {
@@ -23,6 +28,7 @@ _SENSITIVE_KEYS = {
     "authorization",
     "clientid",
     "clientsecret",
+    "channelid",
     "cookie",
     "deviceid",
     "devicename",
@@ -61,7 +67,8 @@ _MESSAGE_KEYS = {
 }
 _ASSIGNED_SENSITIVE_VALUE = re.compile(
     r"(?i)\b(access[_-]?token|app[_-]?(?:id|key|secret)|client[_-]?(?:id|secret)|"
-    r"device[_-]?(?:id|name)|did|family[_-]?id|p2p[_-]?info|refresh[_-]?token|"
+    r"channel[_-]?id|device[_-]?(?:id|name)|did|family[_-]?id|p2p[_-]?info|"
+    r"refresh[_-]?token|"
     r"secret[_-]?(?:id|key)|serial[_-]?number|session[_-]?token|sn|token|uid|"
     r"username|uuid|xp2p[_-]?(?:info|key|secretkey))\b"
     r"([\"']?)(\s*(?:[:=]\s*|\s+))([\"']?)[^\s,;&\"'}]+"
@@ -88,7 +95,7 @@ def build_operation_stage_diagnostics(
         payload["request"] = {
             _safe_field_name(key, index): _safe_context_value(value)
             for index, (key, value) in enumerate(
-                list(request_context.items())[:_MAX_FIELDS]
+                islice(request_context.items(), _MAX_FIELDS)
             )
         }
     if response is not _MISSING:
@@ -99,7 +106,9 @@ def build_operation_stage_diagnostics(
     if result:
         payload["result"] = {
             _safe_field_name(key, index): _safe_context_value(value)
-            for index, (key, value) in enumerate(list(result.items())[:_MAX_FIELDS])
+            for index, (key, value) in enumerate(
+                islice(result.items(), _MAX_FIELDS)
+            )
         }
     if error is not None:
         redactions = _sensitive_text_values(response, sensitive_values)
@@ -116,16 +125,32 @@ def summarize_operation_response(
     sensitive_values: Sequence[object] = (),
 ) -> dict[str, Any]:
     """Return response shape, safe status codes, and sanitized messages."""
-    redactions = _sensitive_text_values(value, sensitive_values)
+    redactions = _sensitive_text_values(
+        value,
+        sensitive_values,
+        budget=[_MAX_NODES],
+    )
     summary: dict[str, Any] = {
         "type": _value_type(value),
         "empty": _is_empty(value),
-        "shape": _response_shape(value, depth=0),
+        "shape": _response_shape(value, depth=0, budget=[_MAX_NODES]),
     }
-    codes = _named_scalar_values(value, _CODE_KEYS, include_text=False)
+    codes = _named_scalar_values(
+        value,
+        _CODE_KEYS,
+        include_text=False,
+        limit=_MAX_CODES,
+        budget=[_MAX_NODES],
+    )
     if codes:
         summary["codes"] = codes
-    messages = _named_scalar_values(value, _MESSAGE_KEYS, include_text=True)
+    messages = _named_scalar_values(
+        value,
+        _MESSAGE_KEYS,
+        include_text=True,
+        limit=_MAX_MESSAGES,
+        budget=[_MAX_NODES],
+    )
     if messages:
         summary["messages"] = [
             {
@@ -137,40 +162,48 @@ def summarize_operation_response(
     return summary
 
 
-def _response_shape(value: Any, *, depth: int) -> Any:
+def _response_shape(value: Any, *, depth: int, budget: list[int]) -> Any:
+    if not _consume_budget(budget):
+        return {"type": _value_type(value), "truncated": True}
     if depth >= _MAX_DEPTH:
         return {"type": _value_type(value), "truncated": True}
     if isinstance(value, Mapping):
-        items = list(value.items())
         fields = [
             {
                 "name": _safe_field_name(key, index),
-                "shape": _response_shape(item, depth=depth + 1),
+                "shape": _response_shape(
+                    item,
+                    depth=depth + 1,
+                    budget=budget,
+                ),
             }
-            for index, (key, item) in enumerate(items[:_MAX_FIELDS])
+            for index, (key, item) in enumerate(
+                islice(value.items(), _MAX_FIELDS)
+            )
+            if budget[0] > 0
         ]
         shape: dict[str, Any] = {
             "type": "object",
-            "field_count": len(items),
+            "field_count": len(value),
             "fields": fields,
         }
-        if len(items) > _MAX_FIELDS:
+        if len(value) > len(fields) or budget[0] <= 0:
             shape["truncated"] = True
         return shape
     if isinstance(value, Sequence) and not isinstance(
         value,
         str | bytes | bytearray,
     ):
-        items = list(value)
         shape = {
             "type": "array",
-            "item_count": len(items),
+            "item_count": len(value),
             "items": [
-                _response_shape(item, depth=depth + 1)
-                for item in items[:_MAX_ITEMS]
+                _response_shape(item, depth=depth + 1, budget=budget)
+                for item in islice(value, _MAX_ITEMS)
+                if budget[0] > 0
             ],
         }
-        if len(items) > _MAX_ITEMS:
+        if len(value) > len(shape["items"]) or budget[0] <= 0:
             shape["truncated"] = True
         return shape
     return {"type": _value_type(value)}
@@ -181,41 +214,57 @@ def _named_scalar_values(
     wanted_keys: set[str],
     *,
     include_text: bool,
+    limit: int,
+    budget: list[int],
     path: str = "$",
     depth: int = 0,
+    found: list[dict[str, Any]] | None = None,
 ) -> list[dict[str, Any]]:
-    if depth >= _MAX_DEPTH:
-        return []
-    found: list[dict[str, Any]] = []
+    if found is None:
+        found = []
+    if (
+        depth >= _MAX_DEPTH
+        or len(found) >= limit
+        or not _consume_budget(budget)
+    ):
+        return found
     if isinstance(value, Mapping):
-        for index, (key, item) in enumerate(list(value.items())[:_MAX_FIELDS]):
+        for index, (key, item) in enumerate(
+            islice(value.items(), _MAX_FIELDS)
+        ):
+            if len(found) >= limit or budget[0] <= 0:
+                break
             safe_key = _safe_field_name(key, index)
             item_path = f"{path}.{safe_key}"
             normalized_key = _normalized_key(key)
             if normalized_key in wanted_keys and _is_safe_scalar(item, include_text):
                 found.append({"path": item_path, "value": item})
-            found.extend(
-                _named_scalar_values(
-                    item,
-                    wanted_keys,
-                    include_text=include_text,
-                    path=item_path,
-                    depth=depth + 1,
-                )
+            _named_scalar_values(
+                item,
+                wanted_keys,
+                include_text=include_text,
+                limit=limit,
+                budget=budget,
+                path=item_path,
+                depth=depth + 1,
+                found=found,
             )
     elif isinstance(value, Sequence) and not isinstance(
         value,
         str | bytes | bytearray,
     ):
-        for index, item in enumerate(list(value)[:_MAX_ITEMS]):
-            found.extend(
-                _named_scalar_values(
-                    item,
-                    wanted_keys,
-                    include_text=include_text,
-                    path=f"{path}[{index}]",
-                    depth=depth + 1,
-                )
+        for index, item in enumerate(islice(value, _MAX_ITEMS)):
+            if len(found) >= limit or budget[0] <= 0:
+                break
+            _named_scalar_values(
+                item,
+                wanted_keys,
+                include_text=include_text,
+                limit=limit,
+                budget=budget,
+                path=f"{path}[{index}]",
+                depth=depth + 1,
+                found=found,
             )
     return found
 
@@ -223,18 +272,28 @@ def _named_scalar_values(
 def _sensitive_text_values(
     value: Any,
     supplied: Sequence[object],
+    *,
+    budget: list[int] | None = None,
 ) -> tuple[str, ...]:
+    if budget is None:
+        budget = [_MAX_NODES]
     values = {
         text
-        for item in supplied
+        for item in islice(supplied, _MAX_REDACTIONS)
         if (text := _redaction_text(item)) is not None
     }
 
     def collect(item: Any, *, key: object = "", depth: int = 0) -> None:
-        if depth >= _MAX_DEPTH:
+        if (
+            depth >= _MAX_DEPTH
+            or len(values) >= _MAX_REDACTIONS
+            or not _consume_budget(budget)
+        ):
             return
         if isinstance(item, Mapping):
-            for child_key, child_value in list(item.items())[:_MAX_FIELDS]:
+            for child_key, child_value in islice(item.items(), _MAX_FIELDS):
+                if len(values) >= _MAX_REDACTIONS or budget[0] <= 0:
+                    break
                 if _normalized_key(child_key) in _SENSITIVE_KEYS:
                     text = _redaction_text(child_value)
                     if text is not None:
@@ -244,7 +303,9 @@ def _sensitive_text_values(
             item,
             str | bytes | bytearray,
         ):
-            for child in list(item)[:_MAX_ITEMS]:
+            for child in islice(item, _MAX_ITEMS):
+                if len(values) >= _MAX_REDACTIONS or budget[0] <= 0:
+                    break
                 collect(child, key=key, depth=depth + 1)
 
     collect(value)
@@ -307,7 +368,14 @@ def _redaction_text(value: object) -> str | None:
         text = str(value)
     else:
         return None
-    return text if len(text) >= 3 else None
+    return text if 3 <= len(text) <= _MAX_REDACTION_LENGTH else None
+
+
+def _consume_budget(budget: list[int]) -> bool:
+    if budget[0] <= 0:
+        return False
+    budget[0] -= 1
+    return True
 
 
 def _is_empty(value: Any) -> bool:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
@@ -1,0 +1,343 @@
+"""Privacy-safe diagnostics for staged cloud operations."""
+
+from __future__ import annotations
+
+import re
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+_MISSING = object()
+_MAX_DEPTH = 5
+_MAX_FIELDS = 40
+_MAX_ITEMS = 4
+_MAX_MESSAGES = 4
+_MAX_MESSAGE_LENGTH = 240
+
+_SAFE_KEY = re.compile(r"^[A-Za-z_][A-Za-z0-9_.-]{0,63}$")
+_SENSITIVE_KEYS = {
+    "accesstoken",
+    "apikey",
+    "appid",
+    "appkey",
+    "appsecret",
+    "authorization",
+    "clientid",
+    "clientsecret",
+    "cookie",
+    "deviceid",
+    "devicename",
+    "did",
+    "familyid",
+    "host",
+    "p2pinfo",
+    "refreshtoken",
+    "secretid",
+    "secretkey",
+    "serialnumber",
+    "sessiontoken",
+    "signature",
+    "sn",
+    "token",
+    "uid",
+    "username",
+    "uuid",
+    "xp2pinfo",
+    "xp2pkey",
+    "xp2psecretkey",
+}
+_CODE_KEYS = {
+    "code",
+    "errorcode",
+    "errno",
+    "statuscode",
+}
+_MESSAGE_KEYS = {
+    "detail",
+    "error",
+    "errormessage",
+    "message",
+    "msg",
+    "reason",
+}
+_ASSIGNED_SENSITIVE_VALUE = re.compile(
+    r"(?i)\b(access[_-]?token|app[_-]?(?:id|key|secret)|client[_-]?(?:id|secret)|"
+    r"device[_-]?(?:id|name)|did|family[_-]?id|p2p[_-]?info|refresh[_-]?token|"
+    r"secret[_-]?(?:id|key)|serial[_-]?number|session[_-]?token|sn|token|uid|"
+    r"username|uuid|xp2p[_-]?(?:info|key|secretkey))\b"
+    r"([\"']?)(\s*(?:[:=]\s*|\s+))([\"']?)[^\s,;&\"'}]+"
+)
+_BEARER_VALUE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
+_URL_VALUE = re.compile(r"(?i)\bhttps?://[^\s,;\"']+")
+_EMAIL_VALUE = re.compile(r"(?i)\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
+_LONG_INTEGER = re.compile(r"\b\d{6,}\b")
+_TOKEN_LIKE_VALUE = re.compile(r"\b[A-Za-z0-9_+/=-]{24,}\b")
+
+
+def build_operation_stage_diagnostics(
+    stage: str,
+    *,
+    request_context: Mapping[str, Any] | None = None,
+    response: Any = _MISSING,
+    result: Mapping[str, Any] | None = None,
+    error: BaseException | None = None,
+    sensitive_values: Sequence[object] = (),
+) -> dict[str, Any]:
+    """Return one bounded stage summary without retaining response values."""
+    payload: dict[str, Any] = {"stage": _safe_local_text(stage)}
+    if request_context:
+        payload["request"] = {
+            _safe_field_name(key, index): _safe_context_value(value)
+            for index, (key, value) in enumerate(
+                list(request_context.items())[:_MAX_FIELDS]
+            )
+        }
+    if response is not _MISSING:
+        payload["response"] = summarize_operation_response(
+            response,
+            sensitive_values=sensitive_values,
+        )
+    if result:
+        payload["result"] = {
+            _safe_field_name(key, index): _safe_context_value(value)
+            for index, (key, value) in enumerate(list(result.items())[:_MAX_FIELDS])
+        }
+    if error is not None:
+        redactions = _sensitive_text_values(response, sensitive_values)
+        payload["error"] = {
+            "type": type(error).__name__,
+            "message": _sanitize_message(str(error), redactions),
+        }
+    return payload
+
+
+def summarize_operation_response(
+    value: Any,
+    *,
+    sensitive_values: Sequence[object] = (),
+) -> dict[str, Any]:
+    """Return response shape, safe status codes, and sanitized messages."""
+    redactions = _sensitive_text_values(value, sensitive_values)
+    summary: dict[str, Any] = {
+        "type": _value_type(value),
+        "empty": _is_empty(value),
+        "shape": _response_shape(value, depth=0),
+    }
+    codes = _named_scalar_values(value, _CODE_KEYS, include_text=False)
+    if codes:
+        summary["codes"] = codes
+    messages = _named_scalar_values(value, _MESSAGE_KEYS, include_text=True)
+    if messages:
+        summary["messages"] = [
+            {
+                "path": item["path"],
+                "text": _sanitize_message(str(item["value"]), redactions),
+            }
+            for item in messages[:_MAX_MESSAGES]
+        ]
+    return summary
+
+
+def _response_shape(value: Any, *, depth: int) -> Any:
+    if depth >= _MAX_DEPTH:
+        return {"type": _value_type(value), "truncated": True}
+    if isinstance(value, Mapping):
+        items = list(value.items())
+        fields = [
+            {
+                "name": _safe_field_name(key, index),
+                "shape": _response_shape(item, depth=depth + 1),
+            }
+            for index, (key, item) in enumerate(items[:_MAX_FIELDS])
+        ]
+        shape: dict[str, Any] = {
+            "type": "object",
+            "field_count": len(items),
+            "fields": fields,
+        }
+        if len(items) > _MAX_FIELDS:
+            shape["truncated"] = True
+        return shape
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        str | bytes | bytearray,
+    ):
+        items = list(value)
+        shape = {
+            "type": "array",
+            "item_count": len(items),
+            "items": [
+                _response_shape(item, depth=depth + 1)
+                for item in items[:_MAX_ITEMS]
+            ],
+        }
+        if len(items) > _MAX_ITEMS:
+            shape["truncated"] = True
+        return shape
+    return {"type": _value_type(value)}
+
+
+def _named_scalar_values(
+    value: Any,
+    wanted_keys: set[str],
+    *,
+    include_text: bool,
+    path: str = "$",
+    depth: int = 0,
+) -> list[dict[str, Any]]:
+    if depth >= _MAX_DEPTH:
+        return []
+    found: list[dict[str, Any]] = []
+    if isinstance(value, Mapping):
+        for index, (key, item) in enumerate(list(value.items())[:_MAX_FIELDS]):
+            safe_key = _safe_field_name(key, index)
+            item_path = f"{path}.{safe_key}"
+            normalized_key = _normalized_key(key)
+            if normalized_key in wanted_keys and _is_safe_scalar(item, include_text):
+                found.append({"path": item_path, "value": item})
+            found.extend(
+                _named_scalar_values(
+                    item,
+                    wanted_keys,
+                    include_text=include_text,
+                    path=item_path,
+                    depth=depth + 1,
+                )
+            )
+    elif isinstance(value, Sequence) and not isinstance(
+        value,
+        str | bytes | bytearray,
+    ):
+        for index, item in enumerate(list(value)[:_MAX_ITEMS]):
+            found.extend(
+                _named_scalar_values(
+                    item,
+                    wanted_keys,
+                    include_text=include_text,
+                    path=f"{path}[{index}]",
+                    depth=depth + 1,
+                )
+            )
+    return found
+
+
+def _sensitive_text_values(
+    value: Any,
+    supplied: Sequence[object],
+) -> tuple[str, ...]:
+    values = {
+        text
+        for item in supplied
+        if (text := _redaction_text(item)) is not None
+    }
+
+    def collect(item: Any, *, key: object = "", depth: int = 0) -> None:
+        if depth >= _MAX_DEPTH:
+            return
+        if isinstance(item, Mapping):
+            for child_key, child_value in list(item.items())[:_MAX_FIELDS]:
+                if _normalized_key(child_key) in _SENSITIVE_KEYS:
+                    text = _redaction_text(child_value)
+                    if text is not None:
+                        values.add(text)
+                collect(child_value, key=child_key, depth=depth + 1)
+        elif isinstance(item, Sequence) and not isinstance(
+            item,
+            str | bytes | bytearray,
+        ):
+            for child in list(item)[:_MAX_ITEMS]:
+                collect(child, key=key, depth=depth + 1)
+
+    collect(value)
+    return tuple(sorted(values, key=len, reverse=True))
+
+
+def _sanitize_message(value: str, redactions: Sequence[str]) -> str:
+    text = value.replace("\r", " ").replace("\n", " ")
+    for sensitive in redactions:
+        text = text.replace(sensitive, "**REDACTED**")
+    text = _ASSIGNED_SENSITIVE_VALUE.sub(
+        lambda match: (
+            f"{match.group(1)}{match.group(2)}{match.group(3)}"
+            f"{match.group(4)}**REDACTED**"
+        ),
+        text,
+    )
+    text = _BEARER_VALUE.sub("Bearer **REDACTED**", text)
+    text = _URL_VALUE.sub("**REDACTED_URL**", text)
+    text = _EMAIL_VALUE.sub("**REDACTED_EMAIL**", text)
+    text = _LONG_INTEGER.sub("**REDACTED_ID**", text)
+    text = _TOKEN_LIKE_VALUE.sub("**REDACTED_VALUE**", text)
+    if len(text) > _MAX_MESSAGE_LENGTH:
+        return f"{text[: _MAX_MESSAGE_LENGTH - 3]}..."
+    return text
+
+
+def _safe_field_name(value: object, index: int) -> str:
+    text = str(value)
+    if _SAFE_KEY.fullmatch(text):
+        return text
+    return f"<dynamic-field-{index}>"
+
+
+def _safe_local_text(value: object) -> str:
+    text = str(value)
+    return text if _SAFE_KEY.fullmatch(text) else "operation"
+
+
+def _safe_context_value(value: Any) -> Any:
+    if isinstance(value, bool) or value is None:
+        return value
+    if isinstance(value, int | float):
+        return value
+    if isinstance(value, str) and _SAFE_KEY.fullmatch(value):
+        return value
+    return {"type": _value_type(value), "present": not _is_empty(value)}
+
+
+def _is_safe_scalar(value: Any, include_text: bool) -> bool:
+    if isinstance(value, bool | int | float) or value is None:
+        return True
+    return include_text and isinstance(value, str)
+
+
+def _redaction_text(value: object) -> str | None:
+    if isinstance(value, str):
+        text = value
+    elif isinstance(value, int):
+        text = str(value)
+    else:
+        return None
+    return text if len(text) >= 3 else None
+
+
+def _is_empty(value: Any) -> bool:
+    if value is None:
+        return True
+    if isinstance(value, str | bytes | bytearray | Mapping | Sequence):
+        return len(value) == 0
+    return False
+
+
+def _normalized_key(value: object) -> str:
+    return re.sub(r"[^a-z0-9]", "", str(value).casefold())
+
+
+def _value_type(value: Any) -> str:
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, int):
+        return "integer"
+    if isinstance(value, float):
+        return "number"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, Mapping):
+        return "object"
+    if isinstance(value, Sequence) and not isinstance(
+        value,
+        str | bytes | bytearray,
+    ):
+        return "array"
+    return type(value).__name__

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
@@ -73,6 +73,16 @@ _ASSIGNED_SENSITIVE_VALUE = re.compile(
     r"username|uuid|xp2p[_-]?(?:info|key|secretkey))\b"
     r"([\"']?)(\s*(?:[:=]\s*|\s+))([\"']?)[^\s,;&\"'}]+"
 )
+_QUOTED_ASSIGNED_SENSITIVE_VALUE = re.compile(
+    r"(?i)\b("
+    r"access[_\s-]?token|app[_\s-]?(?:id|key|secret)|"
+    r"channel[_\s-]?id|client[_\s-]?(?:id|secret)|"
+    r"device[_\s-]?(?:id|name)|did|family[_\s-]?id|"
+    r"p2p[_\s-]?info|refresh[_\s-]?token|secret[_\s-]?(?:id|key)|"
+    r"serial[_\s-]?number|session[_\s-]?token|sn|token|uid|username|uuid|"
+    r"xp2p[_\s-]?(?:info|key|secret(?:[_\s-]?key))"
+    r""")\b(\s*(?:[:=]\s*|\s+))(?P<value>"[^"]*"|'[^']*')"""
+)
 _SPACE_SEPARATED_SENSITIVE_VALUE = re.compile(
     r"(?i)\b("
     r"access\s+token|app\s+(?:id|key|secret)|channel\s+id|"
@@ -324,6 +334,13 @@ def _sanitize_message(value: str, redactions: Sequence[str]) -> str:
     text = value.replace("\r", " ").replace("\n", " ")
     for sensitive in redactions:
         text = text.replace(sensitive, "**REDACTED**")
+    text = _QUOTED_ASSIGNED_SENSITIVE_VALUE.sub(
+        lambda match: (
+            f"{match.group(1)}{match.group(2)}{match.group('value')[0]}"
+            f"**REDACTED**{match.group('value')[-1]}"
+        ),
+        text,
+    )
     text = _SPACE_SEPARATED_SENSITIVE_VALUE.sub(
         lambda match: (
             f"{match.group(1)}{match.group(2)}{match.group(3)}"

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/operation_diagnostics.py
@@ -73,6 +73,14 @@ _ASSIGNED_SENSITIVE_VALUE = re.compile(
     r"username|uuid|xp2p[_-]?(?:info|key|secretkey))\b"
     r"([\"']?)(\s*(?:[:=]\s*|\s+))([\"']?)[^\s,;&\"'}]+"
 )
+_SPACE_SEPARATED_SENSITIVE_VALUE = re.compile(
+    r"(?i)\b("
+    r"access\s+token|app\s+(?:id|key|secret)|channel\s+id|"
+    r"client\s+(?:id|secret)|device\s+(?:id|name)|family\s+id|"
+    r"p2p\s+info|refresh\s+token|secret\s+(?:id|key)|"
+    r"serial\s+number|session\s+token|xp2p\s+(?:info|key|secret\s+key)"
+    r")\b([\"']?)(\s*(?:[:=]\s*|\s+))([\"']?)[^,;&\"'}]+"
+)
 _BEARER_VALUE = re.compile(r"(?i)\bbearer\s+[^\s,;]+")
 _URL_VALUE = re.compile(r"(?i)\bhttps?://[^\s,;\"']+")
 _EMAIL_VALUE = re.compile(r"(?i)\b[^@\s]+@[^@\s]+\.[^@\s]+\b")
@@ -316,6 +324,13 @@ def _sanitize_message(value: str, redactions: Sequence[str]) -> str:
     text = value.replace("\r", " ").replace("\n", " ")
     for sensitive in redactions:
         text = text.replace(sensitive, "**REDACTED**")
+    text = _SPACE_SEPARATED_SENSITIVE_VALUE.sub(
+        lambda match: (
+            f"{match.group(1)}{match.group(2)}{match.group(3)}"
+            f"{match.group(4)}**REDACTED**"
+        ),
+        text,
+    )
     text = _ASSIGNED_SENSITIVE_VALUE.sub(
         lambda match: (
             f"{match.group(1)}{match.group(2)}{match.group(3)}"

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -516,6 +516,24 @@ class DreameMowerDreameHomeCloudProtocol:
             return response["data"]
         return response
 
+    def get_tx_video_user_eligibility(
+        self,
+        access_token: str | None = None,
+        os: int = 1,
+    ) -> Any:
+        """Return the read-only TX video eligibility response for this device."""
+        params = {"did": self._did, "os": os}
+        if access_token:
+            params["accesstoken"] = access_token
+            params["accessToken"] = access_token
+        response = self.request(
+            f"{self.get_api_url()}/dreame-third-video/tx/dev/isDevUser",
+            json.dumps(params, separators=(",", ":")),
+        )
+        if response and "data" in response and response.get("code", 0) == 0:
+            return response["data"]
+        return response
+
     def get_tx_video_p2p_info(
         self,
         access_token: str | None = None,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -529,6 +529,8 @@ class DreameMowerDreameHomeCloudProtocol:
         response = self.request(
             f"{self.get_api_url()}/dreame-third-video/tx/dev/isDevUser",
             json.dumps(params, separators=(",", ":")),
+            retry_count=0,
+            timeout=5,
         )
         if response and "data" in response and response.get("code", 0) == 0:
             return response["data"]
@@ -828,7 +830,7 @@ class DreameMowerDreameHomeCloudProtocol:
             return None
         return api_response["result"]
 
-    def request(self, url: str, data, retry_count=2) -> Any:
+    def request(self, url: str, data, retry_count=2, timeout=20) -> Any:
         _LOGGER.debug(
             "DreameMowerDreameHomeCloudProtocol.request %s %s",
             url,
@@ -839,8 +841,6 @@ class DreameMowerDreameHomeCloudProtocol:
         if not retry_count or retry_count < 0:
             retry_count = 0
         while retries < retry_count + 1:
-            # Original timeout was set to 5, which timed out for map requests.
-            timeout = 20
             try:
                 if self._key_expire and time.time() > self._key_expire:
                     self.login()

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -140,6 +140,7 @@ class DreameLawnMowerVideoCamera(
         self._last_runtime_inputs_ready: bool | None = None
         self._last_runtime_inputs_source: str | None = None
         self._last_runtime_inputs_missing: tuple[str, ...] = ()
+        self._last_runtime_input_diagnostics: dict[str, Any] | None = None
         self._last_stream_health: dict[str, Any] | None = None
         self._last_stream_enable_result: Any | None = None
         self._last_stream_disable_error: str | None = None
@@ -301,6 +302,11 @@ class DreameLawnMowerVideoCamera(
             "last_runtime_inputs_ready": self._last_runtime_inputs_ready,
             "last_runtime_inputs_source": self._last_runtime_inputs_source,
             "last_runtime_inputs_missing": self._last_runtime_inputs_missing,
+            "last_runtime_input_diagnostics": getattr(
+                self,
+                "_last_runtime_input_diagnostics",
+                None,
+            ),
             "last_stream_enable_result": self._last_stream_enable_result,
             "last_stream_disable_error": self._last_stream_disable_error,
             "last_native_runtime_diagnostics": self._last_native_runtime_diagnostics,
@@ -882,7 +888,22 @@ class DreameLawnMowerVideoCamera(
         self,
     ) -> DreameLawnMowerCameraStreamRuntimeInputs:
         """Fetch cloud inputs and stage configuration for health-checked use."""
-        inputs = await self.coordinator.client.async_get_camera_stream_runtime_inputs()
+        try:
+            inputs = (
+                await self.coordinator.client.async_get_camera_stream_runtime_inputs()
+            )
+        except Exception:
+            self._last_runtime_input_diagnostics = sanitize_debug_data(
+                getattr(
+                    self.coordinator.client,
+                    "last_camera_stream_diagnostics",
+                    {},
+                )
+            )
+            raise
+        self._last_runtime_input_diagnostics = sanitize_debug_data(
+            getattr(inputs, "diagnostics", {})
+        )
         self._last_runtime_inputs_ready = inputs.ready
         self._last_runtime_inputs_source = inputs.source
         self._last_runtime_inputs_missing = inputs.missing_required

--- a/tests/test_cloud_key_definition.py
+++ b/tests/test_cloud_key_definition.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import json
+
 import pytest
 
 from dreame_lawn_mower_client import DreameLawnMowerClient
@@ -419,6 +421,53 @@ def test_camera_stream_failure_retains_sanitized_stage_diagnostics() -> None:
     serialized_diagnostics = str(diagnostics)
     assert "secret-token" not in serialized_diagnostics
     assert "device-123456" not in serialized_diagnostics
+
+
+def test_camera_stream_unexpected_failure_records_the_active_stage() -> None:
+    class _MalformedIdentityCloud(_FakeCloud):
+        def get_tx_video_device_identity(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            raise json.JSONDecodeError("Expecting value", "", 0)
+
+    client = _client()
+    client._sync_get_cloud_protocol = lambda: _MalformedIdentityCloud()
+
+    with pytest.raises(json.JSONDecodeError):
+        client._sync_get_camera_stream_inputs()
+
+    diagnostics = client.last_camera_stream_diagnostics
+    assert diagnostics["completed"] is False
+    assert diagnostics["stages"][-1]["stage"] == "cloud_device_identity"
+    assert diagnostics["stages"][-1]["error"]["type"] == "JSONDecodeError"
+
+
+def test_camera_stream_later_failure_redacts_identity_values() -> None:
+    class _FailingP2pCloud(_FakeCloud):
+        def get_tx_video_p2p_info(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            raise client_module.DeviceException(
+                f"request failed for Mower Camera channel-1 {ENCRYPTED_APP_ID}"
+            )
+
+    client = _client()
+    client._sync_get_cloud_protocol = lambda: _FailingP2pCloud()
+
+    with pytest.raises(client_module.DreameLawnMowerConnectionError):
+        client._sync_get_camera_stream_inputs()
+
+    diagnostics = client.last_camera_stream_diagnostics
+    assert diagnostics["completed"] is False
+    assert diagnostics["stages"][-1]["stage"] == "cloud_p2p_info"
+    serialized_diagnostics = str(diagnostics)
+    assert "Mower Camera" not in serialized_diagnostics
+    assert "channel-1" not in serialized_diagnostics
+    assert ENCRYPTED_APP_ID not in serialized_diagnostics
 
 
 def test_camera_stream_setup_failure_replaces_stale_diagnostics() -> None:

--- a/tests/test_cloud_key_definition.py
+++ b/tests/test_cloud_key_definition.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from dreame_lawn_mower_client import DreameLawnMowerClient
 from dreame_lawn_mower_client._loader import load_internal_module
 from dreame_lawn_mower_client.models import (
@@ -221,6 +223,20 @@ def test_camera_stream_inputs_use_tx_video_endpoints() -> None:
     )
     assert result["p2p_info"]["available"] is True
     assert result["p2p_info"]["p2p_info"] == "p2p-info-1"
+    diagnostics = result["diagnostics"]
+    assert diagnostics["ready"] is True
+    assert diagnostics["missing_required"] == ()
+    assert diagnostics["completed"] is True
+    assert [stage["stage"] for stage in diagnostics["stages"]] == [
+        "cloud_access_token",
+        "cloud_device_identity",
+        "cloud_p2p_info",
+    ]
+    serialized_diagnostics = str(diagnostics)
+    assert "access-token-1" not in serialized_diagnostics
+    assert "p2p-info-1" not in serialized_diagnostics
+    assert ENCRYPTED_APP_ID not in serialized_diagnostics
+    assert ENCRYPTED_APP_SECRET not in serialized_diagnostics
 
 
 def test_tx_video_cloud_logs_redact_request_and_response_material() -> None:
@@ -238,6 +254,35 @@ def test_tx_video_cloud_logs_redact_request_and_response_material() -> None:
         "https://example.invalid/ordinary-endpoint",
         '{"status":"ok"}',
     ) == '{"status":"ok"}'
+
+
+def test_tx_video_user_eligibility_uses_read_only_device_endpoint() -> None:
+    cloud = object.__new__(protocol_module.DreameMowerDreameHomeCloudProtocol)
+    cloud._did = "device-1"
+    cloud.get_api_url = lambda: "https://example.invalid"
+    requests: list[tuple[str, str]] = []
+
+    def _request(url: str, payload: str) -> dict[str, object]:
+        requests.append((url, payload))
+        return {"code": 0, "data": {"isDevUser": True}}
+
+    cloud.request = _request
+
+    result = cloud.get_tx_video_user_eligibility(
+        access_token="access-token-1",
+        os=1,
+    )
+
+    assert result == {"isDevUser": True}
+    assert requests == [
+        (
+            "https://example.invalid/dreame-third-video/tx/dev/isDevUser",
+            (
+                '{"did":"device-1","os":1,"accesstoken":"access-token-1",'
+                '"accessToken":"access-token-1"}'
+            ),
+        )
+    ]
 
 
 def test_camera_stream_runtime_inputs_are_redactable_xp2p_contract() -> None:
@@ -296,6 +341,8 @@ def test_camera_stream_runtime_inputs_accept_device_id_alias() -> None:
 
 def test_camera_stream_runtime_inputs_require_tx_identity_fields() -> None:
     class _MissingIdentityCloud(_FakeCloud):
+        eligibility_calls = 0
+
         def get_tx_video_device_identity(
             self,
             access_token: str | None = None,
@@ -309,8 +356,23 @@ def test_camera_stream_runtime_inputs_require_tx_identity_fields() -> None:
                 "name": "Garage Mower",
             }
 
+        def get_tx_video_user_eligibility(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            assert access_token == "access-token-1"
+            assert os == 1
+            self.eligibility_calls += 1
+            return {
+                "isDevUser": True,
+                "account": "private-user@example.test",
+                "did": "device-1",
+            }
+
     client = _client()
-    client._sync_get_cloud_protocol = lambda: _MissingIdentityCloud()
+    cloud = _MissingIdentityCloud()
+    client._sync_get_cloud_protocol = lambda: cloud
 
     result = client._sync_get_camera_stream_runtime_inputs()
 
@@ -321,6 +383,35 @@ def test_camera_stream_runtime_inputs_require_tx_identity_fields() -> None:
     assert "product_id" in result.missing_required
     assert "device_name" in result.missing_required
     assert result.p2p_info == "p2p-info-1"
+    assert cloud.eligibility_calls == 1
+    eligibility = result.diagnostics["stages"][-1]
+    assert eligibility["stage"] == "cloud_user_eligibility"
+    assert eligibility["result"]["is_device_user"] == "True"
+    serialized_diagnostics = str(result.diagnostics)
+    assert "private-user@example.test" not in serialized_diagnostics
+    assert "device-1" not in serialized_diagnostics
+
+
+def test_camera_stream_failure_retains_sanitized_stage_diagnostics() -> None:
+    class _FailingCloud(_FakeCloud):
+        def get_tx_video_access_token(self, os: int = 1) -> dict[str, object]:
+            raise client_module.DeviceException(
+                "accessToken=secret-token failed for device-123456"
+            )
+
+    client = _client()
+    client._sync_get_cloud_protocol = lambda: _FailingCloud()
+
+    with pytest.raises(client_module.DreameLawnMowerConnectionError):
+        client._sync_get_camera_stream_inputs()
+
+    diagnostics = client.last_camera_stream_diagnostics
+    assert diagnostics["completed"] is False
+    assert diagnostics["stages"][0]["stage"] == "cloud_access_token"
+    assert diagnostics["stages"][0]["error"]["type"] == "DeviceException"
+    serialized_diagnostics = str(diagnostics)
+    assert "secret-token" not in serialized_diagnostics
+    assert "device-123456" not in serialized_diagnostics
 
 
 def test_tx_video_identity_decryption_matches_dreamehome_contract() -> None:

--- a/tests/test_cloud_key_definition.py
+++ b/tests/test_cloud_key_definition.py
@@ -228,6 +228,7 @@ def test_camera_stream_inputs_use_tx_video_endpoints() -> None:
     assert diagnostics["missing_required"] == ()
     assert diagnostics["completed"] is True
     assert [stage["stage"] for stage in diagnostics["stages"]] == [
+        "cloud_setup",
         "cloud_access_token",
         "cloud_device_identity",
         "cloud_p2p_info",
@@ -260,10 +261,14 @@ def test_tx_video_user_eligibility_uses_read_only_device_endpoint() -> None:
     cloud = object.__new__(protocol_module.DreameMowerDreameHomeCloudProtocol)
     cloud._did = "device-1"
     cloud.get_api_url = lambda: "https://example.invalid"
-    requests: list[tuple[str, str]] = []
+    requests: list[tuple[str, str, dict[str, int]]] = []
 
-    def _request(url: str, payload: str) -> dict[str, object]:
-        requests.append((url, payload))
+    def _request(
+        url: str,
+        payload: str,
+        **kwargs: int,
+    ) -> dict[str, object]:
+        requests.append((url, payload, kwargs))
         return {"code": 0, "data": {"isDevUser": True}}
 
     cloud.request = _request
@@ -281,6 +286,7 @@ def test_tx_video_user_eligibility_uses_read_only_device_endpoint() -> None:
                 '{"did":"device-1","os":1,"accesstoken":"access-token-1",'
                 '"accessToken":"access-token-1"}'
             ),
+            {"retry_count": 0, "timeout": 5},
         )
     ]
 
@@ -407,11 +413,63 @@ def test_camera_stream_failure_retains_sanitized_stage_diagnostics() -> None:
 
     diagnostics = client.last_camera_stream_diagnostics
     assert diagnostics["completed"] is False
-    assert diagnostics["stages"][0]["stage"] == "cloud_access_token"
-    assert diagnostics["stages"][0]["error"]["type"] == "DeviceException"
+    assert diagnostics["stages"][0]["stage"] == "cloud_setup"
+    assert diagnostics["stages"][1]["stage"] == "cloud_access_token"
+    assert diagnostics["stages"][1]["error"]["type"] == "DeviceException"
     serialized_diagnostics = str(diagnostics)
     assert "secret-token" not in serialized_diagnostics
     assert "device-123456" not in serialized_diagnostics
+
+
+def test_camera_stream_setup_failure_replaces_stale_diagnostics() -> None:
+    client = _client()
+    client._last_camera_stream_diagnostics = {"operation": "stale"}
+
+    def _fail_setup():
+        raise client_module.DreameLawnMowerConnectionError(
+            "Cloud connection is unavailable."
+        )
+
+    client._sync_get_cloud_protocol = _fail_setup
+
+    with pytest.raises(client_module.DreameLawnMowerConnectionError):
+        client._sync_get_camera_stream_inputs()
+
+    diagnostics = client.last_camera_stream_diagnostics
+    assert diagnostics["completed"] is False
+    assert diagnostics["stages"][0]["stage"] == "cloud_setup"
+    assert diagnostics["stages"][0]["error"]["type"] == (
+        "DreameLawnMowerConnectionError"
+    )
+    assert "stale" not in str(diagnostics)
+
+
+def test_camera_stream_eligibility_failure_keeps_incomplete_result() -> None:
+    class _EligibilityFailureCloud(_FakeCloud):
+        def get_tx_video_device_identity(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            return {"message": "identity unavailable"}
+
+        def get_tx_video_user_eligibility(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            raise ValueError("malformed eligibility response")
+
+    client = _client()
+    client._sync_get_cloud_protocol = lambda: _EligibilityFailureCloud()
+
+    result = client._sync_get_camera_stream_runtime_inputs()
+
+    assert result.ready is False
+    eligibility = result.diagnostics["stages"][-1]
+    assert eligibility["stage"] == "cloud_user_eligibility"
+    assert eligibility["error"]["type"] == "ValueError"
+    assert result.diagnostics["completed"] is True
 
 
 def test_tx_video_identity_decryption_matches_dreamehome_contract() -> None:

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -164,7 +164,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
         device=device,
     )
 
-    assert payload["diagnostic_schema_version"] == 6
+    assert payload["diagnostic_schema_version"] == 7
     assert payload["entry"]["username"] == "**REDACTED**"
     assert payload["entry"]["password"] == "**REDACTED**"
     assert payload["entry"]["token"] == "**REDACTED**"
@@ -272,7 +272,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
     }
     assert payload["state_reconciliation"]["warnings"] == []
     assert payload["triage"] == {
-        "schema_version": 6,
+        "schema_version": 7,
         "known_model": True,
         "model": "dreame.mower.g2408",
         "display_model": "A2",
@@ -507,7 +507,7 @@ def test_build_debug_payload_highlights_state_disagreements() -> None:
         "raw_mower_state_looks_docked_but_raw_docked_false",
         "raw_mower_state_differs_from_state_name",
     ]
-    assert payload["triage"]["schema_version"] == 6
+    assert payload["triage"]["schema_version"] == 7
     assert payload["triage"]["error"] == {
         "active": True,
         "code": 73,

--- a/tests/test_diagnostics_download.py
+++ b/tests/test_diagnostics_download.py
@@ -81,6 +81,35 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
             "anonymous_feature": _AnonymousFeature(0),
             "last_stream_error_code": "video_cloud_start_failed",
             "last_stream_error": "accessToken=secret failed",
+            "last_runtime_input_diagnostics": {
+                "operation": "camera_stream_inputs",
+                "stages": [
+                    {
+                        "stage": "cloud_device_identity",
+                        "response": {
+                            "type": "object",
+                            "shape": {
+                                "fields": [
+                                    {
+                                        "name": "deviceName",
+                                        "shape": {"type": "string"},
+                                    },
+                                    {
+                                        "name": "productId",
+                                        "shape": {"type": "string"},
+                                    },
+                                ]
+                            },
+                        },
+                        "error": {
+                            "message": (
+                                "accessToken=secret-token failed for "
+                                "deviceName=private-mower"
+                            )
+                        },
+                    }
+                ],
+            },
         },
     )
     hass = SimpleNamespace(
@@ -137,7 +166,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
     )
 
-    assert payload["diagnostic_schema_version"] == 6
+    assert payload["diagnostic_schema_version"] == 7
     assert payload["report_context"]["integration_version"] == "0.3.0"
     assert payload["report_context"]["home_assistant"]["arch"] == "aarch64"
     assert "user" not in payload["report_context"]["home_assistant"]
@@ -148,6 +177,17 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         "accessToken=**REDACTED** failed"
     )
     assert payload["entities"][0]["attributes"]["anonymous_feature"] == 0
+    operation = payload["entities"][0]["attributes"][
+        "last_runtime_input_diagnostics"
+    ]
+    assert operation["stages"][0]["stage"] == "cloud_device_identity"
+    assert operation["stages"][0]["response"]["shape"]["fields"] == [
+        {"name": "deviceName", "shape": {"type": "string"}},
+        {"name": "productId", "shape": {"type": "string"}},
+    ]
+    assert operation["stages"][0]["error"]["message"] == (
+        "accessToken=**REDACTED** failed for deviceName=**REDACTED**"
+    )
     assert payload["recent_events"][0]["code"] == "video_cloud_start_failed"
     assert payload["recent_events"][0]["message"] == (
         "accessToken=**REDACTED** failed"

--- a/tests/test_operation_diagnostics.py
+++ b/tests/test_operation_diagnostics.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import json
+from collections.abc import Iterator, Mapping
+from typing import Any
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     operation_diagnostics,
@@ -19,11 +21,13 @@ def test_operation_summary_keeps_shape_codes_and_sanitized_messages() -> None:
         "code": 403,
         "message": (
             "accessToken=secret-access-token denied for deviceName=Mower-123456 "
+            "on channelId=10425/private-camera "
             "at https://video.example.test/live?token=another-secret"
         ),
         "data": {
             "accessToken": "secret-access-token",
             "deviceName": "Mower-123456",
+            "channelId": "10425/private-camera",
             "p2pInfo": "secret-p2p-material",
             "features": ["video", "audio"],
         },
@@ -44,9 +48,11 @@ def test_operation_summary_keeps_shape_codes_and_sanitized_messages() -> None:
     assert p2p_field["shape"] == {"type": "string"}
     assert "accessToken=**REDACTED**" in summary["messages"][0]["text"]
     assert "deviceName=**REDACTED**" in summary["messages"][0]["text"]
+    assert "channelId=**REDACTED**" in summary["messages"][0]["text"]
     assert "**REDACTED_URL**" in summary["messages"][0]["text"]
     assert "secret-access-token" not in serialized
     assert "Mower-123456" not in serialized
+    assert "10425/private-camera" not in serialized
     assert "secret-p2p-material" not in serialized
     assert "another-secret" not in serialized
 
@@ -59,6 +65,42 @@ def test_operation_summary_bounds_dynamic_response_fields() -> None:
     assert summary["shape"]["field_count"] == 45
     assert len(summary["shape"]["fields"]) == 40
     assert summary["shape"]["truncated"] is True
+
+
+def test_operation_summary_does_not_materialize_complete_mappings() -> None:
+    class _CountingMapping(Mapping[str, Any]):
+        iterations = 0
+
+        def __len__(self) -> int:
+            return 10_000
+
+        def __iter__(self) -> Iterator[str]:
+            for index in range(10_000):
+                self.iterations += 1
+                yield f"field_{index}"
+
+        def __getitem__(self, key: str) -> int:
+            return int(key.removeprefix("field_"))
+
+    response = _CountingMapping()
+
+    summary = summarize_operation_response(response)
+
+    assert response.iterations <= 200
+    assert summary["shape"]["field_count"] == 10_000
+    assert len(summary["shape"]["fields"]) == 40
+    assert summary["shape"]["truncated"] is True
+
+
+def test_operation_summary_applies_a_global_nested_node_budget() -> None:
+    response: dict[str, Any] = {}
+    for index in range(40):
+        response[f"branch_{index}"] = response
+
+    serialized = json.dumps(summarize_operation_response(response))
+
+    assert len(serialized) < 30_000
+    assert '"truncated": true' in serialized
 
 
 def test_operation_stage_error_never_requires_a_response_payload() -> None:

--- a/tests/test_operation_diagnostics.py
+++ b/tests/test_operation_diagnostics.py
@@ -1,0 +1,79 @@
+"""Privacy and shape tests for reusable staged-operation diagnostics."""
+
+from __future__ import annotations
+
+import json
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    operation_diagnostics,
+)
+
+build_operation_stage_diagnostics = (
+    operation_diagnostics.build_operation_stage_diagnostics
+)
+summarize_operation_response = operation_diagnostics.summarize_operation_response
+
+
+def test_operation_summary_keeps_shape_codes_and_sanitized_messages() -> None:
+    response = {
+        "code": 403,
+        "message": (
+            "accessToken=secret-access-token denied for deviceName=Mower-123456 "
+            "at https://video.example.test/live?token=another-secret"
+        ),
+        "data": {
+            "accessToken": "secret-access-token",
+            "deviceName": "Mower-123456",
+            "p2pInfo": "secret-p2p-material",
+            "features": ["video", "audio"],
+        },
+    }
+
+    summary = summarize_operation_response(response)
+    serialized = json.dumps(summary)
+
+    assert summary["codes"] == [{"path": "$.code", "value": 403}]
+    data_field = next(
+        field for field in summary["shape"]["fields"] if field["name"] == "data"
+    )
+    p2p_field = next(
+        field
+        for field in data_field["shape"]["fields"]
+        if field["name"] == "p2pInfo"
+    )
+    assert p2p_field["shape"] == {"type": "string"}
+    assert "accessToken=**REDACTED**" in summary["messages"][0]["text"]
+    assert "deviceName=**REDACTED**" in summary["messages"][0]["text"]
+    assert "**REDACTED_URL**" in summary["messages"][0]["text"]
+    assert "secret-access-token" not in serialized
+    assert "Mower-123456" not in serialized
+    assert "secret-p2p-material" not in serialized
+    assert "another-secret" not in serialized
+
+
+def test_operation_summary_bounds_dynamic_response_fields() -> None:
+    response = {f"field_{index}": index for index in range(45)}
+
+    summary = summarize_operation_response(response)
+
+    assert summary["shape"]["field_count"] == 45
+    assert len(summary["shape"]["fields"]) == 40
+    assert summary["shape"]["truncated"] is True
+
+
+def test_operation_stage_error_never_requires_a_response_payload() -> None:
+    stage = build_operation_stage_diagnostics(
+        "cloud_access_token",
+        request_context={"did_present": True, "os": 1},
+        error=RuntimeError(
+            "Bearer secret-access-token failed for user@example.test 12345678"
+        ),
+        sensitive_values=("secret-access-token",),
+    )
+
+    assert "response" not in stage
+    assert stage["request"] == {"did_present": True, "os": 1}
+    assert stage["error"]["type"] == "RuntimeError"
+    assert stage["error"]["message"] == (
+        "Bearer **REDACTED** failed for **REDACTED_EMAIL** **REDACTED_ID**"
+    )

--- a/tests/test_operation_diagnostics.py
+++ b/tests/test_operation_diagnostics.py
@@ -135,3 +135,21 @@ def test_operation_summary_redacts_space_separated_device_name() -> None:
     assert message == "device name=**REDACTED**"
     assert "Garage Mower" not in message
     assert "10425/private-camera" not in message
+
+
+def test_operation_summary_redacts_quoted_multi_word_device_name() -> None:
+    summary = summarize_operation_response(
+        {
+            "message": (
+                'deviceName="John\'s Mower" unavailable on '
+                "channelId='Garage \"North\" camera'"
+            )
+        }
+    )
+
+    message = summary["messages"][0]["text"]
+    assert message == (
+        'deviceName="**REDACTED**" unavailable on channelId=\'**REDACTED**\''
+    )
+    assert "John's Mower" not in message
+    assert 'Garage "North" camera' not in message

--- a/tests/test_operation_diagnostics.py
+++ b/tests/test_operation_diagnostics.py
@@ -119,3 +119,19 @@ def test_operation_stage_error_never_requires_a_response_payload() -> None:
     assert stage["error"]["message"] == (
         "Bearer **REDACTED** failed for **REDACTED_EMAIL** **REDACTED_ID**"
     )
+
+
+def test_operation_summary_redacts_space_separated_device_name() -> None:
+    summary = summarize_operation_response(
+        {
+            "message": (
+                "device name=Garage Mower is unavailable while channel id "
+                "10425/private-camera is offline"
+            )
+        }
+    )
+
+    message = summary["messages"][0]["text"]
+    assert message == "device name=**REDACTED**"
+    assert "Garage Mower" not in message
+    assert "10425/private-camera" not in message

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -190,6 +190,71 @@ def test_video_failure_is_sanitized_logged_once_and_preserved(caplog) -> None:
     assert "secret" not in caplog.text
 
 
+def test_video_camera_preserves_runtime_input_telemetry_on_cloud_failure() -> None:
+    async def _raise_cloud_error():
+        raise RuntimeError("cloud request failed")
+
+    entity = _uninitialized_entity()
+    entity.coordinator.client = SimpleNamespace(
+        async_get_camera_stream_runtime_inputs=_raise_cloud_error,
+        last_camera_stream_diagnostics={
+            "operation": "camera_stream_inputs",
+            "stages": [
+                {
+                    "stage": "cloud_access_token",
+                    "error": {
+                        "message": "accessToken=secret-token failed",
+                    },
+                }
+            ],
+        },
+    )
+
+    with pytest.raises(RuntimeError, match="cloud request failed"):
+        asyncio.run(entity._async_get_runtime_inputs())
+
+    diagnostics = entity._last_runtime_input_diagnostics
+    assert diagnostics["stages"][0]["stage"] == "cloud_access_token"
+    assert diagnostics["stages"][0]["error"]["message"] == (
+        "accessToken=**REDACTED** failed"
+    )
+
+
+def test_video_camera_preserves_runtime_input_telemetry_on_incomplete_result() -> None:
+    inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+        source="dreame_third_video_tx",
+        did="device-1",
+        diagnostics={
+            "operation": "camera_stream_inputs",
+            "ready": False,
+            "missing_required": ("product_id", "device_name", "p2p_info"),
+        },
+    )
+
+    async def _runtime_inputs():
+        return inputs
+
+    entity = _uninitialized_entity()
+    entity.coordinator.client = SimpleNamespace(
+        async_get_camera_stream_runtime_inputs=_runtime_inputs,
+    )
+
+    result = asyncio.run(entity._async_get_runtime_inputs())
+
+    assert result is inputs
+    assert entity._last_runtime_input_diagnostics == {
+        "operation": "camera_stream_inputs",
+        "ready": False,
+        "missing_required": ["product_id", "device_name", "p2p_info"],
+    }
+    assert entity._last_runtime_inputs_ready is False
+    assert entity._last_runtime_inputs_missing == (
+        "product_id",
+        "device_name",
+        "p2p_info",
+    )
+
+
 def test_video_camera_auto_policy_prefers_direct_capable_sdk_negotiation() -> None:
     entity = _uninitialized_entity()
     entity._entry.options[CONF_VIDEO_TRANSPORT] = VIDEO_TRANSPORT_AUTO


### PR DESCRIPTION
## Summary

- add a reusable, bounded operation-summary helper for privacy-safe cloud telemetry
- record video setup, access-token, device-identity, P2P, and incomplete-input eligibility stages
- expose the latest staged trace through the Live Video camera and downloaded diagnostics
- document the new diagnostics contract and advance the diagnostics schema to version 7

The optional `isDevUser` check is read-only, runs only when required video inputs are missing, uses one request with a five-second timeout, and cannot replace the original incomplete result. Stream discovery still never calls the pairing endpoint.

## Privacy and safety

The trace keeps response field names and types, safe status codes, required-field presence, and sanitized errors. It does not keep response scalar values, credentials, account/device/channel identifiers, stream URLs, or unbounded payloads. Traversal is depth-, width-, message-, redaction-, and globally node-bounded before the trace reaches Home Assistant state.

## Validation

- 753 repository tests pass
- Ruff passes
- Python compilation and diff checks pass
- independent privacy/correctness review completed; all findings addressed and confirmed

This adds the evidence needed to investigate the A3 AWD 1000 video failure in #53 without requesting temporary account access as the first step. It does not claim to fix that device's stream negotiation yet.