### PR TITLE
Add writable mowing height controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,9 @@ region/account details are especially helpful for moving a device from
 - last-session mission progress and coverage retained after docking, explicitly
   marked with `cached: true` and a `captured_at` timestamp
 - selected-run sensors for mowing action, chosen map, and scoped zone/spot/edge target
-- selected-zone preference sensors for read-only mowing height, efficiency, direction, and obstacle-avoidance details
+- selected-zone preference sensors for mowing height, efficiency, direction, and obstacle-avoidance details
+- standard Home Assistant controls for selected-map preference mode and
+  selected-zone mowing height
 - read-only weather/rain-protection diagnostics
 - read-only weather/rain-protection entities from cached app settings
 - read-only mowing-preference diagnostics
@@ -155,7 +157,8 @@ The following areas are intentionally cautious:
   available, so operation snapshots can show plausible newer builds without
   conflating them with the app-approved update target
 - rain-protection writes are not exposed yet
-- mowing-preference writes are guarded, validated on a supervised A2 no-op write, and still need broader model and firmware validation
+- mowing-preference writes are validated on a supervised A2 no-op write and
+  still need broader model and firmware validation
 - map rendering is read-only; no-go editing, virtual-wall editing, and other map
   editing flows are not exposed yet
 - live video has been validated end to end on a Dreame A2, including Home
@@ -380,6 +383,21 @@ The guarded preference fields include per-zone safe edge mowing through
 `edge_mowing_safe`. Use the dry-run result to inspect the candidate payload
 before confirming a live write.
 
+For normal dashboard and automation use, the integration also exposes:
+
+- **Selected Map Preference Mode**, a `select` entity with `Global` and
+  `Custom` options
+- **Selected Zone Mowing Height**, a `number` entity in centimeters with
+  0.5 cm steps
+
+The height control follows the map and zone chosen by the integration's normal
+selectors. It is writable in `Custom` preference mode; in `Global` mode it
+becomes unavailable instead of implying that a zone-specific value can be
+changed. These standard entities work with Home Assistant dashboards,
+automations, voice assistants, and the companion Lawn Mower Card. The guarded
+service remains available when you need to inspect the complete candidate
+preference payload before sending it.
+
 ## Maps
 
 The map camera uses the confirmed app-map JSON path first. The renderer is
@@ -425,6 +443,8 @@ Current map support now includes:
 - a `Map` select that switches the mower's active map and refreshes the map,
   zone, spot, and edge controls
 - `select` entities for mowing action, edge, zone, and spot scope
+- a `select` for selected-map preference mode and a `number` slider for the
+  selected-zone mowing height
 - services for switching the active mower map and starting explicit zone, spot,
   or edge jobs
 - runtime live-track telemetry surfaced through sensors and map-camera attributes

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -46,6 +46,7 @@ from .dreame_lawn_mower_client.mowing_preferences import (
     normalize_mowing_preference_mode,
 )
 from .entity import DreameLawnMowerEntity
+from .mowing_preference_control import async_update_selected_mowing_preference
 from .services import (
     ATTR_CONFIRM_PREFERENCE_WRITE,
     ATTR_EXECUTE,
@@ -522,33 +523,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         **changes: Any,
     ) -> None:
         """Build or execute a scoped preference update for the selected map/zone."""
-        maps = map_entries(
-            self.coordinator.app_maps,
-            self.coordinator.batch_device_data,
-        )
-        selected_map_index = self._selected_map_index(maps)
-        if selected_map_index is None:
-            raise HomeAssistantError(
-                "No selected or current map is available for mowing "
-                "preference planning."
-            )
-
         requested_changes = preference_change_request(changes)
