### PR TITLE
Clear stale mower error state after recovery

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -219,6 +219,7 @@ class DreameLawnMowerClient:
         self._account_type = account_type
         self._descriptor = descriptor
         self._device: Any | None = None
+        self._latest_snapshot: DreameLawnMowerSnapshot | None = None
         self._latest_runtime_status_blob: DreameLawnMowerStatusBlob | None = None
         self._runtime_live_track_segments: tuple[
             tuple[tuple[int, int], ...],
@@ -322,7 +323,7 @@ class DreameLawnMowerClient:
             token=getattr(device, "token", None) or self._descriptor.token,
             raw=self._descriptor.raw,
         )
-        snapshot = snapshot_from_device(self._descriptor, device)
+        snapshot = self._snapshot_from_device(device)
         try:
             status_blob = await asyncio.to_thread(
                 self._sync_get_status_blob,
@@ -342,6 +343,7 @@ class DreameLawnMowerClient:
             cloud_device_info = self._latest_cloud_device_info
         if isinstance(cloud_device_info, Mapping):
             snapshot = snapshot_with_cloud_presence(snapshot, cloud_device_info)
+        self._latest_snapshot = snapshot
         return snapshot
 
     async def async_start_mowing(self) -> None:
@@ -1062,6 +1064,25 @@ class DreameLawnMowerClient:
             raise DreameLawnMowerConnectionError(str(err)) from err
         return device
 
+    def _snapshot_from_device(self, device: Any) -> DreameLawnMowerSnapshot:
+        """Normalize one coherent device state and retain recovery context."""
+        state_lock = getattr(device, "_state_lock", None)
+        if state_lock is None:
+            snapshot = snapshot_from_device(
+                self._descriptor,
+                device,
+                previous_snapshot=getattr(self, "_latest_snapshot", None),
+            )
+        else:
+            with state_lock:
+                snapshot = snapshot_from_device(
+                    self._descriptor,
+                    device,
+                    previous_snapshot=getattr(self, "_latest_snapshot", None),
+                )
+        self._latest_snapshot = snapshot
+        return snapshot
+
     def _sync_get_remote_control_support(
         self,
         refresh: bool = False,
@@ -1096,7 +1117,7 @@ class DreameLawnMowerClient:
         state_safe: bool | None = None
         state_block_reason: str | None = None
         if mapping:
-            snapshot = snapshot_from_device(self._descriptor, device)
+            snapshot = self._snapshot_from_device(device)
             state_block_reason = remote_control_block_reason(snapshot)
             state_safe = state_block_reason is None
 
@@ -1484,7 +1505,7 @@ class DreameLawnMowerClient:
         language: str | None,
     ) -> dict[str, Any]:
         device = self._sync_update_device()
-        snapshot = snapshot_from_device(self._descriptor, device)
+        snapshot = self._snapshot_from_device(device)
         errors: list[dict[str, str]] = []
         payload: dict[str, Any] = {
             "label": label,
@@ -2060,7 +2081,7 @@ class DreameLawnMowerClient:
         )
 
     def _guard_camera_stream_probe_idle(self, device: Any) -> None:
-        snapshot = snapshot_from_device(self._descriptor, device)
+        snapshot = self._snapshot_from_device(device)
         if reason := camera_stream_block_reason(snapshot):
             raise DreameLawnMowerConnectionError(reason)
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -9,7 +9,7 @@ import base64
 import traceback
 from datetime import datetime
 from random import randrange
-from threading import Timer
+from threading import RLock, Timer
 from typing import Any, Optional
 
 from .app_protocol import mower_realtime_property_name
@@ -171,6 +171,7 @@ class DreameMowerDevice:
         self.unknown_properties: dict[int, dict[str, Any]] = {}
         self.realtime_properties: dict[str, dict[str, Any]] = {}
         self.last_realtime_message: dict[str, Any] | None = None
+        self._state_lock = RLock()
         self.auto_switch_data: dict[DreameMowerAutoSwitchProperty, Any] = None
         self.ai_data: dict[DreameMowerStrAIProperty | DreameMowerAIProperty, Any] = None
         self.available: bool = False  # Last update is successful or not
@@ -320,44 +321,44 @@ class DreameMowerDevice:
             return
 
         _LOGGER.debug("Message Callback: %s", message)
-        self._remember_realtime_message(message)
+        with self._state_lock:
+            self._remember_realtime_message(message)
 
-        if "method" in message:
-            self.available = True
-            if message["method"] == "properties_changed" and "params" in message:
-                params = []
-                map_params = []
-                for param in message["params"]:
-                    matched_property = None
-                    properties = [prop for prop in DreameMowerProperty]
-                    for prop in properties:
-                        if prop in self.property_mapping:
-                            mapping = self.property_mapping[prop]
-                            _LOGGER.debug("Mapping: %s", mapping)
-                            if (
-                                "aiid" not in mapping
-                                and param["siid"] == mapping["siid"]
-                                and param["piid"] == mapping["piid"]
-                            ):
-                                matched_property = prop
-                                if prop in self._default_properties:
-                                    param["did"] = str(prop.value)
-                                    param["code"] = 0
-                                    params.append(param)
-                                else:
-                                    if (
+            if "method" in message:
+                self.available = True
+                if message["method"] == "properties_changed" and "params" in message:
+                    params = []
+                    map_params = []
+                    for param in message["params"]:
+                        matched_property = None
+                        properties = [prop for prop in DreameMowerProperty]
+                        for prop in properties:
+                            if prop in self.property_mapping:
+                                mapping = self.property_mapping[prop]
+                                _LOGGER.debug("Mapping: %s", mapping)
+                                if (
+                                    "aiid" not in mapping
+                                    and param["siid"] == mapping["siid"]
+                                    and param["piid"] == mapping["piid"]
+                                ):
+                                    matched_property = prop
+                                    if prop in self._default_properties:
+                                        param["did"] = str(prop.value)
+                                        param["code"] = 0
+                                        params.append(param)
+                                    elif (
                                         prop is DreameMowerProperty.OBJECT_NAME
                                         or prop is DreameMowerProperty.MAP_DATA
                                         or prop is DreameMowerProperty.ROBOT_TIME
                                         or prop is DreameMowerProperty.OLD_MAP_DATA
                                     ):
                                         map_params.append(param)
-                                break
-                    self._remember_realtime_property(param, matched_property)
-                if len(map_params) and self._map_manager:
-                    self._map_manager.handle_properties(map_params)
+                                    break
+                        self._remember_realtime_property(param, matched_property)
+                    if len(map_params) and self._map_manager:
+                        self._map_manager.handle_properties(map_params)
 
-                self._handle_properties(params)
+                    self._handle_properties(params)
 
     def _handle_properties(self, properties) -> bool:
         changed = False
@@ -556,6 +557,11 @@ class DreameMowerDevice:
             if property_enum is not None
             else mower_realtime_property_name(key)
         )
+        received_at = (
+            self.last_realtime_message.get("received_at")
+            if isinstance(self.last_realtime_message, dict)
+            else None
+        )
         self.realtime_properties[key] = {
             "siid": siid,
             "piid": piid,
@@ -563,7 +569,11 @@ class DreameMowerDevice:
             "code": payload.get("code"),
             "value": copy.deepcopy(payload.get("value")),
             "property_name": property_name,
-            "last_seen": time.time(),
+            "last_seen": (
+                received_at
+                if isinstance(received_at, (int, float))
+                else time.time()
+            ),
         }
 
     def _request_properties(self, properties: list[DreameMowerProperty] = None) -> bool:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -20,6 +20,7 @@ SUPPORTED_ACCOUNT_TYPES = ("dreame", "mova")
 SUPPORTED_MODEL_MARKER = ".mower."
 MIN_REMOTE_CONTROL_BATTERY_LEVEL = 20
 REMOTE_CONTROL_STATES = {"remote_control"}
+REALTIME_STATE_PROPERTY_KEY = "2.1"
 REALTIME_ERROR_PROPERTY_KEY = "2.2"
 
 MODEL_NAME_MAP = {
@@ -158,6 +159,76 @@ def _realtime_error_code_from_device(device: Any) -> int | None:
     return None if code in (None, -1) else code
 
 
+def _realtime_property_last_seen(device: Any, key: str) -> float | None:
+    """Return when a realtime property was received, if ordering is known."""
+    realtime_properties = getattr(device, "realtime_properties", {}) or {}
+    entry = realtime_properties.get(key)
+    if not isinstance(entry, Mapping):
+        return None
+    try:
+        return float(entry.get("last_seen"))
+    except (TypeError, ValueError):
+        return None
+
+
+def _fault_recovery_confirmed(
+    previous_snapshot: DreameLawnMowerSnapshot | None,
+    *,
+    current_state_is_operational: bool,
+    error_code: int | None,
+    realtime_error_code: int | None,
+    device: Any,
+    model: str | None,
+) -> bool:
+    """Return whether a newer operational transition supersedes a fault."""
+    if previous_snapshot is None or not current_state_is_operational:
+        return False
+
+    realtime_fault_code = _active_error_code_from_raw(
+        realtime_error_code,
+        model=model,
+    )
+    error_last_seen = _realtime_property_last_seen(
+        device,
+        REALTIME_ERROR_PROPERTY_KEY,
+    )
+    if (
+        previous_snapshot._error_suppression_active
+        and previous_snapshot._suppressed_error_code == error_code
+    ):
+        if realtime_fault_code is None:
+            return True
+        return bool(
+            realtime_fault_code == error_code
+            and previous_snapshot._suppressed_realtime_error_last_seen is not None
+            and error_last_seen is not None
+            and error_last_seen
+            <= previous_snapshot._suppressed_realtime_error_last_seen
+        )
+
+    if previous_snapshot.activity != "error":
+        return False
+
+    if realtime_fault_code is None:
+        return previous_snapshot.state in {
+            "error",
+            "paused",
+            "monitoring_paused",
+        }
+    if realtime_fault_code != error_code:
+        return False
+
+    state_last_seen = _realtime_property_last_seen(
+        device,
+        REALTIME_STATE_PROPERTY_KEY,
+    )
+    return bool(
+        state_last_seen is not None
+        and error_last_seen is not None
+        and state_last_seen > error_last_seen
+    )
+
+
 def _raw_error_code_from_device(device: Any, error_obj: Any) -> int | None:
     """Return the unmodified error property before enum normalization."""
     try:
@@ -243,6 +314,21 @@ class DreameLawnMowerSnapshot:
     status_notice_source: str | None = None
     raw_error_code: int | None = None
     realtime_error_code: int | None = None
+    _error_suppression_active: bool = field(
+        default=False,
+        repr=False,
+        compare=False,
+    )
+    _suppressed_error_code: int | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    _suppressed_realtime_error_last_seen: float | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     firmware_version: str | None = None
     hardware_version: str | None = None
     serial_number: str | None = None
@@ -901,6 +987,8 @@ def descriptor_from_cloud_record(
 def snapshot_from_device(
     descriptor: DreameLawnMowerDescriptor,
     device: Any,
+    *,
+    previous_snapshot: DreameLawnMowerSnapshot | None = None,
 ) -> DreameLawnMowerSnapshot:
     """Convert the upstream mower device object into a normalized snapshot."""
 
@@ -1041,17 +1129,37 @@ def snapshot_from_device(
         "smart_charging",
     }
 
-    if (
-        has_error
-        and (
+    suppressed_error_code: int | None = None
+    suppressed_realtime_error_last_seen: float | None = None
+    error_suppression_active = False
+    if has_error and _fault_recovery_confirmed(
+        previous_snapshot,
+        current_state_is_operational=(
             state in mowing_states
             or state in returning_states
             or state in docked_states
-        )
+        ),
+        error_code=error_code,
+        realtime_error_code=realtime_error_code,
+        device=device,
+        model=descriptor.model,
     ):
         # The mower can retain the last fault code after it resumes or docks.
-        # Current operational state is stronger evidence that the fault cleared;
-        # keep raw codes for diagnostics without latching entity activity.
+        # Release it only after an observed fault is superseded by operational
+        # evidence; fresh realtime faults remain authoritative.
+        error_suppression_active = True
+        suppressed_error_code = error_code
+        if (
+            _active_error_code_from_raw(
+                realtime_error_code,
+                model=descriptor.model,
+            )
+            == suppressed_error_code
+        ):
+            suppressed_realtime_error_last_seen = _realtime_property_last_seen(
+                device,
+                REALTIME_ERROR_PROPERTY_KEY,
+            )
         error_code = None
         error_name = None
         error_text = None
@@ -1177,6 +1285,11 @@ def snapshot_from_device(
         status_notice_source=status_notice_source,
         raw_error_code=raw_error_code,
         realtime_error_code=realtime_error_code,
+        _error_suppression_active=error_suppression_active,
+        _suppressed_error_code=suppressed_error_code,
+        _suppressed_realtime_error_last_seen=(
+            suppressed_realtime_error_last_seen
+        ),
         firmware_version=getattr(
             getattr(device, "info", None),
             "firmware_version",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -1041,6 +1041,23 @@ def snapshot_from_device(
         "smart_charging",
     }
 
+    if (
+        has_error
+        and (
+            state in mowing_states
+            or state in returning_states
+            or state in docked_states
+        )
+    ):
+        # The mower can retain the last fault code after it resumes or docks.
+        # Current operational state is stronger evidence that the fault cleared;
+        # keep raw codes for diagnostics without latching entity activity.
+        error_code = None
+        error_name = None
+        error_text = None
+        has_error = False
+        error_source = None
+
     if has_error:
         activity = "error"
     elif state in paused_states:

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from types import SimpleNamespace
 
 import pytest
@@ -9,12 +10,19 @@ import pytest
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     device_code_semantics,
 )
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
+    DreameLawnMowerClient,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device import (
     DreameMowerDeviceStatus,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    DreameLawnMowerSnapshot,
     descriptor_from_cloud_record,
     snapshot_from_device,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.types import (
+    DreameMowerProperty,
 )
 
 MowerDeviceCodeTier = device_code_semantics.MowerDeviceCodeTier
@@ -41,7 +49,7 @@ class _ErrorDevice:
             task_status_name="unknown",
             error=SimpleNamespace(value=code),
             error_name=inherited_name,
-            has_error=True,
+            has_error=code not in (None, -1),
             battery_level=80,
             paused=True,
             returning=False,
@@ -75,9 +83,12 @@ def _snapshot(
     inherited_name: str,
     *,
     realtime_error_code: int | None = None,
+    realtime_error_last_seen: float | None = None,
+    realtime_state_last_seen: float | None = None,
     state: str = "PAUSED",
     model: str = "dreame.mower.g2408",
-):
+    previous_snapshot: DreameLawnMowerSnapshot | None = None,
+) -> DreameLawnMowerSnapshot:
     descriptor = descriptor_from_cloud_record(
         {"did": "test", "model": model, "name": "Mower"},
         account_type="dreame",
@@ -86,8 +97,20 @@ def _snapshot(
     assert descriptor is not None
     device = _ErrorDevice(code, inherited_name, state=state)
     if realtime_error_code is not None:
-        device.realtime_properties = {"2.2": {"value": realtime_error_code}}
-    return snapshot_from_device(descriptor, device)
+        device.realtime_properties["2.2"] = {
+            "value": realtime_error_code,
+            "last_seen": realtime_error_last_seen,
+        }
+    if realtime_state_last_seen is not None:
+        device.realtime_properties["2.1"] = {
+            "value": state,
+            "last_seen": realtime_state_last_seen,
+        }
+    return snapshot_from_device(
+        descriptor,
+        device,
+        previous_snapshot=previous_snapshot,
+    )
 
 
 @pytest.mark.parametrize(
@@ -174,12 +197,12 @@ def test_operational_state_releases_stale_fault_code(
     state: str,
     expected_activity: str,
 ) -> None:
-    fault = _snapshot(0, "drop", realtime_error_code=0)
+    fault = _snapshot(0, "drop")
     recovered = _snapshot(
         0,
         "drop",
-        realtime_error_code=0,
         state=state,
+        previous_snapshot=fault,
     )
 
     assert fault.activity == "error"
@@ -189,15 +212,19 @@ def test_operational_state_releases_stale_fault_code(
     assert recovered.error_display is None
     assert recovered.error_source is None
     assert recovered.raw_error_code == 0
-    assert recovered.realtime_error_code == 0
+    assert recovered.realtime_error_code is None
 
 
 def test_operational_state_releases_stale_realtime_only_fault() -> None:
+    fault = _snapshot(0, "drop")
     snapshot = _snapshot(
         None,
         "",
         realtime_error_code=0,
+        realtime_error_last_seen=100,
+        realtime_state_last_seen=200,
         state="MOWING",
+        previous_snapshot=fault,
     )
 
     assert snapshot.activity == "mowing"
@@ -206,6 +233,185 @@ def test_operational_state_releases_stale_realtime_only_fault() -> None:
     assert snapshot.error_source is None
     assert snapshot.raw_error_code is None
     assert snapshot.realtime_error_code == 0
+
+
+def test_recovered_fault_stays_released_across_repeated_refreshes() -> None:
+    fault = _snapshot(0, "drop")
+    recovered = _snapshot(
+        0,
+        "drop",
+        state="MOWING",
+        previous_snapshot=fault,
+    )
+    repeated = _snapshot(
+        0,
+        "drop",
+        state="MOWING",
+        previous_snapshot=recovered,
+    )
+
+    assert recovered.activity == "mowing"
+    assert repeated.activity == "mowing"
+    assert repeated.error_code is None
+    assert repeated.raw_error_code == 0
+
+
+@pytest.mark.parametrize(
+    ("state_last_seen", "error_last_seen"),
+    [
+        (None, None),
+        (100, 100),
+        (100, 200),
+    ],
+)
+def test_fresh_realtime_fault_overrides_operational_state(
+    state_last_seen: float | None,
+    error_last_seen: float | None,
+) -> None:
+    fault = _snapshot(0, "drop")
+    snapshot = _snapshot(
+        None,
+        "",
+        realtime_error_code=0,
+        realtime_error_last_seen=error_last_seen,
+        realtime_state_last_seen=state_last_seen,
+        state="MOWING",
+        previous_snapshot=fault,
+    )
+
+    assert snapshot.activity == "error"
+    assert snapshot.error_code == 0
+    assert snapshot.error_display == "Robot lifted"
+    assert snapshot.error_source == "realtime_property_2.2"
+
+
+def test_newer_operational_event_releases_realtime_fault_seen_while_mowing() -> None:
+    fresh_fault = _snapshot(
+        None,
+        "",
+        realtime_error_code=0,
+        realtime_error_last_seen=200,
+        realtime_state_last_seen=100,
+        state="MOWING",
+    )
+    recovered = _snapshot(
+        None,
+        "",
+        realtime_error_code=0,
+        realtime_error_last_seen=200,
+        realtime_state_last_seen=300,
+        state="MOWING",
+        previous_snapshot=fresh_fault,
+    )
+
+    assert fresh_fault.activity == "error"
+    assert recovered.activity == "mowing"
+    assert recovered.error_code is None
+    assert recovered.realtime_error_code == 0
+
+
+def test_newer_realtime_fault_relatches_after_recovery() -> None:
+    fault = _snapshot(0, "drop")
+    recovered = _snapshot(
+        None,
+        "",
+        realtime_error_code=0,
+        realtime_error_last_seen=100,
+        realtime_state_last_seen=200,
+        state="MOWING",
+        previous_snapshot=fault,
+    )
+    relatched = _snapshot(
+        None,
+        "",
+        realtime_error_code=0,
+        realtime_error_last_seen=300,
+        realtime_state_last_seen=200,
+        state="MOWING",
+        previous_snapshot=recovered,
+    )
+
+    assert recovered.activity == "mowing"
+    assert relatched.activity == "error"
+    assert relatched.error_code == 0
+    assert relatched.error_source == "realtime_property_2.2"
+
+
+def test_fresh_bare_error_flag_is_not_mistaken_for_suppression() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {"did": "test", "model": "dreame.mower.g2408", "name": "Mower"},
+        account_type="dreame",
+        country="eu",
+    )
+    assert descriptor is not None
+    healthy = _snapshot(None, "", state="CHARGING")
+    device = _ErrorDevice(None, "", state="CHARGING")
+    device.status.has_error = True
+
+    snapshot = snapshot_from_device(
+        descriptor,
+        device,
+        previous_snapshot=healthy,
+    )
+
+    assert snapshot.activity == "error"
+    assert snapshot.error_code is None
+    assert snapshot.error_source == "status"
+
+
+def test_client_carries_fault_state_into_recovery_reconciliation() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {"did": "test", "model": "dreame.mower.g2408", "name": "Mower"},
+        account_type="dreame",
+        country="eu",
+    )
+    assert descriptor is not None
+    fault = _snapshot(0, "drop")
+    device = _ErrorDevice(0, "drop", state="MOWING")
+    client = object.__new__(DreameLawnMowerClient)
+    client._descriptor = descriptor
+    client._latest_snapshot = fault
+    client._sync_update_device = lambda: device
+    client._sync_get_status_blob = lambda *_args: None
+    client._sync_get_cached_cloud_device_info = lambda: None
+
+    recovered = asyncio.run(client.async_refresh())
+    repeated = asyncio.run(client.async_refresh())
+
+    assert recovered.activity == "mowing"
+    assert recovered.error_code is None
+    assert repeated.activity == "mowing"
+    assert repeated.error_code is None
+    assert client._latest_snapshot is repeated
+
+
+def test_remote_control_support_reuses_recovered_fault_context() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {"did": "test", "model": "dreame.mower.g2408", "name": "Mower"},
+        account_type="dreame",
+        country="eu",
+    )
+    assert descriptor is not None
+    fault = _snapshot(0, "drop")
+    device = _ErrorDevice(0, "drop", state="CHARGING")
+    device.property_mapping = {
+        DreameMowerProperty.REMOTE_CONTROL: {"siid": 4, "piid": 15}
+    }
+    device.status.status = None
+    device.status.fast_mapping = False
+    device._remote_control = False
+    client = object.__new__(DreameLawnMowerClient)
+    client._descriptor = descriptor
+    client._latest_snapshot = fault
+    client._ensure_device = lambda: device
+
+    support = client._sync_get_remote_control_support(refresh=False)
+
+    assert support.supported is True
+    assert support.state_safe is True
+    assert support.state_block_reason is None
+    assert client._latest_snapshot.activity == "docked"
+    assert client._latest_snapshot.error_code is None
 
 
 def test_recoverable_alert_does_not_latch_error() -> None:

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -26,7 +26,7 @@ mower_fault_active = device_code_semantics.mower_fault_active
 class _ErrorDevice:
     def __init__(
         self,
-        code: int,
+        code: int | None,
         inherited_name: str,
         *,
         state: str = "PAUSED",
@@ -71,7 +71,7 @@ class _ErrorDevice:
 
 
 def _snapshot(
-    code: int,
+    code: int | None,
     inherited_name: str,
     *,
     realtime_error_code: int | None = None,
@@ -160,6 +160,52 @@ def test_mower_native_name_replaces_vacuum_name() -> None:
     assert snapshot.error_name == "robot_tilted"
     assert snapshot.error_text is None
     assert snapshot.error_display == "Robot tilted"
+
+
+@pytest.mark.parametrize(
+    ("state", "expected_activity"),
+    [
+        ("MOWING", "mowing"),
+        ("RETURNING", "returning"),
+        ("CHARGING", "docked"),
+    ],
+)
+def test_operational_state_releases_stale_fault_code(
+    state: str,
+    expected_activity: str,
+) -> None:
+    fault = _snapshot(0, "drop", realtime_error_code=0)
+    recovered = _snapshot(
+        0,
+        "drop",
+        realtime_error_code=0,
+        state=state,
+    )
+
+    assert fault.activity == "error"
+    assert recovered.activity == expected_activity
+    assert recovered.error_code is None
+    assert recovered.error_name is None
+    assert recovered.error_display is None
+    assert recovered.error_source is None
+    assert recovered.raw_error_code == 0
+    assert recovered.realtime_error_code == 0
+
+
+def test_operational_state_releases_stale_realtime_only_fault() -> None:
+    snapshot = _snapshot(
+        None,
+        "",
+        realtime_error_code=0,
+        state="MOWING",
+    )
+
+    assert snapshot.activity == "mowing"
+    assert snapshot.error_code is None
+    assert snapshot.error_display is None
+    assert snapshot.error_source is None
+    assert snapshot.raw_error_code is None
+    assert snapshot.realtime_error_code == 0
 
 
 def test_recoverable_alert_does_not_latch_error() -> None:

--- a/tests/test_unknown_properties.py
+++ b/tests/test_unknown_properties.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from threading import RLock
 from types import SimpleNamespace
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device import (
@@ -19,6 +20,7 @@ def _device_stub() -> tuple[DreameMowerDevice, list[str]]:
     device.unknown_properties = {}
     device.realtime_properties = {}
     device.last_realtime_message = None
+    device._state_lock = RLock()
     device._dirty_data = {}
     device._property_update_callback = {}
     device._ready = True
@@ -158,3 +160,37 @@ def test_message_callback_tracks_realtime_properties_and_unmapped_pairs() -> Non
     assert device.realtime_properties["9.4"]["value"] == {"blob": 123}
     assert device.last_realtime_message is not None
     assert device.last_realtime_message["message"]["method"] == "properties_changed"
+    assert len(
+        {
+            entry["last_seen"]
+            for entry in device.realtime_properties.values()
+        }
+    ) == 1
+
+
+def test_message_callback_applies_known_and_realtime_state_under_one_lock() -> None:
+    device, _updates = _device_stub()
+    original_handle_properties = device._handle_properties
+    lock_owned_during_update = False
+
+    def handle_properties(properties: list[dict[str, object]]) -> bool:
+        nonlocal lock_owned_during_update
+        lock_owned_during_update = device._state_lock._is_owned()
+        assert "2.1" in device.realtime_properties
+        assert "2.2" in device.realtime_properties
+        return original_handle_properties(properties)
+
+    device._handle_properties = handle_properties
+
+    DreameMowerDevice._message_callback(
+        device,
+        {
+            "method": "properties_changed",
+            "params": [
+                {"siid": 2, "piid": 1, "value": 1},
+                {"siid": 2, "piid": 2, "value": 0},
+            ],
+        },
+    )
+
+    assert lock_owned_during_update is True


### PR DESCRIPTION
## Summary

- clear a retained mower fault only after an observed fault is superseded by operational state
- keep fresh realtime `2.2` faults authoritative, including a newer occurrence of the same code
- preserve recovery across later refreshes and every client-owned snapshot consumer
- apply each MQTT property notification as one coherent state update

Some mowers retain the last fault code after they resume, return, or dock. The normalized snapshot now remembers the recovered fault event instead of treating every operational state as healthy. A newer realtime fault relatches the error, while a newer operational `2.1` event can supersede an older `2.2` event. Raw status and realtime codes remain available for diagnostics.

Validation: 803 tests passed; Ruff passed.

Fixes #62