### PR TITLE
Establish client maintenance guardrails

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -110,13 +110,6 @@ from .models import (
     remote_control_block_reason,
     remote_control_state_safe,
 )
-from .point_cloud import (
-    DEFAULT_POINT_CLOUD_MAX_BYTES,
-    DreameLawnMowerPointCloudDownload,
-    DreameLawnMowerPointCloudError,
-    DreameLawnMowerPointCloudMetadata,
-    parse_pcd_metadata,
-)
 from .mowing_preferences import (
     MOWING_PREFERENCE_MODE_FIELD,
     MOWING_PREFERENCE_PROPERTY_KEY,
@@ -135,6 +128,13 @@ from .mowing_tasks import (
     build_zone_mowing_request,
     ensure_mowing_task_succeeded,
 )
+from .point_cloud import (
+    DEFAULT_POINT_CLOUD_MAX_BYTES,
+    DreameLawnMowerPointCloudDownload,
+    DreameLawnMowerPointCloudError,
+    DreameLawnMowerPointCloudMetadata,
+    parse_pcd_metadata,
+)
 from .schedule import (
     EMPTY_SCHEDULE_VERSION,
     SCHEDULE_CHUNK_SIZE,
@@ -149,6 +149,10 @@ from .schedule import (
     schedule_task_summary,
 )
 from .stream_health import DreameLawnMowerStreamUrlProbeResult, probe_stream_url
+from .video_provisioning_status import (
+    XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING,
+    classify_xp2p_provisioning_issue,
+)
 from .video_runtime import (
     DEFAULT_COMMAND_TIMEOUT_US,
     DEFAULT_LAN_FLV_PATH_TEMPLATE,
@@ -164,10 +168,6 @@ from .video_runtime import (
     DreameLawnMowerXp2pProcessRunner,
     DreameLawnMowerXp2pRuntimeDiagnostics,
     diagnose_native_xp2p_runtime,
-)
-from .video_provisioning_status import (
-    XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING,
-    classify_xp2p_provisioning_issue,
 )
 from .xp2p_config import (
     DreameLawnMowerXp2pConfigError,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/apk_research.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/apk_research.py
@@ -312,7 +312,10 @@ def analyze_dreamehome_assets(
     for file_path in sorted(path.rglob("*")):
         if not file_path.is_file():
             continue
-        if normalized_suffixes and file_path.suffix.casefold() not in normalized_suffixes:
+        if (
+            normalized_suffixes
+            and file_path.suffix.casefold() not in normalized_suffixes
+        ):
             continue
         try:
             stat = file_path.stat()
@@ -568,7 +571,13 @@ def _is_candidate_source_file(name: str) -> bool:
     )
 
 
-def _context_snippet(text: str, index: int, term_length: int, *, context_chars: int) -> str:
+def _context_snippet(
+    text: str,
+    index: int,
+    term_length: int,
+    *,
+    context_chars: int,
+) -> str:
     start = max(0, index - context_chars)
     end = min(len(text), index + term_length + context_chars)
     snippet = text[start:end].replace("\r", " ").replace("\n", " ").strip()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -41,12 +41,12 @@ from .batch_device_data import (
     decode_batch_schedule_payload,
 )
 from .camera_probe import CAMERA_PROBE_PROPERTY_KEYS, build_camera_probe_payload
+from .deadline import DeadlineExceededError, run_with_deadline
 from .debug_ota_catalog import (
     build_debug_ota_catalog_url,
     normalize_debug_ota_catalog_payload,
 )
 from .docking import async_stop_then_dock
-from .deadline import DeadlineExceededError, run_with_deadline
 from .exceptions import DeviceException, InvalidActionException
 from .maintenance import (
     CMS_GET_REQUEST,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/deadline.py
@@ -5,9 +5,8 @@ from __future__ import annotations
 import threading
 import time
 from collections.abc import Callable
-from typing import Any, TypeVar
+from typing import Any
 
-_ResultT = TypeVar("_ResultT")
 _MAX_ABANDONED_OPERATIONS = 4
 _operation_slots = threading.BoundedSemaphore(_MAX_ABANDONED_OPERATIONS)
 
@@ -26,11 +25,11 @@ def _close_if_possible(value: Any) -> None:
             pass
 
 
-def run_with_deadline(
-    operation: Callable[[], _ResultT],
+def run_with_deadline[ResultT](
+    operation: Callable[[], ResultT],
     *,
     deadline: float,
-) -> _ResultT:
+) -> ResultT:
     """Run a blocking operation without letting it retain its caller forever.
 
     Socket timeouts only bound periods without network activity. A peer can still

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -5458,12 +5458,12 @@ class DreameMowerDeviceInfo:
                 self.version = int(firmware_version[1])
 
     def __repr__(self):
-        return "%s v%s (%s) @ %s - token: %s" % (
-            self.model,
-            self.version,
-            self.mac,
-            self.network_interface["localIp"] if self.network_interface else "",
+        local_ip = (
+            self.network_interface.get("localIp", "")
+            if self.network_interface
+            else ""
         )
+        return f"{self.model} v{self.version} ({self.mac_address}) @ {local_ip}"
 
     @property
     def network_interface(self) -> str:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map.py
@@ -5656,6 +5656,107 @@ class DreameMowerMapRenderer:
         self.render_complete = True
         return self._to_buffer(self._image if self._cache else image)
 
+    @staticmethod
+    def _segments_layer_needs_update(
+        *,
+        cache_enabled,
+        previous_map,
+        map_data,
+        has_cached_layer,
+    ):
+        return (
+            not cache_enabled
+            or previous_map is None
+            or previous_map.segments != map_data.segments
+            or previous_map.rotation != map_data.rotation
+            or previous_map.cleaning_map != map_data.cleaning_map
+            or (
+                not previous_map.cleaning_map
+                and previous_map.active_segments != map_data.active_segments
+            )
+            or (
+                not previous_map.cleaning_map
+                and previous_map.hidden_segments != map_data.hidden_segments
+            )
+            or (
+                previous_map.cleaning_map
+                and previous_map.neglected_segments != map_data.neglected_segments
+            )
+            or bool(
+                (not map_data.saved_map or map_data.recovery_map)
+                and previous_map.cleanset
+            )
+            != bool(
+                (not map_data.saved_map or map_data.recovery_map)
+                and map_data.cleanset
+            )
+            or not has_cached_layer
+        )
+
+    @staticmethod
+    def _segment_needs_render(
+        *,
+        cache_enabled,
+        previous_map,
+        cached_segments,
+        map_data,
+        segment_id,
+        segment,
+    ):
+        if not cache_enabled or previous_map is None:
+            return True
+
+        previous_segments = previous_map.segments or {}
+        if segment_id not in cached_segments or segment_id not in previous_segments:
+            return True
+        if (
+            previous_segments[segment_id] != segment
+            or previous_map.rotation != map_data.rotation
+        ):
+            return True
+
+        map_has_cleanset = bool(
+            (not map_data.saved_map or map_data.recovery_map) and map_data.cleanset
+        )
+        previous_map_has_cleanset = bool(
+            (not map_data.saved_map or map_data.recovery_map)
+            and previous_map.cleanset
+        )
+        segment_is_visible = bool(
+            (not map_data.active_segments or segment_id in map_data.active_segments)
+            and (
+                not map_data.hidden_segments
+                or segment_id not in map_data.hidden_segments
+            )
+            and not map_data.cleaning_map
+        )
+        previous_segment_was_visible = bool(
+            (
+                not previous_map.active_segments
+                or segment_id in previous_map.active_segments
+            )
+            and (
+                not previous_map.hidden_segments
+                or segment_id not in previous_map.hidden_segments
+            )
+            and not previous_map.cleaning_map
+        )
+        segment_is_neglected = bool(
+            map_data.cleaning_map
+            and map_data.neglected_segments
+            and segment_id in map_data.neglected_segments
+        )
+        previous_segment_was_neglected = bool(
+            previous_map.cleaning_map
+            and previous_map.neglected_segments
+            and segment_id in previous_map.neglected_segments
+        )
+        return (
+            map_has_cleanset != previous_map_has_cleanset
+            or segment_is_visible != previous_segment_was_visible
+            or segment_is_neglected != previous_segment_was_neglected
+        )
+
     def render_objects(self, cached_layers, map_data, robot_status, station_status, map_image, scale):
         layer_size = (int(map_image.size[0] * scale), int(map_image.size[1] * scale))
         line_width = 3 if map_data.dimensions.scale > 2 else 1
@@ -5868,17 +5969,11 @@ class DreameMowerMapRenderer:
             )
         ):
             layers.append(layer)
-            if (
-                not self._cache
-                or self._map_data is None
-                or self._map_data.segments != map_data.segments
-                or self._map_data.rotation != map_data.rotation
-                or (not self._map_data.cleaning_map and self._map_data.active_segments != map_data.active_segments)
-                or (not self._map_data.cleaning_map and self._map_data.hidden_segments != map_data.hidden_segments)
-                or (self._map_data.cleaning_map and self._map_data.neglected_segments != map_data.neglected_segments)
-                or bool((not map_data.saved_map or map_data.recovery_map) and self._map_data.cleanset)
-                != bool((not map_data.saved_map or map_data.recovery_map) and map_data.cleanset)
-                or not cached_layers.get(layer)
+            if self._segments_layer_needs_update(
+                cache_enabled=self._cache,
+                previous_map=self._map_data,
+                map_data=map_data,
+                has_cached_layer=bool(cached_layers.get(layer)),
             ):
                 if MapRendererLayer.SEGMENT not in cached_layers:
                     cached_layers[MapRendererLayer.SEGMENT] = {}
@@ -5890,43 +5985,13 @@ class DreameMowerMapRenderer:
                 changed = False
                 for k in sorted(map_data.segments.keys()):
                     v = map_data.segments[k]
-                    if (
-                        not self._cache
-                        or self._map_data is None
-                        or k not in cached_layers[MapRendererLayer.SEGMENT]
-                        or not self._map_data.segments
-                        or k not in self._map_data.segments
-                        or self._map_data.segments[k] != v
-                        or self._map_data.rotation != map_data.rotation
-                        or bool((not map_data.saved_map or map_data.recovery_map) and self._map_data.cleanset)
-                        != bool((not map_data.saved_map or map_data.recovery_map) and map_data.cleanset)
-                        or bool(
-                            (
-                                (not map_data.active_segments or k in map_data.active_segments)
-                                and (not map_data.hidden_segments or k not in map_data.hidden_segments)
-                                and not map_data.cleaning_map
-                            )
-                        )
-                        != bool(
-                            (
-                                (not self._map_data.active_segments or k in self._map_data.active_segments)
-                                and (not self._map_data.hidden_segments or k not in self._map_data.hidden_segments)
-                                and not self._map_data.cleaning_map
-                            )
-                        )
-                        or bool(
-                            (
-                                map_data.cleaning_map
-                                and (map_data.neglected_segments and k in map_data.neglected_segments)
-                            )
-                        )
-                        != bool(
-                            (
-                                self._map_data.cleaning_map
-                                and self._map_data.neglected_segments
-                                and k in self._map_data.neglected_segments
-                            )
-                        ),
+                    if self._segment_needs_render(
+                        cache_enabled=self._cache,
+                        previous_map=self._map_data,
+                        cached_segments=cached_layers[MapRendererLayer.SEGMENT],
+                        map_data=map_data,
+                        segment_id=k,
+                        segment=v,
                     ):
                         changed = True
                         cached_layers[MapRendererLayer.SEGMENT][k] = self.render_segment(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/types.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/types.py
@@ -1592,7 +1592,7 @@ class Segment(Zone):
         index: int = 0,
         type: int = 0,
         icon: str = None,
-        neighbors: List[int] = [],
+        neighbors: Optional[List[int]] = None,
         cleaning_times: int = None,
         cleaning_mode: int = None,
         order: int = None,
@@ -1607,9 +1607,10 @@ class Segment(Zone):
         self.type = type
         self.index = index
         self.icon = icon
-        self.neighbors = neighbors
+        self.neighbors = neighbors if neighbors is not None else []
         self.order = order
         self.cleaning_times = cleaning_times
+        self.cleaning_mode = cleaning_mode
         self.cleaning_route = None
         self.color_index = None
         self.floor_material = None
@@ -1739,6 +1740,7 @@ class Segment(Zone):
             or self.order != other.order
             or self.cleaning_times != other.cleaning_times
             or self.cleaning_mode != other.cleaning_mode
+            or self.cleaning_route != other.cleaning_route
             or self.floor_material != other.floor_material
             or self.floor_material_direction != other.floor_material_direction
             or self.floor_material_rotated_direction != other.floor_material_rotated_direction

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/video_credentials.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/video_credentials.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from Crypto.Cipher import AES
 
-
 # Dreamehome Android 2.5.8.1 supplies this app-level key to TXVideoSdk.
 # The authenticated getIdentity response returns an encrypted QCloud pair;
 # TXVideoSdk keeps the encrypted values for QCloud and decrypts the same pair

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,7 +56,16 @@ addopts = "-q"
 [tool.ruff]
 target-version = "py313"
 line-length = 88
-exclude = ["custom_components/dreame_lawn_mower/dreame_lawn_mower_client"]
+exclude = [
+  # These inherited protocol/map modules are being modernized in bounded
+  # refactors. Keep the rest of the reusable client under normal CI linting.
+  "custom_components/dreame_lawn_mower/dreame_lawn_mower_client/const.py",
+  "custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py",
+  "custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map.py",
+  "custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py",
+  "custom_components/dreame_lawn_mower/dreame_lawn_mower_client/resources.py",
+  "custom_components/dreame_lawn_mower/dreame_lawn_mower_client/types.py",
+]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "B", "UP"]

--- a/tests/test_device_info.py
+++ b/tests/test_device_info.py
@@ -1,0 +1,22 @@
+"""Regression contracts for device information projection."""
+
+from __future__ import annotations
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device import (
+    DreameMowerDeviceInfo,
+)
+
+
+def test_device_info_repr_is_safe_and_complete() -> None:
+    info = DreameMowerDeviceInfo(
+        {
+            "model": "dreame.mower.g2408",
+            "fw_ver": "4.3.6_0320",
+            "mac": "00:11:22:33:44:55",
+            "netif": {"localIp": "192.0.2.10"},
+        }
+    )
+
+    assert repr(info) == (
+        "dreame.mower.g2408 v320 (00:11:22:33:44:55) @ 192.0.2.10"
+    )

--- a/tests/test_legacy_map_renderer.py
+++ b/tests/test_legacy_map_renderer.py
@@ -1,0 +1,103 @@
+"""Regression contracts for the inherited map renderer."""
+
+from __future__ import annotations
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.map import (
+    DreameMowerMapRenderer,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.types import (
+    MapData,
+    Segment,
+)
+
+
+def _map_with_segment() -> MapData:
+    map_data = MapData()
+    map_data.segments = {1: Segment(1)}
+    map_data.rotation = 0
+    map_data.saved_map = False
+    map_data.recovery_map = False
+    map_data.cleanset = {}
+    map_data.active_segments = None
+    map_data.hidden_segments = None
+    map_data.cleaning_map = False
+    map_data.neglected_segments = None
+    return map_data
+
+
+def test_unchanged_cached_segment_does_not_render_again() -> None:
+    previous_map = _map_with_segment()
+    current_map = _map_with_segment()
+
+    assert (
+        DreameMowerMapRenderer._segment_needs_render(
+            cache_enabled=True,
+            previous_map=previous_map,
+            cached_segments={1: object()},
+            map_data=current_map,
+            segment_id=1,
+            segment=current_map.segments[1],
+        )
+        is False
+    )
+
+
+def test_changed_cached_segment_renders_again() -> None:
+    previous_map = _map_with_segment()
+    current_map = _map_with_segment()
+    current_map.segments[1].order = 2
+
+    assert (
+        DreameMowerMapRenderer._segment_needs_render(
+            cache_enabled=True,
+            previous_map=previous_map,
+            cached_segments={1: object()},
+            map_data=current_map,
+            segment_id=1,
+            segment=current_map.segments[1],
+        )
+        is True
+    )
+
+
+def test_route_change_renders_cached_segment_again() -> None:
+    previous_map = _map_with_segment()
+    current_map = _map_with_segment()
+    current_map.segments[1].cleaning_route = 2
+
+    assert (
+        DreameMowerMapRenderer._segment_needs_render(
+            cache_enabled=True,
+            previous_map=previous_map,
+            cached_segments={1: object()},
+            map_data=current_map,
+            segment_id=1,
+            segment=current_map.segments[1],
+        )
+        is True
+    )
+
+
+def test_cleaning_map_transition_invalidates_segment_layer() -> None:
+    previous_map = _map_with_segment()
+    current_map = _map_with_segment()
+    current_map.cleaning_map = True
+
+    assert (
+        DreameMowerMapRenderer._segments_layer_needs_update(
+            cache_enabled=True,
+            previous_map=previous_map,
+            map_data=current_map,
+            has_cached_layer=True,
+        )
+        is True
+    )
+
+
+def test_segments_do_not_share_default_neighbors() -> None:
+    first = Segment(1)
+    second = Segment(2)
+
+    first.neighbors.append(2)
+
+    assert second.neighbors == []


### PR DESCRIPTION
## What changed

- apply the normal Ruff rules to the modern bundled client code instead of excluding the entire package
- keep six inherited protocol/map modules as explicit, temporary legacy exceptions so cleanup can proceed in reviewable steps without a repository-wide formatting diff
- repair segment renderer cache invalidation for route and cleaning-map changes
- initialize segment state consistently and avoid a shared mutable neighbors list
- make device information diagnostics safe and deterministic
- add focused regression contracts for the repaired behavior

## Why

The reusable client is the core behavior owner, but its blanket lint exclusion allowed correctness defects to hide inside a few very large legacy modules. This establishes a reliable baseline before those modules are decomposed by responsibility. It deliberately avoids broad reformatting or API changes.

## Validation

- 858 tests passed
- Ruff passed across the repository
- `git diff --check` passed
- independent read-only review completed; both cache findings were fixed and confirmed