-        zone_scoped_change = any(
-            key != ATTR_PREFERENCE_MODE for key in requested_changes
-        )
-
-        zone_entries: list[dict[str, object]] = []
-        target_zone_id: int | None = None
-        if zone_scoped_change:
-            zone_entries = current_zone_entries(
-                self.coordinator.batch_device_data,
-                self.coordinator.app_maps,
-                getattr(self.coordinator, "vector_map_details", None),
-                selected_map_index=self.coordinator.selected_map_index,
-            )
-            target_zone_id = self._resolve_zone_id(zone_entries, zone_id=zone_id)
-
         _guard_preference_write_request(
             SimpleNamespace(
                 data={
@@ -557,31 +532,13 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 }
             )
         )
-        result = await self.coordinator.client.async_plan_app_mowing_preference_update(
-            map_index=selected_map_index,
-            area_id=target_zone_id,
+        await async_update_selected_mowing_preference(
+            self.coordinator,
             changes=requested_changes,
+            zone_id=zone_id,
             execute=execute,
             confirm_write=confirm_preference_write,
         )
-        selection_scope: dict[str, Any] = {
-            "selected_map_index": selected_map_index,
-            "selected_map_label": self._selected_map_label(
-                maps,
-                selected_map_index,
-            ),
-        }
-        if target_zone_id is not None:
-            selection_scope["selected_zone_id"] = target_zone_id
-            selection_scope["selected_zone_label"] = self._zone_label_for_id(
-                zone_entries,
-                target_zone_id,
-            )
-        result["selection_scope"] = selection_scope
-        self.coordinator.last_preference_write_result = result
-        self.coordinator.async_update_listeners()
-        if execute:
-            await self.coordinator.async_request_refresh()
 
     async def async_plan_map_preference_mode_update(
         self,

--- a/custom_components/dreame_lawn_mower/mowing_preference_control.py
+++ b/custom_components/dreame_lawn_mower/mowing_preference_control.py
@@ -112,9 +112,14 @@ async def async_update_selected_mowing_preference(
         )
     result["selection_scope"] = selection_scope
     coordinator.last_preference_write_result = result
-    coordinator.async_update_listeners()
     if execute:
+        await coordinator.async_refresh_batch_device_data(
+            force=True,
+            source="mowing_preference_write",
+        )
         await coordinator.async_request_refresh()
+    else:
+        coordinator.async_update_listeners()
     return result
 
 

--- a/custom_components/dreame_lawn_mower/mowing_preference_control.py
+++ b/custom_components/dreame_lawn_mower/mowing_preference_control.py
@@ -1,0 +1,155 @@
+"""Shared Home Assistant control path for map and zone mowing preferences."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from homeassistant.exceptions import HomeAssistantError
+
+from .control_options import current_map_index, current_zone_entries, map_entries
+from .coordinator import DreameLawnMowerCoordinator
+from .dreame_lawn_mower_client.mowing_preferences import (
+    MOWING_PREFERENCE_MODE_FIELD,
+)
+from .sensor_map_data import (
+    _selected_map_preference_summary,
+    _selected_zone_preference_summary,
+)
+
+MOWING_HEIGHT_MIN_CM = 3.5
+MOWING_HEIGHT_MAX_CM = 6.0
+MOWING_HEIGHT_STEP_CM = 0.5
+
+PREFERENCE_MODE_GLOBAL = "Global"
+PREFERENCE_MODE_CUSTOM = "Custom"
+PREFERENCE_MODE_OPTIONS = [PREFERENCE_MODE_GLOBAL, PREFERENCE_MODE_CUSTOM]
+
+
+def selected_map_preference_mode(coordinator: Any) -> str | None:
+    """Return the selected map preference mode as a Home Assistant option."""
+    mode_name = _selected_map_preference_summary(coordinator).get("mode_name")
+    if not isinstance(mode_name, str):
+        return None
+    normalized = mode_name.strip().casefold()
+    if normalized == "global":
+        return PREFERENCE_MODE_GLOBAL
+    if normalized == "custom":
+        return PREFERENCE_MODE_CUSTOM
+    return None
+
+
+def selected_zone_mowing_height(coordinator: Any) -> float | None:
+    """Return the selected zone mowing height in centimeters."""
+    value = _selected_zone_preference_summary(coordinator).get("mowing_height_cm")
+    return float(value) if isinstance(value, int | float) else None
+
+
+def selected_zone_preference_attributes(coordinator: Any) -> dict[str, Any]:
+    """Return the selected zone preference summary for control state attributes."""
+    return _selected_zone_preference_summary(coordinator)
+
+
+async def async_update_selected_mowing_preference(
+    coordinator: DreameLawnMowerCoordinator,
+    *,
+    changes: Mapping[str, Any],
+    zone_id: int | None = None,
+    execute: bool = True,
+    confirm_write: bool = True,
+) -> dict[str, Any]:
+    """Build or execute one preference update for the selected map and zone."""
+    if execute and not confirm_write:
+        raise HomeAssistantError(
+            "Preference writes require explicit confirmation when execution is enabled."
+        )
+    if not changes:
+        raise HomeAssistantError("At least one mowing preference change is required.")
+
+    maps = map_entries(coordinator.app_maps, coordinator.batch_device_data)
+    if not maps:
+        raise HomeAssistantError(
+            "No selected or current map is available for mowing preference updates."
+        )
+    selected_map_index = current_map_index(
+        coordinator.app_maps,
+        coordinator.batch_device_data,
+        selected_map_index=coordinator.selected_map_index,
+    )
+
+    zone_scoped_change = any(key != MOWING_PREFERENCE_MODE_FIELD for key in changes)
+    zone_entries: list[dict[str, Any]] = []
+    target_zone_id: int | None = None
+    if zone_scoped_change:
+        zone_entries = current_zone_entries(
+            coordinator.batch_device_data,
+            coordinator.app_maps,
+            getattr(coordinator, "vector_map_details", None),
+            selected_map_index=coordinator.selected_map_index,
+        )
+        target_zone_id = _resolve_zone_id(
+            zone_entries,
+            selected_zone_id=coordinator.selected_zone_id,
+            requested_zone_id=zone_id,
+        )
+
+    result = await coordinator.client.async_plan_app_mowing_preference_update(
+        map_index=selected_map_index,
+        area_id=target_zone_id,
+        changes=dict(changes),
+        execute=execute,
+        confirm_write=confirm_write,
+    )
+    selection_scope: dict[str, Any] = {
+        "selected_map_index": selected_map_index,
+        "selected_map_label": _map_label(maps, selected_map_index),
+    }
+    if target_zone_id is not None:
+        selection_scope["selected_zone_id"] = target_zone_id
+        selection_scope["selected_zone_label"] = _zone_label(
+            zone_entries,
+            target_zone_id,
+        )
+    result["selection_scope"] = selection_scope
+    coordinator.last_preference_write_result = result
+    coordinator.async_update_listeners()
+    if execute:
+        await coordinator.async_request_refresh()
+    return result
+
+
+def _resolve_zone_id(
+    zone_entries: list[dict[str, Any]],
+    *,
+    selected_zone_id: int | None,
+    requested_zone_id: int | None,
+) -> int:
+    target = requested_zone_id if requested_zone_id is not None else selected_zone_id
+    available = [
+        int(entry["area_id"])
+        for entry in zone_entries
+        if isinstance(entry.get("area_id"), int)
+    ]
+    if target is None and available:
+        target = available[0]
+    if target not in available:
+        raise HomeAssistantError(
+            f"Zone #{target} is not available on the selected map. "
+            f"Available zone ids: {available or 'none'}."
+        )
+    return int(target)
+
+
+def _map_label(maps: list[dict[str, Any]], map_index: int) -> str | None:
+    entry = next((item for item in maps if item.get("map_index") == map_index), None)
+    label = entry.get("label") if isinstance(entry, dict) else None
+    return str(label) if label is not None else None
+
+
+def _zone_label(zone_entries: list[dict[str, Any]], zone_id: int) -> str:
+    entry = next(
+        (item for item in zone_entries if item.get("area_id") == zone_id),
+        None,
+    )
+    label = entry.get("label") if isinstance(entry, dict) else None
+    return str(label) if label is not None else f"Zone #{zone_id}"

--- a/custom_components/dreame_lawn_mower/number.py
+++ b/custom_components/dreame_lawn_mower/number.py
@@ -4,15 +4,26 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.number import NumberEntity
+from homeassistant.components.number import NumberEntity, NumberMode
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
+from homeassistant.exceptions import HomeAssistantError
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import DreameLawnMowerCoordinator
 from .entity import DreameLawnMowerEntity
+from .mowing_preference_control import (
+    MOWING_HEIGHT_MAX_CM,
+    MOWING_HEIGHT_MIN_CM,
+    MOWING_HEIGHT_STEP_CM,
+    PREFERENCE_MODE_CUSTOM,
+    async_update_selected_mowing_preference,
+    selected_map_preference_mode,
+    selected_zone_mowing_height,
+    selected_zone_preference_attributes,
+)
 
 
 async def async_setup_entry(
@@ -22,7 +33,12 @@ async def async_setup_entry(
 ) -> None:
     """Set up Dreame mower number entities."""
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities([DreameLawnMowerVoiceVolumeNumber(coordinator)])
+    async_add_entities(
+        [
+            DreameLawnMowerVoiceVolumeNumber(coordinator),
+            DreameLawnMowerSelectedZoneMowingHeightNumber(coordinator),
+        ]
+    )
 
 
 class DreameLawnMowerVoiceVolumeNumber(DreameLawnMowerEntity, NumberEntity):
@@ -59,6 +75,98 @@ class DreameLawnMowerVoiceVolumeNumber(DreameLawnMowerEntity, NumberEntity):
         await self.coordinator.client.async_set_voice_volume(round(value))
         await self.coordinator.async_refresh_voice_settings(force=True)
         self.coordinator.async_update_listeners()
+
+
+class DreameLawnMowerSelectedZoneMowingHeightNumber(
+    DreameLawnMowerEntity,
+    NumberEntity,
+):
+    """Control the mowing height for the selected map and zone."""
+
+    _attr_name = "Selected Zone Mowing Height"
+    _attr_icon = "mdi:grass"
+    _attr_entity_category = EntityCategory.CONFIG
+    _attr_native_min_value = MOWING_HEIGHT_MIN_CM
+    _attr_native_max_value = MOWING_HEIGHT_MAX_CM
+    _attr_native_step = MOWING_HEIGHT_STEP_CM
+    _attr_native_unit_of_measurement = "cm"
+    _attr_mode = NumberMode.SLIDER
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{self._descriptor.unique_id}_selected_zone_mowing_height"
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return whether the selected zone height can currently be changed."""
+        return (
+            self.coordinator.data is not None
+            and self.native_value is not None
+            and selected_map_preference_mode(self.coordinator) == PREFERENCE_MODE_CUSTOM
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return the selected zone mowing height in centimeters."""
+        return selected_zone_mowing_height(self.coordinator)
+
+    @property
+    def native_min_value(self) -> float:
+        """Include a device-reported value below the conservative UI range."""
+        current = self.native_value
+        return (
+            min(MOWING_HEIGHT_MIN_CM, current)
+            if current is not None
+            else MOWING_HEIGHT_MIN_CM
+        )
+
+    @property
+    def native_max_value(self) -> float:
+        """Include a device-reported value above the conservative UI range."""
+        current = self.native_value
+        return (
+            max(MOWING_HEIGHT_MAX_CM, current)
+            if current is not None
+            else MOWING_HEIGHT_MAX_CM
+        )
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        """Return selected map/zone scope and write availability details."""
+        attributes = selected_zone_preference_attributes(self.coordinator)
+        attributes["write_available"] = self.available
+        if not self.available:
+            attributes["write_unavailable_reason"] = (
+                "Select Custom map preference mode before changing zone height."
+                if selected_map_preference_mode(self.coordinator)
+                != PREFERENCE_MODE_CUSTOM
+                else "Selected zone mowing preference data is unavailable."
+            )
+        return attributes
+
+    async def async_set_native_value(self, value: float) -> None:
+        """Persist the selected zone mowing height through the guarded PRE path."""
+        if selected_map_preference_mode(self.coordinator) != PREFERENCE_MODE_CUSTOM:
+            raise HomeAssistantError(
+                "Select Custom map preference mode before changing zone height."
+            )
+        normalized = float(value)
+        if normalized < self.native_min_value or normalized > self.native_max_value:
+            raise HomeAssistantError(
+                f"Mowing height must be between {self.native_min_value:g} and "
+                f"{self.native_max_value:g} cm for this mower."
+            )
+        steps = round(normalized / MOWING_HEIGHT_STEP_CM)
+        if abs(normalized - steps * MOWING_HEIGHT_STEP_CM) > 1e-6:
+            raise HomeAssistantError(
+                f"Mowing height must use {MOWING_HEIGHT_STEP_CM:g} cm steps."
+            )
+        await async_update_selected_mowing_preference(
+            self.coordinator,
+            changes={"mowing_height_cm": normalized},
+        )
 
 
 def _voice_settings_section(value: dict[str, Any] | None) -> dict[str, Any] | None:

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -34,6 +34,11 @@ from .dreame_lawn_mower_client.client import (
     VOICE_LANGUAGE_LABELS,
 )
 from .entity import DreameLawnMowerEntity
+from .mowing_preference_control import (
+    PREFERENCE_MODE_OPTIONS,
+    async_update_selected_mowing_preference,
+    selected_map_preference_mode,
+)
 
 
 async def async_setup_entry(
@@ -48,6 +53,7 @@ async def async_setup_entry(
             DreameLawnMowerVoiceLanguageSelect(coordinator),
             DreameLawnMowerMapSelect(coordinator),
             DreameLawnMowerMowingActionSelect(coordinator),
+            DreameLawnMowerSelectedMapPreferenceModeSelect(coordinator),
             DreameLawnMowerEdgeSelect(coordinator),
             DreameLawnMowerZoneSelect(coordinator),
             DreameLawnMowerSpotSelect(coordinator),
@@ -193,6 +199,44 @@ class DreameLawnMowerMowingActionSelect(DreameLawnMowerSelectEntity):
                 self.coordinator.async_update_listeners()
                 return
         raise ValueError(f"Unknown mowing action option: {option}")
+
+
+class DreameLawnMowerSelectedMapPreferenceModeSelect(DreameLawnMowerSelectEntity):
+    """Choose whether the selected map uses global or custom zone preferences."""
+
+    _attr_name = "Selected Map Preference Mode"
+    _attr_icon = "mdi:tune-variant"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{self._descriptor.unique_id}_selected_map_preference_mode"
+        )
+
+    @property
+    def available(self) -> bool:
+        """Return whether selected-map preference metadata is available."""
+        return self.coordinator.data is not None and self.current_option is not None
+
+    @property
+    def options(self) -> list[str]:
+        """Return supported mower preference modes."""
+        return list(PREFERENCE_MODE_OPTIONS)
+
+    @property
+    def current_option(self) -> str | None:
+        """Return the selected map preference mode."""
+        return selected_map_preference_mode(self.coordinator)
+
+    async def async_select_option(self, option: str) -> None:
+        """Persist the selected map preference mode through the PREP path."""
+        if option not in PREFERENCE_MODE_OPTIONS:
+            raise ValueError(f"Unknown preference mode option: {option}")
+        await async_update_selected_mowing_preference(
+            self.coordinator,
+            changes={"preference_mode": option.casefold()},
+        )
 
 
 class DreameLawnMowerEdgeSelect(DreameLawnMowerSelectEntity):

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -897,6 +897,7 @@ def test_lawn_mower_plan_zone_preference_update_can_execute_confirmed_write() ->
         selected_zone_id=5,
         selected_spot_id=None,
         last_preference_write_result=None,
+        async_refresh_batch_device_data=AsyncMock(),
         async_request_refresh=AsyncMock(),
         async_update_listeners=lambda: None,
     )
@@ -919,6 +920,10 @@ def test_lawn_mower_plan_zone_preference_update_can_execute_confirmed_write() ->
         },
         execute=True,
         confirm_write=True,
+    )
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
     )
     coordinator.async_request_refresh.assert_awaited_once()
 
@@ -1100,6 +1105,7 @@ def test_lawn_mower_plan_map_preference_mode_update_can_execute_confirmed_write(
         selected_zone_id=None,
         selected_spot_id=None,
         last_preference_write_result=None,
+        async_refresh_batch_device_data=AsyncMock(),
         async_request_refresh=AsyncMock(),
         async_update_listeners=lambda: None,
     )
@@ -1120,6 +1126,10 @@ def test_lawn_mower_plan_map_preference_mode_update_can_execute_confirmed_write(
         changes={"preference_mode": 1},
         execute=True,
         confirm_write=True,
+    )
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
     )
     coordinator.async_request_refresh.assert_awaited_once()
 

--- a/tests/test_mowing_preference_controls.py
+++ b/tests/test_mowing_preference_controls.py
@@ -1,0 +1,139 @@
+"""Contract tests for user-facing mowing preference entities."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+from homeassistant.exceptions import HomeAssistantError
+
+from custom_components.dreame_lawn_mower.number import (
+    DreameLawnMowerSelectedZoneMowingHeightNumber,
+)
+from custom_components.dreame_lawn_mower.select import (
+    DreameLawnMowerSelectedMapPreferenceModeSelect,
+)
+
+
+def _coordinator(*, mode_name: str = "custom") -> SimpleNamespace:
+    client = SimpleNamespace(
+        async_plan_app_mowing_preference_update=AsyncMock(
+            return_value={
+                "source": "app_action_mowing_preference_write",
+                "changed_fields": ["mowing_height_cm"],
+            }
+        )
+    )
+    return SimpleNamespace(
+        client=client,
+        data=SimpleNamespace(available=True),
+        app_maps={
+            "current_map_index": 1,
+            "maps": [
+                {
+                    "idx": 1,
+                    "name": "Back garden",
+                    "current": True,
+                    "available": True,
+                }
+            ],
+        },
+        batch_device_data={
+            "batch_mowing_preferences": {
+                "maps": [
+                    {
+                        "idx": 1,
+                        "mode": 1 if mode_name == "custom" else 0,
+                        "mode_name": mode_name,
+                        "area_count": 1,
+                        "preferences": [
+                            {
+                                "area_id": 5,
+                                "mowing_height_cm": 4.0,
+                            }
+                        ],
+                    }
+                ]
+            }
+        },
+        vector_map_details=None,
+        selected_map_index=1,
+        selected_zone_id=5,
+        last_preference_write_result=None,
+        async_request_refresh=AsyncMock(),
+        async_update_listeners=lambda: None,
+    )
+
+
+def test_preference_mode_select_reads_and_writes_selected_map_mode() -> None:
+    coordinator = _coordinator(mode_name="global")
+    entity = object.__new__(DreameLawnMowerSelectedMapPreferenceModeSelect)
+    entity.coordinator = coordinator
+
+    assert entity.available is True
+    assert entity.options == ["Global", "Custom"]
+    assert entity.current_option == "Global"
+
+    asyncio.run(entity.async_select_option("Custom"))
+
+    coordinator.client.async_plan_app_mowing_preference_update.assert_awaited_once_with(
+        map_index=1,
+        area_id=None,
+        changes={"preference_mode": "custom"},
+        execute=True,
+        confirm_write=True,
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_mowing_height_number_reads_and_writes_selected_zone() -> None:
+    coordinator = _coordinator()
+    entity = object.__new__(DreameLawnMowerSelectedZoneMowingHeightNumber)
+    entity.coordinator = coordinator
+
+    assert entity.available is True
+    assert entity.native_value == 4.0
+    assert entity.native_min_value == 3.5
+    assert entity.native_max_value == 6.0
+    assert entity.extra_state_attributes["selected_zone_id"] == 5
+    assert entity.extra_state_attributes["write_available"] is True
+
+    asyncio.run(entity.async_set_native_value(4.5))
+
+    coordinator.client.async_plan_app_mowing_preference_update.assert_awaited_once_with(
+        map_index=1,
+        area_id=5,
+        changes={"mowing_height_cm": 4.5},
+        execute=True,
+        confirm_write=True,
+    )
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_mowing_height_number_requires_custom_mode() -> None:
+    coordinator = _coordinator(mode_name="global")
+    entity = object.__new__(DreameLawnMowerSelectedZoneMowingHeightNumber)
+    entity.coordinator = coordinator
+
+    assert entity.available is False
+    assert entity.native_value == 4.0
+    assert "Custom" in entity.extra_state_attributes["write_unavailable_reason"]
+
+    with pytest.raises(HomeAssistantError, match="Select Custom"):
+        asyncio.run(entity.async_set_native_value(4.5))
+
+    coordinator.client.async_plan_app_mowing_preference_update.assert_not_awaited()
+
+
+@pytest.mark.parametrize("value", [3.6, 6.5])
+def test_mowing_height_number_rejects_unsupported_control_values(value: float) -> None:
+    coordinator = _coordinator()
+    entity = object.__new__(DreameLawnMowerSelectedZoneMowingHeightNumber)
+    entity.coordinator = coordinator
+
+    with pytest.raises(HomeAssistantError):
+        asyncio.run(entity.async_set_native_value(value))
+
+    coordinator.client.async_plan_app_mowing_preference_update.assert_not_awaited()

--- a/tests/test_mowing_preference_controls.py
+++ b/tests/test_mowing_preference_controls.py
@@ -62,6 +62,7 @@ def _coordinator(*, mode_name: str = "custom") -> SimpleNamespace:
         selected_map_index=1,
         selected_zone_id=5,
         last_preference_write_result=None,
+        async_refresh_batch_device_data=AsyncMock(),
         async_request_refresh=AsyncMock(),
         async_update_listeners=lambda: None,
     )
@@ -84,6 +85,10 @@ def test_preference_mode_select_reads_and_writes_selected_map_mode() -> None:
         changes={"preference_mode": "custom"},
         execute=True,
         confirm_write=True,
+    )
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
     )
     coordinator.async_request_refresh.assert_awaited_once()
 
@@ -108,6 +113,10 @@ def test_mowing_height_number_reads_and_writes_selected_zone() -> None:
         changes={"mowing_height_cm": 4.5},
         execute=True,
         confirm_write=True,
+    )
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
     )
     coordinator.async_request_refresh.assert_awaited_once()
 


### PR DESCRIPTION
## Summary

- add standard Home Assistant controls for the selected map's preference mode and selected zone's mowing height
- keep map and zone resolution, validation, protocol writes, diagnostics, and refresh behavior in one integration-owned control path
- make zone height writable only in Custom mode, with a conservative 3.5-6.0 cm range and 0.5 cm steps
- document the dashboard, automation, and companion-card behavior

## Usage

Choose **Custom** in the **Selected Map Preference Mode** select, choose the target zone, then set **Selected Zone Mowing Height**. Automations can use the normal `select.select_option` and `number.set_value` services.

## Device validation

The PRE write path has supervised Dreame A2 no-op evidence. A physical changed-height write and broader model/firmware coverage are still required, so other decoded preference fields remain on the guarded dry-run service.

## Validation

- Ruff passed for the repository and changed files are formatted
- 159 focused preference/current-map/service tests passed
- the broader Windows run completed all ordinary tests but cannot initialize seven Home Assistant plugin-fixture tests because that plugin imports POSIX-only `fcntl`