### PR TITLE
Add secure on-demand point-cloud downloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,6 +91,8 @@ region/account details are especially helpful for moving a device from
 - guarded mowing-preference update service with dry-run mode by default
 - read-only map camera using the app-map payload when available, with options
   for label scale and clockwise display rotation
+- on-demand PCD point-cloud generation through an authenticated, admin-only
+  Home Assistant download endpoint
 - disabled-by-default all-maps and map-diagnostics cameras
 - live video camera with a managed XP2P runtime on Linux x86_64 and aarch64 hosts
 - runtime telemetry sensors for mission progress, mission area, mower pose, and live-track length
@@ -133,7 +135,8 @@ The following areas are intentionally cautious:
 - the managed video runtime currently supports Linux x86_64 and aarch64 Home
   Assistant hosts, and the mower must be active and away from its station before
   the vendor permits live video
-- 3D map object downloads are metadata-first and not treated as stable
+- 3D point-cloud generation and PCD download are validated on the Dreame A2;
+  other mower families still need field reports
 - manual driving must stay supervised and uses strict state and battery guards
 
 ## Installation
@@ -372,6 +375,20 @@ If the mower has multiple maps, enable the disabled `All Maps` camera to render
 a contact sheet. Use `Map Diagnostics` when the map image is missing or when you
 need source, counts, and parser evidence.
 
+The map camera also advertises a local `point_cloud_api_path` attribute. A
+Home Assistant administrator can sign that path for a short-lived download.
+The integration asks the mower to generate the selected app map, immediately
+captures the transient object, validates the returned PCD file, and serves it
+with `private, no-store` caching. Vendor filenames, cloud-signed URLs, and point
+coordinates are never written to entity state or logs.
+
+The companion
+[Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card) detects
+this attribute and offers an on-demand 3D viewer. It does not generate or
+download garden geometry during an ordinary dashboard render. Select the Hero
+layout's **3D** tab or press **Load 3D map** in another layout when you want to
+fetch it. Point-cloud access is currently restricted to Home Assistant admins.
+
 Current map support now includes:
 
 - a read-only `Map` camera for the active map
@@ -382,6 +399,7 @@ Current map support now includes:
 - services for switching the active mower map and starting explicit zone, spot,
   or edge jobs
 - runtime live-track telemetry surfaced through sensors and map-camera attributes
+- an admin-only, transient PCD point-cloud download for the selected app map
 - circular and rotated rectangular forbidden areas rendered from their compact
   mower map representation
 

--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -16,6 +16,11 @@ from .const import (
     VIDEO_TRANSPORT_AUTO,
 )
 from .coordinator import DreameLawnMowerCoordinator
+from .point_cloud_api import (
+    POINT_CLOUD_API_DATA_KEY,
+    DreameLawnMowerPointCloudAPI,
+    async_setup_point_cloud_api,
+)
 from .services import async_setup_services, async_unload_services
 from .video_lan_cache import DreameLawnMowerVideoLanCache
 from .video_provisioning_cache import DreameLawnMowerVideoProvisioningCache
@@ -63,6 +68,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         platforms = (Platform.CAMERA,)
 
     hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
+    async_setup_point_cloud_api(hass)
     coordinator.loaded_platforms = platforms
     await async_setup_services(hass)
     await hass.config_entries.async_forward_entry_setups(entry, platforms)
@@ -96,6 +102,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     unload_ok = await hass.config_entries.async_unload_platforms(entry, platforms)
     if unload_ok:
         coordinator = hass.data[DOMAIN].pop(entry.entry_id)
