### PR TITLE
Add Evotec Home Assistant project links

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,22 +20,28 @@ For the dashboard shown above, pair this integration with the
 layout automatically finds the integration's map, mission, coverage, and live
 video entities when their names follow the normal Home Assistant device naming.
 
-## More from Evotec
+## 🧩 More from Evotec
 
-This project is part of our Home Assistant family:
-[Dreame Lawn Mower](https://github.com/EvotecIT/homeassistant-dreamelawnmower),
-[Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card),
-[Siegenia](https://github.com/EvotecIT/homeassistant-siegenia),
-[KEF](https://github.com/EvotecIT/homeassistant-kef),
-[Devialet](https://github.com/EvotecIT/homeassistant-devialet), and
-[EasyControlX](https://github.com/EvotecIT/homeassistant-easycontrolx).
+Our Home Assistant projects:
 
-For a native Apple companion,
-[CasaRay](https://casaray.dev/) ([App Store](https://apps.apple.com/us/app/casaray/id6778025328))
-offers a calm whole-home view on iPhone, iPad, and Mac, while
-[Tactra Remote](https://tactra.dev/) ([App Store](https://apps.apple.com/us/app/tactra-remote/id6775426723))
-focuses on Home Assistant media control across iPhone, iPad, Apple Watch, and
-Mac.
+- [Dreame Lawn Mower](https://github.com/EvotecIT/homeassistant-dreamelawnmower)
+  with its companion
+  [Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card)
+- [Siegenia](https://github.com/EvotecIT/homeassistant-siegenia) for local
+  window control
+- [KEF](https://github.com/EvotecIT/homeassistant-kef) for local speaker control
+- [Devialet](https://github.com/EvotecIT/homeassistant-devialet) for local
+  speaker control
+- [EasyControlX](https://github.com/EvotecIT/homeassistant-easycontrolx) for
+  workstation control
+
+Our Apple apps:
+
+- [CasaRay](https://casaray.dev/) offers a calm whole-home view on iPhone, iPad,
+  and Mac. [View it on the App Store](https://apps.apple.com/us/app/casaray/id6778025328).
+- [Tactra Remote](https://tactra.dev/) focuses on Home Assistant media control
+  across iPhone, iPad, Apple Watch, and Mac.
+  [View it on the App Store](https://apps.apple.com/us/app/tactra-remote/id6775426723).
 
 CasaRay's complete-home Free experience remains genuinely useful. CasaRay Plus
 and Tactra purchases help fund continued work on that free experience and these

--- a/README.md
+++ b/README.md
@@ -20,6 +20,29 @@ For the dashboard shown above, pair this integration with the
 layout automatically finds the integration's map, mission, coverage, and live
 video entities when their names follow the normal Home Assistant device naming.
 
+## More from Evotec
+
+This project is part of our Home Assistant family:
+[Dreame Lawn Mower](https://github.com/EvotecIT/homeassistant-dreamelawnmower),
+[Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card),
+[Siegenia](https://github.com/EvotecIT/homeassistant-siegenia),
+[KEF](https://github.com/EvotecIT/homeassistant-kef),
+[Devialet](https://github.com/EvotecIT/homeassistant-devialet), and
+[EasyControlX](https://github.com/EvotecIT/homeassistant-easycontrolx).
+
+For a native Apple companion,
+[CasaRay](https://casaray.dev/) ([App Store](https://apps.apple.com/us/app/casaray/id6778025328))
+offers a calm whole-home view on iPhone, iPad, and Mac, while
+[Tactra Remote](https://tactra.dev/) ([App Store](https://apps.apple.com/us/app/tactra-remote/id6775426723))
+focuses on Home Assistant media control across iPhone, iPad, Apple Watch, and
+Mac.
+
+CasaRay's complete-home Free experience remains genuinely useful. CasaRay Plus
+and Tactra purchases help fund continued work on that free experience and these
+open-source Home Assistant projects. If you prefer to support the open-source
+work directly, [GitHub Sponsors](https://github.com/sponsors/PrzemyslawKlys) is
+another option. None of them is required to use this project.
+
 ## See It In Action
 
 The live-path map combines the stored garden geometry with mower position and


### PR DESCRIPTION
## Summary

- add a compact `More from Evotec` section near the top of the README
- connect the Evotec Home Assistant integrations and Lawn Mower Card so users can discover related projects
- introduce CasaRay and Tactra Remote with product and App Store links
- explain how app purchases and optional GitHub sponsorship support the free experience and open-source maintenance without making either a requirement
