### PR TITLE
Recover live video after docking

### DIFF
--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -75,6 +75,9 @@ _HA_STREAM_START_TIMEOUT = DEFAULT_XP2P_HOST_STARTUP_TIMEOUT + 30.0
 _HA_PLAYBACK_VERIFY_TIMEOUT = 15.0
 _SNAPSHOT_STREAM_START_TIMEOUT = 15.0
 _SNAPSHOT_IMAGE_TIMEOUT = 15.0
+_HA_STREAM_STOP_TIMEOUT = 10.0
+_RUNTIME_SESSION_STOP_TIMEOUT = 20.0
+_CAMERA_STREAM_DISABLE_TIMEOUT = 10.0
 
 
 def _runtime_inputs_not_ready_message(
@@ -139,6 +142,7 @@ class DreameLawnMowerVideoCamera(
         self._runtime: _DreameVideoRuntime | None = None
         self._prepared_runtime: _DreameVideoRuntime | None = None
         self._runtime_prepare_task: asyncio.Task[None] | None = None
+        self._state_gate_cleanup_task: asyncio.Task[None] | None = None
         self._session: DreameLawnMowerXp2pLiveStreamSession | None = None
         self._unverified_playback_session: (
             DreameLawnMowerXp2pLiveStreamSession | None
@@ -168,6 +172,10 @@ class DreameLawnMowerVideoCamera(
         self._last_stream_health: dict[str, Any] | None = None
         self._last_stream_enable_result: Any | None = None
         self._last_stream_disable_error: str | None = None
+        self._last_stream_cleanup_reason: str | None = None
+        self._last_stream_cleanup_error: str | None = None
+        self._last_stream_cleanup_error_stage: str | None = None
+        self._last_stream_cleanup_at: str | None = None
         self._last_native_runtime_diagnostics: dict[str, Any] | None = None
         self._runtime_preparation_error: str | None = None
         self._last_image: bytes | None = None
@@ -195,6 +203,7 @@ class DreameLawnMowerVideoCamera(
         self._last_cached_xp2p_error: str | None = None
         self._last_video_transport: str | None = None
         self._last_video_transport_attempted: str | None = None
+        self._video_capability_observed = snapshot_advertises_video(coordinator.data)
 
     async def async_added_to_hass(self) -> None:
         """Schedule managed runtime preparation without blocking entity setup."""
@@ -252,6 +261,35 @@ class DreameLawnMowerVideoCamera(
             return self._prepared_runtime
         return await self.hass.async_add_executor_job(self._create_runtime)
 
+    def _handle_coordinator_update(self) -> None:
+        """Remember video support and retire sessions when state blocks video."""
+        snapshot = self.coordinator.data
+        if snapshot_advertises_video(snapshot):
+            self._video_capability_observed = True
+
+        block_reason = camera_stream_block_reason(snapshot)
+        cleanup_task = self._state_gate_cleanup_task
+        if (
+            block_reason is not None
+            and (self._session is not None or getattr(self, "stream", None) is not None)
+            and (cleanup_task is None or cleanup_task.done())
+        ):
+            self._state_gate_cleanup_task = self.hass.async_create_task(
+                self._async_cleanup_for_state_gate(block_reason)
+            )
+
+        super()._handle_coordinator_update()
+
+    async def _async_cleanup_for_state_gate(self, block_reason: str) -> None:
+        """Stop an active session after the mower enters a blocked state."""
+        async with self._stream_lock:
+            if self._session is None and getattr(self, "stream", None) is None:
+                return
+            await self._async_stop_active_session(
+                reason="state_gate",
+                trigger=block_reason,
+            )
+
     @property
     def available(self) -> bool:
         """Return whether live video can be requested from Home Assistant."""
@@ -277,7 +315,7 @@ class DreameLawnMowerVideoCamera(
             return False
         if snapshot is None:
             return False
-        return snapshot_advertises_video(snapshot)
+        return self._video_capability_observed
 
     @property
     def device_info(self) -> dict[str, Any]:
@@ -302,6 +340,10 @@ class DreameLawnMowerVideoCamera(
             "video_runtime_mode": self._runtime_mode,
             "video_transport_policy": self._video_transport,
             "video_block_reason": camera_stream_block_reason(self.coordinator.data),
+            "video_capability_advertised": snapshot_advertises_video(
+                self.coordinator.data
+            ),
+            "video_capability_observed": self._video_capability_observed,
             "last_video_transport": self._last_video_transport,
             "last_video_transport_attempted": self._last_video_transport_attempted,
             "lan_video_identity_cached": self._lan_cache.inputs is not None,
@@ -336,6 +378,14 @@ class DreameLawnMowerVideoCamera(
             ),
             "last_stream_enable_result": self._last_stream_enable_result,
             "last_stream_disable_error": self._last_stream_disable_error,
+            "last_stream_cleanup_reason": self._last_stream_cleanup_reason,
+            "last_stream_cleanup_error": self._last_stream_cleanup_error,
+            "last_stream_cleanup_error_stage": self._last_stream_cleanup_error_stage,
+            "last_stream_cleanup_at": self._last_stream_cleanup_at,
+            "stream_cleanup_pending": (
+                self._state_gate_cleanup_task is not None
+                and not self._state_gate_cleanup_task.done()
+            ),
             "last_native_runtime_diagnostics": self._last_native_runtime_diagnostics,
             "last_stream_health": self._last_stream_health,
             "last_stream_session": self._session.as_dict(redact=True)
@@ -445,9 +495,13 @@ class DreameLawnMowerVideoCamera(
                     not getattr(self, "_attr_is_on", True)
                     or self._session is not session
                     or not self._session_is_usable(session)
+                    or camera_stream_block_reason(self.coordinator.data) is not None
                 ):
                     if self._session is session:
-                        await self._async_stop_active_session()
+                        await self._async_stop_active_session(
+                            reason="state_gate",
+                            trigger=camera_stream_block_reason(self.coordinator.data),
+                        )
                     return None, attempted_transport
                 ha_stream = create_stream(
                     self.hass,
@@ -616,8 +670,7 @@ class DreameLawnMowerVideoCamera(
                 stage="runtime_configuration",
             )
             return None
-        if reason := camera_stream_block_reason(self.coordinator.data):
-            self._set_stream_error(reason, stage="mower_state_gate")
+        if self._video_start_is_blocked():
             return None
         if (
             self._video_transport == VIDEO_TRANSPORT_AUTO
@@ -652,6 +705,8 @@ class DreameLawnMowerVideoCamera(
                 return None
             if cached_source is not None:
                 return cached_source
+            if self._video_start_is_blocked():
+                return None
 
         cloud_inputs: DreameLawnMowerCameraStreamRuntimeInputs | None = None
         cloud_inputs_error: Exception | None = None
@@ -683,6 +738,8 @@ class DreameLawnMowerVideoCamera(
                     return None
                 if lan_source is not None:
                     return lan_source
+                if self._video_start_is_blocked():
+                    return None
                 if (
                     self._video_transport == VIDEO_TRANSPORT_AUTO
                     and cached_endpoint is not None
@@ -719,6 +776,8 @@ class DreameLawnMowerVideoCamera(
                                 return None
                             if lan_source is not None:
                                 return lan_source
+                            if self._video_start_is_blocked():
+                                return None
                             self._last_lan_error = (
                                 "Cached endpoint failed: "
                                 f"{cached_error or 'unknown error'} "
@@ -736,6 +795,9 @@ class DreameLawnMowerVideoCamera(
                     "No cached LAN video identity is available. Use Auto or Cloud "
                     "once while the video cloud is reachable to provision it."
                 )
+
+        if self._video_start_is_blocked():
+            return None
 
         stream_enable_attempted = False
         session: DreameLawnMowerXp2pLiveStreamSession | None = None
@@ -785,7 +847,7 @@ class DreameLawnMowerVideoCamera(
             )
             return None
 
-        return self._adopt_stream_session(
+        return await self._async_adopt_stream_session(
             runtime,
             session,
             None,
@@ -824,6 +886,13 @@ class DreameLawnMowerVideoCamera(
             self._set_stream_error(reason, stage="mower_state_gate")
             return False
         return True
+
+    def _video_start_is_blocked(self) -> bool:
+        """Fail a pending start when the latest mower state blocks video."""
+        if reason := camera_stream_block_reason(self.coordinator.data):
+            self._set_stream_error(reason, stage="mower_state_gate")
+            return True
+        return False
 
     async def _async_try_lan_stream(
         self,
@@ -878,7 +947,7 @@ class DreameLawnMowerVideoCamera(
                 f"{sanitize_diagnostic_text(err)}"
             )
             return None
-        return self._adopt_stream_session(
+        return await self._async_adopt_stream_session(
             runtime,
             session,
             stream_health,
@@ -903,7 +972,7 @@ class DreameLawnMowerVideoCamera(
                 else None
             )
             return None
-        return self._adopt_stream_session(
+        return await self._async_adopt_stream_session(
             runtime,
             result.session,
             None,
@@ -1035,6 +1104,48 @@ class DreameLawnMowerVideoCamera(
         self.async_write_ha_state()
         return session.stream_url
 
+    async def _async_adopt_stream_session(
+        self,
+        runtime: _DreameVideoRuntime,
+        session: DreameLawnMowerXp2pLiveStreamSession,
+        stream_health: DreameLawnMowerStreamUrlProbeResult | None,
+        *,
+        transport: str,
+        provisioning_inputs: DreameLawnMowerCameraStreamRuntimeInputs | None = None,
+    ) -> str | None:
+        """Adopt a session only while the latest mower state still permits video."""
+        if reason := camera_stream_block_reason(self.coordinator.data):
+            self._last_stream_cleanup_reason = "state_gate"
+            self._last_stream_cleanup_error = None
+            self._last_stream_cleanup_error_stage = None
+            await self._async_stop_session(runtime, session)
+            camera_toggle_managed = getattr(
+                session,
+                "camera_toggle_managed",
+                getattr(session, "transport", VIDEO_TRANSPORT_CLOUD)
+                != VIDEO_TRANSPORT_LAN,
+            )
+            if camera_toggle_managed:
+                await self._async_disable_camera_stream()
+            self._last_stream_cleanup_at = datetime.now(UTC).isoformat()
+            record_diagnostic_event(
+                self.coordinator,
+                code="video_start_state_changed",
+                source="video_camera",
+                message="Live-video startup was retired after mower state changed.",
+                severity="info",
+                context={"trigger": reason, "transport": transport},
+            )
+            self._set_stream_error(reason, stage="mower_state_gate")
+            return None
+        return self._adopt_stream_session(
+            runtime,
+            session,
+            stream_health,
+            transport=transport,
+            provisioning_inputs=provisioning_inputs,
+        )
+
     def _with_lan_failure(self, cloud_error: str) -> str:
         """Preserve Auto-mode failures without leaking runtime inputs."""
         return video_helpers.format_video_start_failures(
@@ -1114,7 +1225,7 @@ class DreameLawnMowerVideoCamera(
     async def async_turn_off(self) -> None:
         """Stop the current live video session."""
         async with self._stream_lock:
-            await self._async_stop_active_session()
+            await self._async_stop_active_session(reason="turn_off")
             self._attr_is_on = False
             self.async_write_ha_state()
 
@@ -1134,42 +1245,85 @@ class DreameLawnMowerVideoCamera(
                 await prepare_task
             except asyncio.CancelledError:
                 pass
-        async with self._stream_lock:
-            await self._async_stop_active_session()
-
-    async def _async_stop_active_session(self) -> None:
-        """Stop the current runtime session if one is active."""
-        await self._stream_idle_monitor.async_cancel()
-        ha_stream = getattr(self, "stream", None)
-        self.stream = None
-        runtime = self._runtime
-        session = self._session
-        self._runtime = None
-        self._session = None
-        self._unverified_playback_session = None
-        self._pending_provisioning_inputs = None
-        self._attr_is_streaming = False
-        if ha_stream is not None:
+        cleanup_task = self._state_gate_cleanup_task
+        if cleanup_task is not None and cleanup_task is not asyncio.current_task():
             try:
-                await ha_stream.stop()
-            except Exception as err:  # noqa: BLE001 - continue XP2P cleanup.
-                _LOGGER.debug(
-                    "Failed to stop Home Assistant camera stream: %s",
-                    sanitize_diagnostic_text(err),
-                )
-            finally:
-                self._unregister_ha_stream(ha_stream)
-        if runtime is None or session is None:
-            return
-        await self._async_stop_session(runtime, session)
-        camera_toggle_managed = getattr(
-            session,
-            "camera_toggle_managed",
-            getattr(session, "transport", VIDEO_TRANSPORT_CLOUD) != VIDEO_TRANSPORT_LAN,
-        )
-        if camera_toggle_managed:
-            await self._async_disable_camera_stream()
-        self.async_write_ha_state()
+                await cleanup_task
+            except asyncio.CancelledError:
+                pass
+            except Exception as err:  # noqa: BLE001 - unload must still finish.
+                self._record_stream_cleanup_error("state_gate", err)
+        self._state_gate_cleanup_task = None
+        async with self._stream_lock:
+            if self._session is not None or getattr(self, "stream", None) is not None:
+                await self._async_stop_active_session(reason="entity_unload")
+            else:
+                await self._stream_idle_monitor.async_cancel()
+        await super().async_will_remove_from_hass()
+
+    async def _async_stop_active_session(
+        self,
+        *,
+        reason: str = "session_stop",
+        trigger: str | None = None,
+    ) -> None:
+        """Stop the current runtime session if one is active."""
+        self._last_stream_cleanup_reason = reason
+        self._last_stream_cleanup_error = None
+        self._last_stream_cleanup_error_stage = None
+        if trigger is not None:
+            record_diagnostic_event(
+                self.coordinator,
+                code="video_state_gate_cleanup",
+                source="video_camera",
+                message="Active live-video session stopped after mower state changed.",
+                severity="info",
+                context={"reason": reason, "trigger": trigger},
+            )
+        try:
+            await self._stream_idle_monitor.async_cancel()
+            ha_stream = getattr(self, "stream", None)
+            self.stream = None
+            runtime = self._runtime
+            session = self._session
+            self._runtime = None
+            self._session = None
+            self._unverified_playback_session = None
+            self._pending_provisioning_inputs = None
+            self._attr_is_streaming = False
+            if ha_stream is not None:
+                try:
+                    async with asyncio.timeout(_HA_STREAM_STOP_TIMEOUT):
+                        await ha_stream.stop()
+                except TimeoutError:
+                    self._record_stream_cleanup_error(
+                        "home_assistant_stream_stop",
+                        (
+                            "Home Assistant camera stream cleanup timed out after "
+                            f"{_HA_STREAM_STOP_TIMEOUT:g}s."
+                        ),
+                    )
+                except Exception as err:  # noqa: BLE001 - continue XP2P cleanup.
+                    self._record_stream_cleanup_error(
+                        "home_assistant_stream_stop",
+                        err,
+                    )
+                finally:
+                    self._unregister_ha_stream(ha_stream)
+            if runtime is None or session is None:
+                return
+            await self._async_stop_session(runtime, session)
+            camera_toggle_managed = getattr(
+                session,
+                "camera_toggle_managed",
+                getattr(session, "transport", VIDEO_TRANSPORT_CLOUD)
+                != VIDEO_TRANSPORT_LAN,
+            )
+            if camera_toggle_managed:
+                await self._async_disable_camera_stream()
+        finally:
+            self._last_stream_cleanup_at = datetime.now(UTC).isoformat()
+            self.async_write_ha_state()
 
     def _unregister_ha_stream(self, ha_stream: Any) -> None:
         """Remove a discarded HA Stream from the integration registry."""
@@ -1195,13 +1349,23 @@ class DreameLawnMowerVideoCamera(
     ) -> bool:
         """Stop a runtime session without changing entity state bookkeeping."""
         try:
-            await self.hass.async_add_executor_job(runtime.stop_live_stream, session)
+            async with asyncio.timeout(_RUNTIME_SESSION_STOP_TIMEOUT):
+                await self.hass.async_add_executor_job(
+                    runtime.stop_live_stream,
+                    session,
+                )
             return True
-        except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
-            _LOGGER.debug(
-                "Failed to stop Dreame mower live video: %s",
-                sanitize_diagnostic_text(err),
+        except TimeoutError:
+            self._record_stream_cleanup_error(
+                "runtime_session_stop",
+                (
+                    "Dreame mower live-video runtime cleanup timed out after "
+                    f"{_RUNTIME_SESSION_STOP_TIMEOUT:g}s."
+                ),
             )
+            return False
+        except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
+            self._record_stream_cleanup_error("runtime_session_stop", err)
             return False
 
     async def _async_stop_session_for_handoff(
@@ -1220,14 +1384,45 @@ class DreameLawnMowerVideoCamera(
     async def _async_disable_camera_stream(self) -> None:
         """Best-effort app-side video cleanup."""
         try:
-            await self.coordinator.client.async_set_camera_stream_enabled(False)
+            async with asyncio.timeout(_CAMERA_STREAM_DISABLE_TIMEOUT):
+                await self.coordinator.client.async_set_camera_stream_enabled(False)
             self._last_stream_disable_error = None
-        except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
-            self._last_stream_disable_error = sanitize_diagnostic_text(err)
-            _LOGGER.debug(
-                "Failed to disable Dreame mower app video mode: %s",
+        except TimeoutError:
+            self._last_stream_disable_error = (
+                "Dreame app video-mode cleanup timed out after "
+                f"{_CAMERA_STREAM_DISABLE_TIMEOUT:g}s."
+            )
+            self._record_stream_cleanup_error(
+                "camera_stream_disable",
                 self._last_stream_disable_error,
             )
+        except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
+            self._last_stream_disable_error = sanitize_diagnostic_text(err)
+            self._record_stream_cleanup_error(
+                "camera_stream_disable",
+                self._last_stream_disable_error,
+            )
+
+    def _record_stream_cleanup_error(self, stage: str, error: object) -> None:
+        """Retain one safe cleanup failure and add it to shared diagnostics."""
+        safe_error = sanitize_diagnostic_text(error)
+        self._last_stream_cleanup_error = safe_error
+        self._last_stream_cleanup_error_stage = stage
+        record_diagnostic_event(
+            self.coordinator,
+            code=f"video_{stage}_failed",
+            source="video_camera",
+            message=safe_error,
+            context={
+                "cleanup_reason": self._last_stream_cleanup_reason,
+                "transport": self._video_transport,
+            },
+        )
+        _LOGGER.warning(
+            "Dreame mower live-video cleanup failed [%s]: %s",
+            stage,
+            safe_error,
+        )
 
     def _create_runtime(self) -> _DreameVideoRuntime:
         """Create the configured runtime adapter."""

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -78,6 +78,7 @@ _SNAPSHOT_IMAGE_TIMEOUT = 15.0
 _HA_STREAM_STOP_TIMEOUT = 10.0
 _RUNTIME_SESSION_STOP_TIMEOUT = 20.0
 _CAMERA_STREAM_DISABLE_TIMEOUT = 10.0
+_PENDING_RUNTIME_STOPS: dict[str, set[asyncio.Future[Any]]] = {}
 
 
 def _runtime_inputs_not_ready_message(
@@ -225,6 +226,8 @@ class DreameLawnMowerVideoCamera(
                     "Failed to load Dreame video provisioning cache: %s",
                     self._provisioning_cache_error,
                 )
+        if self._persisted_video_capability:
+            self._video_capability_observed = True
         snapshot = self.coordinator.data
         if not self._runtime_configured or (
             self._lan_cache.inputs is None
@@ -269,21 +272,35 @@ class DreameLawnMowerVideoCamera(
 
         block_reason = camera_stream_block_reason(snapshot)
         cleanup_task = self._state_gate_cleanup_task
+        target_session = self._session
+        target_stream = getattr(self, "stream", None)
         if (
             block_reason is not None
-            and (self._session is not None or getattr(self, "stream", None) is not None)
+            and (target_session is not None or target_stream is not None)
             and (cleanup_task is None or cleanup_task.done())
         ):
             self._state_gate_cleanup_task = self.hass.async_create_task(
-                self._async_cleanup_for_state_gate(block_reason)
+                self._async_cleanup_for_state_gate(
+                    block_reason,
+                    target_session,
+                    target_stream,
+                )
             )
 
         super()._handle_coordinator_update()
 
-    async def _async_cleanup_for_state_gate(self, block_reason: str) -> None:
+    async def _async_cleanup_for_state_gate(
+        self,
+        block_reason: str,
+        target_session: DreameLawnMowerXp2pLiveStreamSession | None,
+        target_stream: Any | None,
+    ) -> None:
         """Stop an active session after the mower enters a blocked state."""
         async with self._stream_lock:
-            if self._session is None and getattr(self, "stream", None) is None:
+            if (
+                self._session is not target_session
+                or getattr(self, "stream", None) is not target_stream
+            ):
                 return
             await self._async_stop_active_session(
                 reason="state_gate",
@@ -386,6 +403,7 @@ class DreameLawnMowerVideoCamera(
                 self._state_gate_cleanup_task is not None
                 and not self._state_gate_cleanup_task.done()
             ),
+            "runtime_cleanup_pending": self._runtime_cleanup_pending,
             "last_native_runtime_diagnostics": self._last_native_runtime_diagnostics,
             "last_stream_health": self._last_stream_health,
             "last_stream_session": self._session.as_dict(redact=True)
@@ -670,6 +688,13 @@ class DreameLawnMowerVideoCamera(
                 stage="runtime_configuration",
             )
             return None
+        if self._runtime_cleanup_pending:
+            self._set_stream_error(
+                "Previous live-video runtime cleanup is still in progress. "
+                "Retry shortly.",
+                stage="runtime_cleanup",
+            )
+            return None
         if self._video_start_is_blocked():
             return None
         if (
@@ -811,6 +836,8 @@ class DreameLawnMowerVideoCamera(
                 raise DreameLawnMowerVideoRuntimeError(
                     _runtime_inputs_not_ready_message(cloud_inputs)
                 )
+            if self._video_start_is_blocked():
+                return None
             stream_enable_attempted = True
             self._last_stream_enable_result = sanitize_debug_data(
                 video_helpers.safe_state_attribute(
@@ -818,6 +845,9 @@ class DreameLawnMowerVideoCamera(
                 )
             )
             self._last_stream_disable_error = None
+            if self._video_start_is_blocked():
+                await self._async_disable_camera_stream()
+                return None
             session = await self._async_start_runtime_session(runtime, cloud_inputs)
         except asyncio.CancelledError:
             if runtime is not None and session is not None:
@@ -1115,19 +1145,6 @@ class DreameLawnMowerVideoCamera(
     ) -> str | None:
         """Adopt a session only while the latest mower state still permits video."""
         if reason := camera_stream_block_reason(self.coordinator.data):
-            self._last_stream_cleanup_reason = "state_gate"
-            self._last_stream_cleanup_error = None
-            self._last_stream_cleanup_error_stage = None
-            await self._async_stop_session(runtime, session)
-            camera_toggle_managed = getattr(
-                session,
-                "camera_toggle_managed",
-                getattr(session, "transport", VIDEO_TRANSPORT_CLOUD)
-                != VIDEO_TRANSPORT_LAN,
-            )
-            if camera_toggle_managed:
-                await self._async_disable_camera_stream()
-            self._last_stream_cleanup_at = datetime.now(UTC).isoformat()
             record_diagnostic_event(
                 self.coordinator,
                 code="video_start_state_changed",
@@ -1137,6 +1154,14 @@ class DreameLawnMowerVideoCamera(
                 context={"trigger": reason, "transport": transport},
             )
             self._set_stream_error(reason, stage="mower_state_gate")
+            cleanup_task = asyncio.create_task(
+                self._async_cleanup_rejected_session(runtime, session)
+            )
+            try:
+                await asyncio.shield(cleanup_task)
+            except asyncio.CancelledError:
+                await cleanup_task
+                raise
             return None
         return self._adopt_stream_session(
             runtime,
@@ -1145,6 +1170,28 @@ class DreameLawnMowerVideoCamera(
             transport=transport,
             provisioning_inputs=provisioning_inputs,
         )
+
+    async def _async_cleanup_rejected_session(
+        self,
+        runtime: _DreameVideoRuntime,
+        session: DreameLawnMowerXp2pLiveStreamSession,
+    ) -> None:
+        """Finish cleanup for a state-gated session before cancellation escapes."""
+        self._last_stream_cleanup_reason = "state_gate"
+        self._last_stream_cleanup_error = None
+        self._last_stream_cleanup_error_stage = None
+        try:
+            await self._async_stop_session(runtime, session)
+            camera_toggle_managed = getattr(
+                session,
+                "camera_toggle_managed",
+                getattr(session, "transport", VIDEO_TRANSPORT_CLOUD)
+                != VIDEO_TRANSPORT_LAN,
+            )
+            if camera_toggle_managed:
+                await self._async_disable_camera_stream()
+        finally:
+            self._last_stream_cleanup_at = datetime.now(UTC).isoformat()
 
     def _with_lan_failure(self, cloud_error: str) -> str:
         """Preserve Auto-mode failures without leaking runtime inputs."""
@@ -1349,11 +1396,16 @@ class DreameLawnMowerVideoCamera(
     ) -> bool:
         """Stop a runtime session without changing entity state bookkeeping."""
         try:
+            stop_job = asyncio.ensure_future(
+                self.hass.async_add_executor_job(runtime.stop_live_stream, session)
+            )
+        except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
+            self._record_stream_cleanup_error("runtime_session_stop", err)
+            return False
+        self._register_runtime_stop(stop_job)
+        try:
             async with asyncio.timeout(_RUNTIME_SESSION_STOP_TIMEOUT):
-                await self.hass.async_add_executor_job(
-                    runtime.stop_live_stream,
-                    session,
-                )
+                await asyncio.shield(stop_job)
             return True
         except TimeoutError:
             self._record_stream_cleanup_error(
@@ -1367,6 +1419,50 @@ class DreameLawnMowerVideoCamera(
         except Exception as err:  # noqa: BLE001 - cleanup should not break unload.
             self._record_stream_cleanup_error("runtime_session_stop", err)
             return False
+
+    def _register_runtime_stop(self, stop_job: asyncio.Future[Any]) -> None:
+        """Fence replacement sessions until an executor-backed stop really ends."""
+        key = self._runtime_stop_key
+        jobs = _PENDING_RUNTIME_STOPS.setdefault(key, set())
+        jobs.add(stop_job)
+
+        def _completed(future: asyncio.Future[Any]) -> None:
+            pending = _PENDING_RUNTIME_STOPS.get(key)
+            if pending is not None:
+                pending.discard(future)
+                if not pending:
+                    _PENDING_RUNTIME_STOPS.pop(key, None)
+            if future.cancelled():
+                return
+            try:
+                future.exception()
+            except (asyncio.CancelledError, Exception):
+                pass
+
+        stop_job.add_done_callback(_completed)
+
+    @property
+    def _runtime_stop_key(self) -> str:
+        """Return a stable mower identity shared across entity reloads."""
+        descriptor = getattr(self, "_descriptor", None)
+        return str(
+            getattr(descriptor, "did", None)
+            or getattr(descriptor, "unique_id", None)
+            or self._attr_unique_id
+        )
+
+    @property
+    def _runtime_cleanup_pending(self) -> bool:
+        """Return whether an earlier native stop still owns this mower service."""
+        jobs = _PENDING_RUNTIME_STOPS.get(self._runtime_stop_key)
+        if not jobs:
+            return False
+        active = {job for job in jobs if not job.done()}
+        if active:
+            _PENDING_RUNTIME_STOPS[self._runtime_stop_key] = active
+            return True
+        _PENDING_RUNTIME_STOPS.pop(self._runtime_stop_key, None)
+        return False
 
     async def _async_stop_session_for_handoff(
         self,
@@ -1509,6 +1605,20 @@ class DreameLawnMowerVideoCamera(
     @property
     def _video_transport(self) -> str:
         return video_helpers.video_transport(self._entry)
+
+    @property
+    def _persisted_video_capability(self) -> bool:
+        """Return whether a prior healthy session proves video support."""
+        return bool(
+            (
+                self._lan_cache.inputs is not None
+                and self._lan_cache.endpoint is not None
+            )
+            or (
+                self._provisioning_cache.inputs is not None
+                and self._provisioning_cache.device_config is not None
+            )
+        )
 
     @property
     def _native_library_path(self) -> str | None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -140,6 +140,7 @@ def _uninitialized_entity(*, snapshot: object | None = None):
     entity._runtime = None
     entity._prepared_runtime = None
     entity._runtime_prepare_task = None
+    entity._state_gate_cleanup_task = None
     entity._stream_idle_monitor = SimpleNamespace(
         schedule=lambda _stream, _session: None,
         async_cancel=lambda: asyncio.sleep(0),
@@ -152,9 +153,31 @@ def _uninitialized_entity(*, snapshot: object | None = None):
     entity._provisioning_cache_error = None
     entity._last_cached_xp2p_error = None
     entity._runtime_input_config = None
+    entity._last_error = None
+    entity._last_error_at = None
+    entity._last_error_code = None
+    entity._last_error_stage = None
+    entity._last_runtime_inputs_ready = None
+    entity._last_runtime_inputs_source = None
+    entity._last_runtime_inputs_missing = ()
+    entity._last_runtime_inputs_provisioning_issue = None
+    entity._last_runtime_input_diagnostics = None
+    entity._last_stream_health = None
+    entity._last_stream_enable_result = None
+    entity._last_stream_disable_error = None
+    entity._last_native_runtime_diagnostics = None
+    entity._runtime_preparation_error = None
+    entity._lan_cache_error = None
     entity._last_lan_error = None
     entity._last_video_transport = None
     entity._last_video_transport_attempted = None
+    entity._video_capability_observed = video_camera_module.snapshot_advertises_video(
+        snapshot
+    )
+    entity._last_stream_cleanup_reason = None
+    entity._last_stream_cleanup_error = None
+    entity._last_stream_cleanup_error_stage = None
+    entity._last_stream_cleanup_at = None
     return entity
 
 
@@ -430,6 +453,260 @@ def test_video_camera_available_from_top_level_video_status() -> None:
     entity = _uninitialized_entity(snapshot=snapshot)
 
     assert entity.available is True
+
+
+def test_video_camera_remembers_support_when_metadata_disappears() -> None:
+    snapshot = SimpleNamespace(
+        available=True,
+        state="mowing",
+        activity="mowing",
+        docked=False,
+        raw_docked=False,
+        returning=False,
+        capabilities=("video",),
+        raw_info={},
+        raw_attributes={},
+    )
+    entity = _uninitialized_entity(snapshot=snapshot)
+    entity.coordinator.data = SimpleNamespace(
+        available=True,
+        state="mowing",
+        activity="mowing",
+        docked=False,
+        raw_docked=False,
+        returning=False,
+        capabilities=(),
+        raw_info={},
+        raw_attributes={},
+    )
+
+    with patch.object(
+        video_camera_module.CoordinatorEntity,
+        "_handle_coordinator_update",
+        lambda _entity: None,
+    ):
+        entity._handle_coordinator_update()
+
+    assert entity.available is True
+    assert entity.extra_state_attributes["video_capability_advertised"] is False
+    assert entity.extra_state_attributes["video_capability_observed"] is True
+
+
+def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
+    async def _run() -> tuple[int, int, bool, bool, str | None]:
+        snapshot = SimpleNamespace(
+            available=True,
+            state="mowing",
+            activity="mowing",
+            docked=False,
+            raw_docked=False,
+            returning=False,
+            capabilities=("video",),
+            raw_info={},
+            raw_attributes={},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+        runtime_stops = 0
+        camera_disables = 0
+
+        class _Runtime:
+            def stop_live_stream(self, _session: object) -> None:
+                nonlocal runtime_stops
+                runtime_stops += 1
+
+        class _Client:
+            async def async_set_camera_stream_enabled(self, _enabled: bool) -> None:
+                nonlocal camera_disables
+                camera_disables += 1
+
+        async def _executor(function, *args):
+            return function(*args)
+
+        entity.coordinator.client = _Client()
+        entity.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        entity.hass = SimpleNamespace(
+            async_add_executor_job=_executor,
+            async_create_task=asyncio.create_task,
+            data={},
+        )
+        entity.async_write_ha_state = lambda: None
+        entity.stream = None
+        entity._runtime = _Runtime()
+        entity._session = SimpleNamespace(
+            transport=VIDEO_TRANSPORT_CLOUD,
+            camera_toggle_managed=True,
+        )
+        entity._attr_is_streaming = True
+        entity.coordinator.data = SimpleNamespace(
+            available=True,
+            state="charging",
+            activity="charging",
+            docked=True,
+            raw_docked=True,
+            returning=False,
+            capabilities=(),
+            raw_info={},
+            raw_attributes={},
+        )
+
+        with patch.object(
+            video_camera_module.CoordinatorEntity,
+            "_handle_coordinator_update",
+            lambda _entity: None,
+        ):
+            entity._handle_coordinator_update()
+            cleanup_task = entity._state_gate_cleanup_task
+            assert cleanup_task is not None
+            await cleanup_task
+
+            unavailable_while_docked = not entity.available
+            entity.coordinator.data = SimpleNamespace(
+                available=True,
+                state="mowing",
+                activity="mowing",
+                docked=False,
+                raw_docked=False,
+                returning=False,
+                capabilities=(),
+                raw_info={},
+                raw_attributes={},
+            )
+            entity._handle_coordinator_update()
+
+        events = entity.coordinator.diagnostic_events.as_list()
+        return (
+            runtime_stops,
+            camera_disables,
+            unavailable_while_docked,
+            entity.available,
+            events[0]["code"] if events else None,
+        )
+
+    assert asyncio.run(_run()) == (
+        1,
+        1,
+        True,
+        True,
+        "video_state_gate_cleanup",
+    )
+
+
+def test_video_camera_rejects_cloud_session_when_mower_docks_during_start() -> None:
+    async def _run() -> tuple[
+        str | None,
+        int,
+        list[bool],
+        str | None,
+        str | None,
+        str | None,
+    ]:
+        snapshot = SimpleNamespace(
+            available=True,
+            state="mowing",
+            activity="mowing",
+            docked=False,
+            raw_docked=False,
+            returning=False,
+            capabilities=("video",),
+            raw_info={},
+            raw_attributes={},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+        runtime = object()
+        session = SimpleNamespace(
+            stream_url="http://127.0.0.1/late.flv",
+            transport=VIDEO_TRANSPORT_CLOUD,
+            camera_toggle_managed=True,
+        )
+        runtime_stops = 0
+        camera_toggles: list[bool] = []
+
+        class _Client:
+            last_camera_stream_diagnostics = {}
+
+            async def async_get_camera_stream_runtime_inputs(
+                self,
+            ) -> DreameLawnMowerCameraStreamRuntimeInputs:
+                return DreameLawnMowerCameraStreamRuntimeInputs(
+                    source="test",
+                    did="device-1",
+                    product_id="product-1",
+                    device_name="mower-1",
+                    p2p_info="p2p-info",
+                )
+
+            async def async_set_camera_stream_enabled(self, enabled: bool) -> object:
+                camera_toggles.append(enabled)
+                return {"enabled": enabled}
+
+        async def _start_session(
+            _runtime: object,
+            _inputs: DreameLawnMowerCameraStreamRuntimeInputs,
+            *,
+            camera_toggle_managed: bool = True,
+        ) -> object:
+            assert camera_toggle_managed is True
+            entity.coordinator.data = SimpleNamespace(
+                available=True,
+                state="charging",
+                activity="charging",
+                docked=True,
+                raw_docked=True,
+                returning=False,
+                capabilities=(),
+                raw_info={},
+                raw_attributes={},
+            )
+            return session
+
+        async def _stop_session(
+            actual_runtime: object,
+            actual_session: object,
+        ) -> bool:
+            nonlocal runtime_stops
+            assert actual_runtime is runtime
+            assert actual_session is session
+            runtime_stops += 1
+            return True
+
+        async def _save_lan_identity(_inputs: object) -> None:
+            return None
+
+        async def _executor(function, *args):
+            return function(*args)
+
+        entity.coordinator.client = _Client()
+        entity.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        entity.hass = SimpleNamespace(async_add_executor_job=_executor)
+        entity._lan_cache = SimpleNamespace(
+            inputs=None,
+            endpoint=None,
+            async_save_identity=_save_lan_identity,
+        )
+        entity._prepared_runtime = runtime
+        entity._async_start_runtime_session = _start_session
+        entity._async_stop_session = _stop_session
+        entity.async_write_ha_state = lambda: None
+
+        source = await entity._async_start_stream()
+        events = entity.coordinator.diagnostic_events.as_list()
+        return (
+            source,
+            runtime_stops,
+            camera_toggles,
+            entity._last_error_stage,
+            events[0]["code"] if events else None,
+            entity._last_stream_cleanup_reason,
+        )
+
+    assert asyncio.run(_run()) == (
+        None,
+        1,
+        [True, False],
+        "mower_state_gate",
+        "video_start_state_changed",
+        "state_gate",
+    )
 
 
 def test_runner_command_uses_windows_backslash_and_quote_semantics() -> None:
@@ -856,7 +1133,7 @@ def test_video_camera_does_not_cache_stream_after_turn_off_race() -> None:
             entity._session = session
             return session.stream_url
 
-        async def _stop() -> None:
+        async def _stop(**_kwargs) -> None:
             nonlocal stops
             stops += 1
             entity.stream = None
@@ -1133,6 +1410,7 @@ def test_video_camera_stop_unregisters_cached_home_assistant_stream() -> None:
                 }
             }
         )
+        entity.async_write_ha_state = lambda: None
         await entity._async_stop_active_session()
         return entity.stream, stopped, registry
 
@@ -1186,6 +1464,83 @@ def test_video_camera_stop_continues_after_cached_stream_failure() -> None:
         return runtime_stops, video_disables
 
     assert asyncio.run(_run()) == (1, 1)
+
+
+def test_video_camera_unload_is_bounded_when_every_cleanup_stage_hangs() -> None:
+    async def _run() -> tuple[bool, list[str], str | None, bool]:
+        entity = _uninitialized_entity()
+        entity._descriptor = SimpleNamespace(model="dreame.mower.q2501a")
+        entity.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        base_remove_called = False
+
+        class _Stream:
+            async def stop(self) -> None:
+                await asyncio.get_running_loop().create_future()
+
+        class _Runtime:
+            def stop_live_stream(self, _session: object) -> None:
+                raise AssertionError("The synthetic executor must stay pending")
+
+        class _Client:
+            async def async_set_camera_stream_enabled(self, _enabled: bool) -> None:
+                await asyncio.get_running_loop().create_future()
+
+        async def _base_remove(_entity: object) -> None:
+            nonlocal base_remove_called
+            base_remove_called = True
+
+        def _pending_executor(*_args):
+            return asyncio.get_running_loop().create_future()
+
+        stream = _Stream()
+        entity.stream = stream
+        entity._runtime = _Runtime()
+        entity._session = SimpleNamespace(
+            transport=VIDEO_TRANSPORT_CLOUD,
+            camera_toggle_managed=True,
+        )
+        entity._attr_is_streaming = True
+        entity.coordinator.client = _Client()
+        entity.hass = SimpleNamespace(
+            async_add_executor_job=_pending_executor,
+            data={
+                video_camera_module.STREAM_DOMAIN: {
+                    video_camera_module.ATTR_STREAMS: [stream],
+                }
+            },
+        )
+        entity.async_write_ha_state = lambda: None
+
+        with (
+            patch.object(video_camera_module, "_HA_STREAM_STOP_TIMEOUT", 0.001),
+            patch.object(video_camera_module, "_RUNTIME_SESSION_STOP_TIMEOUT", 0.001),
+            patch.object(video_camera_module, "_CAMERA_STREAM_DISABLE_TIMEOUT", 0.001),
+            patch.object(
+                video_camera_module.CoordinatorEntity,
+                "async_will_remove_from_hass",
+                new=_base_remove,
+            ),
+        ):
+            await entity.async_will_remove_from_hass()
+
+        events = entity.coordinator.diagnostic_events.as_list()
+        return (
+            base_remove_called,
+            [event["code"] for event in events],
+            entity._last_stream_cleanup_error_stage,
+            entity._session is None and entity.stream is None,
+        )
+
+    assert asyncio.run(_run()) == (
+        True,
+        [
+            "video_home_assistant_stream_stop_failed",
+            "video_runtime_session_stop_failed",
+            "video_camera_stream_disable_failed",
+        ],
+        "camera_stream_disable",
+        True,
+    )
 
 
 def test_video_camera_cancellation_stops_completed_native_startup() -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -124,6 +124,12 @@ def _uninitialized_entity(*, snapshot: object | None = None):
         return None
 
     entity = object.__new__(DreameLawnMowerVideoCamera)
+    entity._descriptor = SimpleNamespace(
+        did=f"test-device-{id(entity)}",
+        unique_id=f"test-device-{id(entity)}",
+        model="dreame.mower.test",
+    )
+    entity._attr_unique_id = f"{entity._descriptor.unique_id}_live_video"
     entity._entry = SimpleNamespace(
         options={
             CONF_XP2P_RUNNER_COMMAND: "xp2p-runner",
@@ -492,6 +498,76 @@ def test_video_camera_remembers_support_when_metadata_disappears() -> None:
     assert entity.extra_state_attributes["video_capability_observed"] is True
 
 
+def test_video_camera_restores_support_from_healthy_cache_after_docked_reload() -> None:
+    async def _run() -> tuple[bool, bool]:
+        snapshot = SimpleNamespace(
+            available=True,
+            state="charging",
+            activity="charging",
+            docked=True,
+            raw_docked=True,
+            returning=False,
+            capabilities=(),
+            raw_info={},
+            raw_attributes={},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+
+        class _Cache:
+            loaded = False
+            inputs = None
+            device_config = None
+
+            async def async_load(self) -> None:
+                self.loaded = True
+                self.inputs = object()
+                self.device_config = object()
+
+        async def _executor(function, *args):
+            return function(*args)
+
+        entity._provisioning_cache = _Cache()
+        entity._lan_cache = SimpleNamespace(
+            loaded=True,
+            inputs=None,
+            endpoint=None,
+        )
+        entity.hass = SimpleNamespace(
+            async_add_executor_job=_executor,
+            async_create_task=asyncio.create_task,
+        )
+
+        async def _base_added(_entity: object) -> None:
+            return None
+
+        with patch.object(
+            video_camera_module.CoordinatorEntity,
+            "async_added_to_hass",
+            new=_base_added,
+        ):
+            await entity.async_added_to_hass()
+
+        observed_after_reload = entity._video_capability_observed
+        entity.coordinator.data = SimpleNamespace(
+            available=True,
+            state="mowing",
+            activity="mowing",
+            docked=False,
+            raw_docked=False,
+            returning=False,
+            capabilities=(),
+            raw_info={},
+            raw_attributes={},
+        )
+        available_after_undock = entity.available
+        task = entity._runtime_prepare_task
+        if task is not None:
+            await task
+        return observed_after_reload, available_after_undock
+
+    assert asyncio.run(_run()) == (True, True)
+
+
 def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
     async def _run() -> tuple[int, int, bool, bool, str | None]:
         snapshot = SimpleNamespace(
@@ -589,6 +665,127 @@ def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
         True,
         "video_state_gate_cleanup",
     )
+
+
+def test_video_camera_state_gate_cleanup_does_not_stop_replacement_session() -> None:
+    async def _run() -> int:
+        snapshot = SimpleNamespace(
+            state="charging",
+            activity="charging",
+            docked=True,
+            raw_docked=True,
+            returning=False,
+            capabilities=(),
+            raw_info={},
+            raw_attributes={},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+        old_session = object()
+        old_stream = object()
+        entity._session = old_session
+        entity.stream = old_stream
+        entity.hass = SimpleNamespace(async_create_task=asyncio.create_task)
+        stops = 0
+
+        async def _stop(**_kwargs) -> None:
+            nonlocal stops
+            stops += 1
+
+        entity._async_stop_active_session = _stop
+        await entity._stream_lock.acquire()
+        try:
+            with patch.object(
+                video_camera_module.CoordinatorEntity,
+                "_handle_coordinator_update",
+                lambda _entity: None,
+            ):
+                entity._handle_coordinator_update()
+            cleanup_task = entity._state_gate_cleanup_task
+            assert cleanup_task is not None
+            entity._session = object()
+            entity.stream = object()
+        finally:
+            entity._stream_lock.release()
+        await cleanup_task
+        return stops
+
+    assert asyncio.run(_run()) == 0
+
+
+def test_video_camera_rechecks_state_after_cloud_inputs_before_enable() -> None:
+    async def _run() -> tuple[str | None, list[bool], int, str | None]:
+        snapshot = SimpleNamespace(
+            available=True,
+            state="mowing",
+            activity="mowing",
+            docked=False,
+            raw_docked=False,
+            returning=False,
+            capabilities=("video",),
+            raw_info={},
+            raw_attributes={},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+        runtime = object()
+        camera_toggles: list[bool] = []
+        runtime_starts = 0
+
+        class _Client:
+            last_camera_stream_diagnostics = {}
+
+            async def async_get_camera_stream_runtime_inputs(
+                self,
+            ) -> DreameLawnMowerCameraStreamRuntimeInputs:
+                entity.coordinator.data = SimpleNamespace(
+                    available=True,
+                    state="charging",
+                    activity="charging",
+                    docked=True,
+                    raw_docked=True,
+                    returning=False,
+                    capabilities=(),
+                    raw_info={},
+                    raw_attributes={},
+                )
+                return DreameLawnMowerCameraStreamRuntimeInputs(
+                    source="test",
+                    did="device-1",
+                    product_id="product-1",
+                    device_name="mower-1",
+                    p2p_info="p2p-info",
+                )
+
+            async def async_set_camera_stream_enabled(self, enabled: bool) -> object:
+                camera_toggles.append(enabled)
+                return {"enabled": enabled}
+
+        async def _save_lan_identity(_inputs: object) -> None:
+            return None
+
+        async def _executor(function, *args):
+            return function(*args)
+
+        async def _start_session(*_args, **_kwargs) -> object:
+            nonlocal runtime_starts
+            runtime_starts += 1
+            return object()
+
+        entity.coordinator.client = _Client()
+        entity.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        entity.hass = SimpleNamespace(async_add_executor_job=_executor)
+        entity._lan_cache = SimpleNamespace(
+            inputs=None,
+            endpoint=None,
+            async_save_identity=_save_lan_identity,
+        )
+        entity._prepared_runtime = runtime
+        entity._async_start_runtime_session = _start_session
+        entity.async_write_ha_state = lambda: None
+
+        source = await entity._async_start_stream()
+        return source, camera_toggles, runtime_starts, entity._last_error_stage
+
+    assert asyncio.run(_run()) == (None, [], 0, "mower_state_gate")
 
 
 def test_video_camera_rejects_cloud_session_when_mower_docks_during_start() -> None:
@@ -707,6 +904,61 @@ def test_video_camera_rejects_cloud_session_when_mower_docks_during_start() -> N
         "video_start_state_changed",
         "state_gate",
     )
+
+
+def test_video_camera_rejected_session_cleanup_survives_cancellation() -> None:
+    async def _run() -> tuple[bool, int]:
+        snapshot = SimpleNamespace(
+            state="charging",
+            activity="charging",
+            docked=True,
+            raw_docked=True,
+            returning=False,
+            capabilities=(),
+            raw_info={},
+            raw_attributes={},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+        entity.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        entity.async_write_ha_state = lambda: None
+        stop_started = asyncio.Event()
+        release_stop = asyncio.Event()
+        camera_disables = 0
+
+        async def _stop_session(_runtime: object, _session: object) -> bool:
+            stop_started.set()
+            await release_stop.wait()
+            return True
+
+        async def _disable() -> None:
+            nonlocal camera_disables
+            camera_disables += 1
+
+        entity._async_stop_session = _stop_session
+        entity._async_disable_camera_stream = _disable
+        task = asyncio.create_task(
+            entity._async_adopt_stream_session(
+                object(),
+                SimpleNamespace(
+                    transport=VIDEO_TRANSPORT_CLOUD,
+                    camera_toggle_managed=True,
+                ),
+                None,
+                transport=VIDEO_TRANSPORT_CLOUD,
+            )
+        )
+        await stop_started.wait()
+        task.cancel()
+        await asyncio.sleep(0)
+        release_stop.set()
+        cancelled = False
+        try:
+            await task
+        except asyncio.CancelledError:
+            cancelled = True
+        return cancelled, camera_disables
+
+    assert asyncio.run(_run()) == (True, 1)
 
 
 def test_runner_command_uses_windows_backslash_and_quote_semantics() -> None:
@@ -1541,6 +1793,49 @@ def test_video_camera_unload_is_bounded_when_every_cleanup_stage_hangs() -> None
         "camera_stream_disable",
         True,
     )
+
+
+def test_video_camera_fences_restart_until_timed_out_runtime_stop_finishes() -> None:
+    async def _run() -> tuple[bool, str | None, bool]:
+        shared_did = "shared-timeout-device"
+        pending_stop = asyncio.get_running_loop().create_future()
+        first = _uninitialized_entity()
+        first._descriptor = SimpleNamespace(
+            did=shared_did,
+            unique_id=shared_did,
+            model="dreame.mower.q2501a",
+        )
+        first.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        first.hass = SimpleNamespace(
+            async_add_executor_job=lambda *_args: pending_stop,
+        )
+
+        class _Runtime:
+            @staticmethod
+            def stop_live_stream(_session: object) -> None:
+                return None
+
+        with patch.object(
+            video_camera_module,
+            "_RUNTIME_SESSION_STOP_TIMEOUT",
+            0.001,
+        ):
+            stopped = await first._async_stop_session(_Runtime(), object())
+
+        second = _uninitialized_entity()
+        second._descriptor = first._descriptor
+        second.coordinator.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        second.async_write_ha_state = lambda: None
+        source = await second._async_start_stream()
+        assert source is None
+        error_stage = second._last_error_stage
+
+        pending_stop.set_result(None)
+        await asyncio.sleep(0)
+        await asyncio.sleep(0)
+        return stopped, error_stage, second._runtime_cleanup_pending
+
+    assert asyncio.run(_run()) == (False, "runtime_cleanup", False)
 
 
 def test_video_camera_cancellation_stops_completed_native_startup() -> None:


### PR DESCRIPTION
Fixes #53

## What changed

- remembers confirmed live-video support when later cloud snapshots omit the video metadata, including after a docked config-entry reload with a previously healthy cache
- retires the owned Home Assistant stream, XP2P session, and managed cloud video mode when the mower enters a state that blocks video
- rechecks mower state before cloud enable, XP2P startup, session adoption, and Home Assistant stream creation
- binds delayed state cleanup to the exact session it was scheduled for, so it cannot stop a replacement session
- bounds unload cleanup without allowing a still-running native stop to race the next stream or a reloaded entity
- records sanitized capability, cleanup, timeout, and state-transition diagnostics

## Validation

Ruff and the full test suite pass. Regression coverage includes stream → dock → undock recovery, docked reload, mower-state changes during startup, cancellation during rejected-session cleanup, replacement-session ownership, timed-out runtime-stop fencing, and stalled unload dependencies.

The remaining validation is a repeat of the reported sequence on the physical `dreame.mower.q2501a`.