+        point_cloud_api = hass.data[DOMAIN].get(POINT_CLOUD_API_DATA_KEY)
+        if isinstance(point_cloud_api, DreameLawnMowerPointCloudAPI):
+            point_cloud_api.purge_entry(entry.entry_id)
         await coordinator.async_shutdown()
         if not any(
             isinstance(value, DreameLawnMowerCoordinator)

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -35,6 +35,7 @@ from .image import (
 )
 from .map_attributes import map_camera_attributes
 from .map_cache import DreameLawnMowerMapCameraCache, map_camera_available
+from .point_cloud_api import point_cloud_api_path
 from .video_camera import DreameLawnMowerVideoCamera
 
 _LOGGER = logging.getLogger(__name__)
@@ -146,12 +147,20 @@ class DreameLawnMowerMapCamera(
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Expose the latest cached map summary."""
-        return map_camera_attributes(
+        attributes = map_camera_attributes(
             self._map_cache.last_view,
             image_cached=self._map_cache.last_image is not None,
             refreshed_at=self._map_cache.last_refresh_at,
             last_error=self._map_cache.last_error,
         )
+        map_index = attributes.get("app_current_map_index")
+        if isinstance(map_index, bool) or not isinstance(map_index, int):
+            map_index = 0
+        attributes["point_cloud_api_path"] = point_cloud_api_path(
+            self.coordinator.entry.entry_id,
+            map_index,
+        )
+        return attributes
 
     async def async_camera_image(
         self,

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -22,7 +22,6 @@ from .const import (
     DEFAULT_MAP_ROTATION,
     DOMAIN,
 )
-from .control_options import current_map_index
 from .coordinator import DreameLawnMowerCoordinator
 from .debug import sanitize_diagnostic_text
 from .diagnostic_events import record_diagnostic_event
@@ -36,7 +35,7 @@ from .image import (
 )
 from .map_attributes import map_camera_attributes
 from .map_cache import DreameLawnMowerMapCameraCache, map_camera_available
-from .point_cloud_api import point_cloud_api_path
+from .point_cloud_api import current_point_cloud_api_path
 from .video_camera import DreameLawnMowerVideoCamera
 
 _LOGGER = logging.getLogger(__name__)
@@ -154,14 +153,11 @@ class DreameLawnMowerMapCamera(
             refreshed_at=self._map_cache.last_refresh_at,
             last_error=self._map_cache.last_error,
         )
-        map_index = current_map_index(
+        attributes["point_cloud_api_path"] = current_point_cloud_api_path(
+            self.coordinator.entry.entry_id,
             self.coordinator.app_maps,
             self.coordinator.batch_device_data,
             selected_map_index=self.coordinator.selected_map_index,
-        )
-        attributes["point_cloud_api_path"] = point_cloud_api_path(
-            self.coordinator.entry.entry_id,
-            map_index,
         )
         return attributes
 

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -22,6 +22,7 @@ from .const import (
     DEFAULT_MAP_ROTATION,
     DOMAIN,
 )
+from .control_options import current_map_index
 from .coordinator import DreameLawnMowerCoordinator
 from .debug import sanitize_diagnostic_text
 from .diagnostic_events import record_diagnostic_event
@@ -153,9 +154,11 @@ class DreameLawnMowerMapCamera(
             refreshed_at=self._map_cache.last_refresh_at,
             last_error=self._map_cache.last_error,
         )
-        map_index = attributes.get("app_current_map_index")
-        if isinstance(map_index, bool) or not isinstance(map_index, int):
-            map_index = 0
+        map_index = current_map_index(
+            self.coordinator.app_maps,
+            self.coordinator.batch_device_data,
+            selected_map_index=self.coordinator.selected_map_index,
+        )
         attributes["point_cloud_api_path"] = point_cloud_api_path(
             self.coordinator.entry.entry_id,
             map_index,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -110,6 +110,13 @@ from .models import (
     remote_control_block_reason,
     remote_control_state_safe,
 )
+from .point_cloud import (
+    DEFAULT_POINT_CLOUD_MAX_BYTES,
+    DreameLawnMowerPointCloudDownload,
+    DreameLawnMowerPointCloudError,
+    DreameLawnMowerPointCloudMetadata,
+    parse_pcd_metadata,
+)
 from .mowing_preferences import (
     MOWING_PREFERENCE_MODE_FIELD,
     MOWING_PREFERENCE_PROPERTY_KEY,
@@ -184,6 +191,9 @@ __all__ = [
     "DreameLawnMowerMapDiagnostics",
     "DreameLawnMowerMapSummary",
     "DreameLawnMowerMapView",
+    "DreameLawnMowerPointCloudDownload",
+    "DreameLawnMowerPointCloudError",
+    "DreameLawnMowerPointCloudMetadata",
     "MowingTaskResponseError",
     "DreameLawnMowerRemoteControlSupport",
     "DreameLawnMowerSnapshot",
@@ -219,6 +229,7 @@ __all__ = [
     "DEFAULT_LAN_DISCOVERY_PORT",
     "DEFAULT_LAN_DISCOVERY_TIMEOUT",
     "DEFAULT_LAN_DISCOVERY_VERSION",
+    "DEFAULT_POINT_CLOUD_MAX_BYTES",
     "XP2P_PROTOCOL_AUTO",
     "XP2P_PROTOCOL_TCP",
     "XP2P_PROTOCOL_UDP",
@@ -296,6 +307,7 @@ __all__ = [
     "normalize_debug_ota_catalog_payload",
     "normalize_maintenance_item",
     "parse_lan_video_probe_response",
+    "parse_pcd_metadata",
     "mowing_preference_mode_name",
     "normalize_mowing_preference_mode",
     "remote_control_block_reason",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3816,7 +3816,8 @@ class DreameLawnMowerClient:
         include_urls: bool = False,
     ) -> dict[str, Any]:
         object_result = self._sync_call_app_action(
-            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
+            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+            redact_response=True,
         )
         data = _app_action_data(object_result)
         names = data.get("name") if isinstance(data, Mapping) else None
@@ -3827,19 +3828,20 @@ class DreameLawnMowerClient:
             names = []
 
         objects: list[dict[str, Any]] = []
-        cloud = self._sync_get_cloud_protocol()
+        cloud = self._sync_get_cloud_protocol() if include_urls else None
         for raw_name in names:
             name = str(raw_name)
             item: dict[str, Any] = {
-                "name": name,
                 "extension": _app_object_extension(name),
                 "url_present": False,
             }
             if include_urls:
+                item["name"] = name
                 try:
                     url = (
                         cloud.get_interim_file_url(name)
-                        if hasattr(cloud, "get_interim_file_url")
+                        if cloud is not None
+                        and hasattr(cloud, "get_interim_file_url")
                         else None
                     )
                     item["url_present"] = bool(url)
@@ -3848,13 +3850,15 @@ class DreameLawnMowerClient:
                     item["error"] = str(err)
             objects.append(item)
 
-        return {
+        result = {
             "source": "app_action_obj_3dmap",
             "object_count": len(objects),
             "objects": objects,
-            "raw": _json_safe(object_result, max_depth=4),
             "urls_included": bool(include_urls),
         }
+        if include_urls:
+            result["raw"] = _json_safe(object_result, max_depth=4)
+        return result
 
     def _sync_download_app_map_point_cloud(
         self,
@@ -5786,7 +5790,7 @@ def _app_map_objects_view_metadata(value: Any) -> dict[str, Any]:
     entries = [
         {
             key: item.get(key)
-            for key in ("name", "extension", "url_present", "error")
+            for key in ("extension", "url_present", "error")
             if item.get(key) is not None
         }
         for item in objects

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -981,14 +981,23 @@ class DreameLawnMowerClient:
         max_bytes: int = DEFAULT_POINT_CLOUD_MAX_BYTES,
     ) -> DreameLawnMowerPointCloudDownload:
         """Generate, download, and validate a mower app-map point cloud."""
-        return await asyncio.to_thread(
-            self._sync_download_app_map_point_cloud,
-            map_index,
-            timeout,
-            poll_interval,
-            download_timeout,
-            max_bytes,
-        )
+        timeout = _validate_positive_number(timeout, "generation timeout")
+        deadline = time.monotonic() + timeout
+        try:
+            async with asyncio.timeout(timeout):
+                return await asyncio.to_thread(
+                    self._sync_download_app_map_point_cloud,
+                    map_index,
+                    timeout,
+                    poll_interval,
+                    download_timeout,
+                    max_bytes,
+                    deadline,
+                )
+        except TimeoutError as err:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out."
+            ) from err
 
     async def async_get_cloud_properties(
         self,
@@ -3867,6 +3876,7 @@ class DreameLawnMowerClient:
         poll_interval: float,
         download_timeout: float,
         max_bytes: int,
+        deadline: float | None = None,
     ) -> DreameLawnMowerPointCloudDownload:
         map_index = _validate_point_cloud_map_index(map_index)
         timeout = _validate_positive_number(timeout, "generation timeout")
@@ -3884,7 +3894,15 @@ class DreameLawnMowerClient:
                 "Point-cloud maximum size must be a positive integer."
             )
 
-        deadline = time.monotonic() + timeout
+        deadline = (
+            time.monotonic() + timeout
+            if deadline is None
+            else deadline
+        )
+        if time.monotonic() >= deadline:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out."
+            )
         baseline_result = self._sync_call_point_cloud_action(
             {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
             operation="read the existing point-cloud object state",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -46,6 +46,7 @@ from .debug_ota_catalog import (
     normalize_debug_ota_catalog_payload,
 )
 from .docking import async_stop_then_dock
+from .deadline import DeadlineExceededError, run_with_deadline
 from .exceptions import DeviceException, InvalidActionException
 from .maintenance import (
     CMS_GET_REQUEST,
@@ -3907,6 +3908,7 @@ class DreameLawnMowerClient:
         observed_clear = baseline_name is None
         saw_unusable_point_cloud = False
         rejected_object_names: set[str] = set()
+        object_download_attempts: dict[str, int] = {}
         while time.monotonic() < deadline:
             object_result = self._sync_call_point_cloud_action(
                 {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
@@ -3932,23 +3934,27 @@ class DreameLawnMowerClient:
                 and object_extension.casefold() == "pcd"
                 and fresh_object
                 and object_name not in rejected_object_names
+                and object_download_attempts.get(object_name, 0) < 2
             ):
+                object_download_attempts[object_name] = (
+                    object_download_attempts.get(object_name, 0) + 1
+                )
                 try:
                     raw_url = self._sync_get_point_cloud_download_url(
                         cloud,
                         object_name,
                         deadline=deadline,
                     )
-                except DeviceException:
+                    url = _point_cloud_download_url(raw_url)
+                    content, content_type = _download_point_cloud_content(
+                        url,
+                        timeout=download_timeout,
+                        max_bytes=max_bytes,
+                    )
+                except (DeviceException, DreameLawnMowerPointCloudError):
                     saw_unusable_point_cloud = True
                 else:
                     try:
-                        url = _point_cloud_download_url(raw_url)
-                        content, content_type = _download_point_cloud_content(
-                            url,
-                            timeout=download_timeout,
-                            max_bytes=max_bytes,
-                        )
                         metadata = parse_pcd_metadata(content, max_bytes=max_bytes)
                     except DreameLawnMowerPointCloudError:
                         saw_unusable_point_cloud = True
@@ -5350,7 +5356,11 @@ def _download_point_cloud_content(
         },
     )
     try:
-        with _open_point_cloud_response(request, timeout=timeout) as response:
+        with _open_point_cloud_response(
+            request,
+            timeout=timeout,
+            deadline=deadline,
+        ) as response:
             final_url = response.geturl()
             if urllib.parse.urlsplit(final_url).scheme.casefold() != "https":
                 raise DreameLawnMowerPointCloudError(
@@ -5448,10 +5458,19 @@ def _open_point_cloud_response(
     request: urllib.request.Request,
     *,
     timeout: float,
+    deadline: float,
 ) -> Any:
     """Open one point-cloud URL with HTTPS-only redirect handling."""
     opener = urllib.request.build_opener(_HttpsOnlyPointCloudRedirectHandler())
-    return opener.open(request, timeout=timeout)
+    try:
+        return run_with_deadline(
+            lambda: opener.open(request, timeout=timeout),
+            deadline=deadline,
+        )
+    except DeadlineExceededError as err:
+        raise DreameLawnMowerPointCloudError(
+            "The point-cloud download timed out."
+        ) from err
 
 
 def _set_point_cloud_response_timeout(response: Any, timeout: float) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -5192,6 +5192,7 @@ def _download_point_cloud_content(
     timeout: float,
     max_bytes: int,
 ) -> tuple[bytes, str]:
+    deadline = time.monotonic() + timeout
     request = urllib.request.Request(
         url,
         headers={
@@ -5218,7 +5219,31 @@ def _download_point_cloud_content(
                     raise DreameLawnMowerPointCloudError(
                         "The point-cloud download exceeds the configured size limit."
                     )
-            content = response.read(max_bytes + 1)
+            content_parts: list[bytes] = []
+            received_bytes = 0
+            while True:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise DreameLawnMowerPointCloudError(
+                        "The point-cloud download timed out."
+                    )
+                _set_point_cloud_response_timeout(response, remaining)
+                chunk = response.read(
+                    min(64 * 1024, max_bytes + 1 - received_bytes)
+                )
+                if time.monotonic() >= deadline:
+                    raise DreameLawnMowerPointCloudError(
+                        "The point-cloud download timed out."
+                    )
+                if not chunk:
+                    break
+                content_parts.append(chunk)
+                received_bytes += len(chunk)
+                if received_bytes > max_bytes:
+                    raise DreameLawnMowerPointCloudError(
+                        "The point-cloud download exceeds the configured size limit."
+                    )
+            content = b"".join(content_parts)
             content_type = (
                 response.headers.get_content_type()
                 if hasattr(response.headers, "get_content_type")
@@ -5230,16 +5255,38 @@ def _download_point_cloud_content(
         raise DreameLawnMowerPointCloudError(
             f"The point-cloud download failed with HTTP status {err.code}."
         ) from err
-    except (urllib.error.URLError, TimeoutError, OSError) as err:
+    except TimeoutError as err:
+        raise DreameLawnMowerPointCloudError(
+            "The point-cloud download timed out."
+        ) from err
+    except (urllib.error.URLError, OSError) as err:
         raise DreameLawnMowerPointCloudError(
             "The point-cloud download could not be completed."
         ) from err
 
-    if len(content) > max_bytes:
-        raise DreameLawnMowerPointCloudError(
-            "The point-cloud download exceeds the configured size limit."
-        )
     return content, content_type
+
+
+def _set_point_cloud_response_timeout(response: Any, timeout: float) -> None:
+    """Apply the remaining overall deadline to the active response socket."""
+    response_fp = getattr(response, "fp", None)
+    response_raw = getattr(response_fp, "raw", None)
+    candidates = (
+        response,
+        getattr(response, "_sock", None),
+        response_fp,
+        getattr(response_fp, "_sock", None),
+        response_raw,
+        getattr(response_raw, "_sock", None),
+    )
+    for candidate in candidates:
+        set_timeout = getattr(candidate, "settimeout", None)
+        if callable(set_timeout):
+            set_timeout(timeout)
+            return
+    raise DreameLawnMowerPointCloudError(
+        "The point-cloud download deadline could not be enforced."
+    )
 
 
 def _normalize_app_map_entries(value: Any) -> list[dict[str, Any]]:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3879,21 +3879,24 @@ class DreameLawnMowerClient:
                 "Point-cloud maximum size must be a positive integer."
             )
 
-        baseline_result = self._sync_call_app_action(
-            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
+        deadline = time.monotonic() + timeout
+        baseline_result = self._sync_call_point_cloud_action(
+            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+            operation="read the existing point-cloud object state",
+            deadline=deadline,
+            require_data=True,
         )
         baseline_name = _point_cloud_object_name(
-            _point_cloud_action_data(
-                baseline_result,
-                "read the existing point-cloud object state",
-            ),
+            baseline_result,
             map_index,
         )
 
-        trigger_result = self._sync_call_app_action(
-            {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}}
+        self._sync_call_point_cloud_action(
+            {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
+            operation="start point-cloud generation",
+            deadline=deadline,
+            require_data=False,
         )
-        _point_cloud_action_data(trigger_result, "start point-cloud generation")
 
         cloud = self._sync_get_cloud_protocol()
         if not hasattr(cloud, "get_interim_file_url"):
@@ -3901,18 +3904,17 @@ class DreameLawnMowerClient:
                 "The configured cloud protocol cannot download interim files."
             )
 
-        deadline = time.monotonic() + timeout
         observed_clear = baseline_name is None
         saw_unusable_point_cloud = False
         while time.monotonic() < deadline:
-            object_result = self._sync_call_app_action(
-                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
+            object_result = self._sync_call_point_cloud_action(
+                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+                operation="read the generated point-cloud object state",
+                deadline=deadline,
+                require_data=True,
             )
             object_name = _point_cloud_object_name(
-                _point_cloud_action_data(
-                    object_result,
-                    "read the generated point-cloud object state",
-                ),
+                object_result,
                 map_index,
             )
             if object_name is None:
@@ -3965,6 +3967,44 @@ class DreameLawnMowerClient:
             "The mower did not publish or refresh a point cloud before the timeout."
         )
 
+    def _sync_call_point_cloud_action(
+        self,
+        payload: Mapping[str, Any],
+        *,
+        operation: str,
+        deadline: float,
+        require_data: bool,
+    ) -> Any:
+        """Call one point-cloud action within the shared generation deadline."""
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out."
+            )
+        try:
+            response = self._sync_call_app_action(
+                payload,
+                retry_count=0,
+                timeout=remaining,
+            )
+        except DreameLawnMowerConnectionError as err:
+            if time.monotonic() >= deadline:
+                raise DreameLawnMowerPointCloudError(
+                    "Point-cloud generation timed out."
+                ) from err
+            raise DreameLawnMowerPointCloudError(
+                f"The mower could not {operation}."
+            ) from err
+        if time.monotonic() >= deadline:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out."
+            )
+        return _point_cloud_action_data(
+            response,
+            operation,
+            require_data=require_data,
+        )
+
     def _sync_get_app_map_text(
         self,
         *,
@@ -4015,6 +4055,8 @@ class DreameLawnMowerClient:
         *,
         siid: int = 2,
         aiid: int = 50,
+        retry_count: int | None = None,
+        timeout: float | None = None,
     ) -> Any:
         cloud = self._sync_get_cloud_protocol()
         if not getattr(cloud, "_host", None):
@@ -4026,8 +4068,18 @@ class DreameLawnMowerClient:
             except DeviceException as err:
                 raise DreameLawnMowerConnectionError(str(err)) from err
         try:
+            request_options: dict[str, Any] = {}
+            if retry_count is not None:
+                request_options["retry_count"] = retry_count
+            if timeout is not None:
+                request_options["timeout"] = timeout
             if hasattr(cloud, "call_app_action"):
-                response = cloud.call_app_action(payload, siid=siid, aiid=aiid)
+                response = cloud.call_app_action(
+                    payload,
+                    siid=siid,
+                    aiid=aiid,
+                    **request_options,
+                )
             else:
                 response = cloud.send(
                     "action",
@@ -4037,6 +4089,7 @@ class DreameLawnMowerClient:
                         "aiid": aiid,
                         "in": [payload],
                     },
+                    **request_options,
                 )
         except DeviceException as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
@@ -5102,14 +5155,32 @@ def _app_object_extension(value: str) -> str | None:
     return extension or None
 
 
-def _point_cloud_action_data(value: Any, operation: str) -> Any:
+def _point_cloud_action_data(
+    value: Any,
+    operation: str,
+    *,
+    require_data: bool,
+) -> Any:
     """Normalize point-cloud app-action failures without exposing raw payloads."""
-    try:
-        return _app_action_data(value)
-    except DreameLawnMowerConnectionError as err:
+    if not isinstance(value, Mapping) or value.get("r") != 0:
         raise DreameLawnMowerPointCloudError(
             f"The mower could not {operation}."
-        ) from err
+        )
+    data = value.get("d")
+    if require_data and not isinstance(data, Mapping):
+        raise DreameLawnMowerPointCloudError(
+            f"The mower could not {operation}."
+        )
+    if require_data:
+        names = data.get("name")
+        if not isinstance(names, Sequence) or isinstance(
+            names,
+            str | bytes | bytearray,
+        ):
+            raise DreameLawnMowerPointCloudError(
+                f"The mower could not {operation}."
+            )
+    return data
 
 
 def _point_cloud_object_name(value: Any, map_index: int) -> str | None:
@@ -5201,7 +5272,7 @@ def _download_point_cloud_content(
         },
     )
     try:
-        with urllib.request.urlopen(request, timeout=timeout) as response:
+        with _open_point_cloud_response(request, timeout=timeout) as response:
             final_url = response.geturl()
             if urllib.parse.urlsplit(final_url).scheme.casefold() != "https":
                 raise DreameLawnMowerPointCloudError(
@@ -5265,6 +5336,44 @@ def _download_point_cloud_content(
         ) from err
 
     return content, content_type
+
+
+class _HttpsOnlyPointCloudRedirectHandler(urllib.request.HTTPRedirectHandler):
+    """Reject a redirect before urllib can issue a non-HTTPS request."""
+
+    def redirect_request(
+        self,
+        req: urllib.request.Request,
+        fp: Any,
+        code: int,
+        msg: str,
+        headers: Any,
+        newurl: str,
+    ) -> urllib.request.Request | None:
+        target = urllib.parse.urljoin(req.full_url, newurl)
+        parsed = urllib.parse.urlsplit(target)
+        if parsed.scheme.casefold() != "https" or not parsed.netloc:
+            raise DreameLawnMowerPointCloudError(
+                "The point-cloud download redirected to an insecure URL."
+            )
+        return super().redirect_request(
+            req,
+            fp,
+            code,
+            msg,
+            headers,
+            target,
+        )
+
+
+def _open_point_cloud_response(
+    request: urllib.request.Request,
+    *,
+    timeout: float,
+) -> Any:
+    """Open one point-cloud URL with HTTPS-only redirect handling."""
+    opener = urllib.request.build_opener(_HttpsOnlyPointCloudRedirectHandler())
+    return opener.open(request, timeout=timeout)
 
 
 def _set_point_cloud_response_timeout(response: Any, timeout: float) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3906,6 +3906,7 @@ class DreameLawnMowerClient:
 
         observed_clear = baseline_name is None
         saw_unusable_point_cloud = False
+        rejected_object_names: set[str] = set()
         while time.monotonic() < deadline:
             object_result = self._sync_call_point_cloud_action(
                 {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
@@ -3930,6 +3931,7 @@ class DreameLawnMowerClient:
                 and object_extension is not None
                 and object_extension.casefold() == "pcd"
                 and fresh_object
+                and object_name not in rejected_object_names
             ):
                 try:
                     raw_url = self._sync_get_point_cloud_download_url(
@@ -3950,6 +3952,7 @@ class DreameLawnMowerClient:
                         metadata = parse_pcd_metadata(content, max_bytes=max_bytes)
                     except DreameLawnMowerPointCloudError:
                         saw_unusable_point_cloud = True
+                        rejected_object_names.add(object_name)
                     else:
                         return DreameLawnMowerPointCloudDownload(
                             map_index=map_index,
@@ -3990,6 +3993,8 @@ class DreameLawnMowerClient:
                 payload,
                 retry_count=0,
                 timeout=remaining,
+                deadline=deadline,
+                redact_response=True,
             )
         except DreameLawnMowerConnectionError as err:
             if time.monotonic() >= deadline:
@@ -4085,6 +4090,8 @@ class DreameLawnMowerClient:
         aiid: int = 50,
         retry_count: int | None = None,
         timeout: float | None = None,
+        deadline: float | None = None,
+        redact_response: bool = False,
     ) -> Any:
         cloud = self._sync_get_cloud_protocol()
         if not getattr(cloud, "_host", None):
@@ -4101,6 +4108,10 @@ class DreameLawnMowerClient:
                 request_options["retry_count"] = retry_count
             if timeout is not None:
                 request_options["timeout"] = timeout
+            if deadline is not None:
+                request_options["deadline"] = deadline
+            if redact_response:
+                request_options["redact_response"] = True
             if hasattr(cloud, "call_app_action"):
                 response = cloud.call_app_action(
                     payload,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -9,6 +9,8 @@ import json
 import math
 import re
 import time
+import urllib.error
+import urllib.parse
 import urllib.request
 from collections.abc import Mapping, Sequence
 from dataclasses import replace
@@ -79,6 +81,12 @@ from .models import (
     remote_control_block_reason,
     remote_control_state_safe,
     snapshot_from_device,
+)
+from .point_cloud import (
+    DEFAULT_POINT_CLOUD_MAX_BYTES,
+    DreameLawnMowerPointCloudDownload,
+    DreameLawnMowerPointCloudError,
+    parse_pcd_metadata,
 )
 from .mowing_preferences import (
     MOWING_PREFERENCE_MODE_FIELD,
@@ -960,6 +968,25 @@ class DreameLawnMowerClient:
         return await asyncio.to_thread(
             self._sync_get_app_map_objects,
             include_urls,
+        )
+
+    async def async_download_app_map_point_cloud(
+        self,
+        *,
+        map_index: int = 0,
+        timeout: float = 45.0,
+        poll_interval: float = 2.0,
+        download_timeout: float = 60.0,
+        max_bytes: int = DEFAULT_POINT_CLOUD_MAX_BYTES,
+    ) -> DreameLawnMowerPointCloudDownload:
+        """Generate, download, and validate a mower app-map point cloud."""
+        return await asyncio.to_thread(
+            self._sync_download_app_map_point_cloud,
+            map_index,
+            timeout,
+            poll_interval,
+            download_timeout,
+            max_bytes,
         )
 
     async def async_get_cloud_properties(
@@ -3828,6 +3855,88 @@ class DreameLawnMowerClient:
             "urls_included": bool(include_urls),
         }
 
+    def _sync_download_app_map_point_cloud(
+        self,
+        map_index: int,
+        timeout: float,
+        poll_interval: float,
+        download_timeout: float,
+        max_bytes: int,
+    ) -> DreameLawnMowerPointCloudDownload:
+        map_index = _validate_point_cloud_map_index(map_index)
+        timeout = _validate_positive_number(timeout, "generation timeout")
+        poll_interval = _validate_positive_number(poll_interval, "poll interval")
+        download_timeout = _validate_positive_number(
+            download_timeout,
+            "download timeout",
+        )
+        if (
+            isinstance(max_bytes, bool)
+            or not isinstance(max_bytes, int)
+            or max_bytes <= 0
+        ):
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud maximum size must be a positive integer."
+            )
+
+        trigger_result = self._sync_call_app_action(
+            {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}}
+        )
+        _app_action_data(trigger_result)
+
+        deadline = time.monotonic() + timeout
+        object_name: str | None = None
+        while time.monotonic() < deadline:
+            object_result = self._sync_call_app_action(
+                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
+            )
+            data = _app_action_data(object_result)
+            names = data.get("name") if isinstance(data, Mapping) else None
+            if (
+                isinstance(names, Sequence)
+                and not isinstance(names, str | bytes | bytearray)
+                and map_index < len(names)
+            ):
+                candidate = names[map_index]
+                if isinstance(candidate, str) and candidate.strip():
+                    object_name = candidate.strip()
+                    break
+
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(poll_interval, remaining))
+
+        if object_name is None:
+            raise DreameLawnMowerPointCloudError(
+                "The mower did not publish a point cloud before the timeout."
+            )
+
+        cloud = self._sync_get_cloud_protocol()
+        if not hasattr(cloud, "get_interim_file_url"):
+            raise DreameLawnMowerPointCloudError(
+                "The configured cloud protocol cannot download interim files."
+            )
+        try:
+            raw_url = cloud.get_interim_file_url(object_name)
+        except DeviceException as err:
+            raise DreameLawnMowerPointCloudError(
+                "The cloud did not return a point-cloud download URL."
+            ) from err
+
+        url = _point_cloud_download_url(raw_url)
+        content, content_type = _download_point_cloud_content(
+            url,
+            timeout=download_timeout,
+            max_bytes=max_bytes,
+        )
+        metadata = parse_pcd_metadata(content, max_bytes=max_bytes)
+        return DreameLawnMowerPointCloudDownload(
+            map_index=map_index,
+            content=content,
+            metadata=metadata,
+            content_type=content_type,
+        )
+
     def _sync_get_app_map_text(
         self,
         *,
@@ -4963,6 +5072,121 @@ def _app_object_extension(value: str) -> str | None:
         return None
     extension = name.rsplit(".", 1)[-1].strip()
     return extension or None
+
+
+def _validate_point_cloud_map_index(value: int) -> int:
+    if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 255:
+        raise DreameLawnMowerPointCloudError(
+            "Point-cloud map index must be an integer between 0 and 255."
+        )
+    return value
+
+
+def _validate_positive_number(value: float, label: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, int | float):
+        raise DreameLawnMowerPointCloudError(
+            f"Point-cloud {label} must be a positive number."
+        )
+    normalized = float(value)
+    if not math.isfinite(normalized) or normalized <= 0:
+        raise DreameLawnMowerPointCloudError(
+            f"Point-cloud {label} must be a positive number."
+        )
+    return normalized
+
+
+def _point_cloud_download_url(value: Any) -> str:
+    candidate = value
+    for _ in range(4):
+        if isinstance(candidate, str):
+            stripped = candidate.strip()
+            if stripped.startswith("{"):
+                try:
+                    candidate = json.loads(stripped)
+                except json.JSONDecodeError:
+                    candidate = stripped
+                else:
+                    continue
+            candidate = stripped
+            break
+        if isinstance(candidate, Mapping):
+            candidate = next(
+                (
+                    candidate[key]
+                    for key in ("url", "downloadUrl", "download_url", "data")
+                    if key in candidate
+                ),
+                None,
+            )
+            continue
+        break
+
+    if not isinstance(candidate, str) or not candidate:
+        raise DreameLawnMowerPointCloudError(
+            "The cloud did not return a point-cloud download URL."
+        )
+    parsed = urllib.parse.urlsplit(candidate)
+    if parsed.scheme.casefold() != "https" or not parsed.netloc:
+        raise DreameLawnMowerPointCloudError(
+            "The cloud returned an invalid point-cloud download URL."
+        )
+    return candidate
+
+
+def _download_point_cloud_content(
+    url: str,
+    *,
+    timeout: float,
+    max_bytes: int,
+) -> tuple[bytes, str]:
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Accept": "application/octet-stream, application/pcd, */*",
+            "User-Agent": "homeassistant-dreamelawnmower/point-cloud",
+        },
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            final_url = response.geturl()
+            if urllib.parse.urlsplit(final_url).scheme.casefold() != "https":
+                raise DreameLawnMowerPointCloudError(
+                    "The point-cloud download redirected to an insecure URL."
+                )
+            content_length = response.headers.get("Content-Length")
+            if content_length is not None:
+                try:
+                    declared_bytes = int(content_length)
+                except ValueError as err:
+                    raise DreameLawnMowerPointCloudError(
+                        "The point-cloud download returned an invalid size."
+                    ) from err
+                if declared_bytes < 0 or declared_bytes > max_bytes:
+                    raise DreameLawnMowerPointCloudError(
+                        "The point-cloud download exceeds the configured size limit."
+                    )
+            content = response.read(max_bytes + 1)
+            content_type = (
+                response.headers.get_content_type()
+                if hasattr(response.headers, "get_content_type")
+                else "application/octet-stream"
+            )
+    except DreameLawnMowerPointCloudError:
+        raise
+    except urllib.error.HTTPError as err:
+        raise DreameLawnMowerPointCloudError(
+            f"The point-cloud download failed with HTTP status {err.code}."
+        ) from err
+    except (urllib.error.URLError, TimeoutError, OSError) as err:
+        raise DreameLawnMowerPointCloudError(
+            "The point-cloud download could not be completed."
+        ) from err
+
+    if len(content) > max_bytes:
+        raise DreameLawnMowerPointCloudError(
+            "The point-cloud download exceeds the configured size limit."
+        )
+    return content, content_type
 
 
 def _normalize_app_map_entries(value: Any) -> list[dict[str, Any]]:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3898,7 +3898,7 @@ class DreameLawnMowerClient:
             require_data=False,
         )
 
-        cloud = self._sync_get_cloud_protocol()
+        cloud = self._sync_get_cloud_protocol(deadline=deadline)
         if not hasattr(cloud, "get_interim_file_url"):
             raise DreameLawnMowerPointCloudError(
                 "The configured cloud protocol cannot download interim files."
@@ -4031,6 +4031,7 @@ class DreameLawnMowerClient:
             object_name,
             retry_count=0,
             timeout=remaining,
+            deadline=deadline,
         )
         if time.monotonic() >= deadline:
             raise DreameLawnMowerPointCloudError(
@@ -4093,13 +4094,29 @@ class DreameLawnMowerClient:
         deadline: float | None = None,
         redact_response: bool = False,
     ) -> Any:
-        cloud = self._sync_get_cloud_protocol()
+        cloud = (
+            self._sync_get_cloud_protocol(deadline=deadline)
+            if deadline is not None
+            else self._sync_get_cloud_protocol()
+        )
         if not getattr(cloud, "_host", None):
             try:
+                preflight_options: dict[str, Any] = {}
+                if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise DreameLawnMowerConnectionError(
+                            "Point-cloud cloud setup timed out."
+                        )
+                    preflight_options = {
+                        "retry_count": 0,
+                        "timeout": remaining,
+                        "deadline": deadline,
+                    }
                 if hasattr(cloud, "get_device_info_v2"):
-                    cloud.get_device_info_v2("en")
+                    cloud.get_device_info_v2("en", **preflight_options)
                 elif hasattr(cloud, "get_device_info"):
-                    cloud.get_device_info()
+                    cloud.get_device_info(**preflight_options)
             except DeviceException as err:
                 raise DreameLawnMowerConnectionError(str(err)) from err
         try:
@@ -4109,6 +4126,16 @@ class DreameLawnMowerClient:
             if timeout is not None:
                 request_options["timeout"] = timeout
             if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise DreameLawnMowerConnectionError(
+                        "Point-cloud cloud request timed out."
+                    )
+                request_options["timeout"] = (
+                    min(timeout, remaining)
+                    if timeout is not None
+                    else remaining
+                )
                 request_options["deadline"] = deadline
             if redact_response:
                 request_options["redact_response"] = True
@@ -4619,16 +4646,28 @@ class DreameLawnMowerClient:
 
         return rendered
 
-    def _sync_get_cloud_protocol(self):
+    def _sync_get_cloud_protocol(self, *, deadline: float | None = None):
         device = self._ensure_device()
         protocol = getattr(device, "_protocol", None)
         cloud = getattr(protocol, "cloud", None)
         if cloud is None:
             raise DreameLawnMowerConnectionError("Cloud connection is unavailable.")
-        if not getattr(cloud, "logged_in", False) and not cloud.login():
-            raise DreameLawnMowerConnectionError(
-                "Unable to log in to the mower cloud API."
-            )
+        if not getattr(cloud, "logged_in", False):
+            login_options: dict[str, Any] = {}
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise DreameLawnMowerConnectionError(
+                        "Point-cloud cloud login timed out."
+                    )
+                login_options = {
+                    "timeout": remaining,
+                    "deadline": deadline,
+                }
+            if not cloud.login(**login_options):
+                raise DreameLawnMowerConnectionError(
+                    "Unable to log in to the mower cloud API."
+                )
         return cloud
 
     def _ensure_device(self):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -82,12 +82,6 @@ from .models import (
     remote_control_state_safe,
     snapshot_from_device,
 )
-from .point_cloud import (
-    DEFAULT_POINT_CLOUD_MAX_BYTES,
-    DreameLawnMowerPointCloudDownload,
-    DreameLawnMowerPointCloudError,
-    parse_pcd_metadata,
-)
 from .mowing_preferences import (
     MOWING_PREFERENCE_MODE_FIELD,
     MOWING_PREFERENCE_PROPERTY_KEY,
@@ -106,6 +100,12 @@ from .mowing_tasks import (
     ensure_mowing_task_succeeded,
 )
 from .operation_diagnostics import build_operation_stage_diagnostics
+from .point_cloud import (
+    DEFAULT_POINT_CLOUD_MAX_BYTES,
+    DreameLawnMowerPointCloudDownload,
+    DreameLawnMowerPointCloudError,
+    parse_pcd_metadata,
+)
 from .runtime_state import (
     RESUME_MOWING_REQUEST,
     snapshot_session_control_state,
@@ -3879,62 +3879,90 @@ class DreameLawnMowerClient:
                 "Point-cloud maximum size must be a positive integer."
             )
 
+        baseline_result = self._sync_call_app_action(
+            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
+        )
+        baseline_name = _point_cloud_object_name(
+            _point_cloud_action_data(
+                baseline_result,
+                "read the existing point-cloud object state",
+            ),
+            map_index,
+        )
+
         trigger_result = self._sync_call_app_action(
             {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}}
         )
-        _app_action_data(trigger_result)
-
-        deadline = time.monotonic() + timeout
-        object_name: str | None = None
-        while time.monotonic() < deadline:
-            object_result = self._sync_call_app_action(
-                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
-            )
-            data = _app_action_data(object_result)
-            names = data.get("name") if isinstance(data, Mapping) else None
-            if (
-                isinstance(names, Sequence)
-                and not isinstance(names, str | bytes | bytearray)
-                and map_index < len(names)
-            ):
-                candidate = names[map_index]
-                if isinstance(candidate, str) and candidate.strip():
-                    object_name = candidate.strip()
-                    break
-
-            remaining = deadline - time.monotonic()
-            if remaining > 0:
-                time.sleep(min(poll_interval, remaining))
-
-        if object_name is None:
-            raise DreameLawnMowerPointCloudError(
-                "The mower did not publish a point cloud before the timeout."
-            )
+        _point_cloud_action_data(trigger_result, "start point-cloud generation")
 
         cloud = self._sync_get_cloud_protocol()
         if not hasattr(cloud, "get_interim_file_url"):
             raise DreameLawnMowerPointCloudError(
                 "The configured cloud protocol cannot download interim files."
             )
-        try:
-            raw_url = cloud.get_interim_file_url(object_name)
-        except DeviceException as err:
-            raise DreameLawnMowerPointCloudError(
-                "The cloud did not return a point-cloud download URL."
-            ) from err
 
-        url = _point_cloud_download_url(raw_url)
-        content, content_type = _download_point_cloud_content(
-            url,
-            timeout=download_timeout,
-            max_bytes=max_bytes,
-        )
-        metadata = parse_pcd_metadata(content, max_bytes=max_bytes)
-        return DreameLawnMowerPointCloudDownload(
-            map_index=map_index,
-            content=content,
-            metadata=metadata,
-            content_type=content_type,
+        deadline = time.monotonic() + timeout
+        observed_clear = baseline_name is None
+        saw_unusable_point_cloud = False
+        while time.monotonic() < deadline:
+            object_result = self._sync_call_app_action(
+                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}
+            )
+            object_name = _point_cloud_object_name(
+                _point_cloud_action_data(
+                    object_result,
+                    "read the generated point-cloud object state",
+                ),
+                map_index,
+            )
+            if object_name is None:
+                observed_clear = True
+            object_extension = (
+                _app_object_extension(object_name)
+                if object_name is not None
+                else None
+            )
+            fresh_object = object_name != baseline_name or observed_clear
+            if (
+                object_name is not None
+                and object_extension is not None
+                and object_extension.casefold() == "pcd"
+                and fresh_object
+            ):
+                try:
+                    raw_url = cloud.get_interim_file_url(object_name)
+                except DeviceException:
+                    saw_unusable_point_cloud = True
+                else:
+                    try:
+                        url = _point_cloud_download_url(raw_url)
+                        content, content_type = _download_point_cloud_content(
+                            url,
+                            timeout=download_timeout,
+                            max_bytes=max_bytes,
+                        )
+                        metadata = parse_pcd_metadata(content, max_bytes=max_bytes)
+                    except DreameLawnMowerPointCloudError:
+                        saw_unusable_point_cloud = True
+                    else:
+                        return DreameLawnMowerPointCloudDownload(
+                            map_index=map_index,
+                            content=content,
+                            metadata=metadata,
+                            content_type=content_type,
+                        )
+
+            remaining = deadline - time.monotonic()
+            if remaining > 0:
+                time.sleep(min(poll_interval, remaining))
+
+        if saw_unusable_point_cloud:
+            raise DreameLawnMowerPointCloudError(
+                "The mower published a point cloud, but it could not be downloaded "
+                "and validated before the timeout."
+            )
+        raise DreameLawnMowerPointCloudError(
+            "The mower did not publish or refresh a point cloud before the timeout."
         )
 
     def _sync_get_app_map_text(
@@ -5072,6 +5100,31 @@ def _app_object_extension(value: str) -> str | None:
         return None
     extension = name.rsplit(".", 1)[-1].strip()
     return extension or None
+
+
+def _point_cloud_action_data(value: Any, operation: str) -> Any:
+    """Normalize point-cloud app-action failures without exposing raw payloads."""
+    try:
+        return _app_action_data(value)
+    except DreameLawnMowerConnectionError as err:
+        raise DreameLawnMowerPointCloudError(
+            f"The mower could not {operation}."
+        ) from err
+
+
+def _point_cloud_object_name(value: Any, map_index: int) -> str | None:
+    """Return one indexed object name without exposing the surrounding response."""
+    names = value.get("name") if isinstance(value, Mapping) else None
+    if (
+        not isinstance(names, Sequence)
+        or isinstance(names, str | bytes | bytearray)
+        or map_index >= len(names)
+    ):
+        return None
+    candidate = names[map_index]
+    if not isinstance(candidate, str) or not candidate.strip():
+        return None
+    return candidate.strip()
 
 
 def _validate_point_cloud_map_index(value: int) -> int:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3932,7 +3932,11 @@ class DreameLawnMowerClient:
                 and fresh_object
             ):
                 try:
-                    raw_url = cloud.get_interim_file_url(object_name)
+                    raw_url = self._sync_get_point_cloud_download_url(
+                        cloud,
+                        object_name,
+                        deadline=deadline,
+                    )
                 except DeviceException:
                     saw_unusable_point_cloud = True
                 else:
@@ -4004,6 +4008,30 @@ class DreameLawnMowerClient:
             operation,
             require_data=require_data,
         )
+
+    def _sync_get_point_cloud_download_url(
+        self,
+        cloud: Any,
+        object_name: str,
+        *,
+        deadline: float,
+    ) -> str:
+        """Resolve a signed point-cloud URL within the generation deadline."""
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out."
+            )
+        raw_url = cloud.get_interim_file_url(
+            object_name,
+            retry_count=0,
+            timeout=remaining,
+        )
+        if time.monotonic() >= deadline:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out."
+            )
+        return raw_url
 
     def _sync_get_app_map_text(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3946,16 +3946,25 @@ class DreameLawnMowerClient:
                         deadline=deadline,
                     )
                     url = _point_cloud_download_url(raw_url)
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise DreameLawnMowerPointCloudError(
+                            "Point-cloud generation timed out."
+                        )
                     content, content_type = _download_point_cloud_content(
                         url,
-                        timeout=download_timeout,
+                        timeout=min(download_timeout, remaining),
                         max_bytes=max_bytes,
                     )
                 except (DeviceException, DreameLawnMowerPointCloudError):
                     saw_unusable_point_cloud = True
                 else:
                     try:
-                        metadata = parse_pcd_metadata(content, max_bytes=max_bytes)
+                        metadata = parse_pcd_metadata(
+                            content,
+                            max_bytes=max_bytes,
+                            deadline=deadline,
+                        )
                     except DreameLawnMowerPointCloudError:
                         saw_unusable_point_cloud = True
                         rejected_object_names.add(object_name)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
@@ -1,0 +1,87 @@
+"""Bound potentially blocking connection setup by an absolute deadline."""
+
+from __future__ import annotations
+
+import threading
+import time
+from collections.abc import Callable
+from typing import Any, TypeVar
+
+_ResultT = TypeVar("_ResultT")
+_MAX_ABANDONED_OPERATIONS = 4
+_operation_slots = threading.BoundedSemaphore(_MAX_ABANDONED_OPERATIONS)
+
+
+class DeadlineExceededError(TimeoutError):
+    """Raised when an operation does not finish before its deadline."""
+
+
+def _close_if_possible(value: Any) -> None:
+    """Close a late response without assuming a particular HTTP client."""
+    close = getattr(value, "close", None)
+    if callable(close):
+        close()
+
+
+def run_with_deadline(
+    operation: Callable[[], _ResultT],
+    *,
+    deadline: float,
+) -> _ResultT:
+    """Run a blocking operation without letting it retain its caller forever.
+
+    Socket timeouts only bound periods without network activity. A peer can still
+    trickle response headers indefinitely, so connection setup runs in a daemon
+    thread and the caller observes the absolute deadline. The semaphore bounds
+    abandoned operations if a dependency ignores both its socket timeout and
+    cancellation.
+    """
+    remaining = deadline - time.monotonic()
+    if remaining <= 0 or not _operation_slots.acquire(timeout=remaining):
+        raise DeadlineExceededError("The operation deadline expired.")
+
+    finished = threading.Event()
+    state_lock = threading.Lock()
+    state: dict[str, Any] = {"abandoned": False}
+
+    def worker() -> None:
+        value: Any = None
+        has_value = False
+        try:
+            value = operation()
+            has_value = True
+            with state_lock:
+                if not state["abandoned"]:
+                    state["value"] = value
+                    has_value = False
+        except BaseException as err:
+            with state_lock:
+                if not state["abandoned"]:
+                    state["error"] = err
+        finally:
+            if has_value:
+                _close_if_possible(value)
+            finished.set()
+            _operation_slots.release()
+
+    threading.Thread(
+        target=worker,
+        name="dreame-deadline-operation",
+        daemon=True,
+    ).start()
+
+    remaining = deadline - time.monotonic()
+    if remaining <= 0 or not finished.wait(remaining):
+        late_value: Any = None
+        with state_lock:
+            state["abandoned"] = True
+            late_value = state.pop("value", None)
+        if late_value is not None:
+            _close_if_possible(late_value)
+        raise DeadlineExceededError("The operation deadline expired.")
+
+    with state_lock:
+        error = state.get("error")
+        if error is not None:
+            raise error
+        return state["value"]

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
@@ -20,7 +20,10 @@ def _close_if_possible(value: Any) -> None:
     """Close a late response without assuming a particular HTTP client."""
     close = getattr(value, "close", None)
     if callable(close):
-        close()
+        try:
+            close()
+        except Exception:
+            pass
 
 
 def run_with_deadline(
@@ -59,10 +62,12 @@ def run_with_deadline(
                 if not state["abandoned"]:
                     state["error"] = err
         finally:
-            if has_value:
-                _close_if_possible(value)
-            finished.set()
-            _operation_slots.release()
+            try:
+                if has_value:
+                    _close_if_possible(value)
+            finally:
+                finished.set()
+                _operation_slots.release()
 
     threading.Thread(
         target=worker,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
@@ -69,11 +69,16 @@ def run_with_deadline(
                 finished.set()
                 _operation_slots.release()
 
-    threading.Thread(
+    worker_thread = threading.Thread(
         target=worker,
         name="dreame-deadline-operation",
         daemon=True,
-    ).start()
+    )
+    try:
+        worker_thread.start()
+    except BaseException:
+        _operation_slots.release()
+        raise
 
     remaining = deadline - time.monotonic()
     if remaining <= 0 or not finished.wait(remaining):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import struct
+from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
 
@@ -290,13 +291,14 @@ def _validate_pcd_payload(
         )
         return
 
-    lines = [line for line in payload.splitlines() if line.strip()]
-    if len(lines) != points:
-        raise DreameLawnMowerPointCloudError(
-            "PCD ASCII payload row count does not match its header."
-        )
     scalar_count = sum(counts)
-    for row in lines:
+    row_count = 0
+    for row in _iter_nonempty_ascii_rows(payload):
+        row_count += 1
+        if row_count > points:
+            raise DreameLawnMowerPointCloudError(
+                "PCD ASCII payload row count does not match its header."
+            )
         try:
             values = row.decode("ascii").split()
         except UnicodeDecodeError as err:
@@ -313,6 +315,24 @@ def _validate_pcd_payload(
             types=types,
             counts=counts,
         )
+    if row_count != points:
+        raise DreameLawnMowerPointCloudError(
+            "PCD ASCII payload row count does not match its header."
+        )
+
+
+def _iter_nonempty_ascii_rows(payload: bytes) -> Iterator[bytes]:
+    """Yield one non-empty ASCII PCD row without materializing all rows."""
+    offset = 0
+    payload_bytes = len(payload)
+    while offset < payload_bytes:
+        newline = payload.find(b"\n", offset)
+        if newline < 0:
+            newline = payload_bytes
+        row = payload[offset:newline].rstrip(b"\r")
+        offset = newline + 1
+        if row.strip():
+            yield row
 
 
 def _validate_binary_coordinates(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -13,6 +13,7 @@ MAX_POINT_CLOUD_HEADER_BYTES = 64 * 1024
 _SUPPORTED_DATA_ENCODINGS = frozenset({"ascii", "binary"})
 _SUPPORTED_FIELD_TYPES = frozenset({"F", "I", "U"})
 _SUPPORTED_FIELD_SIZES = frozenset({1, 2, 4, 8})
+_MAX_ASCII_SCALAR_BYTES = 128
 
 
 class DreameLawnMowerPointCloudError(ValueError):
@@ -292,12 +293,17 @@ def _validate_pcd_payload(
         return
 
     scalar_count = sum(counts)
+    max_row_bytes = scalar_count * (_MAX_ASCII_SCALAR_BYTES + 1)
     row_count = 0
     for row in _iter_nonempty_ascii_rows(payload):
         row_count += 1
         if row_count > points:
             raise DreameLawnMowerPointCloudError(
                 "PCD ASCII payload row count does not match its header."
+            )
+        if len(row) > max_row_bytes:
+            raise DreameLawnMowerPointCloudError(
+                "PCD ASCII payload row exceeds the supported size."
             )
         try:
             values = row.decode("ascii").split()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -1,0 +1,281 @@
+"""Validation and metadata for mower point-cloud downloads."""
+
+from __future__ import annotations
+
+import struct
+from dataclasses import dataclass
+from typing import Any
+
+DEFAULT_POINT_CLOUD_MAX_BYTES = 64 * 1024 * 1024
+MAX_POINT_CLOUD_HEADER_BYTES = 64 * 1024
+_SUPPORTED_DATA_ENCODINGS = frozenset({"ascii", "binary", "binary_compressed"})
+_SUPPORTED_FIELD_TYPES = frozenset({"F", "I", "U"})
+_SUPPORTED_FIELD_SIZES = frozenset({1, 2, 4, 8})
+
+
+class DreameLawnMowerPointCloudError(ValueError):
+    """Raised when a downloaded point cloud is invalid or unsupported."""
+
+
+@dataclass(frozen=True, slots=True)
+class DreameLawnMowerPointCloudMetadata:
+    """Describe a validated PCD payload without exposing its coordinates."""
+
+    version: str
+    fields: tuple[str, ...]
+    sizes: tuple[int, ...]
+    types: tuple[str, ...]
+    counts: tuple[int, ...]
+    width: int
+    height: int
+    points: int
+    data_encoding: str
+    bytes_per_point: int
+    header_bytes: int
+    payload_bytes: int
+    total_bytes: int
+
+    @property
+    def has_rgb(self) -> bool:
+        """Return whether the cloud contains an RGB or RGBA field."""
+        return "rgb" in self.fields or "rgba" in self.fields
+
+    def as_dict(self) -> dict[str, Any]:
+        """Return safe JSON-serializable point-cloud metadata."""
+        return {
+            "format": "pcd",
+            "version": self.version,
+            "fields": list(self.fields),
+            "sizes": list(self.sizes),
+            "types": list(self.types),
+            "counts": list(self.counts),
+            "width": self.width,
+            "height": self.height,
+            "points": self.points,
+            "data_encoding": self.data_encoding,
+            "bytes_per_point": self.bytes_per_point,
+            "header_bytes": self.header_bytes,
+            "payload_bytes": self.payload_bytes,
+            "total_bytes": self.total_bytes,
+            "has_rgb": self.has_rgb,
+        }
+
+
+@dataclass(frozen=True, slots=True)
+class DreameLawnMowerPointCloudDownload:
+    """Contain a validated point cloud returned by the reusable client."""
+
+    map_index: int
+    content: bytes
+    metadata: DreameLawnMowerPointCloudMetadata
+    content_type: str = "application/octet-stream"
+    file_extension: str = "pcd"
+
+
+def parse_pcd_metadata(
+    content: bytes,
+    *,
+    max_bytes: int = DEFAULT_POINT_CLOUD_MAX_BYTES,
+) -> DreameLawnMowerPointCloudMetadata:
+    """Validate a PCD payload and return coordinate-free metadata."""
+    if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
+        raise DreameLawnMowerPointCloudError(
+            "Point-cloud maximum size must be a positive integer."
+        )
+    if not isinstance(content, bytes | bytearray | memoryview):
+        raise DreameLawnMowerPointCloudError("Point-cloud content must be bytes.")
+    raw = bytes(content)
+    if not raw:
+        raise DreameLawnMowerPointCloudError("Point-cloud content is empty.")
+    if len(raw) > max_bytes:
+        raise DreameLawnMowerPointCloudError(
+            f"Point-cloud content exceeds the {max_bytes}-byte limit."
+        )
+
+    header, header_bytes = _parse_pcd_header(raw)
+    version = _single_header_value(header, "VERSION")
+    fields = tuple(_header_values(header, "FIELDS"))
+    sizes = _parse_positive_ints(header, "SIZE")
+    types = tuple(_header_values(header, "TYPE"))
+    counts = (
+        _parse_positive_ints(header, "COUNT")
+        if "COUNT" in header
+        else tuple(1 for _ in fields)
+    )
+    width = _parse_nonnegative_int(header, "WIDTH")
+    height = _parse_nonnegative_int(header, "HEIGHT")
+    points = _parse_nonnegative_int(header, "POINTS")
+    data_encoding = _single_header_value(header, "DATA").casefold()
+
+    if version not in {"0.7", ".7"}:
+        raise DreameLawnMowerPointCloudError(
+            f"Unsupported PCD version {version!r}; expected 0.7."
+        )
+    if not fields or not {"x", "y", "z"}.issubset(fields):
+        raise DreameLawnMowerPointCloudError(
+            "PCD fields must include x, y, and z coordinates."
+        )
+    if len({*fields}) != len(fields):
+        raise DreameLawnMowerPointCloudError("PCD fields must be unique.")
+    if not (len(fields) == len(sizes) == len(types) == len(counts)):
+        raise DreameLawnMowerPointCloudError(
+            "PCD FIELDS, SIZE, TYPE, and COUNT lengths do not match."
+        )
+    if any(size not in _SUPPORTED_FIELD_SIZES for size in sizes):
+        raise DreameLawnMowerPointCloudError("PCD contains an unsupported field size.")
+    if any(field_type not in _SUPPORTED_FIELD_TYPES for field_type in types):
+        raise DreameLawnMowerPointCloudError("PCD contains an unsupported field type.")
+    if width * height != points:
+        raise DreameLawnMowerPointCloudError(
+            "PCD WIDTH and HEIGHT do not match the declared point count."
+        )
+    if data_encoding not in _SUPPORTED_DATA_ENCODINGS:
+        raise DreameLawnMowerPointCloudError(
+            f"Unsupported PCD DATA encoding {data_encoding!r}."
+        )
+
+    bytes_per_point = sum(size * count for size, count in zip(sizes, counts))
+    payload = raw[header_bytes:]
+    _validate_pcd_payload(
+        payload,
+        data_encoding=data_encoding,
+        points=points,
+        bytes_per_point=bytes_per_point,
+    )
+    return DreameLawnMowerPointCloudMetadata(
+        version="0.7",
+        fields=fields,
+        sizes=sizes,
+        types=types,
+        counts=counts,
+        width=width,
+        height=height,
+        points=points,
+        data_encoding=data_encoding,
+        bytes_per_point=bytes_per_point,
+        header_bytes=header_bytes,
+        payload_bytes=len(payload),
+        total_bytes=len(raw),
+    )
+
+
+def _parse_pcd_header(content: bytes) -> tuple[dict[str, list[str]], int]:
+    header: dict[str, list[str]] = {}
+    offset = 0
+    limit = min(len(content), MAX_POINT_CLOUD_HEADER_BYTES)
+    while offset < limit:
+        newline = content.find(b"\n", offset, limit)
+        if newline < 0:
+            break
+        line_bytes = content[offset:newline].rstrip(b"\r")
+        offset = newline + 1
+        try:
+            line = line_bytes.decode("ascii")
+        except UnicodeDecodeError as err:
+            raise DreameLawnMowerPointCloudError(
+                "PCD header must contain only ASCII text."
+            ) from err
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        parts = stripped.split()
+        key = parts[0].upper()
+        if key in header:
+            raise DreameLawnMowerPointCloudError(
+                f"PCD header contains duplicate {key} entries."
+            )
+        header[key] = parts[1:]
+        if key == "DATA":
+            return header, offset
+    raise DreameLawnMowerPointCloudError(
+        "PCD header is missing a complete DATA declaration."
+    )
+
+
+def _header_values(header: dict[str, list[str]], key: str) -> list[str]:
+    values = header.get(key)
+    if not values:
+        raise DreameLawnMowerPointCloudError(
+            f"PCD header is missing a {key} value."
+        )
+    return values
+
+
+def _single_header_value(header: dict[str, list[str]], key: str) -> str:
+    values = _header_values(header, key)
+    if len(values) != 1:
+        raise DreameLawnMowerPointCloudError(
+            f"PCD {key} must contain exactly one value."
+        )
+    return values[0]
+
+
+def _parse_positive_ints(
+    header: dict[str, list[str]],
+    key: str,
+) -> tuple[int, ...]:
+    values = _parse_ints(header, key)
+    if any(value <= 0 for value in values):
+        raise DreameLawnMowerPointCloudError(
+            f"PCD {key} values must be positive integers."
+        )
+    return values
+
+
+def _parse_nonnegative_int(header: dict[str, list[str]], key: str) -> int:
+    values = _parse_ints(header, key)
+    if len(values) != 1 or values[0] < 0:
+        raise DreameLawnMowerPointCloudError(
+            f"PCD {key} must be one non-negative integer."
+        )
+    return values[0]
+
+
+def _parse_ints(
+    header: dict[str, list[str]],
+    key: str,
+) -> tuple[int, ...]:
+    try:
+        return tuple(int(value) for value in _header_values(header, key))
+    except ValueError as err:
+        raise DreameLawnMowerPointCloudError(
+            f"PCD {key} contains a non-integer value."
+        ) from err
+
+
+def _validate_pcd_payload(
+    payload: bytes,
+    *,
+    data_encoding: str,
+    points: int,
+    bytes_per_point: int,
+) -> None:
+    expected_bytes = points * bytes_per_point
+    if data_encoding == "binary":
+        if len(payload) != expected_bytes:
+            raise DreameLawnMowerPointCloudError(
+                "PCD binary payload length does not match its header."
+            )
+        return
+
+    if data_encoding == "binary_compressed":
+        if len(payload) < 8:
+            raise DreameLawnMowerPointCloudError(
+                "PCD compressed payload is missing its size prefix."
+            )
+        compressed_bytes, uncompressed_bytes = struct.unpack_from("<II", payload)
+        if uncompressed_bytes != expected_bytes:
+            raise DreameLawnMowerPointCloudError(
+                "PCD compressed payload size does not match its header."
+            )
+        if len(payload) != 8 + compressed_bytes:
+            raise DreameLawnMowerPointCloudError(
+                "PCD compressed payload length is incomplete."
+            )
+        return
+
+    lines = [line for line in payload.splitlines() if line.strip()]
+    if len(lines) != points:
+        raise DreameLawnMowerPointCloudError(
+            "PCD ASCII payload row count does not match its header."
+        )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -14,6 +14,8 @@ _SUPPORTED_DATA_ENCODINGS = frozenset({"ascii", "binary"})
 _SUPPORTED_FIELD_TYPES = frozenset({"F", "I", "U"})
 _SUPPORTED_FIELD_SIZES = frozenset({1, 2, 4, 8})
 _MAX_ASCII_SCALAR_BYTES = 128
+_MAX_ASCII_SCALARS_PER_POINT = 1024
+_MAX_ASCII_ROW_BYTES = 64 * 1024
 
 
 class DreameLawnMowerPointCloudError(ValueError):
@@ -148,6 +150,13 @@ def parse_pcd_metadata(
     if data_encoding not in _SUPPORTED_DATA_ENCODINGS:
         raise DreameLawnMowerPointCloudError(
             f"Unsupported PCD DATA encoding {data_encoding!r}."
+        )
+    if (
+        data_encoding == "ascii"
+        and sum(counts) > _MAX_ASCII_SCALARS_PER_POINT
+    ):
+        raise DreameLawnMowerPointCloudError(
+            "PCD ASCII point contains too many scalar values."
         )
 
     bytes_per_point = sum(
@@ -293,7 +302,10 @@ def _validate_pcd_payload(
         return
 
     scalar_count = sum(counts)
-    max_row_bytes = scalar_count * (_MAX_ASCII_SCALAR_BYTES + 1)
+    max_row_bytes = min(
+        _MAX_ASCII_ROW_BYTES,
+        scalar_count * (_MAX_ASCII_SCALAR_BYTES + 1),
+    )
     row_count = 0
     for row in _iter_nonempty_ascii_rows(payload):
         row_count += 1

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -317,7 +317,10 @@ def _validate_pcd_payload(
     )
     row_count = 0
     bytes_since_deadline_check = 0
-    for row in _iter_nonempty_ascii_rows(payload):
+    for row in _iter_nonempty_ascii_rows(
+        payload,
+        max_row_bytes=max_row_bytes,
+    ):
         bytes_since_deadline_check += len(row) + 1
         if bytes_since_deadline_check >= _VALIDATION_DEADLINE_CHECK_BYTES:
             _ensure_validation_deadline(deadline)
@@ -354,7 +357,11 @@ def _validate_pcd_payload(
         )
 
 
-def _iter_nonempty_ascii_rows(payload: bytes) -> Iterator[bytes]:
+def _iter_nonempty_ascii_rows(
+    payload: bytes,
+    *,
+    max_row_bytes: int,
+) -> Iterator[bytes]:
     """Yield one non-empty ASCII PCD row without materializing all rows."""
     offset = 0
     payload_bytes = len(payload)
@@ -362,6 +369,16 @@ def _iter_nonempty_ascii_rows(payload: bytes) -> Iterator[bytes]:
         newline = payload.find(b"\n", offset)
         if newline < 0:
             newline = payload_bytes
+        row_bytes = newline - offset
+        if row_bytes > max_row_bytes:
+            allowed_trailing_carriage_return = (
+                row_bytes == max_row_bytes + 1
+                and payload[newline - 1] == 0x0D
+            )
+            if not allowed_trailing_carriage_return:
+                raise DreameLawnMowerPointCloudError(
+                    "PCD ASCII payload row exceeds the supported size."
+                )
         row = payload[offset:newline].rstrip(b"\r")
         offset = newline + 1
         if row.strip():

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -2,13 +2,14 @@
 
 from __future__ import annotations
 
+import math
 import struct
 from dataclasses import dataclass
 from typing import Any
 
 DEFAULT_POINT_CLOUD_MAX_BYTES = 64 * 1024 * 1024
 MAX_POINT_CLOUD_HEADER_BYTES = 64 * 1024
-_SUPPORTED_DATA_ENCODINGS = frozenset({"ascii", "binary", "binary_compressed"})
+_SUPPORTED_DATA_ENCODINGS = frozenset({"ascii", "binary"})
 _SUPPORTED_FIELD_TYPES = frozenset({"F", "I", "U"})
 _SUPPORTED_FIELD_SIZES = frozenset({1, 2, 4, 8})
 
@@ -125,6 +126,19 @@ def parse_pcd_metadata(
         raise DreameLawnMowerPointCloudError("PCD contains an unsupported field size.")
     if any(field_type not in _SUPPORTED_FIELD_TYPES for field_type in types):
         raise DreameLawnMowerPointCloudError("PCD contains an unsupported field type.")
+    if any(
+        field_type == "F" and size not in {4, 8}
+        for field_type, size in zip(types, sizes, strict=True)
+    ):
+        raise DreameLawnMowerPointCloudError(
+            "PCD floating-point fields must use 4-byte or 8-byte values."
+        )
+    for coordinate in ("x", "y", "z"):
+        coordinate_index = fields.index(coordinate)
+        if types[coordinate_index] != "F" or counts[coordinate_index] != 1:
+            raise DreameLawnMowerPointCloudError(
+                "PCD x, y, and z coordinates must be scalar floating-point fields."
+            )
     if width * height != points:
         raise DreameLawnMowerPointCloudError(
             "PCD WIDTH and HEIGHT do not match the declared point count."
@@ -134,13 +148,19 @@ def parse_pcd_metadata(
             f"Unsupported PCD DATA encoding {data_encoding!r}."
         )
 
-    bytes_per_point = sum(size * count for size, count in zip(sizes, counts))
+    bytes_per_point = sum(
+        size * count for size, count in zip(sizes, counts, strict=True)
+    )
     payload = raw[header_bytes:]
     _validate_pcd_payload(
         payload,
         data_encoding=data_encoding,
         points=points,
         bytes_per_point=bytes_per_point,
+        fields=fields,
+        sizes=sizes,
+        types=types,
+        counts=counts,
     )
     return DreameLawnMowerPointCloudMetadata(
         version="0.7",
@@ -249,6 +269,10 @@ def _validate_pcd_payload(
     data_encoding: str,
     points: int,
     bytes_per_point: int,
+    fields: tuple[str, ...],
+    sizes: tuple[int, ...],
+    types: tuple[str, ...],
+    counts: tuple[int, ...],
 ) -> None:
     expected_bytes = points * bytes_per_point
     if data_encoding == "binary":
@@ -256,22 +280,14 @@ def _validate_pcd_payload(
             raise DreameLawnMowerPointCloudError(
                 "PCD binary payload length does not match its header."
             )
-        return
-
-    if data_encoding == "binary_compressed":
-        if len(payload) < 8:
-            raise DreameLawnMowerPointCloudError(
-                "PCD compressed payload is missing its size prefix."
-            )
-        compressed_bytes, uncompressed_bytes = struct.unpack_from("<II", payload)
-        if uncompressed_bytes != expected_bytes:
-            raise DreameLawnMowerPointCloudError(
-                "PCD compressed payload size does not match its header."
-            )
-        if len(payload) != 8 + compressed_bytes:
-            raise DreameLawnMowerPointCloudError(
-                "PCD compressed payload length is incomplete."
-            )
+        _validate_binary_coordinates(
+            payload,
+            points=points,
+            bytes_per_point=bytes_per_point,
+            fields=fields,
+            sizes=sizes,
+            counts=counts,
+        )
         return
 
     lines = [line for line in payload.splitlines() if line.strip()]
@@ -279,3 +295,90 @@ def _validate_pcd_payload(
         raise DreameLawnMowerPointCloudError(
             "PCD ASCII payload row count does not match its header."
         )
+    scalar_count = sum(counts)
+    for row in lines:
+        try:
+            values = row.decode("ascii").split()
+        except UnicodeDecodeError as err:
+            raise DreameLawnMowerPointCloudError(
+                "PCD ASCII payload must contain only ASCII text."
+            ) from err
+        if len(values) != scalar_count:
+            raise DreameLawnMowerPointCloudError(
+                "PCD ASCII payload column count does not match its header."
+            )
+        _validate_ascii_scalars(
+            values,
+            sizes=sizes,
+            types=types,
+            counts=counts,
+        )
+
+
+def _validate_binary_coordinates(
+    payload: bytes,
+    *,
+    points: int,
+    bytes_per_point: int,
+    fields: tuple[str, ...],
+    sizes: tuple[int, ...],
+    counts: tuple[int, ...],
+) -> None:
+    """Reject non-finite binary coordinates before a frontend parses them."""
+    field_offsets: dict[str, tuple[int, int]] = {}
+    offset = 0
+    for field, size, count in zip(fields, sizes, counts, strict=True):
+        field_offsets[field] = (offset, size)
+        offset += size * count
+
+    coordinates = tuple(field_offsets[field] for field in ("x", "y", "z"))
+    for point_index in range(points):
+        point_offset = point_index * bytes_per_point
+        for coordinate_offset, coordinate_size in coordinates:
+            value = struct.unpack_from(
+                "<f" if coordinate_size == 4 else "<d",
+                payload,
+                point_offset + coordinate_offset,
+            )[0]
+            if not math.isfinite(value):
+                raise DreameLawnMowerPointCloudError(
+                    "PCD coordinates must contain only finite values."
+                )
+
+
+def _validate_ascii_scalars(
+    values: list[str],
+    *,
+    sizes: tuple[int, ...],
+    types: tuple[str, ...],
+    counts: tuple[int, ...],
+) -> None:
+    """Validate every declared ASCII scalar and its numeric range."""
+    scalar_index = 0
+    for size, field_type, count in zip(sizes, types, counts, strict=True):
+        for _ in range(count):
+            token = values[scalar_index]
+            scalar_index += 1
+            try:
+                if field_type == "F":
+                    value = float(token)
+                    if size == 4:
+                        value = struct.unpack("<f", struct.pack("<f", value))[0]
+                    if not math.isfinite(value):
+                        raise ValueError
+                    continue
+
+                value = int(token, 10)
+                bits = size * 8
+                minimum = -(1 << (bits - 1)) if field_type == "I" else 0
+                maximum = (
+                    (1 << (bits - 1)) - 1
+                    if field_type == "I"
+                    else (1 << bits) - 1
+                )
+                if not minimum <= value <= maximum:
+                    raise ValueError
+            except (OverflowError, ValueError, struct.error) as err:
+                raise DreameLawnMowerPointCloudError(
+                    "PCD ASCII payload contains an invalid scalar value."
+                ) from err

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import math
 import struct
+import time
 from collections.abc import Iterator
 from dataclasses import dataclass
 from typing import Any
@@ -16,6 +17,7 @@ _SUPPORTED_FIELD_SIZES = frozenset({1, 2, 4, 8})
 _MAX_ASCII_SCALAR_BYTES = 128
 _MAX_ASCII_SCALARS_PER_POINT = 1024
 _MAX_ASCII_ROW_BYTES = 64 * 1024
+_VALIDATION_DEADLINE_CHECK_BYTES = 64 * 1024
 
 
 class DreameLawnMowerPointCloudError(ValueError):
@@ -81,6 +83,7 @@ def parse_pcd_metadata(
     content: bytes,
     *,
     max_bytes: int = DEFAULT_POINT_CLOUD_MAX_BYTES,
+    deadline: float | None = None,
 ) -> DreameLawnMowerPointCloudMetadata:
     """Validate a PCD payload and return coordinate-free metadata."""
     if isinstance(max_bytes, bool) or not isinstance(max_bytes, int) or max_bytes <= 0:
@@ -89,7 +92,9 @@ def parse_pcd_metadata(
         )
     if not isinstance(content, bytes | bytearray | memoryview):
         raise DreameLawnMowerPointCloudError("Point-cloud content must be bytes.")
+    _ensure_validation_deadline(deadline)
     raw = bytes(content)
+    _ensure_validation_deadline(deadline)
     if not raw:
         raise DreameLawnMowerPointCloudError("Point-cloud content is empty.")
     if len(raw) > max_bytes:
@@ -172,7 +177,9 @@ def parse_pcd_metadata(
         sizes=sizes,
         types=types,
         counts=counts,
+        deadline=deadline,
     )
+    _ensure_validation_deadline(deadline)
     return DreameLawnMowerPointCloudMetadata(
         version="0.7",
         fields=fields,
@@ -284,6 +291,7 @@ def _validate_pcd_payload(
     sizes: tuple[int, ...],
     types: tuple[str, ...],
     counts: tuple[int, ...],
+    deadline: float | None,
 ) -> None:
     expected_bytes = points * bytes_per_point
     if data_encoding == "binary":
@@ -298,6 +306,7 @@ def _validate_pcd_payload(
             fields=fields,
             sizes=sizes,
             counts=counts,
+            deadline=deadline,
         )
         return
 
@@ -307,7 +316,12 @@ def _validate_pcd_payload(
         scalar_count * (_MAX_ASCII_SCALAR_BYTES + 1),
     )
     row_count = 0
+    bytes_since_deadline_check = 0
     for row in _iter_nonempty_ascii_rows(payload):
+        bytes_since_deadline_check += len(row) + 1
+        if bytes_since_deadline_check >= _VALIDATION_DEADLINE_CHECK_BYTES:
+            _ensure_validation_deadline(deadline)
+            bytes_since_deadline_check = 0
         row_count += 1
         if row_count > points:
             raise DreameLawnMowerPointCloudError(
@@ -333,6 +347,7 @@ def _validate_pcd_payload(
             types=types,
             counts=counts,
         )
+    _ensure_validation_deadline(deadline)
     if row_count != points:
         raise DreameLawnMowerPointCloudError(
             "PCD ASCII payload row count does not match its header."
@@ -361,6 +376,7 @@ def _validate_binary_coordinates(
     fields: tuple[str, ...],
     sizes: tuple[int, ...],
     counts: tuple[int, ...],
+    deadline: float | None,
 ) -> None:
     """Reject non-finite binary coordinates before a frontend parses them."""
     field_offsets: dict[str, tuple[int, int]] = {}
@@ -370,7 +386,13 @@ def _validate_binary_coordinates(
         offset += size * count
 
     coordinates = tuple(field_offsets[field] for field in ("x", "y", "z"))
+    deadline_check_interval = max(
+        1,
+        _VALIDATION_DEADLINE_CHECK_BYTES // bytes_per_point,
+    )
     for point_index in range(points):
+        if point_index % deadline_check_interval == 0:
+            _ensure_validation_deadline(deadline)
         point_offset = point_index * bytes_per_point
         for coordinate_offset, coordinate_size in coordinates:
             value = struct.unpack_from(
@@ -382,6 +404,15 @@ def _validate_binary_coordinates(
                 raise DreameLawnMowerPointCloudError(
                     "PCD coordinates must contain only finite values."
                 )
+    _ensure_validation_deadline(deadline)
+
+
+def _ensure_validation_deadline(deadline: float | None) -> None:
+    """Stop CPU-bound validation after the caller's absolute deadline."""
+    if deadline is not None and time.monotonic() >= deadline:
+        raise DreameLawnMowerPointCloudError(
+            "Point-cloud validation timed out."
+        )
 
 
 def _validate_ascii_scalars(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -19,6 +19,7 @@ from miio.miioprotocol import MiIOProtocol
 
 from .exceptions import DeviceException
 from .const import DREAME_STRINGS, MOVA_STRINGS
+from .deadline import DeadlineExceededError, run_with_deadline
 from .mqtt_tls import create_cloud_mqtt_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
@@ -109,6 +110,27 @@ def _read_cloud_response_text_with_deadline(
 
     encoding = getattr(response, "encoding", None) or "utf-8"
     return content.decode(encoding)
+
+
+def _post_cloud_response(
+    session: Any,
+    url: str,
+    request_options: dict[str, Any],
+    *,
+    deadline: float | None,
+) -> Any:
+    """Post while bounding the response-header phase by an absolute deadline."""
+    if deadline is None:
+        return session.post(url, **request_options)
+    try:
+        return run_with_deadline(
+            lambda: session.post(url, **request_options),
+            deadline=deadline,
+        )
+    except DeadlineExceededError as err:
+        raise requests.exceptions.Timeout(
+            "The cloud response timed out."
+        ) from err
 
 
 class DreameMowerDeviceProtocol(MiIOProtocol):
@@ -426,9 +448,11 @@ class DreameMowerDreameHomeCloudProtocol:
             }
             if deadline is not None:
                 request_options["stream"] = True
-            response = self._session.post(
+            response = _post_cloud_response(
+                self._session,
                 self.get_api_url() + self._strings[17],
-                **request_options,
+                request_options,
+                deadline=deadline,
             )
             if deadline is not None:
                 try:
@@ -1086,8 +1110,19 @@ class DreameMowerDreameHomeCloudProtocol:
                     "timeout": timeout,
                 }
                 if deadline is not None:
+                    remaining = deadline - time.monotonic()
+                    if remaining <= 0:
+                        raise requests.exceptions.Timeout(
+                            "The cloud response timed out."
+                        )
+                    request_options["timeout"] = min(timeout, remaining)
                     request_options["stream"] = True
-                response = self._session.post(url, **request_options)
+                response = _post_cloud_response(
+                    self._session,
+                    url,
+                    request_options,
+                    deadline=deadline,
+                )
                 if deadline is not None:
                     try:
                         response_text = _read_cloud_response_text_with_deadline(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -771,7 +771,12 @@ class DreameMowerDreameHomeCloudProtocol:
 
         return api_response["data"]
 
-    def get_interim_file_url(self, object_name: str = "") -> str:
+    def get_interim_file_url(
+        self,
+        object_name: str = "",
+        retry_count: int = 2,
+        timeout: float = 20,
+    ) -> str:
         api_response = self._api_call(
             f"{self._strings[23]}/{self._strings[39]}/{self._strings[55]}",
             {
@@ -780,6 +785,8 @@ class DreameMowerDreameHomeCloudProtocol:
                 self._strings[40]: object_name,
                 self._strings[21]: self._country,
             },
+            retry_count=retry_count,
+            timeout=timeout,
         )
         if api_response is None or "data" not in api_response:
             return None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -1166,7 +1166,15 @@ class DreameMowerDreameHomeCloudProtocol:
                 return json.loads(response_text)
             elif response.status_code == 401 and self._secondary_key:
                 _LOGGER.debug("Execute api call failed: Token Expired")
-                self.login()
+                if deadline is None:
+                    self.login()
+                else:
+                    remaining = deadline - time.monotonic()
+                    if remaining > 0:
+                        self.login(
+                            timeout=min(timeout, remaining),
+                            deadline=deadline,
+                        )
             else:
                 _LOGGER.warn(
                     "Execute api call failed with response: %s",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -26,6 +26,9 @@ _TX_VIDEO_API_PATH = "/dreame-third-video/tx/"
 _REDACTED_TX_VIDEO_PAYLOAD = "<redacted TX video payload>"
 _INTERIM_FILE_API_PATH = "/dreame-user-iot/iotfile/getDownloadUrl"
 _REDACTED_INTERIM_FILE_PAYLOAD = "<redacted interim file payload>"
+_REDACTED_APP_ACTION_RESPONSE = "<redacted app action response>"
+_DEADLINE_RESPONSE_CHUNK_BYTES = 8 * 1024
+_MAX_DEADLINE_RESPONSE_BYTES = 1024 * 1024
 
 
 def _cloud_request_log_value(url: str, value: Any) -> Any:
@@ -35,6 +38,77 @@ def _cloud_request_log_value(url: str, value: Any) -> Any:
     if _INTERIM_FILE_API_PATH in url and value is not None:
         return _REDACTED_INTERIM_FILE_PAYLOAD
     return value
+
+
+def _app_action_response_log_value(value: Any, *, redact: bool) -> Any:
+    """Hide private point-cloud object names from app-action response logs."""
+    if redact and value is not None:
+        return _REDACTED_APP_ACTION_RESPONSE
+    return value
+
+
+def _set_cloud_response_timeout(response: Any, timeout: float) -> None:
+    """Apply the remaining overall deadline to a streamed response socket."""
+    raw = getattr(response, "raw", None)
+    raw_fp = getattr(raw, "_fp", None)
+    response_fp = getattr(raw_fp, "fp", None)
+    response_raw = getattr(response_fp, "raw", None)
+    candidates = (
+        response,
+        raw,
+        getattr(raw, "_sock", None),
+        raw_fp,
+        response_fp,
+        response_raw,
+        getattr(response_raw, "_sock", None),
+    )
+    for candidate in candidates:
+        set_timeout = getattr(candidate, "settimeout", None)
+        if callable(set_timeout):
+            set_timeout(timeout)
+            return
+    raise requests.exceptions.Timeout(
+        "The cloud response deadline could not be enforced."
+    )
+
+
+def _read_cloud_response_text_with_deadline(
+    response: Any,
+    *,
+    deadline: float,
+    max_bytes: int = _MAX_DEADLINE_RESPONSE_BYTES,
+) -> str:
+    """Read a bounded response body while enforcing an absolute deadline."""
+    raw = getattr(response, "raw", None)
+    read_chunk = getattr(raw, "read1", None)
+    if not callable(read_chunk):
+        raise requests.exceptions.Timeout(
+            "The cloud response deadline could not be enforced."
+        )
+
+    content = bytearray()
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise requests.exceptions.Timeout("The cloud response timed out.")
+        _set_cloud_response_timeout(response, remaining)
+        chunk = read_chunk(
+            min(
+                _DEADLINE_RESPONSE_CHUNK_BYTES,
+                max_bytes + 1 - len(content),
+            ),
+            decode_content=True,
+        )
+        if time.monotonic() >= deadline:
+            raise requests.exceptions.Timeout("The cloud response timed out.")
+        if not chunk:
+            break
+        content.extend(chunk)
+        if len(content) > max_bytes:
+            raise ValueError("The cloud response exceeded the maximum size.")
+
+    encoding = getattr(response, "encoding", None) or "utf-8"
+    return content.decode(encoding)
 
 
 class DreameMowerDeviceProtocol(MiIOProtocol):
@@ -136,13 +210,24 @@ class DreameMowerDreameHomeCloudProtocol:
 
         self._queue.put((callback, url, params, retry_count))
 
-    def _api_call(self, url, params=None, retry_count=2, timeout=20):
+    def _api_call(
+        self,
+        url,
+        params=None,
+        retry_count=2,
+        timeout=20,
+        *,
+        deadline: float | None = None,
+        redact_response: bool = False,
+    ):
         return self.request(
             f"{self.get_api_url()}/{url}",
             json.dumps(params, separators=(",", ":")
                        ) if params is not None else None,
             retry_count,
             timeout,
+            deadline=deadline,
+            redact_response=redact_response,
         )
 
     def get_api_url(self) -> str:
@@ -663,6 +748,9 @@ class DreameMowerDreameHomeCloudProtocol:
         parameters,
         retry_count: int = 2,
         timeout: float = 20,
+        *,
+        deadline: float | None = None,
+        redact_response: bool = False,
     ) -> Any:
         host = ""
         if self._host and len(self._host):
@@ -682,9 +770,17 @@ class DreameMowerDreameHomeCloudProtocol:
             },
             retry_count,
             timeout,
+            deadline=deadline,
+            redact_response=redact_response,
+        )
+        logged_response = _app_action_response_log_value(
+            api_response,
+            redact=redact_response,
         )
         _LOGGER.debug(
-            "DreameMowerDreameHomeCloudProtocol.send api_response: %s", api_response)
+            "DreameMowerDreameHomeCloudProtocol.send api_response: %s",
+            logged_response,
+        )
         self._id = self._id + 1
         if isinstance(api_response, Mapping) and api_response.get("code") == 80001:
             # Seems to be a valid error message from the server which translates to:
@@ -692,7 +788,9 @@ class DreameMowerDreameHomeCloudProtocol:
             # While the time out was a return value from the server, implying that the
             # the server correctly handled the request.
             _LOGGER.debug(
-                "DreameMowerDreameHomeCloudProtocol.send 80001, return none: %s", api_response)
+                "DreameMowerDreameHomeCloudProtocol.send 80001, return none: %s",
+                logged_response,
+            )
             return None
 
         if (
@@ -703,7 +801,7 @@ class DreameMowerDreameHomeCloudProtocol:
         ):
             _LOGGER.debug(
                 "DreameMowerDreameHomeCloudProtocol.send accepted without result: %s",
-                api_response,
+                logged_response,
             )
             return None
 
