### PR TITLE
Classify missing XP2P provisioning and validate A3 video

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ Support levels in this table mean:
 | Dreame A2 (`dreame.mower.g2408`) | Validated | Primary live development device, including schedules, maps, remote control, guarded preference writes, and diagnostics |
 | MOVA LiDAX Ultra 1000 (`mova.mower.g2529c`) | Recognized | Added from a MOVAhome EU diagnostics report; commands and battery are reported working, state handling now accepts model-specific cloud property ids |
 | Dreame A3 AWD Pro 3500 (`dreame.mower.g2541e`) | Recognized | Added from a Dreamehome EU diagnostics report; needs broader live confirmation before it is considered validated |
-| Dreame A3 AWD 1000 (`dreame.mower.q2501a`) | Recognized | Core entities, maps, and mower state are field-confirmed on firmware `4.3.6_0418`; live video still needs model-specific runtime proof |
+| Dreame A3 AWD 1000 (`dreame.mower.q2501a`) | Validated | Core entities, maps, mower state, and cloud live video are field-confirmed on firmware `4.3.6_0418`; video worked after the same mower was bound to an EU account, while its previous RU account lacked the required cloud video identity |
 | Newer A-series mower (`dreame.mower.g3255`) | Recognized | Raw model has been observed in code mapping, but the public retail name is still unverified |
 | Dreame A1 (`dreame.mower.p2255`) | Recognized | Model mapping is present; needs fixtures and live validation |
 | Dreame A1 Pro (`dreame.mower.g2422`) | Recognized | Model mapping is present; needs fixtures and live validation |
@@ -460,6 +460,25 @@ response values, account or device identifiers, credentials, stream URLs, or
 unbounded payloads. This lets maintainers distinguish unsupported models,
 malformed vendor responses, and missing provisioning without asking users to
 share an account as the first debugging step.
