### PR TITLE
Use mower-native device codes for error state

### DIFF
--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -321,6 +321,7 @@ class DreameLawnMowerCaptureTaskStatusProbeButton(
         payload = task_status_probe_payload(
             scan,
             captured_at=datetime.now(UTC).isoformat(),
+            model=self._descriptor.model,
         )
         self.coordinator.last_task_status_probe_result = payload
         self.coordinator.async_update_listeners()

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -274,7 +274,7 @@ def _active_error_from_snapshot(snapshot: Any) -> bool:
     """Return whether the normalized snapshot contains an active error signal."""
     error_code = getattr(snapshot, "error_code", None)
     return bool(
-        error_code not in (None, -1, 0)
+        error_code not in (None, -1)
         or not _is_no_error_value(getattr(snapshot, "error_name", None))
         or not _is_no_error_value(getattr(snapshot, "error_text", None))
         or not _is_no_error_value(getattr(snapshot, "error_display", None))
@@ -427,6 +427,9 @@ def _collect_state_reconciliation(snapshot: Any, device: Any) -> dict[str, Any]:
             ),
             "display": _normalize_debug_value(
                 getattr(snapshot, "status_notice_display", None)
+            ),
+            "tier": _normalize_debug_value(
+                getattr(snapshot, "status_notice_tier", None)
             ),
             "source": _normalize_debug_value(
                 getattr(snapshot, "status_notice_source", None)
@@ -633,6 +636,9 @@ def _collect_triage_summary(
             ),
             "display": _normalize_debug_value(
                 getattr(snapshot, "status_notice_display", None)
+            ),
+            "tier": _normalize_debug_value(
+                getattr(snapshot, "status_notice_tier", None)
             ),
             "source": _normalize_debug_value(
                 getattr(snapshot, "status_notice_source", None)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -6,7 +6,7 @@ import json
 from collections.abc import Mapping, Sequence
 from typing import Final
 
-from .device_code_semantics import MOWER_DEVICE_CODE_NAMES
+from .device_code_semantics import mower_device_code_name
 from .models import DreameLawnMowerStatusBlob
 
 MOWER_RAW_STATUS_PROPERTY_KEY: Final[str] = "1.1"
@@ -110,8 +110,12 @@ def mower_state_key(value: object) -> str | None:
     return MOWER_STATE_KEYS.get(str(value))
 
 
-def mower_error_label(value: object) -> str | None:
-    """Return a cleaned mower error label for a raw `2.2` value."""
+def mower_error_label(
+    value: object,
+    *,
+    model: str | None = None,
+) -> str | None:
+    """Return a mower-native device-code label for raw property `2.2`."""
     if value is None:
         return None
 
@@ -119,21 +123,9 @@ def mower_error_label(value: object) -> str | None:
         code = int(value)
     except (TypeError, ValueError):
         return None
-    if code in (-1, 0):
+    if code == -1:
         return "No error"
-    confirmed = _clean_label(MOWER_DEVICE_CODE_NAMES.get(code))
-    if confirmed is not None:
-        return confirmed
-
-    try:
-        from .const import ERROR_CODE_TO_ERROR_NAME
-        from .types import DreameMowerErrorCode
-
-        enum_value = DreameMowerErrorCode(code)
-        inherited = _clean_label(ERROR_CODE_TO_ERROR_NAME.get(enum_value))
-        return f"Unverified {inherited.casefold()}" if inherited else None
-    except (ImportError, ValueError):
-        return None
+    return _clean_label(mower_device_code_name(code, model=model))
 
 
 def decode_mower_task_status(value: object) -> dict[str, object] | None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -3990,6 +3990,7 @@ class DreameLawnMowerClient:
                 entry,
                 language=language,
                 key_definition=cloud_key_definition,
+                model=self._descriptor.model,
             )
             for entry in sorted(
                 rendered,
@@ -4338,6 +4339,7 @@ class DreameLawnMowerClient:
         *,
         language: str,
         key_definition: Mapping[str, Any] | None = None,
+        model: str | None = None,
     ) -> dict[str, Any]:
         rendered = dict(entry)
         key = str(rendered.get("key", ""))
@@ -4366,7 +4368,7 @@ class DreameLawnMowerClient:
                     rendered["decoded_label"] = label
                     rendered["decoded_label_source"] = "bundled_mower_protocol"
         elif key == MOWER_ERROR_PROPERTY_KEY and not rendered.get("decoded_label"):
-            label = mower_error_label(value)
+            label = mower_error_label(value, model=model)
             if label:
                 rendered["decoded_label"] = label
                 rendered["decoded_label_source"] = "bundled_mower_errors"
@@ -5946,6 +5948,7 @@ def _operation_snapshot_summary(snapshot: DreameLawnMowerSnapshot) -> dict[str, 
         "status_notice_code": snapshot.status_notice_code,
         "status_notice_name": snapshot.status_notice_name,
         "status_notice_display": snapshot.status_notice_display,
+        "status_notice_tier": snapshot.status_notice_tier,
         "status_notice_source": snapshot.status_notice_source,
         "raw_error_code": snapshot.raw_error_code,
         "realtime_error_code": snapshot.realtime_error_code,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -13,6 +13,11 @@ from threading import Timer
 from typing import Any, Optional
 
 from .app_protocol import mower_realtime_property_name
+from .device_code_semantics import (
+    MowerDeviceCodeTier,
+    mower_device_code_definition,
+    mower_device_code_name,
+)
 from .types import (
     PIID,
     DIID,
@@ -30,7 +35,6 @@ from .types import (
     DreameMowerState,
     DreameMowerStateOld,
     DreameMowerStatus,
-    DreameMowerErrorCode,
     DreameMowerRelocationStatus,
     DreameMowerCleaningMode,
     DreameMowerStreamStatus,
@@ -70,8 +74,6 @@ from .const import (
     RELOCATION_STATUS_CODE_TO_NAME,
     TASK_STATUS_CODE_TO_NAME,
     STATE_CODE_TO_STATE,
-    ERROR_CODE_TO_ERROR_NAME,
-    ERROR_CODE_TO_ERROR_DESCRIPTION,
     STATUS_CODE_TO_NAME,
     STREAM_STATUS_TO_NAME,
     WIDER_CORNER_COVERAGE_TO_NAME,
@@ -83,7 +85,6 @@ from .const import (
     SEGMENT_VISIBILITY_CODE_TO_NAME,
     VOICE_ASSISTANT_LANGUAGE_TO_NAME,
     TASK_TYPE_TO_NAME,
-    ERROR_CODE_TO_IMAGE_INDEX,
     CONSUMABLE_TO_LIFE_WARNING_DESCRIPTION,
     PROPERTY_TO_NAME,
     DEVICE_KEY,
@@ -130,7 +131,6 @@ from .const import (
     ATTR_HAS_TEMPORARY_MAP,
     ATTR_CAPABILITIES,
 )
-from .resources import ERROR_IMAGE
 from .exceptions import (
     DeviceUpdateFailedException,
     InvalidActionException,
@@ -2249,7 +2249,9 @@ class DreameMowerDevice:
             self._update_property(DreameMowerProperty.SQUEEGEE_LEFT, 100)
             self._update_property(DreameMowerProperty.SQUEEGEE_TIME_LEFT, 100)
         elif action is DreameMowerAction.CLEAR_WARNING:
-            self._update_property(DreameMowerProperty.ERROR, DreameMowerErrorCode.NO_ERROR.value)
+            # Mower property 2.2 uses -1 for no active device code. Vacuum
+            # clients used 0, but the A2 catalog assigns 0 to robot lifted.
+            self._update_property(DreameMowerProperty.ERROR, -1)
 
         # Update listeners
         if cleaning_action or self._consumable_change:
@@ -3002,8 +3004,9 @@ class DreameMowerDevice:
         return self.start_custom(DreameMowerStatus.CLEANING.value, "3")
 
     def clear_warning(self) -> dict[str, Any] | None:
-        """Clear warning error code from the mower cleaner."""
-        if self.status.has_warning:
+        """Clear an actionable device-code notice from the mower."""
+        device_code = self.status.device_code
+        if self.status.has_warning and device_code is not None:
             return self.call_action(
                 DreameMowerAction.CLEAR_WARNING,
                 [
@@ -3012,7 +3015,7 @@ class DreameMowerDevice:
                             DreameMowerProperty.CLEANING_PROPERTIES,
                             self.property_mapping,
                         ),
-                        "value": f"[{self.status.error.value}]",
+                        "value": f"[{device_code}]",
                     }
                 ],
             )
@@ -4107,14 +4110,6 @@ class DreameMowerDeviceStatus:
         self.voice_assistant_language_list = {v: k for k, v in VOICE_ASSISTANT_LANGUAGE_TO_NAME.items()}
         self.segment_cleaning_mode_list = {}
         self.segment_cleaning_route_list = {}
-        self.warning_codes = [
-            DreameMowerErrorCode.BLOCKED,
-            DreameMowerErrorCode.STATION_DISCONNECTED,
-            DreameMowerErrorCode.SELF_TEST_FAILED,
-            DreameMowerErrorCode.LOW_BATTERY_TURN_OFF,
-            DreameMowerErrorCode.UNKNOWN_WARNING_2,
-        ]
-
         self.cleaning_mode = None
         self.ai_policy_accepted = False
         self.go_to_zone: GoToZoneSettings = None
@@ -4381,38 +4376,38 @@ class DreameMowerDeviceStatus:
         return 0 if faults == "" or faults == " " else faults
 
     @property
-    def error(self) -> DreameMowerErrorCode:
-        """Return error of the device."""
+    def device_code(self) -> int | None:
+        """Return the raw mower device code from property 2.2."""
         value = self._get_property(DreameMowerProperty.ERROR)
-        if value is not None and value in DreameMowerErrorCode._value2member_map_:
-            if (
-                value == DreameMowerErrorCode.LOW_BATTERY_TURN_OFF.value
-                or value == DreameMowerErrorCode.UNKNOWN_WARNING_2.value
-            ):
-                return DreameMowerErrorCode.NO_ERROR
-            return DreameMowerErrorCode(value)
-        if value is not None:
-            _LOGGER.debug("ERROR_CODE not supported: %s", value)
-        return DreameMowerErrorCode.UNKNOWN
+        try:
+            return int(value) if value is not None else None
+        except (TypeError, ValueError):
+            _LOGGER.debug("DEVICE_CODE not numeric: %s", value)
+            return None
+
+    @property
+    def error(self) -> int | None:
+        """Deprecated raw alias for :attr:`device_code`."""
+        return self.device_code
 
     @property
     def error_name(self) -> str:
-        """Return error as string for translation."""
-        if not self.has_error and not self.has_warning:
-            return ERROR_CODE_TO_ERROR_NAME.get(DreameMowerErrorCode.NO_ERROR)
-        return ERROR_CODE_TO_ERROR_NAME.get(self.error, STATE_UNKNOWN)
+        """Return a mower-native device-code name."""
+        value = self.device_code
+        if value in (None, -1):
+            return "no_error"
+        return mower_device_code_name(value, model=self._device_model) or STATE_UNKNOWN
 
     @property
     def error_description(self) -> str:
-        """Return error description of the device."""
-        return ERROR_CODE_TO_ERROR_DESCRIPTION.get(self.error, [STATE_UNKNOWN, ""])
+        """Return a mower-native device-code description."""
+        name = self.error_name
+        return [name.replace("_", " ").capitalize(), ""] if name else [STATE_UNKNOWN, ""]
 
     @property
     def error_image(self) -> str:
-        """Return error image of the device as base64 string."""
-        if not self.has_error:
-            return None
-        return ERROR_IMAGE.get(ERROR_CODE_TO_IMAGE_INDEX.get(self.error, 19))
+        """Return no image; bundled images belong to vacuum fault meanings."""
+        return None
 
     @property
     def robot_status(self) -> int:  # TODO: Convert to enum
@@ -4430,15 +4425,30 @@ class DreameMowerDeviceStatus:
 
     @property
     def has_error(self) -> bool:
-        """Returns true when an error is present."""
-        error = self.error
-        return bool(error.value > 0 and not self.has_warning and error is not DreameMowerErrorCode.BATTERY_LOW)
+        """Return whether the mower-native code is a hard fault."""
+        value = self.device_code
+        definition = mower_device_code_definition(value, model=self._device_model)
+        if definition is not None:
+            return definition.tier is MowerDeviceCodeTier.ERROR
+        if value in (None, -1):
+            return False
+        return self.state is DreameMowerState.ERROR
 
     @property
     def has_warning(self) -> bool:
-        """Returns true when a warning is present and available for dismiss."""
-        error = self.error
-        return bool(error.value > 0 and error in self.warning_codes)
+        """Return whether the mower-native code is an alert/attention item."""
+        value = self.device_code
+        definition = mower_device_code_definition(value, model=self._device_model)
+        return bool(
+            definition is not None
+            and definition.tier
+            in {MowerDeviceCodeTier.ALERT, MowerDeviceCodeTier.ATTENTION}
+        )
+
+    @property
+    def _device_model(self) -> str | None:
+        """Return the current cloud model used for device-code overrides."""
+        return getattr(self._device.info, "model", None) if self._device.info else None
 
     @property
     def scheduled_clean(self) -> bool:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
@@ -1,41 +1,222 @@
-"""Classify values from the mower device-code channel."""
+"""Mower-native classification for the shared ``2.2`` device-code channel.
+
+The inherited client called this an error property and decoded it with a vacuum
+error enum. Mowers also use the channel for alerts, maintenance reminders,
+lifecycle notifications, and operating conditions, so numeric overlap with a
+vacuum code is not evidence of a mower fault.
+
+The base registry is the mower community's cross-model table. The A2 overrides
+come from the g2408 Dreame app plugin fault catalog, whose FAULT/ALERT/INFO
+metadata distinguishes hard faults from notifications. Unknown codes remain
+visible but are never promoted to hard faults solely because a vacuum enum
+happens to contain the same number.
+"""
 
 from __future__ import annotations
 
+from dataclasses import dataclass
+from enum import StrEnum
 from typing import Final
 
-# User-confirmed fault meanings that require intervention.
-MOWER_FAULT_CODE_NAMES: Final[dict[int, str]] = {
-    2: "mower_stuck",
-    23: "emergency_stop_pressed",
-    31: "left_wheel_speed",
+
+class MowerDeviceCodeTier(StrEnum):
+    """User-impact tier assigned by mower-native metadata."""
+
+    ERROR = "error"
+    ATTENTION = "attention"
+    ALERT = "alert"
+    INFO = "info"
+
+
+@dataclass(frozen=True, slots=True)
+class MowerDeviceCodeDefinition:
+    """Meaning and impact of one mower device code."""
+
+    name: str
+    tier: MowerDeviceCodeTier
+
+
+def _definitions(
+    tier: MowerDeviceCodeTier,
+    entries: dict[int, str],
+) -> dict[int, MowerDeviceCodeDefinition]:
+    return {
+        code: MowerDeviceCodeDefinition(name=name, tier=tier)
+        for code, name in entries.items()
+    }
+
+
+# Shared mower registry. Model-specific app catalogs override entries below.
+_BASE_DEVICE_CODES: Final[dict[int, MowerDeviceCodeDefinition]] = {
+    **_definitions(
+        MowerDeviceCodeTier.ERROR,
+        {
+            1: "robot_tilted",
+            2: "mower_stuck",
+            3: "path_to_station_too_narrow",
+            4: "left_drive_wheel_error",
+            5: "right_drive_wheel_error",
+            6: "blade_height_motor_error",
+            7: "blade_disc_blocked",
+            8: "blade_disc_side_motor_error",
+            9: "bumper_error",
+            10: "charging_error",
+            11: "battery_temperature_too_high",
+            12: "lidar_blocked",
+            13: "lidar_temperature_high_without_map",
+            14: "lidar_temperature_high_with_map",
+            15: "lidar_temperature_too_high",
+            16: "lidar_dirty",
+            17: "lidar_error",
+            18: "location_signal_weak",
+            19: "location_lost",
+            20: "sensor_error",
+            21: "mower_in_no_go_zone",
+            22: "mower_outside_map",
+            23: "emergency_stop_pressed",
+            24: "battery_critically_low",
+            25: "map_file_damaged",
+            26: "mower_too_far_from_map",
+            27: "human_detected",
+            28: "blades_worn",
+            29: "station_brush_worn",
+            30: "maintenance_due",
+            37: "path_blocked",
+            73: "top_cover_open",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.ALERT,
+        {
+            31: "return_to_station_failed",
+            32: "docking_failed",
+            33: "positioning_failed_with_map",
+            34: "positioning_failed_without_map",
+            35: "positioning_error",
+            36: "task_start_failed",
+            38: "lidar_dirty",
+            39: "camera_dirty",
+            40: "camera_error",
+            41: "camera_blocked",
+            42: "charging_paused_battery_too_hot",
+            43: "charging_paused_battery_too_cold",
+            44: "automatic_boundary_detection_stopped",
+            45: "automatic_boundary_side_detection_stopped",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.INFO,
+        {
+            0: "no_device_code",
+            46: "boundary_detection_completed",
+            47: "new_map_created",
+            48: "mowing_task_completed",
+            49: "some_zones_unreachable",
+            50: "mowing_task_started",
+            51: "patrol_task_started",
+            52: "point_and_go_started",
+            53: "scheduled_mowing_started",
+            54: "low_battery_returning",
+            55: "scheduled_mowing_suspended_low_battery",
+            56: "bad_weather_protection_active",
+            57: "scheduled_mowing_interrupted_by_rain",
+            58: "scheduled_mowing_suspended_by_rain",
+            59: "frost_protection_returning",
+            60: "scheduled_mowing_suspended_by_frost",
+            61: "do_not_disturb_returning",
+            62: "scheduled_mowing_suspended_by_do_not_disturb",
+            63: "scheduled_mowing_skipped_mower_busy",
+            64: "scheduled_mowing_suspended_by_remote_control",
+            65: "scheduled_mowing_suspended_by_emergency_stop",
+            66: "scheduled_mowing_suspended_top_cover_open",
+            67: "scheduled_mowing_suspended_by_fault",
+            68: "scheduled_mowing_timed_out",
+            69: "station_not_connected_to_working_area",
+            70: "resuming_unfinished_task",
+            71: "idle_timeout_returning",
+            72: "pause_timeout_returning",
+        },
+    ),
 }
 
-# Normal operating conditions that can change what the mower does without
-# requiring intervention. These remain visible as status notices while the
-# mower entity continues to report its real activity.
-# A2 firmware uses code 56 for bad-weather protection; the inherited vacuum
-# enum reuses 56 for a laser fault and must not decide mower entity state.
-MOWER_STATUS_NOTICE_CODE_NAMES: Final[dict[int, str]] = {
-    53: "scheduled_task_started",
-    54: "low_battery",
-    56: "bad_weather_protection_active",
+
+# Dreame A2 / g2408 app-plugin differences. In particular, 16 and 59 do not
+# mean what the cross-model registry says, and codes 27-30 are attention items
+# rather than hard faults.
+_A2_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
+    **_definitions(
+        MowerDeviceCodeTier.ERROR,
+        {
+            0: "robot_lifted",
+            59: "battery_temperature_too_low",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.ATTENTION,
+        {
+            27: "human_detected",
+            28: "blades_worn",
+            29: "station_brush_worn",
+            30: "maintenance_due",
+            74: "patrol_task_completed",
+            75: "maintenance_point_reached",
+            76: "maintenance_point_unreachable",
+            77: "error_while_going_to_maintenance_point",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.INFO,
+        {
+            16: "scheduled_mowing_suspended_low_light",
+            47: "task_cancelled",
+        },
+    ),
 }
 
-# Mower firmware also sends lifecycle events through property 2.2, which the
-# inherited vacuum model calls an error property. Codes 48/50 are task
-# finish/start, 61/70 are DND start/end, and 63 is a schedule suspension while
-# the mower is already working.
-MOWER_INFORMATIONAL_EVENT_CODES: Final[frozenset[int]] = frozenset(
-    {48, 50, 61, 63, 70}
+_A1_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
+    **_definitions(
+        MowerDeviceCodeTier.ERROR,
+        {
+            19: "emergency_stop_pressed",
+            73: "robot_lifted",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.INFO,
+        {
+            53: "mowing_started",
+            70: "mowing_resumed_after_charging",
+        },
+    ),
+}
+
+_MOVA_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
+    **_definitions(
+        MowerDeviceCodeTier.ERROR,
+        {
+            0: "robot_lifted",
+            55: "cannot_start_low_battery",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.ATTENTION,
+        {
+            30: "maintenance_due",
+        },
+    ),
+}
+
+_A2_MODELS: Final[frozenset[str]] = frozenset({"dreame.mower.g2408", "g2408"})
+_A1_MODELS: Final[frozenset[str]] = frozenset(
+    {
+        "dreame.mower.p2255",
+        "dreame.mower.g2422",
+        "p2255",
+        "g2422",
+    }
 )
-
-MOWER_DEVICE_CODE_NAMES: Final[dict[int, str]] = {
-    **MOWER_FAULT_CODE_NAMES,
-    **MOWER_STATUS_NOTICE_CODE_NAMES,
-}
-MOWER_NON_FAULT_CODES: Final[frozenset[int]] = frozenset(
-    {*MOWER_STATUS_NOTICE_CODE_NAMES, *MOWER_INFORMATIONAL_EVENT_CODES}
+_MOVA_MODELS: Final[frozenset[str]] = frozenset(
+    {"mova.mower.g2529c", "g2529c"}
 )
 
 
@@ -49,23 +230,129 @@ def mower_device_code(value: object) -> int | None:
         return None
 
 
-def mower_fault_code(value: object) -> int | None:
-    """Return an active hard-fault code, excluding notices and events."""
+def mower_device_code_definition(
+    value: object,
+    *,
+    model: str | None = None,
+) -> MowerDeviceCodeDefinition | None:
+    """Return the mower-native definition for a code and model."""
     code = mower_device_code(value)
-    if code in (None, -1, 0) or code in MOWER_NON_FAULT_CODES:
+    if code is None or code == -1:
+        return None
+
+    normalized_model = str(model or "").strip().casefold()
+    if normalized_model in _A2_MODELS:
+        definition = _A2_DEVICE_CODE_OVERRIDES.get(code)
+        if definition is not None:
+            return definition
+    elif normalized_model in _A1_MODELS:
+        definition = _A1_DEVICE_CODE_OVERRIDES.get(code)
+        if definition is not None:
+            return definition
+    elif normalized_model in _MOVA_MODELS:
+        definition = _MOVA_DEVICE_CODE_OVERRIDES.get(code)
+        if definition is not None:
+            return definition
+
+    return _BASE_DEVICE_CODES.get(code)
+
+
+def mower_device_code_name(
+    value: object,
+    *,
+    model: str | None = None,
+) -> str | None:
+    """Return a stable mower-native name, including an honest unknown label."""
+    code = mower_device_code(value)
+    if code is None or code == -1:
+        return None
+    definition = mower_device_code_definition(code, model=model)
+    if definition is not None:
+        return definition.name
+    return f"unknown_mower_device_code_{code}"
+
+
+def mower_device_code_tier(
+    value: object,
+    *,
+    model: str | None = None,
+) -> MowerDeviceCodeTier | None:
+    """Return the mower-native impact tier for a known code."""
+    definition = mower_device_code_definition(value, model=model)
+    return definition.tier if definition is not None else None
+
+
+def mower_fault_code(
+    value: object,
+    *,
+    model: str | None = None,
+) -> int | None:
+    """Return an active hard-fault code; unknown codes are not guessed."""
+    code = mower_device_code(value)
+    definition = mower_device_code_definition(code, model=model)
+    if definition is None or definition.tier is not MowerDeviceCodeTier.ERROR:
         return None
     return code
 
 
-def mower_fault_active(value: object) -> bool | None:
-    """Return whether a valid device-code value represents a hard fault."""
+def mower_fault_active(
+    value: object,
+    *,
+    model: str | None = None,
+) -> bool | None:
+    """Return whether a valid device-code value is a known hard fault."""
     code = mower_device_code(value)
     if code is None:
         return None
-    return mower_fault_code(code) is not None
+    return mower_fault_code(code, model=model) is not None
 
 
-def mower_status_notice_code(value: object) -> int | None:
-    """Return a known non-fault operating-condition code."""
+def mower_status_notice_code(
+    value: object,
+    *,
+    model: str | None = None,
+) -> int | None:
+    """Return an alert/info/unknown code that must not latch mower ERROR."""
     code = mower_device_code(value)
-    return code if code in MOWER_STATUS_NOTICE_CODE_NAMES else None
+    if code in (None, -1):
+        return None
+    definition = mower_device_code_definition(code, model=model)
+    if definition is not None and definition.name == "no_device_code":
+        return None
+    if definition is None or definition.tier is not MowerDeviceCodeTier.ERROR:
+        return code
+    return None
+
+
+def mower_status_notice_name(
+    value: object,
+    *,
+    model: str | None = None,
+) -> str | None:
+    """Return a stable name for a non-fault mower notification."""
+    code = mower_status_notice_code(value, model=model)
+    return mower_device_code_name(code, model=model) if code is not None else None
+
+
+# Compatibility exports for callers that only need the shared registry.
+MOWER_DEVICE_CODE_NAMES: Final[dict[int, str]] = {
+    code: definition.name for code, definition in _BASE_DEVICE_CODES.items()
+}
+MOWER_FAULT_CODE_NAMES: Final[dict[int, str]] = {
+    code: definition.name
+    for code, definition in _BASE_DEVICE_CODES.items()
+    if definition.tier is MowerDeviceCodeTier.ERROR
+}
+MOWER_STATUS_NOTICE_CODE_NAMES: Final[dict[int, str]] = {
+    code: definition.name
+    for code, definition in _BASE_DEVICE_CODES.items()
+    if definition.tier is not MowerDeviceCodeTier.ERROR
+}
+MOWER_INFORMATIONAL_EVENT_CODES: Final[frozenset[int]] = frozenset(
+    code
+    for code, definition in _BASE_DEVICE_CODES.items()
+    if definition.tier is MowerDeviceCodeTier.INFO
+)
+MOWER_NON_FAULT_CODES: Final[frozenset[int]] = frozenset(
+    MOWER_STATUS_NOTICE_CODE_NAMES
+)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
@@ -14,9 +14,12 @@ MOWER_FAULT_CODE_NAMES: Final[dict[int, str]] = {
 # Normal operating conditions that can change what the mower does without
 # requiring intervention. These remain visible as status notices while the
 # mower entity continues to report its real activity.
+# A2 firmware uses code 56 for bad-weather protection; the inherited vacuum
+# enum reuses 56 for a laser fault and must not decide mower entity state.
 MOWER_STATUS_NOTICE_CODE_NAMES: Final[dict[int, str]] = {
-    53: "rain_detected",
+    53: "scheduled_task_started",
     54: "low_battery",
+    56: "bad_weather_protection_active",
 }
 
 # Mower firmware also sends lifecycle events through property 2.2, which the

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -7,12 +7,12 @@ from dataclasses import asdict, dataclass, field
 from typing import Any
 
 from .device_code_semantics import (
-    MOWER_DEVICE_CODE_NAMES,
-    MOWER_FAULT_CODE_NAMES,
-    MOWER_NON_FAULT_CODES,
-    MOWER_STATUS_NOTICE_CODE_NAMES,
+    mower_device_code_definition,
+    mower_device_code_name,
+    mower_device_code_tier,
     mower_fault_code,
     mower_status_notice_code,
+    mower_status_notice_name,
 )
 from .video_provisioning_status import classify_xp2p_provisioning_issue
 
@@ -130,21 +130,6 @@ def _mower_terminology(value: str | None) -> str | None:
     return _MOWER_TERMINOLOGY.get(text.casefold(), text)
 
 
-def _error_name_from_code(value: int | None) -> str | None:
-    """Return the bundled vendor error name for a numeric code, if known."""
-    if value in (None, -1, 0):
-        return None
-    if value in MOWER_DEVICE_CODE_NAMES:
-        return MOWER_DEVICE_CODE_NAMES[value]
-    try:
-        from .const import ERROR_CODE_TO_ERROR_NAME
-        from .types import DreameMowerErrorCode
-
-        return ERROR_CODE_TO_ERROR_NAME.get(DreameMowerErrorCode(value))
-    except (ImportError, ValueError):
-        return None
-
-
 def _error_code_from_raw(value: Any) -> int | None:
     """Return a numeric error code from raw app/status values."""
     if value is None:
@@ -155,9 +140,13 @@ def _error_code_from_raw(value: Any) -> int | None:
         return None
 
 
-def _active_error_code_from_raw(value: Any) -> int | None:
+def _active_error_code_from_raw(
+    value: Any,
+    *,
+    model: str | None = None,
+) -> int | None:
     """Return a numeric active error code from raw app/status values."""
-    return mower_fault_code(value)
+    return mower_fault_code(value, model=model)
 
 
 def _realtime_error_code_from_device(device: Any) -> int | None:
@@ -166,7 +155,7 @@ def _realtime_error_code_from_device(device: Any) -> int | None:
     entry = realtime_properties.get(REALTIME_ERROR_PROPERTY_KEY)
     value = entry.get("value") if isinstance(entry, Mapping) else entry
     code = _error_code_from_raw(value)
-    return None if code in (None, -1, 0) else code
+    return None if code in (None, -1) else code
 
 
 def _raw_error_code_from_device(device: Any, error_obj: Any) -> int | None:
@@ -179,23 +168,7 @@ def _raw_error_code_from_device(device: Any, error_obj: Any) -> int | None:
         value = None
     if value is not None:
         return _error_code_from_raw(value)
-    return _error_code_from_raw(getattr(error_obj, "value", None))
-
-
-def _status_explicitly_reports_no_error(
-    *,
-    status_has_error: bool,
-    error_code: int | None,
-    error_name: str | None,
-    error_text: str | None,
-) -> bool:
-    """Return whether the normal status stream explicitly says no error."""
-    return bool(
-        not status_has_error
-        and error_code in (-1, 0)
-        and _is_no_error_text(error_name)
-        and _is_no_error_text(error_text)
-    )
+    return _error_code_from_raw(getattr(error_obj, "value", error_obj))
 
 
 def _friendly_error_display(
@@ -203,20 +176,14 @@ def _friendly_error_display(
     error_code: int | None,
     error_name: str | None,
     error_text: str | None,
+    model: str | None = None,
 ) -> str | None:
     """Return the best user-facing error while preserving raw text elsewhere."""
-    if error_code not in (None, -1, 0):
-        confirmed = _friendly_error_name(MOWER_FAULT_CODE_NAMES.get(error_code))
-        if confirmed is not None:
-            return confirmed
-        inherited = (
-            _friendly_error_name(error_name)
-            or _friendly_error_name(_error_name_from_code(error_code))
-            or (None if _is_no_error_text(error_text) else error_text)
+    if error_code not in (None, -1):
+        mower_name = _friendly_error_name(
+            mower_device_code_name(error_code, model=model)
         )
-        return (
-            f"Unverified {inherited.casefold()}" if inherited else f"Error {error_code}"
-        )
+        return mower_name or f"Unknown mower device code {error_code}"
 
     return _friendly_error_name(error_name) or error_text
 
@@ -272,6 +239,7 @@ class DreameLawnMowerSnapshot:
     status_notice_code: int | None = None
     status_notice_name: str | None = None
     status_notice_display: str | None = None
+    status_notice_tier: str | None = None
     status_notice_source: str | None = None
     raw_error_code: int | None = None
     realtime_error_code: int | None = None
@@ -957,50 +925,83 @@ def snapshot_from_device(
     error_text = _as_optional_str(status_attributes.get("error"))
     raw_error_code = _raw_error_code_from_device(device, error_obj)
     realtime_error_code = _realtime_error_code_from_device(device)
-    error_code = raw_error_code
-    status_notice_code = mower_status_notice_code(raw_error_code)
+    raw_code_definition = mower_device_code_definition(
+        raw_error_code,
+        model=descriptor.model,
+    )
+    raw_fault_code = _active_error_code_from_raw(
+        raw_error_code,
+        model=descriptor.model,
+    )
+    error_code = raw_fault_code
+    status_notice_code = mower_status_notice_code(
+        raw_error_code,
+        model=descriptor.model,
+    )
     status_notice_source = "status" if status_notice_code is not None else None
     status_has_error = bool(getattr(device.status, "has_error", False))
-    if raw_error_code in MOWER_NON_FAULT_CODES:
-        # Preserve normal mower notices/events for diagnostics without letting
-        # the inherited vacuum error model turn them into entity errors.
+
+    if raw_fault_code is not None:
+        # Numeric mower codes own their meaning. Never retain a label or
+        # description produced by the inherited vacuum enum.
+        error_name = mower_device_code_name(
+            raw_fault_code,
+            model=descriptor.model,
+        )
+        error_text = None
+        has_error = True
+    elif raw_error_code not in (None, -1):
+        # Known alerts/info and unknown mower codes remain diagnostic notices.
+        # Unknown numeric overlap with a vacuum code is not a hard fault.
         error_name = None
         error_text = None
-        error_code = None
-        status_has_error = False
-    error_code_active = _active_error_code_from_raw(error_code) is not None
-    error_name_active = not _is_no_error_text(error_name)
-    error_text_active = not _is_no_error_text(error_text)
-    has_only_bare_error_flag = (
-        status_has_error
-        and error_code is None
-        and error_name is None
-        and error_text is None
-    )
-    has_error = bool(
-        error_code_active
-        or error_name_active
-        or error_text_active
-        or has_only_bare_error_flag
-    )
-    error_source: str | None = "status" if has_error else None
-    status_reports_no_error = (
-        raw_error_code in MOWER_NON_FAULT_CODES
-        or _status_explicitly_reports_no_error(
-            status_has_error=status_has_error,
-            error_code=error_code,
-            error_name=error_name,
-            error_text=error_text,
+        has_error = bool(
+            raw_code_definition is None
+            and state == "error"
         )
-    )
-    if not has_error and not status_reports_no_error:
-        realtime_fault_code = _active_error_code_from_raw(realtime_error_code)
+        if has_error:
+            error_code = raw_error_code
+            error_name = mower_device_code_name(
+                raw_error_code,
+                model=descriptor.model,
+            )
+            status_notice_code = None
+            status_notice_source = None
+    elif raw_error_code == -1:
+        error_code = -1
+        has_error = False
+    else:
+        # A bare flag remains a last-resort signal only when no numeric mower
+        # code exists. An explicit mower state of ERROR is stronger evidence.
+        has_error = bool(
+            state == "error"
+            or (
+                status_has_error
+                and error_name is None
+                and error_text is None
+            )
+        )
+
+    error_source: str | None = "status" if has_error else None
+    if not has_error and raw_error_code is None:
+        realtime_fault_code = _active_error_code_from_raw(
+            realtime_error_code,
+            model=descriptor.model,
+        )
         if realtime_fault_code is not None:
             error_code = realtime_fault_code
+            error_name = mower_device_code_name(
+                realtime_fault_code,
+                model=descriptor.model,
+            )
+            error_text = None
             has_error = True
             error_source = f"realtime_property_{REALTIME_ERROR_PROPERTY_KEY}"
         elif status_notice_code is None:
-            status_notice_code = mower_status_notice_code(realtime_error_code)
+            status_notice_code = mower_status_notice_code(
+                realtime_error_code,
+                model=descriptor.model,
+            )
             if status_notice_code is not None:
                 status_notice_source = (
                     f"realtime_property_{REALTIME_ERROR_PROPERTY_KEY}"
@@ -1131,12 +1132,30 @@ def snapshot_from_device(
             error_code=error_code,
             error_name=error_name,
             error_text=error_text,
+            model=descriptor.model,
         ),
         error_source=error_source,
         status_notice_code=status_notice_code,
-        status_notice_name=MOWER_STATUS_NOTICE_CODE_NAMES.get(status_notice_code),
+        status_notice_name=mower_status_notice_name(
+            status_notice_code,
+            model=descriptor.model,
+        ),
         status_notice_display=_friendly_error_name(
-            MOWER_STATUS_NOTICE_CODE_NAMES.get(status_notice_code)
+            mower_status_notice_name(
+                status_notice_code,
+                model=descriptor.model,
+            )
+        ),
+        status_notice_tier=(
+            tier.value
+            if (
+                tier := mower_device_code_tier(
+                    status_notice_code,
+                    model=descriptor.model,
+                )
+            )
+            is not None
+            else ("unknown" if status_notice_code is not None else None)
         ),
         status_notice_source=status_notice_source,
         raw_error_code=raw_error_code,

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -264,6 +264,11 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 "status_notice_display",
                 None,
             ),
+            "status_notice_tier": getattr(
+                snapshot,
+                "status_notice_tier",
+                None,
+            ),
             "status_notice_source": getattr(
                 snapshot,
                 "status_notice_source",

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -128,7 +128,7 @@ SENSORS = [
         key="error_code",
         name="Error Code",
         value_fn=lambda snapshot: (
-            "none" if snapshot.error_code in (None, -1, 0) else snapshot.error_code
+            "none" if snapshot.error_code in (None, -1) else snapshot.error_code
         ),
         icon="mdi:numeric",
         entity_category=EntityCategory.DIAGNOSTIC,

--- a/custom_components/dreame_lawn_mower/task_status_probe.py
+++ b/custom_components/dreame_lawn_mower/task_status_probe.py
@@ -14,7 +14,11 @@ from .dreame_lawn_mower_client.app_protocol import (
     MOWER_TASK_PROPERTY_KEY,
     MOWER_TIME_PROPERTY_KEY,
 )
-from .dreame_lawn_mower_client.device_code_semantics import mower_fault_active
+from .dreame_lawn_mower_client.device_code_semantics import (
+    mower_device_code,
+    mower_device_code_definition,
+    mower_fault_active,
+)
 
 TASK_STATUS_PROBE_KEYS = (
     MOWER_RUNTIME_STATUS_PROPERTY_KEY,
@@ -39,10 +43,11 @@ def task_status_probe_payload(
     scan: Mapping[str, Any],
     *,
     captured_at: str | None = None,
+    model: str | None = None,
 ) -> dict[str, Any]:
     """Return a compact HA/log payload from one task-status property scan."""
     entries = scan.get("entries", [])
-    summary = task_status_probe_summary(scan)
+    summary = task_status_probe_summary(scan, model=model)
     payload: dict[str, Any] = {
         "captured_at": captured_at,
         "source": "cloud_property_task_status",
@@ -64,7 +69,11 @@ def task_status_probe_payload(
     }
 
 
-def task_status_probe_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
+def task_status_probe_summary(
+    payload: Mapping[str, Any],
+    *,
+    model: str | None = None,
+) -> dict[str, Any]:
     """Return compact app state/task/error evidence from a scan payload."""
     entries = payload.get("entries", [])
     scan_summary = payload.get("summary", {})
@@ -99,8 +108,16 @@ def task_status_probe_summary(payload: Mapping[str, Any]) -> dict[str, Any]:
             "task_status": task_entry.get("task_status")
             if isinstance(task_entry, Mapping)
             else None,
-            "error": _error_summary(error_entry),
-            "error_active": _error_active(error_entry),
+            "error": _error_summary(
+                error_entry,
+                state_entry=state_entry,
+                model=model,
+            ),
+            "error_active": _error_active(
+                error_entry,
+                state_entry=state_entry,
+                model=model,
+            ),
             "battery_level": _entry_value(battery_entry),
             "device_time": _entry_json_value(time_entry),
             "status_matrix": _status_matrix_summary(status_matrix_entry),
@@ -215,7 +232,12 @@ def _state_summary(entry: Mapping[str, Any] | None) -> dict[str, Any] | None:
     )
 
 
-def _error_summary(entry: Mapping[str, Any] | None) -> dict[str, Any] | None:
+def _error_summary(
+    entry: Mapping[str, Any] | None,
+    *,
+    state_entry: Mapping[str, Any] | None = None,
+    model: str | None = None,
+) -> dict[str, Any] | None:
     if not isinstance(entry, Mapping):
         return None
     return _drop_empty(
@@ -223,15 +245,36 @@ def _error_summary(entry: Mapping[str, Any] | None) -> dict[str, Any] | None:
             "value": _entry_value(entry),
             "label": entry.get("decoded_label"),
             "label_source": entry.get("decoded_label_source"),
-            "active": _error_active(entry),
+            "active": _error_active(
+                entry,
+                state_entry=state_entry,
+                model=model,
+            ),
         }
     )
 
 
-def _error_active(entry: Mapping[str, Any] | None) -> bool | None:
+def _error_active(
+    entry: Mapping[str, Any] | None,
+    *,
+    state_entry: Mapping[str, Any] | None = None,
+    model: str | None = None,
+) -> bool | None:
     if not isinstance(entry, Mapping):
         return None
-    return mower_fault_active(_entry_value(entry))
+    value = _entry_value(entry)
+    active = mower_fault_active(value, model=model)
+    if active is not False:
+        return active
+
+    code = mower_device_code(value)
+    definition = mower_device_code_definition(code, model=model)
+    explicit_error_state = str(_entry_value(state_entry)).strip() == "4"
+    return bool(
+        code not in (None, -1)
+        and definition is None
+        and explicit_error_state
+    )
 
 
 def _status_blob_summary(entry: Mapping[str, Any] | None) -> dict[str, Any] | None:

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -68,7 +68,7 @@ Last updated: 2026-04-21
   `3.1` while preserving genuinely unknown keys for discovery.
 - Home Assistant has disabled-by-default `Capture Task Status Probe` and
   `Last Task Status Probe` diagnostics for a one-shot read-only view of app
-  state `2.1`, error `2.2`, task object `2.50`, device time `2.51`, battery
+  state `2.1`, device code `2.2`, task object `2.50`, device time `2.51`, battery
   `3.1`, and the service-5 discovery cluster.
 - `examples/task_status_probe.py` repeatedly samples the task/status keys and
   summarizes whether mower state or task status changed, including values seen
@@ -304,20 +304,23 @@ Last updated: 2026-04-21
   no decoded weather switch, rain-protection tuple, or active protection end
   time, with no probe errors. A simultaneous task/status sample showed the mower
   charging, battery moving from `42` to `43`, task `TASK` still executing with
-  operation `6`, error code `54` decoded as `Edge`, and unknown key `5.106=1`
-  while charging.
+  operation `6`, and device code `54`. The old `Edge` label came from the
+  inherited vacuum enum; the mower catalog identifies `54` as low-battery
+  return-to-station information. Unknown key `5.106=1` was also present.
 - A later read-only sample on 2026-04-19 showed the mower still charging at
-  battery `63`, task `TASK` still executing with operation `6`, and app error
-  property `2.2=54` (`Edge`) still active. Weather protection again returned
+  battery `63`, task `TASK` still executing with operation `6`, and app device
+  property `2.2=54` still active. Weather protection again returned
   `WRP=[1,8,0]` with no `RPET` end time, so rain protection is configured but
   an active rain-delay window has not yet been observed. After the active-state
   split was added, a live read-only probe returned
   `rain_protection_enabled=true` and `rain_protection_active=false`.
-- Normalized snapshots now use app realtime property `2.2` as a conservative
-  fallback when the legacy status object says `No error`. Home Assistant error
-  sensors and operation/debug snapshots expose the effective error plus
-  `error_source`, `raw_error_code`, and `realtime_error_code` so this mismatch
-  stays debuggable.
+- Normalized snapshots classify property `2.2` with mower-native model
+  metadata. Hard faults drive the Home Assistant error state; alerts,
+  maintenance items, lifecycle messages, and operating conditions remain
+  visible as status notices. Unknown codes stay diagnostic unless the mower
+  also reports its explicit error state. Snapshots expose `error_source`,
+  `raw_error_code`, `realtime_error_code`, and the status-notice tier so the
+  classification remains debuggable.
 - A narrow service-5 read-only scan on 2026-04-19 returned non-empty unknown
   values `5.104=3`, `5.105=1`, `5.106=1`, and `5.107=90`. No app bundle or
   public key-definition label has been found for these yet, so keep them as a
@@ -366,7 +369,8 @@ Last updated: 2026-04-21
   rather than the app-approved OTA target.
 - Realtime key meanings are still being learned. Known useful keys include
   `1.1` as a raw status blob, `1.4` as a runtime status blob, `2.1` as mower
-  state, `2.2` as mower error, `2.50` as task status, `2.51` as device time,
+  state, `2.2` as the mower device-code channel, `2.50` as task status,
+  `2.51` as device time,
   and `3.1` as battery. The service-5 cluster `5.104` through `5.107` is still
   unknown; live samples have shown `5.106` values including `6`, `7`, and `1`
   across mowing, docked, and charging states.

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -266,7 +266,9 @@ A second live scan through `examples/property_probe.py` against a small docked r
 - `2.1 = 13`
   The app-derived mower state label decodes this to `Charging Completed`.
 - `2.2 = 31`
-  This is likely another mower state or error-adjacent field and should be tracked in future scans.
+  The original client decoded this as vacuum “left wheel speed.” The A2 app
+  catalog identifies it as a recoverable return-to-station failure alert, so
+  it remains visible without forcing the mower entity into a hard-error state.
 - `1.1 = [206,0,0,...]`
   This looks like a compact raw status blob rather than a simple scalar property. The current Python scanner now also renders it as `20` bytes of hex: `ce000000000000000080006401ff000080d0b4ce`.
 
@@ -283,7 +285,9 @@ The reusable Python client now includes cloud probe helpers so this research can
 - `async_scan_cloud_properties(...)` for chunked `siid.piid` range scans
 - `build_cloud_property_summary(...)` to quickly identify non-empty, decoded, hinted, and blob-like scan results
 - `mower_state_label(value)` for the app-derived `2.1` state key
-- `mower_error_label(value)` for known mower error codes seen through `2.2`
+- `mower_error_label(value, model=...)` for mower-native device-code labels
+  seen through `2.2`; the model-aware classifier separates hard faults from
+  alerts, attention items, information, and unknown codes
 
 Use `python examples/cloud_probe.py` to query these endpoints directly with the same credentials used by the integration.
 

--- a/tests/test_a2_error_fixture.py
+++ b/tests/test_a2_error_fixture.py
@@ -1,123 +1,33 @@
-"""Fixture-driven checks for the paused A2 wheel-speed error capture."""
+"""Regression checks for the historical A2 code-31 diagnostic capture."""
 
 from __future__ import annotations
 
-from types import SimpleNamespace
-
-from custom_components.dreame_lawn_mower.binary_sensor import BINARY_SENSORS
-from custom_components.dreame_lawn_mower.sensor import SENSORS
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    device_code_semantics,
+)
 
 from .fixture_data import load_json_fixture
 
 
-def _snapshot() -> SimpleNamespace:
+def test_a2_capture_proves_the_old_vacuum_label_was_not_mower_evidence() -> None:
     payload = load_json_fixture("a2_paused_left_wheel_error_diagnostics.json")
-    values = payload["data"]["snapshot"]
-    return SimpleNamespace(
-        **values,
-        mower_state_name=values["state_name"],
-        mowing_task_status_name=values["task_status_name"],
-        mowing_mode_name=values["cleaning_mode_name"],
-        mowed_area=values.get("cleaned_area"),
-        mowing_time=values.get("cleaning_time"),
+    snapshot = payload["data"]["snapshot"]
+
+    # Keep the immutable capture as provenance: the old client used the vacuum
+    # enum to turn A2 code 31 into "left wheel speed".
+    assert snapshot["state"] == "paused"
+    assert snapshot["error_code"] == 31
+    assert snapshot["error_name"] == "left_wheell_speed"
+
+    # The mower-native A2 catalog identifies the same value as a recoverable
+    # return-to-station alert, so it must not latch LawnMowerActivity.ERROR.
+    model = snapshot["descriptor"]["model"]
+    assert (
+        device_code_semantics.mower_device_code_name(31, model=model)
+        == "return_to_station_failed"
     )
-
-
-def test_a2_error_fixture_preserves_paused_state_context() -> None:
-    snapshot = _snapshot()
-
-    assert snapshot.state == "paused"
-    assert snapshot.activity == "error"
-    assert snapshot.battery_level == 74
-    assert snapshot.error_code == 31
-    assert snapshot.error_name == "left_wheell_speed"
-    assert snapshot.error_text == "Left wheell speed"
-    assert snapshot.error_display == "Left wheel speed"
-    assert snapshot.state_name == "paused"
-    assert snapshot.task_status_name == "unknown"
-    assert snapshot.raw_attributes["mower_state"] == "paused"
-    assert snapshot.raw_attributes["running"] is False
-    assert snapshot.started is True
-
-
-def test_a2_error_fixture_exposes_expected_sensor_set() -> None:
-    snapshot = _snapshot()
-
-    visible = {
-        description.name
-        for description in SENSORS
-        if description.exists_fn(snapshot)
-    }
-
-    assert visible == {
-        "Activity",
-        "Battery",
-        "Cloud Update Time",
-        "Error",
-        "Error Code",
-        "Firmware Version",
-        "Hardware Version",
-        "Last Realtime Method",
-        "Manual Drive Block Reason",
-        "Mower State",
-        "Raw Error",
-        "Realtime Property Count",
-        "Serial Number",
-        "State Name",
-        "Status Notice",
-        "Task Status",
-        "Unknown Property Count",
-    }
-
-
-def test_a2_error_fixture_reports_expected_normalized_sensor_values() -> None:
-    snapshot = _snapshot()
-    sensors = {description.name: description for description in SENSORS}
-
-    assert sensors["Activity"].value_fn(snapshot) == "error"
-    assert sensors["State Name"].value_fn(snapshot) == "paused"
-    assert sensors["Task Status"].value_fn(snapshot) == "unknown"
-    assert sensors["Error Code"].value_fn(snapshot) == 31
-    assert sensors["Raw Error"].value_fn(snapshot) == "Left wheell speed"
-    assert sensors["Manual Drive Block Reason"].value_fn(snapshot) == (
-        "Remote control is blocked while error is active."
+    assert (
+        device_code_semantics.mower_device_code_tier(31, model=model)
+        is device_code_semantics.MowerDeviceCodeTier.ALERT
     )
-
-
-def test_a2_error_fixture_exposes_expected_binary_sensor_set() -> None:
-    snapshot = _snapshot()
-
-    visible = {
-        description.name
-        for description in BINARY_SENSORS
-        if description.exists_fn(snapshot)
-    }
-
-    assert visible == {
-        "Charging",
-        "Docked",
-        "Error Active",
-        "Mapping Available",
-        "Manual Drive Safe",
-        "Mowing",
-        "Online",
-        "Paused",
-        "Raw Paused Flag",
-        "Raw Returning Flag",
-        "Raw Running Flag",
-        "Returning",
-        "Scheduled Task",
-        "Task Active",
-    }
-
-
-def test_a2_error_fixture_reports_expected_normalized_state_flags() -> None:
-    snapshot = _snapshot()
-    sensors = {description.name: description for description in BINARY_SENSORS}
-
-    assert sensors["Error Active"].value_fn(snapshot) is True
-    assert sensors["Docked"].value_fn(snapshot) is False
-    assert sensors["Paused"].value_fn(snapshot) is False
-    assert sensors["Mowing"].value_fn(snapshot) is False
-    assert sensors["Returning"].value_fn(snapshot) is False
-    assert sensors["Manual Drive Safe"].value_fn(snapshot) is False
+    assert device_code_semantics.mower_fault_active(31, model=model) is False

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -25,7 +25,7 @@ def test_property_annotations_label_known_mower_state_and_error_keys() -> None:
     assert state_entry["state_key"] == "charging_completed"
     assert state_entry["decoded_label"] == "Charging Completed"
     assert error_entry["property_hint"] == "mower_error"
-    assert error_entry["decoded_label"] == "Left wheel speed"
+    assert error_entry["decoded_label"] == "Return to station failed"
     assert error_entry["decoded_label_source"] == "bundled_mower_errors"
 
 

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -279,7 +279,12 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
         "activity": "paused",
         "state": "paused",
         "error": {"active": False, "code": None, "display": None, "source": None},
-        "status_notice": {"code": None, "display": None, "source": None},
+        "status_notice": {
+            "code": None,
+            "display": None,
+            "tier": None,
+            "source": None,
+        },
         "manual_drive": {"safe": True, "block_reason": None},
         "available": True,
         "capabilities": ["lidar_navigation", "map"],

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -256,7 +256,7 @@ def test_snapshot_uses_state_name_before_boolean_helpers() -> None:
     assert snapshot.capabilities == ("lidar_navigation", "map")
 
 
-def test_snapshot_prioritizes_error_activity_but_keeps_paused_state_context() -> None:
+def test_snapshot_reclassifies_inherited_code_31_as_mower_alert() -> None:
     descriptor = descriptor_from_cloud_record(
         {
             "did": "device-1",
@@ -271,15 +271,18 @@ def test_snapshot_prioritizes_error_activity_but_keeps_paused_state_context() ->
 
     snapshot = snapshot_from_device(descriptor, _FakeErrorDevice())
 
-    assert snapshot.activity == "error"
+    assert snapshot.activity == "paused"
     assert snapshot.state == "paused"
-    assert snapshot.error_code == 31
-    assert snapshot.error_name == "left_wheell_speed"
-    assert snapshot.error_text == "Left wheell speed"
-    assert snapshot.error_display == "Left wheel speed"
+    assert snapshot.error_code is None
+    assert snapshot.error_name is None
+    assert snapshot.error_text is None
+    assert snapshot.error_display is None
+    assert snapshot.status_notice_code == 31
+    assert snapshot.status_notice_name == "return_to_station_failed"
+    assert snapshot.status_notice_tier == "alert"
 
 
-def test_snapshot_uses_error_code_label_when_text_says_no_error() -> None:
+def test_snapshot_uses_mower_alert_when_vacuum_text_says_no_error() -> None:
     descriptor = descriptor_from_cloud_record(
         {
             "did": "device-1",
@@ -303,11 +306,13 @@ def test_snapshot_uses_error_code_label_when_text_says_no_error() -> None:
 
     snapshot = snapshot_from_device(descriptor, device)
 
-    assert snapshot.activity == "error"
-    assert snapshot.error_code == 31
-    assert snapshot.error_name == "no_error"
-    assert snapshot.error_text == "No error"
-    assert snapshot.error_display == "Left wheel speed"
+    assert snapshot.activity == "paused"
+    assert snapshot.error_code is None
+    assert snapshot.error_name is None
+    assert snapshot.error_text is None
+    assert snapshot.error_display is None
+    assert snapshot.status_notice_code == 31
+    assert snapshot.status_notice_display == "Return to station failed"
 
 
 def test_snapshot_falls_back_to_error_code_when_label_is_unknown() -> None:
@@ -335,7 +340,9 @@ def test_snapshot_falls_back_to_error_code_when_label_is_unknown() -> None:
     snapshot = snapshot_from_device(descriptor, device)
 
     assert snapshot.activity == "error"
-    assert snapshot.error_display == "Error 73"
+    assert snapshot.error_name == "top_cover_open"
+    assert snapshot.error_text is None
+    assert snapshot.error_display == "Top cover open"
 
 
 def test_snapshot_keeps_realtime_error_diagnostic_when_status_says_no_error() -> None:

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -4,6 +4,7 @@ from io import BytesIO
 from types import SimpleNamespace
 from typing import Any
 
+import pytest
 from homeassistant.const import Platform
 from PIL import Image, ImageFont
 
@@ -824,6 +825,37 @@ def test_task_status_probe_payload_keeps_compact_app_state() -> None:
         ],
         "error_count": 0,
     }
+
+
+@pytest.mark.parametrize(
+    ("code", "expected_active"),
+    [(999, True), (56, False)],
+)
+def test_task_status_probe_uses_explicit_error_state_only_for_unknown_codes(
+    code: int,
+    expected_active: bool,
+) -> None:
+    payload = task_status_probe_payload(
+        {
+            "entries": [
+                {
+                    "key": "2.1",
+                    "value": "4",
+                    "decoded_label": "Paused due to errors",
+                    "state_key": "paused",
+                },
+                {
+                    "key": "2.2",
+                    "value": str(code),
+                    "decoded_label": "Device code",
+                },
+            ]
+        },
+        model="dreame.mower.g2408",
+    )
+
+    assert payload["summary"]["error_active"] is expected_active
+    assert payload["summary"]["error"]["active"] is expected_active
 
 
 def test_weather_probe_result_attributes_are_compact() -> None:

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -6,10 +6,21 @@ from types import SimpleNamespace
 
 import pytest
 
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    device_code_semantics,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device import (
+    DreameMowerDeviceStatus,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
     descriptor_from_cloud_record,
     snapshot_from_device,
 )
+
+MowerDeviceCodeTier = device_code_semantics.MowerDeviceCodeTier
+mower_device_code_name = device_code_semantics.mower_device_code_name
+mower_device_code_tier = device_code_semantics.mower_device_code_tier
+mower_fault_active = device_code_semantics.mower_fault_active
 
 
 class _ErrorDevice:
@@ -65,9 +76,10 @@ def _snapshot(
     *,
     realtime_error_code: int | None = None,
     state: str = "PAUSED",
+    model: str = "dreame.mower.g2408",
 ):
     descriptor = descriptor_from_cloud_record(
-        {"did": "test", "model": "dreame.mower.g2408", "name": "Mower"},
+        {"did": "test", "model": model, "name": "Mower"},
         account_type="dreame",
         country="eu",
     )
@@ -83,7 +95,7 @@ def _snapshot(
     [
         (2, "cliff", "Mower stuck"),
         (23, "heart", "Emergency stop pressed"),
-        (31, "left_wheell_speed", "Left wheel speed"),
+        (59, "no_go_zone", "Battery temperature too low"),
     ],
 )
 def test_mower_fault_codes_override_vacuum_labels(
@@ -101,9 +113,9 @@ def test_mower_fault_codes_override_vacuum_labels(
 @pytest.mark.parametrize(
     ("code", "inherited_name", "state", "expected_activity", "expected_notice"),
     [
-        (53, "unknown", "MOWING", "mowing", "Scheduled task started"),
-        (54, "edge", "RETURNING", "returning", "Low battery"),
-        (54, "edge", "CHARGING", "docked", "Low battery"),
+        (53, "unknown", "MOWING", "mowing", "Scheduled mowing started"),
+        (54, "edge", "RETURNING", "returning", "Low battery returning"),
+        (54, "edge", "CHARGING", "docked", "Low battery returning"),
         (
             56,
             "laser",
@@ -141,12 +153,139 @@ def test_mower_operating_conditions_are_not_hard_errors(
     assert snapshot.realtime_error_code == code
 
 
-def test_unconfirmed_vacuum_error_name_is_marked_unverified() -> None:
+def test_mower_native_name_replaces_vacuum_name() -> None:
     snapshot = _snapshot(1, "drop")
 
     assert snapshot.activity == "error"
-    assert snapshot.error_name == "drop"
-    assert snapshot.error_display == "Unverified drop"
+    assert snapshot.error_name == "robot_tilted"
+    assert snapshot.error_text is None
+    assert snapshot.error_display == "Robot tilted"
+
+
+def test_recoverable_alert_does_not_latch_error() -> None:
+    snapshot = _snapshot(31, "left_wheell_speed")
+
+    assert snapshot.activity == "paused"
+    assert snapshot.error_code is None
+    assert snapshot.error_name is None
+    assert snapshot.status_notice_code == 31
+    assert snapshot.status_notice_name == "return_to_station_failed"
+    assert snapshot.status_notice_display == "Return to station failed"
+    assert snapshot.status_notice_tier == "alert"
+
+
+def test_unknown_numeric_code_is_visible_without_becoming_a_vacuum_error() -> None:
+    snapshot = _snapshot(999, "return_to_charge_failed")
+
+    assert snapshot.activity == "paused"
+    assert snapshot.error_code is None
+    assert snapshot.error_display is None
+    assert snapshot.status_notice_code == 999
+    assert snapshot.status_notice_name == "unknown_mower_device_code_999"
+    assert snapshot.status_notice_tier == "unknown"
+
+
+def test_unknown_numeric_code_uses_explicit_mower_error_state_as_fallback() -> None:
+    snapshot = _snapshot(999, "return_to_charge_failed", state="ERROR")
+
+    assert snapshot.activity == "error"
+    assert snapshot.error_code == 999
+    assert snapshot.error_name == "unknown_mower_device_code_999"
+    assert snapshot.error_display == "Unknown mower device code 999"
+    assert snapshot.status_notice_code is None
+
+
+def test_model_overrides_prevent_cross_model_code_guesses() -> None:
+    assert mower_device_code_name(0) == "no_device_code"
+    assert mower_fault_active(0) is False
+    assert (
+        mower_device_code_name(0, model="dreame.mower.g2408")
+        == "robot_lifted"
+    )
+    assert mower_fault_active(0, model="dreame.mower.g2408") is True
+    assert (
+        mower_device_code_name(19, model="dreame.mower.p2255")
+        == "emergency_stop_pressed"
+    )
+    assert (
+        mower_device_code_name(0, model="mova.mower.g2529c")
+        == "robot_lifted"
+    )
+    assert mower_fault_active(0, model="mova.mower.g2529c") is True
+    assert (
+        mower_device_code_name(0, model="mova.mower.x1234")
+        == "no_device_code"
+    )
+    assert mower_fault_active(0, model="mova.mower.x1234") is False
+
+
+@pytest.mark.parametrize(
+    "model",
+    [None, "dreame.mower.p2255", "dreame.mower.x1234", "mova.mower.x1234"],
+)
+def test_base_no_device_code_is_not_a_status_notice(model: str | None) -> None:
+    assert (
+        device_code_semantics.mower_status_notice_code(0, model=model)
+        is None
+    )
+
+
+@pytest.mark.parametrize(
+    ("code", "tier"),
+    [
+        (2, MowerDeviceCodeTier.ERROR),
+        (27, MowerDeviceCodeTier.ATTENTION),
+        (31, MowerDeviceCodeTier.ALERT),
+        (56, MowerDeviceCodeTier.INFO),
+    ],
+)
+def test_a2_app_tiers_are_preserved(
+    code: int,
+    tier: MowerDeviceCodeTier,
+) -> None:
+    assert mower_device_code_tier(code, model="dreame.mower.g2408") is tier
+
+
+def test_a2_catalog_has_a_meaning_for_every_observed_app_code() -> None:
+    for code in range(78):
+        assert (
+            device_code_semantics.mower_device_code_definition(
+                code,
+                model="dreame.mower.g2408",
+            )
+            is not None
+        )
+
+
+@pytest.mark.parametrize(
+    ("code", "has_error", "has_warning", "name"),
+    [
+        (2, True, False, "mower_stuck"),
+        (31, False, True, "return_to_station_failed"),
+        (56, False, False, "bad_weather_protection_active"),
+    ],
+)
+def test_inherited_device_status_uses_mower_registry(
+    code: int,
+    has_error: bool,
+    has_warning: bool,
+    name: str,
+) -> None:
+    device = SimpleNamespace(
+        info=SimpleNamespace(model="dreame.mower.g2408"),
+        capability=SimpleNamespace(new_state=True),
+    )
+    device.get_property = lambda prop: (
+        code if getattr(prop, "name", None) == "ERROR" else 3
+    )
+    status = DreameMowerDeviceStatus(device)
+
+    assert status.device_code == code
+    assert status.error == code
+    assert status.has_error is has_error
+    assert status.has_warning is has_warning
+    assert status.error_name == name
+    assert status.error_image is None
 
 
 @pytest.mark.parametrize(

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -101,9 +101,17 @@ def test_mower_fault_codes_override_vacuum_labels(
 @pytest.mark.parametrize(
     ("code", "inherited_name", "state", "expected_activity", "expected_notice"),
     [
-        (53, "unknown", "MOWING", "mowing", "Rain detected"),
+        (53, "unknown", "MOWING", "mowing", "Scheduled task started"),
         (54, "edge", "RETURNING", "returning", "Low battery"),
         (54, "edge", "CHARGING", "docked", "Low battery"),
+        (
+            56,
+            "laser",
+            "RETURNING",
+            "returning",
+            "Bad weather protection active",
+        ),
+        (56, "laser", "CHARGING", "docked", "Bad weather protection active"),
     ],
 )
 def test_mower_operating_conditions_are_not_hard_errors(

--- a/tests/test_python_package.py
+++ b/tests/test_python_package.py
@@ -284,11 +284,12 @@ def test_public_package_exports_app_protocol_helpers() -> None:
     )
     assert mower_state_label("75") == "Paused at maintenance point"
     assert mower_state_label(999) is None
-    assert mower_error_label(31) == "Left wheel speed"
-    assert mower_error_label(1) == "Unverified drop"
+    assert mower_error_label(31) == "Return to station failed"
+    assert mower_error_label(1) == "Robot tilted"
     assert mower_error_label(-1) == "No error"
-    assert mower_error_label(0) == "No error"
-    assert mower_error_label(99999) is None
+    assert mower_error_label(0) == "No device code"
+    assert mower_error_label(0, model="dreame.mower.g2408") == "Robot lifted"
+    assert mower_error_label(99999) == "Unknown mower device code 99999"
     assert decode_mower_status_blob([206, 0, 206]).frame_valid is True
     assert decode_mower_task_status('{"d":{"exe":true},"t":"TASK"}') == {
         "type": "TASK",


### PR DESCRIPTION
## What changed

- classify the shared `2.2` device-code channel with mower-native, model-aware meanings instead of the inherited vacuum error enum
- keep alerts, lifecycle events, and operating conditions visible as status notices without forcing the lawn-mower entity into `error`
- correct A2 code `56` to **Bad weather protection active** and code `31` to **Return to station failed**
- preserve raw status/realtime codes in diagnostics and use the mower's explicit error state as the fallback for unknown numeric codes
- limit A1 and MOVA overrides to verified models so rebadged or unknown devices are not guessed

## Why

An A2 could be fully docked with raw state `charging_completed` while Home Assistant reported `error`. The integration interpreted mower code `56` through the vacuum enum as a laser fault, even though the mower app uses it as an informational weather-protection condition.

This moves classification into one mower-specific owner and prevents other overlapping vacuum numbers from producing the same false state.

## Compatibility and limits

Raw codes remain available for diagnostics. The old vacuum constant tables remain for compatibility, but they no longer decide entity state, labels, warning severity, or error imagery. Internal legacy actions such as `clear_warning` still need device-specific validation before they can be claimed as mower features.

## Validation

The 780-test non-config-flow suite, Ruff, compilation, and diff checks pass on top of v0.2.14. A separate read-only local review found three model/fallback inconsistencies; all were fixed and confirmed in a targeted follow-up.