@@ -715,7 +813,9 @@ class DreameMowerDreameHomeCloudProtocol:
             or "result" not in api_response["data"]
         ):
             _LOGGER.warning(
-                "DreameMowerDreameHomeCloudProtocol.send failed: %s", api_response)
+                "DreameMowerDreameHomeCloudProtocol.send failed: %s",
+                logged_response,
+            )
             return None
         return api_response["data"]["result"]
 
@@ -726,6 +826,9 @@ class DreameMowerDreameHomeCloudProtocol:
         aiid: int = 50,
         retry_count: int = 2,
         timeout: float = 20,
+        *,
+        deadline: float | None = None,
+        redact_response: bool = False,
     ) -> Any:
         """Call the mobile-app action bridge used by mower plugin commands."""
         return self.send(
@@ -738,6 +841,8 @@ class DreameMowerDreameHomeCloudProtocol:
             },
             retry_count=retry_count,
             timeout=timeout,
+            deadline=deadline,
+            redact_response=redact_response,
         )
 
     def get_file(self, url: str, retry_count: int = 4) -> Any:
@@ -851,7 +956,16 @@ class DreameMowerDreameHomeCloudProtocol:
             return None
         return api_response["result"]
 
-    def request(self, url: str, data, retry_count=2, timeout=20) -> Any:
+    def request(
+        self,
+        url: str,
+        data,
+        retry_count=2,
+        timeout=20,
+        *,
+        deadline: float | None = None,
+        redact_response: bool = False,
+    ) -> Any:
         _LOGGER.debug(
             "DreameMowerDreameHomeCloudProtocol.request %s %s",
             url,
@@ -861,6 +975,7 @@ class DreameMowerDreameHomeCloudProtocol:
         retries = 0
         if not retry_count or retry_count < 0:
             retry_count = 0
+        response_text = None
         while retries < retry_count + 1:
             try:
                 if self._key_expire and time.time() > self._key_expire:
@@ -880,12 +995,24 @@ class DreameMowerDreameHomeCloudProtocol:
                 if self._country == "cn":
                     headers[self._strings[48]] = self._strings[4]
 
-                response = self._session.post(
-                    url,
-                    headers=headers,
-                    data=data,
-                    timeout=timeout,
-                )
+                request_options = {
+                    "headers": headers,
+                    "data": data,
+                    "timeout": timeout,
+                }
+                if deadline is not None:
+                    request_options["stream"] = True
+                response = self._session.post(url, **request_options)
+                if deadline is not None:
+                    try:
+                        response_text = _read_cloud_response_text_with_deadline(
+                            response,
+                            deadline=deadline,
+                        )
+                    finally:
+                        response.close()
+                else:
+                    response_text = response.text
                 break
             except requests.exceptions.Timeout:
                 retries = retries + 1
@@ -911,16 +1038,22 @@ class DreameMowerDreameHomeCloudProtocol:
                 self._connected = True
                 _LOGGER.debug(
                     "DreameMowerDreameHomeCloudProtocol.request response.text: %s",
-                    _cloud_request_log_value(url, response.text),
+                    _app_action_response_log_value(
+                        _cloud_request_log_value(url, response_text),
+                        redact=redact_response,
+                    ),
                 )
-                return json.loads(response.text)
+                return json.loads(response_text)
             elif response.status_code == 401 and self._secondary_key:
                 _LOGGER.debug("Execute api call failed: Token Expired")
                 self.login()
             else:
                 _LOGGER.warn(
                     "Execute api call failed with response: %s",
-                    _cloud_request_log_value(url, response.text),
+                    _app_action_response_log_value(
+                        _cloud_request_log_value(url, response_text),
+                        redact=redact_response,
+                    ),
                 )
 
         if self._fail_count == 5:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -24,12 +24,16 @@ from .mqtt_tls import create_cloud_mqtt_ssl_context
 _LOGGER = logging.getLogger(__name__)
 _TX_VIDEO_API_PATH = "/dreame-third-video/tx/"
 _REDACTED_TX_VIDEO_PAYLOAD = "<redacted TX video payload>"
+_INTERIM_FILE_API_PATH = "/dreame-user-iot/iotfile/getDownloadUrl"
+_REDACTED_INTERIM_FILE_PAYLOAD = "<redacted interim file payload>"
 
 
 def _cloud_request_log_value(url: str, value: Any) -> Any:
-    """Hide TX video credentials and P2P material from cloud request logs."""
+    """Hide sensitive cloud request and response material from logs."""
     if _TX_VIDEO_API_PATH in url and value is not None:
         return _REDACTED_TX_VIDEO_PAYLOAD
+    if _INTERIM_FILE_API_PATH in url and value is not None:
+        return _REDACTED_INTERIM_FILE_PAYLOAD
     return value
 
 
@@ -132,12 +136,13 @@ class DreameMowerDreameHomeCloudProtocol:
 
         self._queue.put((callback, url, params, retry_count))
 
-    def _api_call(self, url, params=None, retry_count=2):
+    def _api_call(self, url, params=None, retry_count=2, timeout=20):
         return self.request(
             f"{self.get_api_url()}/{url}",
             json.dumps(params, separators=(",", ":")
                        ) if params is not None else None,
             retry_count,
+            timeout,
         )
 
     def get_api_url(self) -> str:
@@ -652,7 +657,13 @@ class DreameMowerDreameHomeCloudProtocol:
             retry_count,
         )
 