+
+### Live video identity is not provisioned
+
+The integration reports `device_triple_missing` when both Dreame video identity
+endpoints return vendor code `10000`, `设备三元组不存在` ("device triple does not
+exist"), and the required `product_id`, `device_name`, and `p2p_info` fields are
+absent. This means Dreame has not provisioned the mower's XP2P video identity
+for the current account or region; it is not a video-runtime or model-support
+failure.
+
+Check live video in Dreamehome or MOVAhome first. If it is missing there too,
+contact Dreame support and include the diagnostics capture. A field report for
+an A3 AWD 1000 found this condition on an RU account and confirmed working video
+after the same mower was rebound to an EU account. That is one account/device
+result, not evidence that every device in a region behaves the same way.
+
+Changing account region requires pairing the mower to another account and can
+discard cloud-stored maps and settings. Treat that as a last resort, not the
+normal fix for `device_triple_missing`.
 
 For issue reports, include:
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -158,6 +158,10 @@ from .video_runtime import (
     DreameLawnMowerXp2pRuntimeDiagnostics,
     diagnose_native_xp2p_runtime,
 )
+from .video_provisioning_status import (
+    XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING,
+    classify_xp2p_provisioning_issue,
+)
 from .xp2p_config import (
     DreameLawnMowerXp2pConfigError,
     DreameLawnMowerXp2pDeviceConfig,
@@ -222,6 +226,7 @@ __all__ = [
     "XP2P_PROTOCOL_AUTO",
     "XP2P_PROTOCOL_TCP",
     "XP2P_PROTOCOL_UDP",
+    "XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING",
     "MAP_PROBE_PROPERTY_KEYS",
     "MAP_HISTORY_PROPERTY_KEYS",
     "MOWER_BLUETOOTH_PROPERTY_KEY",
@@ -266,6 +271,7 @@ __all__ = [
     "decode_batch_ota_info",
     "decode_batch_schedule_payload",
     "cms_values_from_app_data",
+    "classify_xp2p_provisioning_issue",
     "decode_mower_status_blob",
     "decode_mower_task_status",
     "decode_mowing_preference_payload",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -2048,6 +2048,7 @@ class DreameLawnMowerClient:
                     },
                 )
         diagnostics["completed"] = True
+        diagnostics["provisioning_issue"] = runtime_inputs.provisioning_issue
         return output
 
     def _sync_get_camera_stream_runtime_inputs(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -14,6 +14,7 @@ from .device_code_semantics import (
     mower_fault_code,
     mower_status_notice_code,
 )
+from .video_provisioning_status import classify_xp2p_provisioning_issue
 
 SUPPORTED_ACCOUNT_TYPES = ("dreame", "mova")
 SUPPORTED_MODEL_MARKER = ".mower."
@@ -695,6 +696,14 @@ class DreameLawnMowerCameraStreamRuntimeInputs:
         return not self.missing_required
 
     @property
+    def provisioning_issue(self) -> str | None:
+        """Return a stable issue classified from privacy-safe cloud telemetry."""
+        return classify_xp2p_provisioning_issue(
+            self.diagnostics,
+            missing_required=self.missing_required,
+        )
+
+    @property
     def missing_lan_required(self) -> tuple[str, ...]:
         """Return identity fields missing from direct same-LAN startup."""
         return tuple(
@@ -738,6 +747,7 @@ class DreameLawnMowerCameraStreamRuntimeInputs:
         payload["xp2p_id"] = self.xp2p_id
         payload["ready"] = self.ready
         payload["missing_required"] = self.missing_required
+        payload["provisioning_issue"] = self.provisioning_issue
         payload["lan_identity_ready"] = self.lan_identity_ready
         payload["missing_lan_required"] = self.missing_lan_required
         payload["qcloud_credential_state"] = self.qcloud_credential_state
@@ -785,6 +795,7 @@ def remote_control_block_reason(snapshot: Any) -> str | None:
     activity = str(getattr(snapshot, "activity", None) or "").casefold()
     remote_control_active = state in REMOTE_CONTROL_STATES
     raw_running = bool(raw_attributes.get("running"))
+    docked = bool(getattr(snapshot, "docked", False)) or activity == "docked"
     mapping = bool(raw_attributes.get("mapping"))
     battery_level = getattr(snapshot, "battery_level", None)
 
@@ -805,7 +816,7 @@ def remote_control_block_reason(snapshot: Any) -> str | None:
     mower_active = (
         bool(getattr(snapshot, "mowing", False))
         or activity == "mowing"
-        or raw_running
+        or (raw_running and not docked)
     )
     if mower_active and not remote_control_active:
         return "Remote control is blocked while the mower is active."

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/video_provisioning_status.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/video_provisioning_status.py
@@ -1,0 +1,81 @@
+"""Classify privacy-safe Dreame XP2P provisioning diagnostics."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING = "device_triple_missing"
+
+_DEVICE_TRIPLE_REQUIRED_FIELDS = frozenset(
+    {"product_id", "device_name", "p2p_info"}
+)
+_DEVICE_TRIPLE_MISSING_CODE = 10000
+_DEVICE_TRIPLE_MISSING_MESSAGES = frozenset(
+    {
+        "设备三元组不存在",
+        "the device triple does not exist",
+        "device triple does not exist",
+    }
+)
+_DEVICE_TRIPLE_STAGES = frozenset(
+    {"cloud_device_identity", "cloud_p2p_info"}
+)
+
+
+def classify_xp2p_provisioning_issue(
+    diagnostics: Mapping[str, Any],
+    *,
+    missing_required: Sequence[str],
+) -> str | None:
+    """Return a stable provisioning issue from sanitized cloud-stage evidence."""
+    if not _DEVICE_TRIPLE_REQUIRED_FIELDS.issubset(missing_required):
+        return None
+
+    matching_stages: set[str] = set()
+    stages = diagnostics.get("stages")
+    if not _is_sequence(stages):
+        return None
+
+    for stage in stages:
+        if not isinstance(stage, Mapping):
+            continue
+        stage_name = stage.get("stage")
+        if stage_name not in _DEVICE_TRIPLE_STAGES:
+            continue
+        response = stage.get("response")
+        if not isinstance(response, Mapping):
+            continue
+        if _has_device_triple_missing_response(response):
+            matching_stages.add(str(stage_name))
+
+    if matching_stages == _DEVICE_TRIPLE_STAGES:
+        return XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING
+    return None
+
+
+def _has_device_triple_missing_response(response: Mapping[str, Any]) -> bool:
+    codes = response.get("codes")
+    messages = response.get("messages")
+    if not _is_sequence(codes) or not _is_sequence(messages):
+        return False
+
+    code_matches = any(
+        isinstance(item, Mapping)
+        and item.get("value") == _DEVICE_TRIPLE_MISSING_CODE
+        for item in codes
+    )
+    message_matches = any(
+        isinstance(item, Mapping)
+        and str(item.get("text") or "").strip().casefold()
+        in _DEVICE_TRIPLE_MISSING_MESSAGES
+        for item in messages
+    )
+    return code_matches and message_matches
+
+
+def _is_sequence(value: Any) -> bool:
+    return isinstance(value, Sequence) and not isinstance(
+        value,
+        str | bytes | bytearray,
+    )

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -46,6 +46,9 @@ from .dreame_lawn_mower_client.models import (
     snapshot_advertises_video,
 )
 from .dreame_lawn_mower_client.stream_health import DreameLawnMowerStreamUrlProbeResult
+from .dreame_lawn_mower_client.video_provisioning_status import (
+    XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING,
+)
 from .dreame_lawn_mower_client.video_runtime import (
     DreameLawnMowerNativeXp2pRuntime,
     DreameLawnMowerVideoRuntimeError,
@@ -72,6 +75,26 @@ _HA_STREAM_START_TIMEOUT = DEFAULT_XP2P_HOST_STARTUP_TIMEOUT + 30.0
 _HA_PLAYBACK_VERIFY_TIMEOUT = 15.0
 _SNAPSHOT_STREAM_START_TIMEOUT = 15.0
 _SNAPSHOT_IMAGE_TIMEOUT = 15.0
+
+
+def _runtime_inputs_not_ready_message(
+    inputs: DreameLawnMowerCameraStreamRuntimeInputs,
+) -> str:
+    """Return a useful, credential-free explanation for missing XP2P inputs."""
+    if (
+        inputs.provisioning_issue
+        == XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING
+    ):
+        return (
+            "Dreame cloud has not provisioned an XP2P video identity for this "
+            "mower on the current account/region. Confirm that live video works "
+            "in Dreamehome or MOVAhome; contact Dreame support if it is also "
+            "missing there."
+        )
+    return (
+        "Dreame cloud did not return required XP2P fields: "
+        + ", ".join(inputs.missing_required)
+    )
 
 
 class _DreameVideoRuntime(Protocol):
@@ -140,6 +163,7 @@ class DreameLawnMowerVideoCamera(
         self._last_runtime_inputs_ready: bool | None = None
         self._last_runtime_inputs_source: str | None = None
         self._last_runtime_inputs_missing: tuple[str, ...] = ()
+        self._last_runtime_inputs_provisioning_issue: str | None = None
         self._last_runtime_input_diagnostics: dict[str, Any] | None = None
         self._last_stream_health: dict[str, Any] | None = None
         self._last_stream_enable_result: Any | None = None
@@ -302,6 +326,9 @@ class DreameLawnMowerVideoCamera(
             "last_runtime_inputs_ready": self._last_runtime_inputs_ready,
             "last_runtime_inputs_source": self._last_runtime_inputs_source,
             "last_runtime_inputs_missing": self._last_runtime_inputs_missing,
+            "last_runtime_inputs_provisioning_issue": (
+                self._last_runtime_inputs_provisioning_issue
+            ),
             "last_runtime_input_diagnostics": getattr(
                 self,
                 "_last_runtime_input_diagnostics",
@@ -720,8 +747,7 @@ class DreameLawnMowerVideoCamera(
                 cloud_inputs = await self._async_get_runtime_inputs()
             if not cloud_inputs.ready:
                 raise DreameLawnMowerVideoRuntimeError(
-                    "Dreame cloud did not return required XP2P fields: "
-                    + ", ".join(cloud_inputs.missing_required)
+                    _runtime_inputs_not_ready_message(cloud_inputs)
                 )
             stream_enable_attempted = True
             self._last_stream_enable_result = sanitize_debug_data(
@@ -907,6 +933,7 @@ class DreameLawnMowerVideoCamera(
         self._last_runtime_inputs_ready = inputs.ready
         self._last_runtime_inputs_source = inputs.source
         self._last_runtime_inputs_missing = inputs.missing_required
+        self._last_runtime_inputs_provisioning_issue = inputs.provisioning_issue
         if inputs.lan_identity_ready:
             try:
                 await self._lan_cache.async_save_identity(inputs)

--- a/dreame_lawn_mower_client/video_provisioning_status.py
+++ b/dreame_lawn_mower_client/video_provisioning_status.py
@@ -1,0 +1,8 @@
+"""Wrapper module for reusable XP2P provisioning classification."""
+
+from ._loader import load_internal_module
+
+_internal = load_internal_module("video_provisioning_status")
+
+__all__ = [name for name in dir(_internal) if not name.startswith("_")]
+globals().update({name: getattr(_internal, name) for name in __all__})

--- a/tests/fixtures/q2501a_eu_xp2p_ready.json
+++ b/tests/fixtures/q2501a_eu_xp2p_ready.json
@@ -1,0 +1,47 @@
+{
+  "operation": "camera_stream_inputs",
+  "version": 1,
+  "stages": [
+    {
+      "stage": "cloud_setup",
+      "result": {
+        "available": true,
+        "logged_in": true
+      }
+    },
+    {
+      "stage": "cloud_access_token",
+      "result": {
+        "access_token_present": true
+      }
+    },
+    {
+      "stage": "cloud_device_identity",
+      "response": {
+        "type": "object"
+      },
+      "result": {
+        "channel_id_present": true,
+        "product_id_present": true,
+        "device_name_present": true,
+        "secret_id_present": true,
+        "secret_key_present": true,
+        "app_id_present": true,
+        "app_secret_present": true
+      }
+    },
+    {
+      "stage": "cloud_p2p_info",
+      "response": {
+        "type": "object"
+      },
+      "result": {
+        "p2p_info_present": true,
+        "available": true
+      }
+    }
+  ],
+  "ready": true,
+  "missing_required": [],
+  "completed": true
+}

--- a/tests/fixtures/q2501a_ru_xp2p_unprovisioned.json
+++ b/tests/fixtures/q2501a_ru_xp2p_unprovisioned.json
@@ -1,0 +1,96 @@
+{
+  "operation": "camera_stream_inputs",
+  "version": 1,
+  "stages": [
+    {
+      "stage": "cloud_setup",
+      "result": {
+        "available": true,
+        "logged_in": true
+      }
+    },
+    {
+      "stage": "cloud_access_token",
+      "result": {
+        "access_token_present": true
+      }
+    },
+    {
+      "stage": "cloud_device_identity",
+      "response": {
+        "type": "object",
+        "codes": [
+          {
+            "path": "$.code",
+            "value": 10000
+          }
+        ],
+        "messages": [
+          {
+            "path": "$.msg",
+            "text": "设备三元组不存在"
+          }
+        ]
+      },
+      "result": {
+        "channel_id_present": false,
+        "product_id_present": false,
+        "device_name_present": false,
+        "secret_id_present": false,
+        "secret_key_present": false,
+        "app_id_present": false,
+        "app_secret_present": false
+      }
+    },
+    {
+      "stage": "cloud_p2p_info",
+      "response": {
+        "type": "object",
+        "codes": [
+          {
+            "path": "$.code",
+            "value": 10000
+          }
+        ],
+        "messages": [
+          {
+            "path": "$.msg",
+            "text": "设备三元组不存在"
+          }
+        ]
+      },
+      "result": {
+        "p2p_info_present": false,
+        "available": true
+      }
+    },
+    {
+      "stage": "cloud_user_eligibility",
+      "response": {
+        "type": "object",
+        "codes": [
+          {
+            "path": "$.code",
+            "value": 10000
+          }
+        ],
+        "messages": [
+          {
+            "path": "$.msg",
+            "text": "设备三元组不存在"
+          }
+        ]
+      },
+      "result": {
+        "is_device_user": null
+      }
+    }
+  ],
+  "ready": false,
+  "missing_required": [
+    "product_id",
+    "device_name",
+    "p2p_info"
+  ],
+  "completed": true
+}

--- a/tests/test_cloud_key_definition.py
+++ b/tests/test_cloud_key_definition.py
@@ -400,6 +400,53 @@ def test_camera_stream_runtime_inputs_require_tx_identity_fields() -> None:
     assert "device-1" not in serialized_diagnostics
 
 
+def test_camera_stream_inputs_classify_unprovisioned_device_triple() -> None:
+    class _UnprovisionedCloud(_FakeCloud):
+        @staticmethod
+        def _missing_triple() -> dict[str, object]:
+            return {
+                "code": 10000,
+                "success": False,
+                "msg": "设备三元组不存在",
+            }
+
+        def get_tx_video_device_identity(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            assert access_token == "access-token-1"
+            assert os == 1
+            return self._missing_triple()
+
+        def get_tx_video_p2p_info(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            assert access_token == "access-token-1"
+            assert os == 1
+            return self._missing_triple()
+
+        def get_tx_video_user_eligibility(
+            self,
+            access_token: str | None = None,
+            os: int = 1,
+        ) -> dict[str, object]:
+            assert access_token == "access-token-1"
+            assert os == 1
+            return self._missing_triple()
+
+    client = _client()
+    client._sync_get_cloud_protocol = lambda: _UnprovisionedCloud()
+
+    result = client._sync_get_camera_stream_runtime_inputs()
+
+    assert result.ready is False
+    assert result.provisioning_issue == "device_triple_missing"
+    assert result.diagnostics["provisioning_issue"] == "device_triple_missing"
+
+
 def test_camera_stream_failure_retains_sanitized_stage_diagnostics() -> None:
     class _FailingCloud(_FakeCloud):
         def get_tx_video_access_token(self, os: int = 1) -> dict[str, object]:

--- a/tests/test_python_package.py
+++ b/tests/test_python_package.py
@@ -22,6 +22,7 @@ from dreame_lawn_mower_client import (
     MOWER_TIME_PROPERTY_KEY,
     MOWING_PREFERENCE_PROPERTY_KEY,
     MOWING_PREFERENCE_UPDATE_FIELDS,
+    XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING,
     DreameLawnMowerCameraFeatureSupport,
     DreameLawnMowerCameraStreamRuntimeInputs,
     DreameLawnMowerClient,
@@ -55,6 +56,7 @@ from dreame_lawn_mower_client import (
     build_map_probe_payload,
     build_schedule_enable_status_request,
     build_schedule_upload_requests,
+    classify_xp2p_provisioning_issue,
     decode_batch_mowing_preferences,
     decode_batch_ota_info,
     decode_batch_schedule_payload,
@@ -136,6 +138,11 @@ def test_public_package_exports_map_helpers() -> None:
     assert callable(firmware_update_support_from_device)
     assert callable(remote_control_block_reason)
     assert callable(remote_control_state_safe)
+    assert callable(classify_xp2p_provisioning_issue)
+    assert (
+        XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING
+        == "device_triple_missing"
+    )
     assert callable(key_definition_label)
     assert callable(analyze_decompiled_sources)
     assert callable(analyze_dreamehome_assets)

--- a/tests/test_remote_control.py
+++ b/tests/test_remote_control.py
@@ -194,6 +194,17 @@ def test_remote_control_support_reports_unsafe_state_without_hiding_protocol() -
     )
 
 
+def test_remote_control_ignores_stale_running_flag_while_docked() -> None:
+    device = _FakeRemoteControlDevice()
+    device.status.attributes["running"] = True
+    client = _client_with_device(device)
+
+    support = client._sync_get_remote_control_support()
+
+    assert support.state_safe is True
+    assert support.state_block_reason is None
+
+
 def test_remote_control_move_step_blocks_unsafe_nonzero_commands() -> None:
     device = _FakeRemoteControlDevice()
     device.status.battery_level = 19

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -253,6 +253,63 @@ def test_video_camera_preserves_runtime_input_telemetry_on_incomplete_result() -
         "device_name",
         "p2p_info",
     )
+    assert entity._last_runtime_inputs_provisioning_issue is None
+
+
+def test_video_camera_explains_unprovisioned_device_triple() -> None:
+    diagnostics = load_json_fixture("q2501a_ru_xp2p_unprovisioned.json")
+    inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+        source="dreame_third_video_tx",
+        did="sanitized-device",
+        diagnostics=diagnostics,
+    )
+
+    message = video_camera_module._runtime_inputs_not_ready_message(inputs)
+
+    assert "has not provisioned an XP2P video identity" in message
+    assert "current account/region" in message
+    assert "Dreamehome or MOVAhome" in message
+    assert "product_id" not in message
+
+
+def test_video_camera_cloud_start_surfaces_unprovisioned_device_triple() -> None:
+    async def _run() -> tuple[str | None, str | None, str | None]:
+        diagnostics = load_json_fixture("q2501a_ru_xp2p_unprovisioned.json")
+        inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+            source="dreame_third_video_tx",
+            did="sanitized-device",
+            diagnostics=diagnostics,
+        )
+
+        class _Client:
+            async def async_get_camera_stream_runtime_inputs(self) -> object:
+                return inputs
+
+            async def async_set_camera_stream_enabled(
+                self,
+                _enabled: bool,
+            ) -> None:
+                raise AssertionError("Unprovisioned video must not be enabled")
+
+        entity = _uninitialized_entity()
+        entity.coordinator = SimpleNamespace(client=_Client(), data=object())
+        entity._prepared_runtime = object()
+        entity._async_stop_active_session = lambda: asyncio.sleep(0)
+        entity.async_write_ha_state = lambda: None
+
+        source = await entity._async_start_stream()
+        return (
+            source,
+            entity._last_error,
+            entity._last_runtime_inputs_provisioning_issue,
+        )
+
+    source, error, issue = asyncio.run(_run())
+
+    assert source is None
+    assert error is not None
+    assert "has not provisioned an XP2P video identity" in error
+    assert issue == "device_triple_missing"
 
 
 def test_video_camera_auto_policy_prefers_direct_capable_sdk_negotiation() -> None:

--- a/tests/test_video_provisioning_status.py
+++ b/tests/test_video_provisioning_status.py
@@ -1,0 +1,61 @@
+"""Fixture-driven XP2P provisioning classification contracts."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+
+from dreame_lawn_mower_client import (
+    XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING,
+    DreameLawnMowerCameraStreamRuntimeInputs,
+    classify_xp2p_provisioning_issue,
+)
+
+from .fixture_data import load_json_fixture
+
+
+def test_q2501a_ru_trace_classifies_missing_device_triple() -> None:
+    diagnostics = load_json_fixture("q2501a_ru_xp2p_unprovisioned.json")
+    inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+        source="dreame_third_video_tx",
+        did="sanitized-device",
+        diagnostics=diagnostics,
+    )
+
+    assert (
+        inputs.provisioning_issue
+        == XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING
+    )
+    assert inputs.as_dict(redact=True)["provisioning_issue"] == (
+        XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING
+    )
+
+
+def test_q2501a_eu_trace_remains_ready_without_provisioning_issue() -> None:
+    diagnostics = load_json_fixture("q2501a_eu_xp2p_ready.json")
+    inputs = DreameLawnMowerCameraStreamRuntimeInputs(
+        source="dreame_third_video_tx",
+        did="sanitized-device",
+        product_id="present",
+        device_name="present",
+        p2p_info="present",
+        diagnostics=diagnostics,
+    )
+
+    assert inputs.ready is True
+    assert inputs.provisioning_issue is None
+
+
+def test_generic_missing_inputs_are_not_mislabeled_as_device_triple_issue() -> None:
+    diagnostics = deepcopy(
+        load_json_fixture("q2501a_ru_xp2p_unprovisioned.json")
+    )
+    diagnostics["stages"][2]["response"]["messages"][0]["text"] = (
+        "temporary service failure"
+    )
+
+    issue = classify_xp2p_provisioning_issue(
+        diagnostics,
+        missing_required=("product_id", "device_name", "p2p_info"),
+    )
+
+    assert issue is None


### PR DESCRIPTION
## What changed

- classify the exact privacy-safe Dreame response for a missing XP2P device triple as `device_triple_missing`
- expose that stable state through the reusable Python client and the Home Assistant camera diagnostics
- replace the generic missing-fields failure with guidance to verify video in Dreamehome or MOVAhome and contact Dreame when the vendor app is also affected
- ignore a stale raw `running` flag when the mower is already normalized as docked, avoiding the misleading active-mower remote-control block
- add sanitized same-device RU-failure and EU-success fixtures from the A3 AWD 1000 report
- mark `dreame.mower.q2501a` as validated for core behavior and cloud live video on firmware `4.3.6_0418`

## Support boundary

The field evidence covers one mower moved from an RU account without an XP2P identity to an EU account where video worked in both the vendor app and Home Assistant. It does not claim that every RU device is affected. The troubleshooting guidance also warns that rebinding to another account/region can discard cloud-stored maps and settings.

## Validation

- 764 tests passed
- Ruff passed
- package wheel built successfully and contains both internal and public provisioning-classifier modules
- manifest and Python package versions remain aligned
- independent privacy/correctness review found no actionable issues

Closes #53