### PR TITLE
Keep maintenance reminders from overriding mower activity

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
@@ -78,11 +78,16 @@ _BASE_DEVICE_CODES: Final[dict[int, MowerDeviceCodeDefinition]] = {
             25: "map_file_damaged",
             26: "mower_too_far_from_map",
             27: "human_detected",
+            37: "path_blocked",
+            73: "top_cover_open",
+        },
+    ),
+    **_definitions(
+        MowerDeviceCodeTier.ATTENTION,
+        {
             28: "blades_worn",
             29: "station_brush_worn",
             30: "maintenance_due",
-            37: "path_blocked",
-            73: "top_cover_open",
         },
     ),
     **_definitions(
@@ -141,8 +146,8 @@ _BASE_DEVICE_CODES: Final[dict[int, MowerDeviceCodeDefinition]] = {
 
 
 # Dreame A2 / g2408 app-plugin differences. In particular, 16 and 59 do not
-# mean what the cross-model registry says, and codes 27-30 are attention items
-# rather than hard faults.
+# mean what the cross-model registry says, and human detection is an attention
+# notice rather than a hard fault.
 _A2_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
     **_definitions(
         MowerDeviceCodeTier.ERROR,
@@ -155,9 +160,6 @@ _A2_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
         MowerDeviceCodeTier.ATTENTION,
         {
             27: "human_detected",
-            28: "blades_worn",
-            29: "station_brush_worn",
-            30: "maintenance_due",
             74: "patrol_task_completed",
             75: "maintenance_point_reached",
             76: "maintenance_point_unreachable",
@@ -196,12 +198,6 @@ _MOVA_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
         {
             0: "robot_lifted",
             55: "cannot_start_low_battery",
-        },
-    ),
-    **_definitions(
-        MowerDeviceCodeTier.ATTENTION,
-        {
-            30: "maintenance_due",
         },
     ),
 }

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -498,6 +498,35 @@ def test_a2_app_tiers_are_preserved(
     assert mower_device_code_tier(code, model="dreame.mower.g2408") is tier
 
 
+@pytest.mark.parametrize(
+    ("code", "expected_name"),
+    [
+        (28, "blades_worn"),
+        (29, "station_brush_worn"),
+        (30, "maintenance_due"),
+    ],
+)
+def test_attention_notices_do_not_override_mowing_for_model_variants(
+    code: int,
+    expected_name: str,
+) -> None:
+    snapshot = _snapshot(
+        code,
+        "fan_speed_error",
+        realtime_error_code=code,
+        state="MOWING",
+        model="dreame.mower.x1234",
+    )
+
+    assert snapshot.state == "mowing"
+    assert snapshot.activity == "mowing"
+    assert snapshot.error_code is None
+    assert snapshot.error_display is None
+    assert snapshot.status_notice_code == code
+    assert snapshot.status_notice_name == expected_name
+    assert snapshot.status_notice_tier == "attention"
+
+
 def test_a2_catalog_has_a_meaning_for_every_observed_app_code() -> None:
     for code in range(78):
         assert (


### PR DESCRIPTION
## What changed

- treat worn blades, worn station brushes, and general maintenance reminders as attention notices across mower model variants
- keep the mower entity on its real activity, such as `mowing`, while exposing the maintenance notice separately
- remove duplicate A2 and MOVA overrides now owned by the shared mower code table
- add regression coverage for model variants receiving codes 28–30 while mowing

## Why

Maintenance reminders do not mean the mower is unsafe or unable to operate. A model variant could correctly label code `30` as `maintenance_due` but still inherit the generic hard-error tier, causing Home Assistant to show `error` while the mower continued mowing.

Fixes #73