-    def send(self, method, parameters, retry_count: int = 2) -> Any:
+    def send(
+        self,
+        method,
+        parameters,
+        retry_count: int = 2,
+        timeout: float = 20,
+    ) -> Any:
         host = ""
         if self._host and len(self._host):
             host = f"-{self._host.split('.')[0]}"
@@ -670,6 +681,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 },
             },
             retry_count,
+            timeout,
         )
         _LOGGER.debug(
             "DreameMowerDreameHomeCloudProtocol.send api_response: %s", api_response)
@@ -713,6 +725,7 @@ class DreameMowerDreameHomeCloudProtocol:
         siid: int = 2,
         aiid: int = 50,
         retry_count: int = 2,
+        timeout: float = 20,
     ) -> Any:
         """Call the mobile-app action bridge used by mower plugin commands."""
         return self.send(
@@ -724,6 +737,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 "in": [payload],
             },
             retry_count=retry_count,
+            timeout=timeout,
         )
 
     def get_file(self, url: str, retry_count: int = 4) -> Any:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -374,7 +374,12 @@ class DreameMowerDreameHomeCloudProtocol:
                 return info
         return None
 
-    def login(self) -> bool:
+    def login(
+        self,
+        timeout: float = 10,
+        *,
+        deadline: float | None = None,
+    ) -> bool:
         self._session.close()
         self._session = requests.session()
         self._logged_in = False
@@ -406,14 +411,37 @@ class DreameMowerDreameHomeCloudProtocol:
             if self._country == "cn":
                 headers[self._strings[48]] = self._strings[4]
 
+            request_timeout = timeout
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise requests.exceptions.Timeout(
+                        "The cloud login timed out."
+                    )
+                request_timeout = min(request_timeout, remaining)
+            request_options = {
+                "headers": headers,
+                "data": data,
+                "timeout": request_timeout,
+            }
+            if deadline is not None:
+                request_options["stream"] = True
             response = self._session.post(
                 self.get_api_url() + self._strings[17],
-                headers=headers,
-                data=data,
-                timeout=10,
+                **request_options,
             )
+            if deadline is not None:
+                try:
+                    response_text = _read_cloud_response_text_with_deadline(
+                        response,
+                        deadline=deadline,
+                    )
+                finally:
+                    response.close()
+            else:
+                response_text = response.text
             if response.status_code == 200:
-                data = json.loads(response.text)
+                data = json.loads(response_text)
                 if self._strings[18] in data:
                     self._key = data.get(self._strings[18])
                     self._secondary_key = data.get(self._strings[19])
@@ -426,17 +454,20 @@ class DreameMowerDreameHomeCloudProtocol:
                     self._ti = data.get(self._strings[22], self._ti)
             else:
                 try:
-                    data = json.loads(response.text)
+                    data = json.loads(response_text)
                     if "error_description" in data and "refresh token" in data["error_description"]:
                         self._secondary_key = None
-                        return self.login()
+                        return self.login(timeout=timeout, deadline=deadline)
                 except:
                     pass
-                _LOGGER.error("Login failed: %s => %s -- %s -- %s", response.text,
+                _LOGGER.error("Login failed: %s => %s -- %s -- %s", response_text,
                               self.get_api_url() + self._strings[17], headers, data)
         except requests.exceptions.Timeout:
             response = None
-            _LOGGER.warning("Login Failed: Read timed out. (read timeout=10)")
+            _LOGGER.warning(
+                "Login Failed: Read timed out. (read timeout=%s)",
+                timeout,
+            )
         except Exception as ex:
             response = None
             _LOGGER.error("Login failed: %s", str(ex))
@@ -446,9 +477,19 @@ class DreameMowerDreameHomeCloudProtocol:
             self._connected = True
         return self._logged_in
 
-    def get_devices(self) -> Any:
+    def get_devices(
+        self,
+        retry_count: int = 2,
+        timeout: float = 20,
+        *,
+        deadline: float | None = None,
+    ) -> Any:
         response = self._api_call(
-            f"{self._strings[23]}/{self._strings[24]}/{self._strings[27]}/{self._strings[28]}")
+            f"{self._strings[23]}/{self._strings[24]}/{self._strings[27]}/{self._strings[28]}",
+            retry_count=retry_count,
+            timeout=timeout,
+            deadline=deadline,
+        )
         _LOGGER.debug(
             "DreameMowerDreameHomeCloudProtocol.get_devices %s", response)
         if response:
