### PR TITLE
Reconcile docked state after stale returning telemetry

### DIFF
--- a/README.md
+++ b/README.md
@@ -161,9 +161,9 @@ The following areas are intentionally cautious:
   still need broader model and firmware validation
 - map rendering is read-only; no-go editing, virtual-wall editing, and other map
   editing flows are not exposed yet
-- live video has been validated end to end on a Dreame A2, including Home
-  Assistant HLS playback; other Tencent-video mower models and firmware still
-  need field validation
+- live video has been validated end to end on a Dreame A2 and on an A3 AWD 1000
+  (`dreame.mower.q2501a`, firmware `4.3.6_0418`) using an EU account; other
+  Tencent-video mower models and firmware still need field validation
 - the managed video runtime currently supports Linux x86_64 and aarch64 Home
   Assistant hosts, and the mower must be active and away from its station before
   the vendor permits live video
@@ -237,6 +237,14 @@ station. Requesting the camera does not start or move the mower. The existing
 native-library and persistent-runner options remain available as advanced
 overrides for development or unsupported host platforms.
 
+On the field-tested A3 AWD 1000, XP2P negotiation takes about 30–40 seconds and
+the media source supports one consumer at a time. Opening a still-image request
+while the Home Assistant panel is already playing HLS can make that competing
+request fail. A vendor-timed session can also finish normally and leave the
+camera idle on its last frame; request **Stream** again to negotiate a new
+session. These timings and limits are model/firmware observations, not promises
+for every mower.
+
 The integration exposes two video transport policies. The default uses the
 proven cloud-provisioned XP2P path. `Auto` can restart from health-checked cached
 provisioning and lets Tencent negotiate the available network route. It also
@@ -274,8 +282,8 @@ apps:
   transport policy promises startup with all internet connectivity removed.
 - Home Assistant can display and save the current JPEG frame, but the vendor's
   stored photo gallery is not exposed.
-- Live video is field-validated on the A2 only. A3 AWD Pro and MOVA camera
-  variants still need their own runtime-input and playback proof.
+- Live video is field-validated on the A2 and A3 AWD 1000. A3 AWD Pro and MOVA
+  camera variants still need their own runtime-input and playback proof.
 - Patrol movement, arbitrary voice-prompt playback, and two-way live talk are
   separate control/audio features and are not implemented by this camera.
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -1132,6 +1132,15 @@ def snapshot_from_device(
         "charging",
         "smart_charging",
     }
+    raw_docked = bool(getattr(device.status, "docked", False))
+    raw_charging_source = status_attributes.get(
+        "charging",
+        getattr(device.status, "charging", None),
+    )
+    raw_charging = (
+        None if raw_charging_source is None else bool(raw_charging_source)
+    )
+    confirmed_at_station = bool(raw_docked or raw_charging)
 
     suppressed_error_code: int | None = None
     suppressed_realtime_error_last_seen: float | None = None
@@ -1172,6 +1181,10 @@ def snapshot_from_device(
 
     if has_error:
         activity = "error"
+    elif state in returning_states and confirmed_at_station:
+        # The app state can lag on RETURNING after the mower is physically
+        # docked. Explicit dock/charging flags are stronger station evidence.
+        activity = "docked"
     elif state in paused_states:
         activity = "paused"
     elif state in returning_states:
@@ -1190,16 +1203,8 @@ def snapshot_from_device(
         activity = "mowing"
     else:
         activity = "idle"
-    raw_docked = bool(getattr(device.status, "docked", False))
     effective_docked = bool(
         raw_docked or state in docked_states or activity == "docked"
-    )
-    raw_charging_source = status_attributes.get(
-        "charging",
-        getattr(device.status, "charging", None),
-    )
-    raw_charging = (
-        None if raw_charging_source is None else bool(raw_charging_source)
     )
     effective_charging = bool(raw_charging or state in charging_states)
     raw_started = bool(

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from dreame_lawn_mower_client.models import (
     descriptor_from_cloud_record,
     display_name_for_model,
@@ -503,6 +505,57 @@ def test_snapshot_treats_docked_sticky_returning_as_raw_only() -> None:
     assert snapshot.raw_started is True
     assert snapshot.returning is False
     assert snapshot.raw_returning is True
+
+
+@pytest.mark.parametrize(
+    ("raw_docked", "raw_charging"),
+    [
+        (True, False),
+        (False, True),
+        (True, True),
+    ],
+)
+def test_snapshot_prefers_station_flags_over_stale_returning_state(
+    raw_docked: bool,
+    raw_charging: bool,
+) -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-1",
+            "model": "dreame.mower.q2501a",
+            "customName": "Garden Mower",
+        },
+        account_type="dreame",
+        country="eu",
+    )
+
+    assert descriptor is not None
+
+    device = _FakeDevice()
+    device.status.state = SimpleNamespace(name="RETURNING")
+    device.status.state_name = "returning"
+    device.status.docked = raw_docked
+    device.status.returning = True
+    device.status.running = True
+    device.status.attributes = {
+        **device.status.attributes,
+        "charging": raw_charging,
+        "mower_state": "returning",
+        "returning": True,
+    }
+
+    snapshot = snapshot_from_device(descriptor, device)
+
+    assert snapshot.state == "returning"
+    assert snapshot.activity == "docked"
+    assert snapshot.docked is True
+    assert snapshot.raw_docked is raw_docked
+    assert snapshot.charging is raw_charging
+    assert snapshot.raw_charging is raw_charging
+    assert snapshot.started is False
+    assert snapshot.returning is False
+    assert snapshot.raw_returning is True
+    assert snapshot.mowing is False
 
 
 def test_snapshot_treats_returning_running_flag_as_returning_not_mowing() -> None:


### PR DESCRIPTION
## Summary

- report the mower as docked when the vendor state still says `returning` but explicit docked or charging telemetry confirms it is at the station
- preserve the stale vendor state and raw flags in diagnostics while keeping genuine errors and non-returning activity precedence unchanged
- document the field-validated A3 AWD 1000 video behavior, including its observed 30–40 second startup, single-consumer stream, and manual restart after a vendor-timed session ends

## Why

The final A3 AWD 1000 retest in #53 confirms that v0.2.27 restores live video in session B without restarting Home Assistant. The same report also confirms a separate display-state mismatch: after docking, the mower can remain `returning` even though `docked` and `charging` already report that it is home.

This change reconciles only that evidenced contradiction. The existing stop-then-dock command orchestration is unchanged; any mower that physically stops or becomes unavailable during a dock command still needs a separate diagnostics/log capture before changing the vendor command sequence.

## Validation

The focused state, docking, and maintenance-code contracts pass, as do Ruff and the full repository test lane. An independent safety review found no actionable issues.