### PR TITLE
Recover video availability after stale returning state

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -906,13 +906,6 @@ def camera_stream_block_reason(snapshot: Any) -> str | None:
         )
     if bool(raw_attributes.get("mapping")) or bool(raw_attributes.get("fast_mapping")):
         return "Camera stream handshake probe is blocked while mapping."
-    if (
-        bool(getattr(snapshot, "returning", False))
-        or state == "returning"
-        or activity == "returning"
-        or bool(raw_attributes.get("returning"))
-    ):
-        return "Camera stream handshake probe is blocked while returning to dock."
 
     known_video_activity = (
         bool(getattr(snapshot, "mowing", False))
@@ -920,6 +913,17 @@ def camera_stream_block_reason(snapshot: Any) -> str | None:
         or state in {"mowing", "paused"}
         or activity in {"mowing", "paused"}
     )
+    if (
+        bool(getattr(snapshot, "returning", False))
+        or state == "returning"
+        or activity == "returning"
+        or (
+            bool(raw_attributes.get("returning"))
+            and not known_video_activity
+        )
+    ):
+        return "Camera stream handshake probe is blocked while returning to dock."
+
     if bool(raw_attributes.get("running")) and not known_video_activity:
         return (
             "Camera stream handshake probe is blocked while the mower reports "

--- a/tests/test_camera_features.py
+++ b/tests/test_camera_features.py
@@ -131,6 +131,24 @@ def test_camera_stream_allows_known_mowing_state_required_by_a2() -> None:
     assert camera_stream_block_reason(snapshot) is None
 
 
+def test_camera_stream_prefers_normalized_mowing_over_stale_raw_returning() -> None:
+    snapshot = SimpleNamespace(
+        state="mowing",
+        activity="mowing",
+        mowing=True,
+        paused=False,
+        returning=False,
+        raw_docked=False,
+        raw_attributes={
+            "running": True,
+            "returning": True,
+            "status": "Returning",
+        },
+    )
+
+    assert camera_stream_block_reason(snapshot) is None
+
+
 def test_camera_stream_blocks_normalized_docked_state_without_raw_flag() -> None:
     snapshot = SimpleNamespace(
         state="docked",
@@ -158,8 +176,18 @@ def test_camera_stream_blocks_returning_and_ambiguous_active_states() -> None:
         raw_docked=False,
         raw_attributes={"running": True},
     )
+    raw_returning = SimpleNamespace(
+        state="unknown",
+        activity="idle",
+        mowing=False,
+        paused=False,
+        returning=False,
+        raw_docked=False,
+        raw_attributes={"returning": True},
+    )
 
     assert "returning" in camera_stream_block_reason(returning)
+    assert "returning" in camera_stream_block_reason(raw_returning)
     assert "unrecognized active state" in camera_stream_block_reason(ambiguous)
 
 

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -663,8 +663,8 @@ def test_video_camera_restores_support_from_healthy_cache_after_docked_reload() 
     assert asyncio.run(_run()) == (True, True)
 
 
-def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
-    async def _run() -> tuple[int, int, bool, bool, str | None]:
+def test_video_camera_dock_transition_recovers_from_stale_raw_returning() -> None:
+    async def _run() -> tuple[int, int, bool, bool, list[str], str | None]:
         snapshot = SimpleNamespace(
             available=True,
             state="mowing",
@@ -689,6 +689,9 @@ def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
             async def async_set_camera_stream_enabled(self, _enabled: bool) -> None:
                 nonlocal camera_disables
                 camera_disables += 1
+                raise RuntimeError(
+                    "Dreame app video toggle returned an invalid response"
+                )
 
         async def _executor(function, *args):
             return function(*args)
@@ -740,7 +743,11 @@ def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
                 returning=False,
                 capabilities=(),
                 raw_info={},
-                raw_attributes={},
+                raw_attributes={
+                    "running": True,
+                    "returning": True,
+                    "status": "Returning",
+                },
             )
             entity._handle_coordinator_update()
 
@@ -750,7 +757,8 @@ def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
             camera_disables,
             unavailable_while_docked,
             entity.available,
-            events[0]["code"] if events else None,
+            [event["code"] for event in events],
+            entity._last_stream_cleanup_error_stage,
         )
 
     assert asyncio.run(_run()) == (
@@ -758,7 +766,11 @@ def test_video_camera_dock_transition_cleans_up_and_recovers() -> None:
         1,
         True,
         True,
-        "video_state_gate_cleanup",
+        [
+            "video_state_gate_cleanup",
+            "video_camera_stream_disable_failed",
+        ],
+        "camera_stream_disable",
     )
 
 


### PR DESCRIPTION
## Summary

- let confirmed normalized `mowing` or `paused` state override a lagging raw `returning` flag
- keep docked, mapping, normalized returning, raw-only returning, and ambiguous active states blocked
- cover the full dock-cleanup-to-next-session recovery path even when the vendor video-disable call fails

## Why

The latest A3 AWD 1000 diagnostics in #53 show the mower normalized as `mowing` while the vendor payload still reports `returning: true`. The camera gate currently treats that stale raw flag as authoritative, so Home Assistant keeps the camera unavailable and never reaches the next stream attempt.

Local runtime and session ownership are already cleared before the best-effort vendor disable call. This change fixes the actual availability gate without weakening confirmed station or movement safety states.

## Validation

Focused camera contracts, Ruff, `git diff --check`, and the full repository test lane pass. An independent safety review found no actionable issues.

## Hardware verification

The remaining proof is the reporter's physical `q2501a` sequence: session A → dock → session B without reloading Home Assistant. This PR intentionally does not auto-close #53 before that result.