@@ -486,7 +527,14 @@ class DreameMowerDreameHomeCloudProtocol:
             return data
         return None
 
-    def get_device_info_v2(self, lang: str | None = None) -> Any:
+    def get_device_info_v2(
+        self,
+        lang: str | None = None,
+        retry_count: int = 2,
+        timeout: float = 20,
+        *,
+        deadline: float | None = None,
+    ) -> Any:
         params = {"did": self._did}
         if lang:
             params["lang"] = lang
@@ -494,6 +542,9 @@ class DreameMowerDreameHomeCloudProtocol:
         response = self.request(
             f"{self.get_api_url()}/dreame-user-iot/iotuserbind/device/info",
             json.dumps(params, separators=(",", ":")),
+            retry_count=retry_count,
+            timeout=timeout,
+            deadline=deadline,
         )
         if response and "data" in response and response["code"] == 0:
             data = response["data"]
@@ -663,10 +714,19 @@ class DreameMowerDreameHomeCloudProtocol:
             return response["data"]
         return None
 
-    def get_device_info(self) -> Any:
+    def get_device_info(
+        self,
+        retry_count: int = 2,
+        timeout: float = 20,
+        *,
+        deadline: float | None = None,
+    ) -> Any:
         response = self._api_call(
             f"{self._strings[23]}/{self._strings[24]}/{self._strings[27]}/{self._strings[29]}",
             {"did": self._did},
+            retry_count=retry_count,
+            timeout=timeout,
+            deadline=deadline,
         )
         if response and "data" in response and response["code"] == 0:
             data = response["data"]
@@ -674,6 +734,9 @@ class DreameMowerDreameHomeCloudProtocol:
             response = self._api_call(
                 f"{self._strings[23]}/{self._strings[25]}/{self._strings[30]}",
                 {"did": self._did},
+                retry_count=retry_count,
+                timeout=timeout,
+                deadline=deadline,
             )
             if response and "data" in response and response["code"] == 0:
                 if self._strings[31] in response["data"]:
@@ -684,7 +747,11 @@ class DreameMowerDreameHomeCloudProtocol:
                 else:
                     _LOGGER.debug(
                         "Get Device OTC Info Retrying with fallback... (%s)", response)
-                    devices = self.get_devices()
+                    devices = self.get_devices(
+                        retry_count=retry_count,
+                        timeout=timeout,
+                        deadline=deadline,
+                    )
                     if devices is not None:
                         found = list(
                             filter(
@@ -881,6 +948,8 @@ class DreameMowerDreameHomeCloudProtocol:
         object_name: str = "",
         retry_count: int = 2,
         timeout: float = 20,
+        *,
+        deadline: float | None = None,
     ) -> str:
         api_response = self._api_call(
             f"{self._strings[23]}/{self._strings[39]}/{self._strings[55]}",
@@ -892,6 +961,7 @@ class DreameMowerDreameHomeCloudProtocol:
             },
             retry_count=retry_count,
             timeout=timeout,
+            deadline=deadline,
         )
         if api_response is None or "data" not in api_response:
             return None
@@ -979,7 +1049,22 @@ class DreameMowerDreameHomeCloudProtocol:
         while retries < retry_count + 1:
             try:
                 if self._key_expire and time.time() > self._key_expire:
-                    self.login()
+                    if deadline is None:
+                        self.login()
+                    else:
+                        remaining = deadline - time.monotonic()
+                        if remaining <= 0:
+                            raise requests.exceptions.Timeout(
+                                "The cloud response timed out."
+                            )
+                        if not self.login(
+                            timeout=min(timeout, remaining),
+                            deadline=deadline,
+                        ):
+                            raise requests.exceptions.Timeout(
+                                "The cloud login did not complete before "
+                                "the response deadline."
+                            )
 
                 headers = {
                     "Accept": "*/*",

--- a/custom_components/dreame_lawn_mower/manifest.json
+++ b/custom_components/dreame_lawn_mower/manifest.json
@@ -7,6 +7,7 @@
   ],
   "config_flow": true,
   "dependencies": [
+    "http",
     "stream"
   ],
   "documentation": "https://github.com/EvotecIT/homeassistant-dreamelawnmower",

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -86,6 +86,9 @@ class DreameLawnMowerPointCloudAPI:
         self._cache_ttl = cache_ttl
         self._cache_max_entries = cache_max_entries
         self._cache: OrderedDict[tuple[str, int], _CacheEntry] = OrderedDict()
+        self._cache_expiry_handles: dict[
+            tuple[str, int], asyncio.TimerHandle
+        ] = {}
         self._inflight: dict[tuple[str, int], _InflightGeneration] = {}
         self._entry_epochs: dict[str, int] = {}
 
@@ -177,7 +180,7 @@ class DreameLawnMowerPointCloudAPI:
     def purge_entry(self, entry_id: str) -> None:
         """Discard private cache state for one unloaded entry."""
         for key in [key for key in self._cache if key[0] == entry_id]:
-            self._cache.pop(key, None)
+            self._remove_cache_entry(key)
         self._entry_epochs[entry_id] = self._entry_epochs.get(entry_id, 0) + 1
 
     async def _async_generate(
@@ -199,13 +202,22 @@ class DreameLawnMowerPointCloudAPI:
             raise DreameLawnMowerPointCloudError(
                 "The mower entry changed during point-cloud generation."
             )
+        created_at = time.monotonic()
+        self._remove_cache_entry(key)
         self._cache[key] = _CacheEntry(
-            created_at=time.monotonic(),
+            created_at=created_at,
             download=download,
+        )
+        self._cache_expiry_handles[key] = asyncio.get_running_loop().call_later(
+            max(0.0, self._cache_ttl),
+            self._expire_cache_entry,
+            key,
+            created_at,
         )
         self._cache.move_to_end(key)
         while len(self._cache) > self._cache_max_entries:
-            self._cache.popitem(last=False)
+            oldest_key = next(iter(self._cache))
+            self._remove_cache_entry(oldest_key)
         return download
 
     @callback
@@ -236,10 +248,29 @@ class DreameLawnMowerPointCloudAPI:
         if cached is None:
             return None
         if now - cached.created_at >= self._cache_ttl:
-            self._cache.pop(key, None)
+            self._remove_cache_entry(key)
             return None
         self._cache.move_to_end(key)
         return cached
+
+    @callback
+    def _expire_cache_entry(
+        self,
+        key: tuple[str, int],
+        created_at: float,
+    ) -> None:
+        """Evict only the cache generation scheduled by this timer."""
+        cached = self._cache.get(key)
+        if cached is not None and cached.created_at == created_at:
+            self._remove_cache_entry(key)
+
+    @callback
+    def _remove_cache_entry(self, key: tuple[str, int]) -> None:
+        """Remove one cache entry and cancel its pending expiry timer."""
+        self._cache.pop(key, None)
+        handle = self._cache_expiry_handles.pop(key, None)
+        if handle is not None:
+            handle.cancel()
 
 
 class DreameLawnMowerPointCloudView(HomeAssistantView):

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -1,0 +1,205 @@
+"""Authenticated, private delivery of mower point-cloud files."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import TYPE_CHECKING
+
+from aiohttp import web
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.components.http.decorators import require_admin
+from homeassistant.core import HomeAssistant, callback
+
+from .const import DOMAIN
+from .debug import sanitize_diagnostic_text
+from .dreame_lawn_mower_client import (
+    DreameLawnMowerPointCloudDownload,
+    DreameLawnMowerPointCloudError,
+)
+
+if TYPE_CHECKING:
+    from .coordinator import DreameLawnMowerCoordinator
+
+_LOGGER = logging.getLogger(__name__)
+
+POINT_CLOUD_API_DATA_KEY = "point_cloud_api"
+POINT_CLOUD_API_PATH = f"/api/{DOMAIN}/point-cloud"
+POINT_CLOUD_CACHE_TTL_SECONDS = 60.0
+POINT_CLOUD_CACHE_MAX_ENTRIES = 4
+
+
+def point_cloud_api_path(entry_id: str, map_index: int) -> str:
+    """Return the local authenticated API path advertised to frontends."""
+    return f"{POINT_CLOUD_API_PATH}/{entry_id}/{map_index}"
+
+
+@dataclass(frozen=True, slots=True)
+class _CacheEntry:
+    """Store a generated point cloud briefly in private process memory."""
+
+    created_at: float
+    download: DreameLawnMowerPointCloudDownload
+
+
+class DreameLawnMowerPointCloudAPI:
+    """Coordinate bounded, de-duplicated point-cloud downloads."""
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        *,
+        cache_ttl: float = POINT_CLOUD_CACHE_TTL_SECONDS,
+        cache_max_entries: int = POINT_CLOUD_CACHE_MAX_ENTRIES,
+    ) -> None:
+        self._hass = hass
+        self._cache_ttl = cache_ttl
+        self._cache_max_entries = cache_max_entries
+        self._cache: OrderedDict[tuple[str, int], _CacheEntry] = OrderedDict()
+        self._locks: dict[tuple[str, int], asyncio.Lock] = {}
+
+    async def async_get(
+        self,
+        entry_id: str,
+        map_index: int,
+        *,
+        refresh: bool = False,
+    ) -> DreameLawnMowerPointCloudDownload:
+        """Return one private point cloud, reusing recent/in-flight work."""
+        coordinator = self._coordinator(entry_id)
+        key = (entry_id, map_index)
+        requested_at = time.monotonic()
+        cached = self._fresh_cache_entry(key, requested_at)
+        if cached is not None and not refresh:
+            return cached.download
+
+        lock = self._locks.setdefault(key, asyncio.Lock())
+        async with lock:
+            cached = self._fresh_cache_entry(key, time.monotonic())
+            if cached is not None and (
+                not refresh or cached.created_at >= requested_at
+            ):
+                return cached.download
+
+            download = await coordinator.client.async_download_app_map_point_cloud(
+                map_index=map_index
+            )
+            self._cache[key] = _CacheEntry(
+                created_at=time.monotonic(),
+                download=download,
+            )
+            self._cache.move_to_end(key)
+            while len(self._cache) > self._cache_max_entries:
+                self._cache.popitem(last=False)
+            return download
+
+    @callback
+    def purge_entry(self, entry_id: str) -> None:
+        """Discard private cache and lock state for one unloaded entry."""
+        for key in [key for key in self._cache if key[0] == entry_id]:
+            self._cache.pop(key, None)
+        for key in [key for key in self._locks if key[0] == entry_id]:
+            self._locks.pop(key, None)
+
+    def _coordinator(self, entry_id: str) -> DreameLawnMowerCoordinator:
+        coordinator = self._hass.data.get(DOMAIN, {}).get(entry_id)
+        if coordinator is None or not hasattr(coordinator, "client"):
+            raise web.HTTPNotFound(text="Dreame lawn mower entry not found.")
+        return coordinator
+
+    def _fresh_cache_entry(
+        self,
+        key: tuple[str, int],
+        now: float,
+    ) -> _CacheEntry | None:
+        cached = self._cache.get(key)
+        if cached is None:
+            return None
+        if now - cached.created_at >= self._cache_ttl:
+            self._cache.pop(key, None)
+            return None
+        self._cache.move_to_end(key)
+        return cached
+
+
+class DreameLawnMowerPointCloudView(HomeAssistantView):
+    """Serve a generated PCD file to authenticated Home Assistant admins."""
+
+    url = f"{POINT_CLOUD_API_PATH}/{{entry_id}}/{{map_index}}"
+    name = "api:dreame_lawn_mower:point_cloud"
+    requires_auth = True
+
+    def __init__(self, api: DreameLawnMowerPointCloudAPI) -> None:
+        self._api = api
+
+    @require_admin
+    async def get(
+        self,
+        request: web.Request,
+        entry_id: str,
+        map_index: str,
+    ) -> web.Response:
+        """Generate and return one private PCD download."""
+        try:
+            normalized_index = int(map_index)
+        except ValueError as err:
+            raise web.HTTPBadRequest(text="Invalid point-cloud map index.") from err
+        if not 0 <= normalized_index <= 255:
+            raise web.HTTPBadRequest(text="Invalid point-cloud map index.")
+
+        refresh = request.query.get("refresh") == "1"
+        try:
+            download = await self._api.async_get(
+                entry_id,
+                normalized_index,
+                refresh=refresh,
+            )
+        except web.HTTPException:
+            raise
+        except DreameLawnMowerPointCloudError as err:
+            _LOGGER.warning(
+                "Dreame point-cloud download failed: %s",
+                sanitize_diagnostic_text(err),
+            )
+            raise web.HTTPBadGateway(
+                text="The mower point cloud is temporarily unavailable."
+            ) from err
+        except Exception as err:  # noqa: BLE001 - keep private cloud details private.
+            _LOGGER.warning(
+                "Unexpected Dreame point-cloud download failure: %s",
+                sanitize_diagnostic_text(err),
+            )
+            raise web.HTTPBadGateway(
+                text="The mower point cloud is temporarily unavailable."
+            ) from err
+
+        return web.Response(
+            body=download.content,
+            content_type="application/octet-stream",
+            headers={
+                "Cache-Control": "private, no-store",
+                "Content-Disposition": (
+                    f'attachment; filename="dreame-map-{normalized_index}.pcd"'
+                ),
+                "X-Content-Type-Options": "nosniff",
+            },
+        )
+
+
+@callback
+def async_setup_point_cloud_api(
+    hass: HomeAssistant,
+) -> DreameLawnMowerPointCloudAPI:
+    """Register the point-cloud view once per Home Assistant instance."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    existing = domain_data.get(POINT_CLOUD_API_DATA_KEY)
+    if isinstance(existing, DreameLawnMowerPointCloudAPI):
+        return existing
+
+    api = DreameLawnMowerPointCloudAPI(hass)
+    hass.http.register_view(DreameLawnMowerPointCloudView(api))
+    domain_data[POINT_CLOUD_API_DATA_KEY] = api
+    return api

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -15,7 +15,6 @@ from homeassistant.components.http.decorators import require_admin
 from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
-from .debug import sanitize_diagnostic_text
 from .dreame_lawn_mower_client import (
     DreameLawnMowerPointCloudDownload,
     DreameLawnMowerPointCloudError,
@@ -59,7 +58,11 @@ class DreameLawnMowerPointCloudAPI:
         self._cache_ttl = cache_ttl
         self._cache_max_entries = cache_max_entries
         self._cache: OrderedDict[tuple[str, int], _CacheEntry] = OrderedDict()
-        self._locks: dict[tuple[str, int], asyncio.Lock] = {}
+        self._inflight: dict[
+            tuple[str, int],
+            asyncio.Task[DreameLawnMowerPointCloudDownload],
+        ] = {}
+        self._entry_epochs: dict[str, int] = {}
 
     async def async_get(
         self,
@@ -76,17 +79,57 @@ class DreameLawnMowerPointCloudAPI:
         if cached is not None and not refresh:
             return cached.download
 
-        lock = self._locks.setdefault(key, asyncio.Lock())
-        async with lock:
-            cached = self._fresh_cache_entry(key, time.monotonic())
-            if cached is not None and (
-                not refresh or cached.created_at >= requested_at
-            ):
-                return cached.download
-
-            download = await coordinator.client.async_download_app_map_point_cloud(
-                map_index=map_index
+        task = self._inflight.get(key)
+        if task is None:
+            epoch = self._entry_epochs.get(entry_id, 0)
+            generation = self._async_generate(
+                key,
+                coordinator,
+                epoch=epoch,
             )
+            create_task = getattr(self._hass, "async_create_task", None)
+            if callable(create_task):
+                task = create_task(
+                    generation,
+                    name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
+                )
+            else:
+                task = asyncio.create_task(
+                    generation,
+                    name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
+                )
+            self._inflight[key] = task
+            task.add_done_callback(
+                lambda completed, *, inflight_key=key: self._generation_done(
+                    inflight_key,
+                    completed,
+                )
+            )
+
+        # The HTTP requester may disconnect while asyncio.to_thread keeps running.
+        # Shield the shared generation so another request joins it instead of
+        # launching a second mower-side job.
+        return await asyncio.shield(task)
+
+    @callback
+    def purge_entry(self, entry_id: str) -> None:
+        """Discard private cache state for one unloaded entry."""
+        for key in [key for key in self._cache if key[0] == entry_id]:
+            self._cache.pop(key, None)
+        self._entry_epochs[entry_id] = self._entry_epochs.get(entry_id, 0) + 1
+
+    async def _async_generate(
+        self,
+        key: tuple[str, int],
+        coordinator: DreameLawnMowerCoordinator,
+        *,
+        epoch: int,
+    ) -> DreameLawnMowerPointCloudDownload:
+        """Run and cache one generation independently of HTTP waiters."""
+        download = await coordinator.client.async_download_app_map_point_cloud(
+            map_index=key[1]
+        )
+        if self._entry_epochs.get(key[0], 0) == epoch:
             self._cache[key] = _CacheEntry(
                 created_at=time.monotonic(),
                 download=download,
@@ -94,15 +137,19 @@ class DreameLawnMowerPointCloudAPI:
             self._cache.move_to_end(key)
             while len(self._cache) > self._cache_max_entries:
                 self._cache.popitem(last=False)
-            return download
+        return download
 
     @callback
-    def purge_entry(self, entry_id: str) -> None:
-        """Discard private cache and lock state for one unloaded entry."""
-        for key in [key for key in self._cache if key[0] == entry_id]:
-            self._cache.pop(key, None)
-        for key in [key for key in self._locks if key[0] == entry_id]:
-            self._locks.pop(key, None)
+    def _generation_done(
+        self,
+        key: tuple[str, int],
+        task: asyncio.Task[DreameLawnMowerPointCloudDownload],
+    ) -> None:
+        """Retire an in-flight generation only after its actual work finishes."""
+        if self._inflight.get(key) is task:
+            self._inflight.pop(key, None)
+        if not task.cancelled():
+            task.exception()
 
     def _coordinator(self, entry_id: str) -> DreameLawnMowerCoordinator:
         coordinator = self._hass.data.get(DOMAIN, {}).get(entry_id)
@@ -160,18 +207,12 @@ class DreameLawnMowerPointCloudView(HomeAssistantView):
         except web.HTTPException:
             raise
         except DreameLawnMowerPointCloudError as err:
-            _LOGGER.warning(
-                "Dreame point-cloud download failed: %s",
-                sanitize_diagnostic_text(err),
-            )
+            _LOGGER.warning("Dreame point-cloud generation or validation failed")
             raise web.HTTPBadGateway(
                 text="The mower point cloud is temporarily unavailable."
             ) from err
         except Exception as err:  # noqa: BLE001 - keep private cloud details private.
-            _LOGGER.warning(
-                "Unexpected Dreame point-cloud download failure: %s",
-                sanitize_diagnostic_text(err),
-            )
+            _LOGGER.warning("Unexpected Dreame point-cloud generation failure")
             raise web.HTTPBadGateway(
                 text="The mower point cloud is temporarily unavailable."
             ) from err

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -6,8 +6,9 @@ import asyncio
 import logging
 import time
 from collections import OrderedDict
+from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
@@ -15,6 +16,7 @@ from homeassistant.components.http.decorators import require_admin
 from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
+from .control_options import current_map_index
 from .dreame_lawn_mower_client import (
     DreameLawnMowerPointCloudDownload,
     DreameLawnMowerPointCloudError,
@@ -34,6 +36,24 @@ POINT_CLOUD_CACHE_MAX_ENTRIES = 4
 def point_cloud_api_path(entry_id: str, map_index: int) -> str:
     """Return the local authenticated API path advertised to frontends."""
     return f"{POINT_CLOUD_API_PATH}/{entry_id}/{map_index}"
+
+
+def current_point_cloud_api_path(
+    entry_id: str,
+    app_maps: Mapping[str, Any] | None,
+    batch_device_data: Mapping[str, Any] | None = None,
+    *,
+    selected_map_index: int | None = None,
+) -> str:
+    """Return the API path for the coordinator's current map scope."""
+    return point_cloud_api_path(
+        entry_id,
+        current_map_index(
+            app_maps,
+            batch_device_data,
+            selected_map_index=selected_map_index,
+        ),
+    )
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -44,6 +44,14 @@ class _CacheEntry:
     download: DreameLawnMowerPointCloudDownload
 
 
+@dataclass(frozen=True, slots=True)
+class _InflightGeneration:
+    """Track one generation and the config-entry lifetime that started it."""
+
+    epoch: int
+    task: asyncio.Task[DreameLawnMowerPointCloudDownload]
+
+
 class DreameLawnMowerPointCloudAPI:
     """Coordinate bounded, de-duplicated point-cloud downloads."""
 
@@ -58,10 +66,7 @@ class DreameLawnMowerPointCloudAPI:
         self._cache_ttl = cache_ttl
         self._cache_max_entries = cache_max_entries
         self._cache: OrderedDict[tuple[str, int], _CacheEntry] = OrderedDict()
-        self._inflight: dict[
-            tuple[str, int],
-            asyncio.Task[DreameLawnMowerPointCloudDownload],
-        ] = {}
+        self._inflight: dict[tuple[str, int], _InflightGeneration] = {}
         self._entry_epochs: dict[str, int] = {}
 
     async def async_get(
@@ -79,37 +84,74 @@ class DreameLawnMowerPointCloudAPI:
         if cached is not None and not refresh:
             return cached.download
 
-        task = self._inflight.get(key)
-        if task is None:
-            epoch = self._entry_epochs.get(entry_id, 0)
-            generation = self._async_generate(
-                key,
-                coordinator,
-                epoch=epoch,
+        epoch = self._entry_epochs.get(entry_id, 0)
+        inflight = self._inflight.get(key)
+        if inflight is not None:
+            if inflight.epoch == epoch:
+                return await asyncio.shield(inflight.task)
+            await self._async_discard_stale_generation(key, inflight)
+            return await self.async_get(entry_id, map_index, refresh=refresh)
+
+        other_generation = next(
+            (
+                (other_key, generation)
+                for other_key, generation in self._inflight.items()
+                if other_key[0] == entry_id
+            ),
+            None,
+        )
+        if other_generation is not None:
+            other_key, inflight = other_generation
+            if inflight.epoch != epoch:
+                await self._async_discard_stale_generation(other_key, inflight)
+                return await self.async_get(entry_id, map_index, refresh=refresh)
+            raise DreameLawnMowerPointCloudError(
+                "Another point-cloud generation is already in progress "
+                "for this mower."
             )
-            create_task = getattr(self._hass, "async_create_task", None)
-            if callable(create_task):
-                task = create_task(
-                    generation,
-                    name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
-                )
-            else:
-                task = asyncio.create_task(
-                    generation,
-                    name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
-                )
-            self._inflight[key] = task
-            task.add_done_callback(
-                lambda completed, *, inflight_key=key: self._generation_done(
-                    inflight_key,
-                    completed,
-                )
+
+        generation = self._async_generate(
+            key,
+            coordinator,
+            epoch=epoch,
+        )
+        create_task = getattr(self._hass, "async_create_task", None)
+        if callable(create_task):
+            task = create_task(
+                generation,
+                name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
             )
+        else:
+            task = asyncio.create_task(
+                generation,
+                name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
+            )
+        inflight = _InflightGeneration(epoch=epoch, task=task)
+        self._inflight[key] = inflight
+        task.add_done_callback(
+            lambda completed, *, inflight_key=key: self._generation_done(
+                inflight_key,
+                completed,
+            )
+        )
 
         # The HTTP requester may disconnect while asyncio.to_thread keeps running.
         # Shield the shared generation so another request joins it instead of
         # launching a second mower-side job.
         return await asyncio.shield(task)
+
+    async def _async_discard_stale_generation(
+        self,
+        key: tuple[str, int],
+        inflight: _InflightGeneration,
+    ) -> None:
+        """Wait for old-entry work to finish without returning its result."""
+        try:
+            await asyncio.shield(inflight.task)
+        except Exception:  # noqa: BLE001 - stale result and details are discarded.
+            pass
+        if self._inflight.get(key) is inflight:
+            self._inflight.pop(key, None)
 
     @callback
     def purge_entry(self, entry_id: str) -> None:
@@ -126,17 +168,24 @@ class DreameLawnMowerPointCloudAPI:
         epoch: int,
     ) -> DreameLawnMowerPointCloudDownload:
         """Run and cache one generation independently of HTTP waiters."""
+        if self._entry_epochs.get(key[0], 0) != epoch:
+            raise DreameLawnMowerPointCloudError(
+                "The mower entry changed before point-cloud generation started."
+            )
         download = await coordinator.client.async_download_app_map_point_cloud(
             map_index=key[1]
         )
-        if self._entry_epochs.get(key[0], 0) == epoch:
-            self._cache[key] = _CacheEntry(
-                created_at=time.monotonic(),
-                download=download,
+        if self._entry_epochs.get(key[0], 0) != epoch:
+            raise DreameLawnMowerPointCloudError(
+                "The mower entry changed during point-cloud generation."
             )
-            self._cache.move_to_end(key)
-            while len(self._cache) > self._cache_max_entries:
-                self._cache.popitem(last=False)
+        self._cache[key] = _CacheEntry(
+            created_at=time.monotonic(),
+            download=download,
+        )
+        self._cache.move_to_end(key)
+        while len(self._cache) > self._cache_max_entries:
+            self._cache.popitem(last=False)
         return download
 
     @callback
@@ -146,7 +195,8 @@ class DreameLawnMowerPointCloudAPI:
         task: asyncio.Task[DreameLawnMowerPointCloudDownload],
     ) -> None:
         """Retire an in-flight generation only after its actual work finishes."""
-        if self._inflight.get(key) is task:
+        inflight = self._inflight.get(key)
+        if inflight is not None and inflight.task is task:
             self._inflight.pop(key, None)
         if not task.cancelled():
             task.exception()

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -3298,7 +3298,7 @@ def _app_map_object_summary(value: Any) -> dict[str, Any] | None:
     objects = [
         {
             key: item.get(key)
-            for key in ("name", "extension", "url_present", "error")
+            for key in ("extension", "url_present", "error")
             if item.get(key) is not None
         }
         for item in value.get("objects", [])

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -144,20 +144,24 @@ Last updated: 2026-04-21
 - The app-map helper downloads every created map returned by `MAPL`; the HA map
   camera still renders the current map image, but its attributes expose compact
   all-map metadata (`app_map_count`, `app_current_map_index`, `app_maps`, etc.).
-- `OBJ type=3dmap` is also wired as read-only object metadata through
-  `async_get_app_map_objects()`. A live A2 probe returned two `.bin` object
-  names. Expiring object URLs are intentionally opt-in and omitted from default
-  probe output. Direct HTTP GETs against the tested generated URLs returned
-  404 XML, so treat 3D objects as metadata-only until a downloadable path is
-  confirmed. HA map camera attributes expose safe 3D object metadata through
-  `app_map_object_count` and `app_map_objects`, without signed URLs.
-- A follow-up live check while the 3D map was visible in Dreamehome again
-  returned two `.bin` object names. Opt-in signed URL generation succeeded, but
-  direct HEAD/GET checks still returned XML error responses (`403`/`404`), so
-  do not treat the 3D binary download path as solved.
-- `examples/app_map_probe.py --probe-object-downloads` performs that download
-  check repeatably and redacts signed URLs by default. It records sanitized HEAD
-  and ranged GET statuses for each generated object URL.
+- The generated 3D-map path is now solved on the live A2. App action
+  `{"m":"a","p":0,"o":10,"d":{"idx":0}}` requests map generation; polling
+  `OBJ type=3dmap` then exposes a short-lived object name that must be resolved
+  immediately through `getDownloadUrl`.
+- A 2026-07-23 A2 run returned a standard binary PCD 0.7 file with
+  `x y z rgb`, 152,318 points, and 2,437,272 bytes. The public
+  `async_download_app_map_point_cloud()` API reproduced the same result while
+  the mower remained docked at `charging_completed`.
+- `examples/point_cloud_probe.py` prints coordinate-free PCD metadata and writes
+  geometry only when `--out` is explicitly supplied. The older
+  `app_map_probe.py --probe-object-downloads` path remains useful only for
+  comparing stale metadata objects that previously returned `403`/`404`.
+- Home Assistant exposes the generated PCD through an authenticated,
+  admin-only, local download endpoint. It keeps bytes in a short bounded
+  in-memory cache, deduplicates concurrent generation, serves
+  `private, no-store`, and publishes only `point_cloud_api_path` to map-camera
+  state. Vendor object names, signed URLs, and coordinates stay out of state
+  and logs.
 - `examples/app_map_probe.py --render-dir <dir>` now renders every drawable app
   map to PNG files while keeping raw coordinate payloads out of JSON unless
   `--include-payload` is explicitly set. A live read-only A2 run rendered both
@@ -450,6 +454,7 @@ $env:DREAME_ACCOUNT_TYPE = [Environment]::GetEnvironmentVariable('DREAME_ACCOUNT
 python examples\app_map_probe.py --out app-map-current.json
 python examples\app_map_probe.py --probe-object-downloads --out app-map-objects.json
 python examples\app_map_probe.py --render-dir app-map-renders --out app-map-render.json
+python examples\point_cloud_probe.py
 ```
 
 Only use `--include-payload` for local parser/renderer work. It includes raw
@@ -459,7 +464,8 @@ expiring signed URLs to the ignored output file. Use `--skip-objects` when you
 only want the 2D map payload. `--probe-object-downloads` generates URLs
 internally but redacts them unless `--include-object-urls` is also set.
 `--render-dir` writes per-map PNGs and redacts raw coordinates from JSON unless
-`--include-payload` is also set.
+`--include-payload` is also set. The confirmed point-cloud probe prints only
+metadata unless `--out <path>.pcd` is explicitly supplied.
 
 Render the current app-map fallback PNG:
 
@@ -610,9 +616,9 @@ credentials into repo files.
   `semantic` neutral for now; summaries expose `semantic_count`,
   `semantic_boundary_point_count`, and `semantic_key_counts` as evidence fields
   until more mower captures prove what those entries mean.
-- `OBJ type=3dmap` object names and signed-looking download URLs are
-  discoverable, but the tested URLs returned 404 XML. The `.bin` format is not
-  downloaded or decoded yet.
+- Collect point-cloud field reports from non-A2 models. The A2 generation,
+  download, PCD validation, Home Assistant delivery, and Lovelace viewer path
+  are solved; LiDAX and other families still need confirmation.
 - Keep the map camera/entity disabled by default until the renderer has stable
   fixtures from more mower states and models.
 - Keep sampling the realtime/raw status blobs across transitions. Current

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -337,22 +337,27 @@ The successful map path is the app action bridge described above. On
   Assistant map camera renders the current map image, and its attributes expose
   compact metadata for every app map so secondary maps remain visible without
   switching the rendered camera frame.
-- `OBJ type=3dmap`: two `.bin` object names. Calling the app-side
-  `/dreame-user-iot/iotfile/getDownloadUrl` helper with those names returns
-  OSS-looking URLs, but direct GETs against the tested URLs returned 404 XML.
-  HA map attributes now expose object count and object names/extensions without
-  signed URLs. The binary format is therefore not downloaded or decoded yet.
-- A follow-up live check while the 3D map was visible in Dreamehome again
-  returned two `.bin` object names. Opt-in signed URL generation succeeded, but
-  direct HEAD/GET checks still returned XML error responses (`403`/`404`), so
-  the app download context or required headers remain unsolved.
-- The decompiled Dreamehome plugin shows `getOBJ(type)` sends
-  `{"m":"g","t":"OBJ","d":{"type":type}}`. It also has a direct download flow
-  that calls `/dreame-user-iot/iotfile/getDownloadUrl` with `{filename, model}`
-  and passes the returned URL to `RNFS.downloadFile`; no custom download headers
-  are visible in that flow. A separate mower action helper sends
-  `{"m":"a","o":16,"d":{"type":type,"url":url}}`, but we have not yet verified
-  whether the A2 uses that action for 3D map binaries.
+- Historical `OBJ type=3dmap` reads returned stale `.bin` metadata whose signed
+  URLs failed with `403`/`404`. Those objects are not the generated PCD flow.
+- A live A2 run on 2026-07-23 confirmed the complete sequence:
+  `{"m":"a","p":0,"o":10,"d":{"idx":0}}` requests generation, then
+  `{"m":"g","t":"OBJ","d":{"type":"3dmap"}}` briefly publishes the generated
+  object name. The client must resolve that name immediately through
+  `/dreame-user-iot/iotfile/getDownloadUrl`; the returned HTTPS URL needs no
+  custom download headers.
+- The generated file was a standard PCD 0.7 binary with fields `x y z rgb`,
+  152,318 finite points, 991 observed colors, and 2,437,272 total bytes.
+  Repeating the flow through the new public client returned the same validated
+  format and counts while the mower remained docked at
+  `charging_completed`.
+- `async_download_app_map_point_cloud()` now owns the generation, transient
+  object capture, bounded HTTPS download, and PCD validation. It returns bytes
+  plus coordinate-free metadata and deliberately omits the vendor filename and
+  signed URL.
+- Home Assistant serves those bytes only through an authenticated admin-only
+  local endpoint with `private, no-store` caching, a short in-memory TTL, and
+  in-flight request deduplication. The map camera publishes only its local
+  `point_cloud_api_path`.
 
 Use `python examples/app_map_probe.py --out app-map-current.json` for a focused
 read-only probe that omits raw coordinates by default. Add `--include-payload`
@@ -360,9 +365,13 @@ only for local parser/rendering work.
 
 Use
 `python examples/app_map_probe.py --probe-object-downloads --out app-map-objects.json`
-to generate object URLs internally and record sanitized HEAD/ranged GET results.
-Signed object URLs are redacted from the output unless `--include-object-urls` is
-explicitly added for local-only debugging.
+only when comparing the older metadata objects. It records sanitized
+HEAD/ranged GET results and redacts signed URLs unless
+`--include-object-urls` is explicitly added for local-only debugging.
+
+Use `python examples/point_cloud_probe.py` for the confirmed generation flow.
+It prints PCD metadata without coordinates or signed cloud details. Add
+`--out garden-map.pcd` only for intentional local geometry analysis.
 
 Use
 `python examples/app_map_probe.py --render-dir app-map-renders --out app-map-render.json`

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -103,6 +103,7 @@ upgrade does not create duplicate entities.
 - guarded mowing-preference planning and optional live PRE writes from current
   app payloads, with explicit confirmation required before execution
 - read-only app-map retrieval, all-map summaries, and simple map rendering
+- on-demand app-map point-cloud generation, bounded download, and PCD validation
 - weather/rain-protection and mowing-preference diagnostics
 - firmware/update evidence gathering without claiming unverified OTA support
 - guarded remote-control support helpers for supervised short movement pulses
@@ -114,6 +115,29 @@ Prefer read-only calls while investigating a mower. Methods and examples that
 can move the mower or change mower settings use explicit execution flags,
 confirmation flags, or state guards. Do not run live movement or write probes
 from automations.
+
+## Point Clouds
+
+`async_download_app_map_point_cloud()` owns the complete mower/cloud flow:
+
+```python
+from pathlib import Path
+
+download = await client.async_download_app_map_point_cloud(map_index=0)
+print(download.metadata.as_dict())
+
+# Persist geometry only when you explicitly need a local PCD file.
+Path("garden-map.pcd").write_bytes(download.content)
+```
+
+The method triggers app action `o:10`, polls the transient `OBJ` 3D-map slot,
+resolves its short-lived cloud download immediately, enforces HTTPS, time, and
+size limits, and validates PCD 0.7 before returning. The result deliberately
+does not expose the vendor filename or cloud-signed URL.
+
+Use `python examples/point_cloud_probe.py` to print coordinate-free metadata.
+Add `--out garden-map.pcd` only when you intentionally want to persist private
+garden geometry.
 
 ## Package Layout
 
@@ -141,6 +165,7 @@ service, config-flow, and registry behavior in `custom_components`.
 
 - `examples/cloud_probe.py`
 - `examples/app_map_probe.py`
+- `examples/point_cloud_probe.py`
 - `examples/batch_device_data_probe.py`
 - `examples/schedule_probe.py`
 - `examples/schedule_write_probe.py`

--- a/examples/point_cloud_probe.py
+++ b/examples/point_cloud_probe.py
@@ -1,0 +1,91 @@
+"""Generate and validate one mower point cloud through the public client."""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+from pathlib import Path
+
+from dreame_lawn_mower_client import DreameLawnMowerClient
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate one mower point cloud and print coordinate-free PCD metadata."
+        )
+    )
+    parser.add_argument(
+        "--device-index",
+        type=int,
+        default=0,
+        help="Zero-based discovered mower index.",
+    )
+    parser.add_argument(
+        "--map-index",
+        type=int,
+        default=0,
+        help="Zero-based app map index.",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        help="Optional local .pcd output. Omit it to avoid persisting geometry.",
+    )
+    return parser
+
+
+async def main() -> None:
+    args = _build_parser().parse_args()
+    username = os.environ["DREAME_USERNAME"]
+    password = os.environ["DREAME_PASSWORD"]
+    country = os.environ.get("DREAME_COUNTRY", "eu")
+    account_type = os.environ.get("DREAME_ACCOUNT_TYPE", "dreame")
+
+    devices = await DreameLawnMowerClient.async_discover_devices(
+        username=username,
+        password=password,
+        country=country,
+        account_type=account_type,
+    )
+    if not devices:
+        raise RuntimeError("No mower devices found.")
+    if args.device_index < 0 or args.device_index >= len(devices):
+        raise RuntimeError(
+            f"Invalid device index {args.device_index}; found {len(devices)}."
+        )
+
+    client = DreameLawnMowerClient(
+        username=username,
+        password=password,
+        country=country,
+        account_type=account_type,
+        descriptor=devices[args.device_index],
+    )
+    try:
+        download = await client.async_download_app_map_point_cloud(
+            map_index=args.map_index
+        )
+        result = {
+            "device": {
+                "name": devices[args.device_index].name,
+                "model": devices[args.device_index].display_model,
+            },
+            "map_index": download.map_index,
+            "metadata": download.metadata.as_dict(),
+            "saved_to": None,
+        }
+        if args.out is not None:
+            if args.out.exists():
+                raise RuntimeError(f"Refusing to overwrite existing file: {args.out}")
+            args.out.write_bytes(download.content)
+            result["saved_to"] = str(args.out)
+        print(json.dumps(result, indent=2, sort_keys=True))
+    finally:
+        await client.async_close()
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -37,9 +37,11 @@ class _FakeAppMapCloud:
         *,
         siid: int = 2,
         aiid: int = 50,
+        redact_response: bool = False,
     ) -> dict[str, object]:
         assert siid == 2
         assert aiid == 50
+        assert redact_response is (payload.get("t") == "OBJ")
         self.calls.append(payload)
         command = payload.get("t")
         if command == "MAPL":
@@ -273,8 +275,37 @@ def test_app_map_object_urls_are_opt_in() -> None:
     assert objects["source"] == "app_action_obj_3dmap"
     assert objects["object_count"] == 1
     assert objects["urls_included"] is True
+    assert objects["objects"][0]["name"].endswith("map-one.0233.bin")
     assert objects["objects"][0]["url_present"] is True
     assert objects["objects"][0]["url"].startswith("https://example.invalid/")
+
+
+def test_app_map_object_state_omits_names_and_redacts_action_logs() -> None:
+    client = _client()
+    call_options: list[dict[str, object]] = []
+
+    def call_app_action(
+        payload: dict[str, object],
+        **kwargs: object,
+    ) -> dict[str, object]:
+        call_options.append(kwargs)
+        return {
+            "r": 0,
+            "d": {"name": ["private/generated-map.pcd"]},
+        }
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda: object()
+
+    objects = client._sync_get_app_map_objects(include_urls=False)
+
+    assert call_options == [{"redact_response": True}]
+    assert objects == {
+        "source": "app_action_obj_3dmap",
+        "object_count": 1,
+        "objects": [{"extension": "pcd", "url_present": False}],
+        "urls_included": False,
+    }
 
 
 def test_map_view_falls_back_to_rendered_app_map() -> None:
@@ -323,13 +354,12 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
         "available_map_count": 1,
         "created_map_count": 1,
         "object_count": 1,
-        "object_error": None,
-        "objects": [
-            {
-                "name": "ali_dreame/2025/04/23/device/map-one.0233.bin",
-                "extension": "bin",
-                "url_present": False,
-            }
+            "object_error": None,
+            "objects": [
+                {
+                    "extension": "bin",
+                    "url_present": False,
+                }
         ],
         "maps": [
             {

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -1227,12 +1227,10 @@ def test_app_map_object_attributes_are_compact() -> None:
             "extension_counts": {"bin": 1, "obj": 1},
             "objects": [
                 {
-                    "name": "ali_dreame/2025/04/23/device/map-one.0233.bin",
                     "extension": "bin",
                     "url_present": False,
                 },
                 {
-                    "name": "ali_dreame/2025/04/23/device/model.obj",
                     "extension": "obj",
                     "url_present": False,
                 },

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -124,8 +124,8 @@ def test_map_camera_attributes_include_all_app_map_metadata() -> None:
             "object_count": 2,
             "object_error": None,
             "objects": [
-                {"name": "map-a.bin", "extension": "bin", "url_present": False},
-                {"name": "map-b.bin", "extension": "bin", "url_present": False},
+                {"extension": "bin", "url_present": False},
+                {"extension": "bin", "url_present": False},
             ],
             "maps": [
                 {"idx": 0, "current": True, "available": True},
@@ -149,8 +149,8 @@ def test_map_camera_attributes_include_all_app_map_metadata() -> None:
     assert attributes["app_map_object_count"] == 2
     assert attributes["app_map_object_error"] is None
     assert attributes["app_map_objects"] == [
-        {"name": "map-a.bin", "extension": "bin", "url_present": False},
-        {"name": "map-b.bin", "extension": "bin", "url_present": False},
+        {"extension": "bin", "url_present": False},
+        {"extension": "bin", "url_present": False},
     ]
     assert attributes["app_maps"] == [
         {"idx": 0, "current": True, "available": True},

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+from custom_components.dreame_lawn_mower.camera import DreameLawnMowerMapCamera
 from custom_components.dreame_lawn_mower.map_attributes import map_camera_attributes
 from custom_components.dreame_lawn_mower.map_cache import (
     DreameLawnMowerMapCameraCache,
@@ -158,6 +159,48 @@ def test_map_camera_attributes_include_all_app_map_metadata() -> None:
     ]
     assert attributes["map_has_live_path"] is None
     assert attributes["map_details"] is None
+
+
+def test_point_cloud_path_uses_coordinator_current_map_over_stale_camera_view() -> None:
+    """The 3D endpoint follows a map switch before the camera cache refreshes."""
+    stale_view = DreameLawnMowerMapView(
+        source="app_action_map",
+        app_maps={
+            "current_map_index": 0,
+            "maps": [
+                {"idx": 0, "current": True},
+                {"idx": 1, "current": False},
+            ],
+        },
+    )
+    camera = SimpleNamespace(
+        _map_cache=SimpleNamespace(
+            last_view=stale_view,
+            last_image=None,
+            last_refresh_at=None,
+            last_error=None,
+        ),
+        coordinator=SimpleNamespace(
+            app_maps={
+                "current_map_index": 1,
+                "maps": [
+                    {"idx": 0, "current": False},
+                    {"idx": 1, "current": True},
+                ],
+            },
+            batch_device_data=None,
+            selected_map_index=1,
+            entry=SimpleNamespace(entry_id="entry-1"),
+        ),
+    )
+
+    attributes = DreameLawnMowerMapCamera.extra_state_attributes.fget(camera)
+
+    assert attributes["app_current_map_index"] == 0
+    assert (
+        attributes["point_cloud_api_path"]
+        == "/api/dreame_lawn_mower/point-cloud/entry-1/1"
+    )
 
 
 def test_map_camera_attributes_include_live_path_metadata() -> None:

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -6,7 +6,6 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
-from custom_components.dreame_lawn_mower.camera import DreameLawnMowerMapCamera
 from custom_components.dreame_lawn_mower.map_attributes import map_camera_attributes
 from custom_components.dreame_lawn_mower.map_cache import (
     DreameLawnMowerMapCameraCache,
@@ -159,48 +158,6 @@ def test_map_camera_attributes_include_all_app_map_metadata() -> None:
     ]
     assert attributes["map_has_live_path"] is None
     assert attributes["map_details"] is None
-
-
-def test_point_cloud_path_uses_coordinator_current_map_over_stale_camera_view() -> None:
-    """The 3D endpoint follows a map switch before the camera cache refreshes."""
-    stale_view = DreameLawnMowerMapView(
-        source="app_action_map",
-        app_maps={
-            "current_map_index": 0,
-            "maps": [
-                {"idx": 0, "current": True},
-                {"idx": 1, "current": False},
-            ],
-        },
-    )
-    camera = SimpleNamespace(
-        _map_cache=SimpleNamespace(
-            last_view=stale_view,
-            last_image=None,
-            last_refresh_at=None,
-            last_error=None,
-        ),
-        coordinator=SimpleNamespace(
-            app_maps={
-                "current_map_index": 1,
-                "maps": [
-                    {"idx": 0, "current": False},
-                    {"idx": 1, "current": True},
-                ],
-            },
-            batch_device_data=None,
-            selected_map_index=1,
-            entry=SimpleNamespace(entry_id="entry-1"),
-        ),
-    )
-
-    attributes = DreameLawnMowerMapCamera.extra_state_attributes.fget(camera)
-
-    assert attributes["app_current_map_index"] == 0
-    assert (
-        attributes["point_cloud_api_path"]
-        == "/api/dreame_lawn_mower/point-cloud/entry-1/1"
-    )
 
 
 def test_map_camera_attributes_include_live_path_metadata() -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -24,6 +24,7 @@ from dreame_lawn_mower_client._loader import load_internal_module
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 
 _internal_client_module = load_internal_module("client")
+_internal_point_cloud_module = load_internal_module("point_cloud")
 _internal_protocol_module = load_internal_module("protocol")
 
 
@@ -443,6 +444,84 @@ def test_point_cloud_action_response_enforces_overall_deadline(
         )
 
     assert applied_timeouts == pytest.approx([0.8])
+
+
+def test_point_cloud_401_reauthentication_uses_remaining_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [f"header-{index}" for index in range(53)]
+    cloud._strings = strings
+    cloud._country = "eu"
+    cloud._ti = "ti"
+    cloud._key = "key"
+    cloud._key_expire = None
+    cloud._secondary_key = "refresh"
+    cloud._session = SimpleNamespace()
+    cloud._connected = True
+    cloud._fail_count = 0
+    login_options: list[dict[str, Any]] = []
+    cloud.login = lambda **kwargs: login_options.append(kwargs) or True
+    response = SimpleNamespace(status_code=401, close=lambda: None)
+    monkeypatch.setattr(
+        _internal_protocol_module,
+        "_post_cloud_response",
+        lambda session, url, request_options, *, deadline: response,
+    )
+    monkeypatch.setattr(
+        _internal_protocol_module,
+        "_read_cloud_response_text_with_deadline",
+        lambda response, *, deadline: "",
+    )
+    monkeypatch.setattr(
+        _internal_protocol_module.time,
+        "monotonic",
+        lambda: 100.0,
+    )
+
+    assert cloud.request(
+        "https://cloud.example.invalid/action",
+        "{}",
+        retry_count=0,
+        timeout=20,
+        deadline=101.0,
+    ) is None
+
+    assert login_options == [
+        {"timeout": pytest.approx(1.0), "deadline": 101.0}
+    ]
+
+
+def test_pcd_validation_stops_at_absolute_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+
+    def monotonic() -> float:
+        nonlocal calls
+        calls += 1
+        return 100.0 if calls < 4 else 101.0
+
+    monkeypatch.setattr(
+        _internal_point_cloud_module.time,
+        "monotonic",
+        monotonic,
+    )
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="validation timed out",
+    ):
+        parse_pcd_metadata(
+            _binary_pcd(
+                (1.0, 2.0, 3.0, 0x123456),
+                (4.0, 5.0, 6.0, 0x654321),
+            ),
+            deadline=101.0,
+        )
+
+    assert calls >= 4
 
 
 def test_point_cloud_action_log_redacts_private_object_response() -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import struct
 import urllib.error
 from email.message import Message
+from types import SimpleNamespace
 from typing import Any
 
 import pytest
@@ -59,7 +60,13 @@ def _client() -> DreameLawnMowerClient:
 class _FakeResponse:
     def __init__(self, content: bytes, url: str) -> None:
         self._content = content
+        self._offset = 0
         self._url = url
+        self.fp = SimpleNamespace(
+            raw=SimpleNamespace(
+                _sock=SimpleNamespace(settimeout=lambda timeout: None),
+            )
+        )
         self.headers = Message()
         self.headers["Content-Length"] = str(len(content))
         self.headers["Content-Type"] = "application/octet-stream"
@@ -74,7 +81,9 @@ class _FakeResponse:
         return self._url
 
     def read(self, size: int) -> bytes:
-        return self._content[:size]
+        chunk = self._content[self._offset : self._offset + size]
+        self._offset += len(chunk)
+        return chunk
 
 
 def test_parse_pcd_metadata_accepts_binary_xyz_rgb() -> None:
@@ -221,3 +230,42 @@ def test_download_point_cloud_error_does_not_expose_signed_url(
     assert "HTTP status 403" in str(captured.value)
     assert signed_url not in str(captured.value)
     assert signed_url not in repr(captured.value)
+
+
+def test_download_point_cloud_enforces_overall_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signed_url = "https://downloads.example.invalid/object?private=signature"
+    read_calls = 0
+    applied_timeouts: list[float] = []
+    response = _FakeResponse(b"chunk", signed_url)
+    del response.headers["Content-Length"]
+    response.fp.raw._sock.settimeout = applied_timeouts.append
+
+    def read(size: int) -> bytes:
+        nonlocal read_calls
+        read_calls += 1
+        return b"chunk"
+
+    response.read = read
+    monotonic_values = iter([100.0, 100.2, 101.1])
+    monkeypatch.setattr(
+        client_module.time,
+        "monotonic",
+        lambda: next(monotonic_values),
+    )
+    monkeypatch.setattr(
+        client_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: response,
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError, match="timed out"):
+        _internal_client_module._download_point_cloud_content(
+            signed_url,
+            timeout=1.0,
+            max_bytes=1024,
+        )
+
+    assert read_calls == 1
+    assert applied_timeouts == pytest.approx([0.8])

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -21,6 +21,7 @@ from dreame_lawn_mower_client._loader import load_internal_module
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 
 _internal_client_module = load_internal_module("client")
+_internal_protocol_module = load_internal_module("protocol")
 
 
 def _binary_pcd(*points: tuple[float, float, float, int]) -> bytes:
@@ -38,6 +39,22 @@ def _binary_pcd(*points: tuple[float, float, float, int]) -> bytes:
     ).encode()
     payload = b"".join(struct.pack("<fffI", *point) for point in points)
     return header + payload
+
+
+def _ascii_pcd(point_count: int) -> bytes:
+    header = (
+        "# .PCD v0.7\n"
+        "VERSION 0.7\n"
+        "FIELDS x y z\n"
+        "SIZE 4 4 4\n"
+        "TYPE F F F\n"
+        "COUNT 1 1 1\n"
+        f"WIDTH {point_count}\n"
+        "HEIGHT 1\n"
+        f"POINTS {point_count}\n"
+        "DATA ascii\n"
+    ).encode()
+    return header + (b"1 2 3\n" * point_count)
 
 
 def _client() -> DreameLawnMowerClient:
@@ -103,6 +120,16 @@ def test_parse_pcd_metadata_accepts_binary_xyz_rgb() -> None:
     assert metadata.as_dict()["total_bytes"] == len(content)
 
 
+def test_parse_pcd_metadata_validates_ascii_rows_incrementally() -> None:
+    content = _ascii_pcd(10_000)
+
+    metadata = parse_pcd_metadata(content)
+
+    assert metadata.points == 10_000
+    assert metadata.data_encoding == "ascii"
+    assert metadata.payload_bytes == 60_000
+
+
 @pytest.mark.parametrize(
     "content, message",
     [
@@ -157,6 +184,7 @@ def test_download_point_cloud_uses_a2_generation_flow(
 ) -> None:
     client = _client()
     calls: list[dict[str, Any]] = []
+    call_options: list[dict[str, Any]] = []
     responses = iter(
         [
             {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
@@ -167,8 +195,12 @@ def test_download_point_cloud_uses_a2_generation_flow(
         ]
     )
 
-    def call_app_action(payload: dict[str, Any]) -> dict[str, Any]:
+    def call_app_action(
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
         calls.append(payload)
+        call_options.append(kwargs)
         return next(responses)
 
     signed_url = "https://downloads.example.invalid/object?private=signature"
@@ -183,9 +215,12 @@ def test_download_point_cloud_uses_a2_generation_flow(
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
     downloads = iter([b"not a pcd", content])
     monkeypatch.setattr(
-        client_module.urllib.request,
-        "urlopen",
-        lambda request, timeout: _FakeResponse(next(downloads), request.full_url),
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout: _FakeResponse(
+            next(downloads),
+            request.full_url,
+        ),
     )
 
     result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
@@ -197,6 +232,8 @@ def test_download_point_cloud_uses_a2_generation_flow(
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
     ]
+    assert all(options["retry_count"] == 0 for options in call_options)
+    assert all(0 < options["timeout"] <= 5 for options in call_options)
     assert result.map_index == 0
     assert result.content == content
     assert result.metadata.points == 1
@@ -218,7 +255,11 @@ def test_download_point_cloud_error_does_not_expose_signed_url(
             None,
         )
 
-    monkeypatch.setattr(client_module.urllib.request, "urlopen", fail_download)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        fail_download,
+    )
 
     with pytest.raises(DreameLawnMowerPointCloudError) as captured:
         _internal_client_module._download_point_cloud_content(
@@ -230,6 +271,42 @@ def test_download_point_cloud_error_does_not_expose_signed_url(
     assert "HTTP status 403" in str(captured.value)
     assert signed_url not in str(captured.value)
     assert signed_url not in repr(captured.value)
+
+
+def test_download_point_cloud_rejects_insecure_redirect_before_following() -> None:
+    request = urllib.request.Request(
+        "https://downloads.example.invalid/private-object"
+    )
+    handler = _internal_client_module._HttpsOnlyPointCloudRedirectHandler()
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="redirected to an insecure URL",
+    ):
+        handler.redirect_request(
+            request,
+            None,
+            302,
+            "Found",
+            Message(),
+            "http://downloads.example.invalid/private-object",
+        )
+
+
+def test_interim_file_cloud_logs_redact_request_and_response() -> None:
+    url = (
+        "https://eu.example.invalid/"
+        "dreame-user-iot/iotfile/getDownloadUrl"
+    )
+
+    assert _internal_protocol_module._cloud_request_log_value(
+        url,
+        '{"filename":"private/generated-map.pcd"}',
+    ) == "<redacted interim file payload>"
+    assert _internal_protocol_module._cloud_request_log_value(
+        url,
+        '{"data":"https://downloads.example.invalid/object?secret=signature"}',
+    ) == "<redacted interim file payload>"
 
 
 def test_download_point_cloud_enforces_overall_deadline(
@@ -252,12 +329,12 @@ def test_download_point_cloud_enforces_overall_deadline(
     monkeypatch.setattr(
         client_module.time,
         "monotonic",
-        lambda: next(monotonic_values),
+        lambda: next(monotonic_values, 101.1),
     )
     monkeypatch.setattr(
-        client_module.urllib.request,
-        "urlopen",
-        lambda request, timeout: response,
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout: response,
     )
 
     with pytest.raises(DreameLawnMowerPointCloudError, match="timed out"):
@@ -269,3 +346,74 @@ def test_download_point_cloud_enforces_overall_deadline(
 
     assert read_calls == 1
     assert applied_timeouts == pytest.approx([0.8])
+
+
+def test_point_cloud_app_action_uses_and_enforces_remaining_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    options: list[dict[str, Any]] = []
+
+    def call_app_action(
+        payload: dict[str, Any],
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        options.append(kwargs)
+        return {"r": 0, "d": {}}
+
+    client._sync_call_app_action = call_app_action
+    monotonic_values = iter([100.2, 101.1])
+    monkeypatch.setattr(
+        client_module.time,
+        "monotonic",
+        lambda: next(monotonic_values, 101.1),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError, match="timed out"):
+        client._sync_call_point_cloud_action(
+            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+            operation="read the generated point-cloud object state",
+            deadline=101.0,
+            require_data=True,
+        )
+
+    assert options == [
+        {
+            "retry_count": 0,
+            "timeout": pytest.approx(0.8),
+        }
+    ]
+
+
+@pytest.mark.parametrize(
+    "failed_poll",
+    [
+        None,
+        {"r": 0, "d": {}},
+    ],
+)
+def test_download_point_cloud_rejects_ambiguous_failed_object_poll(
+    monkeypatch: pytest.MonkeyPatch,
+    failed_poll: Any,
+) -> None:
+    client = _client()
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
+            {"r": 0},
+            failed_poll,
+        ]
+    )
+    client._sync_call_app_action = lambda payload, **kwargs: next(responses)
+    client._sync_get_cloud_protocol = lambda: type(
+        "Cloud",
+        (),
+        {"get_interim_file_url": lambda self, name: None},
+    )()
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="could not read the generated point-cloud object state",
+    ):
+        client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import struct
 import threading
 import time
@@ -772,6 +773,64 @@ def test_deadline_slot_is_released_when_late_response_close_fails() -> None:
         )
         == "available"
     )
+
+
+def test_deadline_slot_is_released_when_worker_thread_cannot_start(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def fail_start(thread: threading.Thread) -> None:
+        raise RuntimeError("thread capacity exhausted")
+
+    with monkeypatch.context() as patcher:
+        patcher.setattr(
+            _internal_deadline_module.threading.Thread,
+            "start",
+            fail_start,
+        )
+        for _ in range(4):
+            with pytest.raises(RuntimeError, match="capacity exhausted"):
+                _internal_deadline_module.run_with_deadline(
+                    lambda: "not started",
+                    deadline=time.monotonic() + 1,
+                )
+
+    assert (
+        _internal_deadline_module.run_with_deadline(
+            lambda: "available",
+            deadline=time.monotonic() + 1,
+        )
+        == "available"
+    )
+
+
+def test_point_cloud_generation_deadline_includes_executor_queue_time(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    queued = asyncio.Event()
+
+    async def wait_in_executor_queue(
+        function: Any,
+        *args: Any,
+    ) -> Any:
+        queued.set()
+        await asyncio.Event().wait()
+
+    monkeypatch.setattr(
+        _internal_client_module.asyncio,
+        "to_thread",
+        wait_in_executor_queue,
+    )
+
+    async def run() -> None:
+        with pytest.raises(
+            DreameLawnMowerPointCloudError,
+            match="generation timed out",
+        ):
+            await client.async_download_app_map_point_cloud(timeout=0.01)
+        assert queued.is_set()
+
+    asyncio.run(run())
 
 
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 from typing import Any
 
 import pytest
+import requests
 
 import dreame_lawn_mower_client.client as client_module
 from dreame_lawn_mower_client import (
@@ -190,7 +191,7 @@ def test_download_point_cloud_uses_a2_generation_flow(
             {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
             {"r": 0},
             {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
-            {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
+            {"r": 0, "d": {"name": ["private/generated-map-2.pcd"]}},
             {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
         ]
     )
@@ -401,8 +402,128 @@ def test_point_cloud_app_action_uses_and_enforces_remaining_deadline(
         {
             "retry_count": 0,
             "timeout": pytest.approx(0.8),
+            "deadline": 101.0,
+            "redact_response": True,
         }
     ]
+
+
+def test_point_cloud_action_response_enforces_overall_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    applied_timeouts: list[float] = []
+    raw = SimpleNamespace()
+    raw._fp = SimpleNamespace(
+        fp=SimpleNamespace(
+            raw=SimpleNamespace(
+                _sock=SimpleNamespace(settimeout=applied_timeouts.append)
+            )
+        )
+    )
+    raw.read1 = lambda size, *, decode_content: b'{"code":0}'
+    response = SimpleNamespace(raw=raw, encoding="utf-8")
+    monotonic_values = iter([100.2, 101.1])
+    monkeypatch.setattr(
+        _internal_protocol_module.time,
+        "monotonic",
+        lambda: next(monotonic_values, 101.1),
+    )
+
+    with pytest.raises(requests.exceptions.Timeout, match="timed out"):
+        _internal_protocol_module._read_cloud_response_text_with_deadline(
+            response,
+            deadline=101.0,
+        )
+
+    assert applied_timeouts == pytest.approx([0.8])
+
+
+def test_point_cloud_action_log_redacts_private_object_response() -> None:
+    private_response = {
+        "data": {
+            "result": {
+                "out": [
+                    {
+                        "value": {
+                            "r": 0,
+                            "d": {"name": ["private/generated-map.pcd"]},
+                        }
+                    }
+                ]
+            }
+        }
+    }
+
+    assert _internal_protocol_module._app_action_response_log_value(
+        private_response,
+        redact=True,
+    ) == "<redacted app action response>"
+    assert (
+        _internal_protocol_module._app_action_response_log_value(
+            private_response,
+            redact=False,
+        )
+        is private_response
+    )
+
+
+def test_ascii_point_cloud_rejects_oversized_row_before_splitting() -> None:
+    content = _ascii_pcd(1).replace(
+        b"1 2 3\n",
+        (b"0 " * 10_000) + b"\n",
+    )
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="row exceeds the supported size",
+    ):
+        parse_pcd_metadata(content)
+
+
+def test_point_cloud_does_not_redownload_same_rejected_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    action_count = 0
+    download_count = 0
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        nonlocal action_count
+        action_count += 1
+        if action_count == 1:
+            return {"r": 0, "d": {"name": ["private/previous-map.pcd"]}}
+        if action_count == 2:
+            return {"r": 0}
+        return {"r": 0, "d": {"name": ["private/rejected-map.pcd"]}}
+
+    cloud = SimpleNamespace(
+        get_interim_file_url=lambda name, **kwargs: (
+            "https://downloads.example.invalid/object"
+        )
+    )
+
+    def open_response(request: Any, *, timeout: float) -> _FakeResponse:
+        nonlocal download_count
+        download_count += 1
+        return _FakeResponse(b"not a pcd", request.full_url)
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda: cloud
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        open_response,
+    )
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="could not be downloaded and validated",
+    ):
+        client._sync_download_app_map_point_cloud(0, 0.01, 0.001, 10, 1024)
+
+    assert action_count > 3
+    assert download_count == 1
 
 
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -568,6 +568,27 @@ def test_ascii_point_cloud_rejects_oversized_row_before_splitting() -> None:
         parse_pcd_metadata(content)
 
 
+def test_ascii_row_iterator_rejects_oversized_row_before_slicing() -> None:
+    class SliceGuard(bytes):
+        def __getitem__(self, key: Any) -> Any:
+            if isinstance(key, slice) and key.stop - key.start > 16:
+                raise AssertionError("oversized row was sliced")
+            return super().__getitem__(key)
+
+    payload = SliceGuard((b"0 " * 100) + b"\n")
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="row exceeds the supported size",
+    ):
+        list(
+            _internal_point_cloud_module._iter_nonempty_ascii_rows(
+                payload,
+                max_row_bytes=16,
+            )
+        )
+
+
 def test_ascii_point_cloud_rejects_attacker_controlled_scalar_count() -> None:
     content = _ascii_pcd(1)
     content = content.replace(b"FIELDS x y z\n", b"FIELDS x y z extra\n")

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 import struct
+import threading
+import time
 import urllib.error
 from email.message import Message
 from types import SimpleNamespace
@@ -231,7 +233,7 @@ def test_download_point_cloud_uses_a2_generation_flow(
     monkeypatch.setattr(
         _internal_client_module,
         "_open_point_cloud_response",
-        lambda request, *, timeout: _FakeResponse(
+        lambda request, *, timeout, deadline: _FakeResponse(
             next(downloads),
             request.full_url,
         ),
@@ -267,7 +269,12 @@ def test_download_point_cloud_error_does_not_expose_signed_url(
 ) -> None:
     signed_url = "https://downloads.example.invalid/object?secret=do-not-log"
 
-    def fail_download(request: Any, timeout: float) -> None:
+    def fail_download(
+        request: Any,
+        *,
+        timeout: float,
+        deadline: float,
+    ) -> None:
         raise urllib.error.HTTPError(
             request.full_url,
             403,
@@ -355,7 +362,7 @@ def test_download_point_cloud_enforces_overall_deadline(
     monkeypatch.setattr(
         _internal_client_module,
         "_open_point_cloud_response",
-        lambda request, *, timeout: response,
+        lambda request, *, timeout, deadline: response,
     )
 
     with pytest.raises(DreameLawnMowerPointCloudError, match="timed out"):
@@ -517,7 +524,12 @@ def test_point_cloud_does_not_redownload_same_rejected_object(
         )
     )
 
-    def open_response(request: Any, *, timeout: float) -> _FakeResponse:
+    def open_response(
+        request: Any,
+        *,
+        timeout: float,
+        deadline: float,
+    ) -> _FakeResponse:
         nonlocal download_count
         download_count += 1
         return _FakeResponse(b"not a pcd", request.full_url)
@@ -536,6 +548,109 @@ def test_point_cloud_does_not_redownload_same_rejected_object(
 
     assert action_count > 3
     assert download_count == 1
+
+
+def test_point_cloud_retries_transient_download_for_same_object(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    action_count = 0
+    download_count = 0
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        nonlocal action_count
+        action_count += 1
+        if action_count == 1:
+            return {"r": 0, "d": {"name": ["private/previous-map.pcd"]}}
+        if action_count == 2:
+            return {"r": 0}
+        return {"r": 0, "d": {"name": ["private/generated-map.pcd"]}}
+
+    def open_response(
+        request: Any,
+        *,
+        timeout: float,
+        deadline: float,
+    ) -> _FakeResponse:
+        nonlocal download_count
+        download_count += 1
+        if download_count == 1:
+            raise urllib.error.URLError("temporary failure")
+        return _FakeResponse(content, request.full_url)
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        )
+    )
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        open_response,
+    )
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert result.content == content
+    assert download_count == 2
+
+
+def test_point_cloud_header_receive_observes_absolute_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    release = threading.Event()
+
+    class BlockingOpener:
+        def open(self, request: Any, *, timeout: float) -> _FakeResponse:
+            release.wait(5)
+            return _FakeResponse(b"", request.full_url)
+
+    monkeypatch.setattr(
+        _internal_client_module.urllib.request,
+        "build_opener",
+        lambda *handlers: BlockingOpener(),
+    )
+    request = urllib.request.Request(
+        "https://downloads.example.invalid/private-object"
+    )
+    started = time.monotonic()
+    try:
+        with pytest.raises(DreameLawnMowerPointCloudError, match="timed out"):
+            _internal_client_module._open_point_cloud_response(
+                request,
+                timeout=5,
+                deadline=time.monotonic() + 0.05,
+            )
+    finally:
+        release.set()
+
+    assert time.monotonic() - started < 1
+
+
+def test_cloud_header_receive_observes_absolute_deadline() -> None:
+    release = threading.Event()
+
+    class BlockingSession:
+        def post(self, url: str, **options: Any) -> Any:
+            release.wait(5)
+            return SimpleNamespace(close=lambda: None)
+
+    started = time.monotonic()
+    try:
+        with pytest.raises(requests.exceptions.Timeout, match="timed out"):
+            _internal_protocol_module._post_cloud_response(
+                BlockingSession(),
+                "https://cloud.example.invalid/action",
+                {"timeout": 5, "stream": True},
+                deadline=time.monotonic() + 0.05,
+            )
+    finally:
+        release.set()
+
+    assert time.monotonic() - started < 1
 
 
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -108,6 +108,31 @@ def test_parse_pcd_metadata_accepts_binary_xyz_rgb() -> None:
             b"WIDTH 0\nHEIGHT 1\nPOINTS 0\nDATA binary\n",
             "x, y, and z",
         ),
+        (
+            b"VERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\n"
+            b"WIDTH 1\nHEIGHT 1\nPOINTS 1\nDATA ascii\n1 2\n",
+            "column count",
+        ),
+        (
+            b"VERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\n"
+            b"WIDTH 1\nHEIGHT 1\nPOINTS 1\nDATA ascii\n1 invalid 3\n",
+            "invalid scalar",
+        ),
+        (
+            b"VERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\n"
+            b"WIDTH 1\nHEIGHT 1\nPOINTS 1\nDATA ascii\n1e100 2 3\n",
+            "invalid scalar",
+        ),
+        (
+            b"VERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\n"
+            b"WIDTH 1\nHEIGHT 1\nPOINTS 1\nDATA binary_compressed\n"
+            b"\x00\x00\x00\x00\x0c\x00\x00\x00",
+            "Unsupported PCD DATA encoding",
+        ),
+        (
+            _binary_pcd((float("nan"), 2.0, 3.0, 0x123456)),
+            "finite values",
+        ),
     ],
 )
 def test_parse_pcd_metadata_rejects_invalid_payloads(
@@ -125,8 +150,10 @@ def test_download_point_cloud_uses_a2_generation_flow(
     calls: list[dict[str, Any]] = []
     responses = iter(
         [
+            {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
             {"r": 0},
-            {"r": 0, "d": {"name": [""]}},
+            {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
+            {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
             {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
         ]
     )
@@ -145,16 +172,19 @@ def test_download_point_cloud_uses_a2_generation_flow(
     client._sync_call_app_action = call_app_action
     client._sync_get_cloud_protocol = lambda: cloud
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    downloads = iter([b"not a pcd", content])
     monkeypatch.setattr(
         client_module.urllib.request,
         "urlopen",
-        lambda request, timeout: _FakeResponse(content, request.full_url),
+        lambda request, timeout: _FakeResponse(next(downloads), request.full_url),
     )
 
     result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
 
     assert calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
     ]

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1,0 +1,193 @@
+"""Regression checks for point-cloud generation, download, and validation."""
+
+from __future__ import annotations
+
+import struct
+import urllib.error
+from email.message import Message
+from typing import Any
+
+import pytest
+
+import dreame_lawn_mower_client.client as client_module
+from dreame_lawn_mower_client import (
+    DreameLawnMowerClient,
+    DreameLawnMowerPointCloudError,
+    DreameLawnMowerPointCloudMetadata,
+    parse_pcd_metadata,
+)
+from dreame_lawn_mower_client._loader import load_internal_module
+from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
+
+_internal_client_module = load_internal_module("client")
+
+
+def _binary_pcd(*points: tuple[float, float, float, int]) -> bytes:
+    header = (
+        "# .PCD v0.7\n"
+        "VERSION 0.7\n"
+        "FIELDS x y z rgb\n"
+        "SIZE 4 4 4 4\n"
+        "TYPE F F F U\n"
+        "COUNT 1 1 1 1\n"
+        f"WIDTH {len(points)}\n"
+        "HEIGHT 1\n"
+        f"POINTS {len(points)}\n"
+        "DATA binary\n"
+    ).encode()
+    payload = b"".join(struct.pack("<fffI", *point) for point in points)
+    return header + payload
+
+
+def _client() -> DreameLawnMowerClient:
+    return DreameLawnMowerClient(
+        username="user@example.invalid",
+        password="secret",
+        country="eu",
+        account_type="dreame",
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-1",
+            name="Garage Mower",
+            model="dreame.mower.g2408",
+            display_model="A2",
+            account_type="dreame",
+            country="eu",
+        ),
+    )
+
+
+class _FakeResponse:
+    def __init__(self, content: bytes, url: str) -> None:
+        self._content = content
+        self._url = url
+        self.headers = Message()
+        self.headers["Content-Length"] = str(len(content))
+        self.headers["Content-Type"] = "application/octet-stream"
+
+    def __enter__(self) -> _FakeResponse:
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        return None
+
+    def geturl(self) -> str:
+        return self._url
+
+    def read(self, size: int) -> bytes:
+        return self._content[:size]
+
+
+def test_parse_pcd_metadata_accepts_binary_xyz_rgb() -> None:
+    content = _binary_pcd(
+        (1.0, 2.0, 3.0, 0xFF0000),
+        (-1.0, -2.0, 0.5, 0x00FF00),
+    )
+
+    metadata = parse_pcd_metadata(content)
+
+    assert isinstance(metadata, DreameLawnMowerPointCloudMetadata)
+    assert metadata.points == 2
+    assert metadata.fields == ("x", "y", "z", "rgb")
+    assert metadata.data_encoding == "binary"
+    assert metadata.bytes_per_point == 16
+    assert metadata.has_rgb is True
+    assert metadata.as_dict()["total_bytes"] == len(content)
+
+
+@pytest.mark.parametrize(
+    "content, message",
+    [
+        (b"", "empty"),
+        (
+            b"VERSION 0.7\nFIELDS x y z\nSIZE 4 4 4\nTYPE F F F\n"
+            b"WIDTH 1\nHEIGHT 1\nPOINTS 1\nDATA binary\n",
+            "payload length",
+        ),
+        (
+            b"VERSION 0.7\nFIELDS x y\nSIZE 4 4\nTYPE F F\n"
+            b"WIDTH 0\nHEIGHT 1\nPOINTS 0\nDATA binary\n",
+            "x, y, and z",
+        ),
+    ],
+)
+def test_parse_pcd_metadata_rejects_invalid_payloads(
+    content: bytes,
+    message: str,
+) -> None:
+    with pytest.raises(DreameLawnMowerPointCloudError, match=message):
+        parse_pcd_metadata(content)
+
+
+def test_download_point_cloud_uses_a2_generation_flow(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0},
+            {"r": 0, "d": {"name": [""]}},
+            {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any]) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    signed_url = "https://downloads.example.invalid/object?private=signature"
+    cloud = type(
+        "Cloud",
+        (),
+        {"get_interim_file_url": lambda self, name: signed_url},
+    )()
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda: cloud
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        client_module.urllib.request,
+        "urlopen",
+        lambda request, timeout: _FakeResponse(content, request.full_url),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.map_index == 0
+    assert result.content == content
+    assert result.metadata.points == 1
+    assert not hasattr(result, "url")
+    assert not hasattr(result, "object_name")
+
+
+def test_download_point_cloud_error_does_not_expose_signed_url(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signed_url = "https://downloads.example.invalid/object?secret=do-not-log"
+
+    def fail_download(request: Any, timeout: float) -> None:
+        raise urllib.error.HTTPError(
+            request.full_url,
+            403,
+            "Forbidden",
+            Message(),
+            None,
+        )
+
+    monkeypatch.setattr(client_module.urllib.request, "urlopen", fail_download)
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        _internal_client_module._download_point_cloud_content(
+            signed_url,
+            timeout=10,
+            max_bytes=1024,
+        )
+
+    assert "HTTP status 403" in str(captured.value)
+    assert signed_url not in str(captured.value)
+    assert signed_url not in repr(captured.value)

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -24,6 +24,7 @@ from dreame_lawn_mower_client._loader import load_internal_module
 from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 
 _internal_client_module = load_internal_module("client")
+_internal_deadline_module = load_internal_module("deadline")
 _internal_point_cloud_module = load_internal_module("point_cloud")
 _internal_protocol_module = load_internal_module("protocol")
 
@@ -730,6 +731,47 @@ def test_cloud_header_receive_observes_absolute_deadline() -> None:
         release.set()
 
     assert time.monotonic() - started < 1
+
+
+def test_deadline_slot_is_released_when_late_response_close_fails() -> None:
+    for _ in range(4):
+        release = threading.Event()
+        close_called = threading.Event()
+
+        class BadResponse:
+            def __init__(self, close_event: threading.Event) -> None:
+                self.close_event = close_event
+
+            def close(self) -> None:
+                self.close_event.set()
+                raise RuntimeError("cleanup failed")
+
+        def operation(
+            release_event: threading.Event = release,
+            close_event: threading.Event = close_called,
+        ) -> BadResponse:
+            release_event.wait(5)
+            return BadResponse(close_event)
+
+        try:
+            with pytest.raises(
+                _internal_deadline_module.DeadlineExceededError,
+            ):
+                _internal_deadline_module.run_with_deadline(
+                    operation,
+                    deadline=time.monotonic() + 0.01,
+                )
+        finally:
+            release.set()
+        assert close_called.wait(1)
+
+    assert (
+        _internal_deadline_module.run_with_deadline(
+            lambda: "available",
+            deadline=time.monotonic() + 1,
+        )
+        == "available"
+    )
 
 
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -204,10 +204,23 @@ def test_download_point_cloud_uses_a2_generation_flow(
         return next(responses)
 
     signed_url = "https://downloads.example.invalid/object?private=signature"
+    interim_file_options: list[dict[str, Any]] = []
+
+    def get_interim_file_url(
+        name: str,
+        **kwargs: Any,
+    ) -> str:
+        interim_file_options.append(kwargs)
+        return signed_url
+
     cloud = type(
         "Cloud",
         (),
-        {"get_interim_file_url": lambda self, name: signed_url},
+        {
+            "get_interim_file_url": lambda self, name, **kwargs: (
+                get_interim_file_url(name, **kwargs)
+            )
+        },
     )()
     content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
     client._sync_call_app_action = call_app_action
@@ -234,6 +247,13 @@ def test_download_point_cloud_uses_a2_generation_flow(
     ]
     assert all(options["retry_count"] == 0 for options in call_options)
     assert all(0 < options["timeout"] <= 5 for options in call_options)
+    assert len(interim_file_options) == 2
+    assert all(
+        options["retry_count"] == 0 for options in interim_file_options
+    )
+    assert all(
+        0 < options["timeout"] <= 5 for options in interim_file_options
+    )
     assert result.map_index == 0
     assert result.content == content
     assert result.metadata.points == 1
@@ -385,6 +405,42 @@ def test_point_cloud_app_action_uses_and_enforces_remaining_deadline(
     ]
 
 
+def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    options: list[dict[str, Any]] = []
+
+    def get_interim_file_url(
+        object_name: str,
+        **kwargs: Any,
+    ) -> str:
+        options.append(kwargs)
+        return "https://downloads.example.invalid/object"
+
+    cloud = SimpleNamespace(get_interim_file_url=get_interim_file_url)
+    monotonic_values = iter([100.2, 101.1])
+    monkeypatch.setattr(
+        client_module.time,
+        "monotonic",
+        lambda: next(monotonic_values, 101.1),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError, match="timed out"):
+        client._sync_get_point_cloud_download_url(
+            cloud,
+            "private/generated-map.pcd",
+            deadline=101.0,
+        )
+
+    assert options == [
+        {
+            "retry_count": 0,
+            "timeout": pytest.approx(0.8),
+        }
+    ]
+
+
 @pytest.mark.parametrize(
     "failed_poll",
     [
@@ -408,7 +464,7 @@ def test_download_point_cloud_rejects_ambiguous_failed_object_poll(
     client._sync_get_cloud_protocol = lambda: type(
         "Cloud",
         (),
-        {"get_interim_file_url": lambda self, name: None},
+        {"get_interim_file_url": lambda self, name, **kwargs: None},
     )()
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
 

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -225,7 +225,7 @@ def test_download_point_cloud_uses_a2_generation_flow(
     )()
     content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
     client._sync_call_app_action = call_app_action
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
     downloads = iter([b"not a pcd", content])
     monkeypatch.setattr(
@@ -480,6 +480,21 @@ def test_ascii_point_cloud_rejects_oversized_row_before_splitting() -> None:
         parse_pcd_metadata(content)
 
 
+def test_ascii_point_cloud_rejects_attacker_controlled_scalar_count() -> None:
+    content = _ascii_pcd(1)
+    content = content.replace(b"FIELDS x y z\n", b"FIELDS x y z extra\n")
+    content = content.replace(b"SIZE 4 4 4\n", b"SIZE 4 4 4 4\n")
+    content = content.replace(b"TYPE F F F\n", b"TYPE F F F F\n")
+    content = content.replace(b"COUNT 1 1 1\n", b"COUNT 1 1 1 1000000\n")
+    content = content.replace(b"1 2 3\n", (b"0 " * 10_000) + b"\n")
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="too many scalar values",
+    ):
+        parse_pcd_metadata(content)
+
+
 def test_point_cloud_does_not_redownload_same_rejected_object(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -508,7 +523,7 @@ def test_point_cloud_does_not_redownload_same_rejected_object(
         return _FakeResponse(b"not a pcd", request.full_url)
 
     client._sync_call_app_action = call_app_action
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
     monkeypatch.setattr(
         _internal_client_module,
         "_open_point_cloud_response",
@@ -516,10 +531,7 @@ def test_point_cloud_does_not_redownload_same_rejected_object(
     )
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
 
-    with pytest.raises(
-        DreameLawnMowerPointCloudError,
-        match="could not be downloaded and validated",
-    ):
+    with pytest.raises(DreameLawnMowerPointCloudError):
         client._sync_download_app_map_point_cloud(0, 0.01, 0.001, 10, 1024)
 
     assert action_count > 3
@@ -558,6 +570,114 @@ def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(
         {
             "retry_count": 0,
             "timeout": pytest.approx(0.8),
+            "deadline": 101.0,
+        }
+    ]
+
+
+def test_interim_file_protocol_forwards_absolute_deadline() -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [""] * 56
+    strings[21] = "country"
+    strings[23] = "iot"
+    strings[35] = "model"
+    strings[39] = "file"
+    strings[40] = "filename"
+    strings[55] = "download"
+    cloud._strings = strings
+    cloud._did = "device-1"
+    cloud._model = "dreame.mower.g2408"
+    cloud._country = "eu"
+    options: list[dict[str, Any]] = []
+
+    def api_call(*args: Any, **kwargs: Any) -> dict[str, str]:
+        options.append(kwargs)
+        return {"data": "https://downloads.example.invalid/object"}
+
+    cloud._api_call = api_call
+
+    assert cloud.get_interim_file_url(
+        "private/generated-map.pcd",
+        retry_count=0,
+        timeout=0.8,
+        deadline=101.0,
+    ) == "https://downloads.example.invalid/object"
+    assert options == [
+        {
+            "retry_count": 0,
+            "timeout": 0.8,
+            "deadline": 101.0,
+        }
+    ]
+
+
+def test_point_cloud_preflight_uses_remaining_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    login_options: list[dict[str, Any]] = []
+    info_options: list[dict[str, Any]] = []
+    action_options: list[dict[str, Any]] = []
+
+    class Cloud:
+        logged_in = False
+        _host = None
+
+        def login(self, **kwargs: Any) -> bool:
+            login_options.append(kwargs)
+            self.logged_in = True
+            return True
+
+        def get_device_info_v2(self, lang: str, **kwargs: Any) -> None:
+            info_options.append(kwargs)
+            self._host = "host.example.invalid"
+
+        def call_app_action(
+            self,
+            payload: dict[str, Any],
+            **kwargs: Any,
+        ) -> dict[str, Any]:
+            action_options.append(kwargs)
+            return {"out": [{"value": {"r": 0, "d": {}}}]}
+
+    cloud = Cloud()
+    client._device = SimpleNamespace(
+        _protocol=SimpleNamespace(cloud=cloud),
+    )
+    monotonic_values = iter([100.1, 100.2])
+    monkeypatch.setattr(
+        client_module.time,
+        "monotonic",
+        lambda: next(monotonic_values, 100.2),
+    )
+
+    client._sync_call_app_action(
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        retry_count=0,
+        timeout=0.9,
+        deadline=101.0,
+        redact_response=True,
+    )
+
+    assert login_options == [
+        {"timeout": pytest.approx(0.9), "deadline": 101.0}
+    ]
+    assert info_options == [
+        {
+            "retry_count": 0,
+            "timeout": pytest.approx(0.8),
+            "deadline": 101.0,
+        }
+    ]
+    assert action_options == [
+        {
+            "siid": 2,
+            "aiid": 50,
+            "retry_count": 0,
+            "timeout": pytest.approx(0.8),
+            "deadline": 101.0,
+            "redact_response": True,
         }
     ]
 
@@ -582,7 +702,7 @@ def test_download_point_cloud_rejects_ambiguous_failed_object_poll(
         ]
     )
     client._sync_call_app_action = lambda payload, **kwargs: next(responses)
-    client._sync_get_cloud_protocol = lambda: type(
+    client._sync_get_cloud_protocol = lambda **kwargs: type(
         "Cloud",
         (),
         {"get_interim_file_url": lambda self, name, **kwargs: None},

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -12,6 +12,9 @@ from aiohttp import web
 from homeassistant.exceptions import Unauthorized
 
 from custom_components.dreame_lawn_mower.const import DOMAIN
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    DreameLawnMowerPointCloudError,
+)
 from custom_components.dreame_lawn_mower.point_cloud_api import (
     POINT_CLOUD_API_DATA_KEY,
     DreameLawnMowerPointCloudAPI,
@@ -162,6 +165,108 @@ def test_point_cloud_api_keeps_generation_alive_after_waiter_cancellation() -> N
     asyncio.run(run())
 
     assert calls == 1
+
+
+def test_point_cloud_api_limits_each_mower_to_one_generation() -> None:
+    calls: list[int] = []
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        calls.append(kwargs["map_index"])
+        started.set()
+        await release.wait()
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        first = asyncio.create_task(api.async_get("entry-1", 0, refresh=True))
+        await started.wait()
+        with pytest.raises(
+            DreameLawnMowerPointCloudError,
+            match="already in progress",
+        ):
+            await api.async_get("entry-1", 1, refresh=True)
+        assert calls == [0]
+        release.set()
+        assert await first == _download(0)
+
+    asyncio.run(run())
+
+    assert calls == [0]
+
+
+def test_point_cloud_api_discards_inflight_result_after_entry_reload() -> None:
+    old_started = asyncio.Event()
+    old_release = asyncio.Event()
+    old_result = _download()
+    new_result = _download()
+    old_calls = 0
+    new_calls = 0
+
+    async def old_download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal old_calls
+        old_calls += 1
+        old_started.set()
+        await old_release.wait()
+        return old_result
+
+    async def new_download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal new_calls
+        new_calls += 1
+        return new_result
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=old_download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        old_request = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await old_started.wait()
+        api.purge_entry("entry-1")
+        hass.data[DOMAIN]["entry-1"] = SimpleNamespace(
+            client=SimpleNamespace(
+                async_download_app_map_point_cloud=new_download,
+            )
+        )
+
+        reloaded_request = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await asyncio.sleep(0)
+        assert new_calls == 0
+        old_release.set()
+        with pytest.raises(DreameLawnMowerPointCloudError, match="entry changed"):
+            await old_request
+        assert await reloaded_request is new_result
+
+    asyncio.run(run())
+
+    assert old_calls == 1
+    assert new_calls == 1
 
 
 def test_point_cloud_api_purges_unloaded_entry() -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -83,6 +83,39 @@ def test_point_cloud_api_caches_recent_downloads() -> None:
     assert calls == 1
 
 
+def test_point_cloud_api_evicts_downloads_when_ttl_expires() -> None:
+    calls = 0
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal calls
+        calls += 1
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass, cache_ttl=0.01)
+
+    async def run() -> None:
+        await api.async_get("entry-1", 0)
+        assert api._cache
+        await asyncio.sleep(0.03)
+        assert not api._cache
+        await api.async_get("entry-1", 0)
+
+    asyncio.run(run())
+
+    assert calls == 2
+
+
 def test_point_cloud_api_deduplicates_concurrent_refreshes() -> None:
     calls = 0
     started = asyncio.Event()

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -20,6 +20,7 @@ from custom_components.dreame_lawn_mower.point_cloud_api import (
     DreameLawnMowerPointCloudAPI,
     DreameLawnMowerPointCloudView,
     async_setup_point_cloud_api,
+    current_point_cloud_api_path,
     point_cloud_api_path,
 )
 from dreame_lawn_mower_client import (
@@ -321,6 +322,22 @@ def test_point_cloud_api_path_is_local_and_contains_no_cloud_details() -> None:
     assert path == "/api/dreame_lawn_mower/point-cloud/entry-1/2"
     assert path.startswith("/")
     assert "http" not in path
+
+
+def test_current_point_cloud_path_follows_selected_map_before_cache_refresh() -> None:
+    path = current_point_cloud_api_path(
+        "entry-1",
+        {
+            "current_map_index": 0,
+            "maps": [
+                {"idx": 0, "current": True},
+                {"idx": 1, "current": False},
+            ],
+        },
+        selected_map_index=1,
+    )
+
+    assert path == "/api/dreame_lawn_mower/point-cloud/entry-1/1"
 
 
 class _FakeRequest(dict[str, Any]):

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -1,0 +1,216 @@
+"""Regression checks for private Home Assistant point-cloud delivery."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from homeassistant.exceptions import Unauthorized
+
+from custom_components.dreame_lawn_mower.const import DOMAIN
+from custom_components.dreame_lawn_mower.point_cloud_api import (
+    POINT_CLOUD_API_DATA_KEY,
+    DreameLawnMowerPointCloudAPI,
+    DreameLawnMowerPointCloudView,
+    async_setup_point_cloud_api,
+    point_cloud_api_path,
+)
+from dreame_lawn_mower_client import (
+    DreameLawnMowerPointCloudDownload,
+    DreameLawnMowerPointCloudMetadata,
+)
+
+
+def _download(map_index: int = 0) -> DreameLawnMowerPointCloudDownload:
+    content = b"private-pcd"
+    return DreameLawnMowerPointCloudDownload(
+        map_index=map_index,
+        content=content,
+        metadata=DreameLawnMowerPointCloudMetadata(
+            version="0.7",
+            fields=("x", "y", "z"),
+            sizes=(4, 4, 4),
+            types=("F", "F", "F"),
+            counts=(1, 1, 1),
+            width=1,
+            height=1,
+            points=1,
+            data_encoding="binary",
+            bytes_per_point=12,
+            header_bytes=100,
+            payload_bytes=12,
+            total_bytes=112,
+        ),
+    )
+
+
+def test_point_cloud_api_caches_recent_downloads() -> None:
+    calls = 0
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal calls
+        calls += 1
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        first = await api.async_get("entry-1", 0)
+        second = await api.async_get("entry-1", 0)
+        assert first is second
+
+    asyncio.run(run())
+
+    assert calls == 1
+
+
+def test_point_cloud_api_deduplicates_concurrent_refreshes() -> None:
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        first = asyncio.create_task(api.async_get("entry-1", 0, refresh=True))
+        second = asyncio.create_task(api.async_get("entry-1", 0, refresh=True))
+        await started.wait()
+        release.set()
+        results = await asyncio.gather(first, second)
+        assert results[0] is results[1]
+
+    asyncio.run(run())
+
+    assert calls == 1
+
+
+def test_point_cloud_api_purges_unloaded_entry() -> None:
+    calls = 0
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal calls
+        calls += 1
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        await api.async_get("entry-1", 0)
+        api.purge_entry("entry-1")
+        await api.async_get("entry-1", 0)
+
+    asyncio.run(run())
+
+    assert calls == 2
+
+
+def test_point_cloud_api_registration_is_idempotent() -> None:
+    registered: list[object] = []
+    hass = SimpleNamespace(
+        data={},
+        http=SimpleNamespace(register_view=registered.append),
+    )
+
+    first = async_setup_point_cloud_api(hass)
+    second = async_setup_point_cloud_api(hass)
+
+    assert first is second
+    assert hass.data[DOMAIN][POINT_CLOUD_API_DATA_KEY] is first
+    assert len(registered) == 1
+
+
+def test_point_cloud_api_path_is_local_and_contains_no_cloud_details() -> None:
+    path = point_cloud_api_path("entry-1", 2)
+
+    assert path == "/api/dreame_lawn_mower/point-cloud/entry-1/2"
+    assert path.startswith("/")
+    assert "http" not in path
+
+
+class _FakeRequest(dict[str, Any]):
+    def __init__(self, *, is_admin: bool, query: dict[str, str] | None = None) -> None:
+        super().__init__(hass_user=SimpleNamespace(is_admin=is_admin))
+        self.query = query or {}
+
+
+def test_point_cloud_view_returns_private_attachment_to_admin() -> None:
+    calls: list[tuple[str, int, bool]] = []
+
+    async def get(
+        entry_id: str,
+        map_index: int,
+        *,
+        refresh: bool,
+    ) -> DreameLawnMowerPointCloudDownload:
+        calls.append((entry_id, map_index, refresh))
+        return _download(map_index)
+
+    view = DreameLawnMowerPointCloudView(SimpleNamespace(async_get=get))
+
+    response = asyncio.run(
+        view.get(
+            _FakeRequest(is_admin=True, query={"refresh": "1"}),
+            "entry-1",
+            "2",
+        )
+    )
+
+    assert calls == [("entry-1", 2, True)]
+    assert response.body == b"private-pcd"
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Content-Disposition"] == (
+        'attachment; filename="dreame-map-2.pcd"'
+    )
+    assert response.headers["X-Content-Type-Options"] == "nosniff"
+
+
+def test_point_cloud_view_requires_admin() -> None:
+    view = DreameLawnMowerPointCloudView(SimpleNamespace())
+
+    async def run() -> None:
+        with pytest.raises(Unauthorized):
+            await view.get(_FakeRequest(is_admin=False), "entry-1", "0")
+
+    asyncio.run(run())

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
+from aiohttp import web
 from homeassistant.exceptions import Unauthorized
 
 from custom_components.dreame_lawn_mower.const import DOMAIN
@@ -115,6 +117,53 @@ def test_point_cloud_api_deduplicates_concurrent_refreshes() -> None:
     assert calls == 1
 
 
+def test_point_cloud_api_keeps_generation_alive_after_waiter_cancellation() -> None:
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        disconnected = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await started.wait()
+        disconnected.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await disconnected
+
+        replacement = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await asyncio.sleep(0)
+        assert calls == 1
+        release.set()
+        assert await replacement == _download()
+
+    asyncio.run(run())
+
+    assert calls == 1
+
+
 def test_point_cloud_api_purges_unloaded_entry() -> None:
     calls = 0
 
@@ -214,3 +263,27 @@ def test_point_cloud_view_requires_admin() -> None:
             await view.get(_FakeRequest(is_admin=False), "entry-1", "0")
 
     asyncio.run(run())
+
+
+def test_point_cloud_view_does_not_log_private_exception_details(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    private_detail = (
+        "https://downloads.example.invalid/private-map.pcd?secret=do-not-log"
+    )
+
+    async def get(*args: Any, **kwargs: Any) -> None:
+        raise RuntimeError(private_detail)
+
+    view = DreameLawnMowerPointCloudView(SimpleNamespace(async_get=get))
+
+    async def run() -> None:
+        with pytest.raises(web.HTTPBadGateway):
+            await view.get(_FakeRequest(is_admin=True), "entry-1", "0")
+
+    with caplog.at_level(logging.WARNING):
+        asyncio.run(run())
+
+    assert "point-cloud generation failure" in caplog.text
+    assert private_detail not in caplog.text
+    assert "do-not-log" not in caplog.text


### PR DESCRIPTION
## Summary

- add a reusable client API that triggers A2 3D-map generation, captures only a newly published transient object, downloads it over bounded HTTPS, and validates PCD 0.7 before returning it
- expose the PCD through an authenticated, administrator-only Home Assistant endpoint with no-store responses, a bounded in-memory cache, and cancellation-safe in-flight deduplication
- publish only the local API path on the map camera; vendor filenames, signed URLs, and point coordinates stay out of entity state and logs
- add a coordinate-free probe plus user/developer documentation for the companion Lovelace viewer

Companion viewer: EvotecIT/lovelace-lawn-mower-card#17.

## Live A2 evidence

A docked Dreame A2 produced a binary PCD with `x y z rgb`, 152,318 finite points, and 2,437,272 bytes. The public client reproduced that format without persisting geometry. Later repeated probes did not republish the transient object; the hardened flow now times out instead of returning an older OBJ entry. Other models and firmware still need field confirmation.

## Validation

- Ruff passes on the changed Python and tests
- 59 focused map/point-cloud/API tests pass with the CI plugin settings
- 806 tests pass in the complete CI-style integration suite; the established WSL/Home Assistant lane also passes
- independent local review covered parser safety, requester cancellation, stale-object handling, logging privacy, and public API behavior

Closes #55