### PR TITLE
Fix MOVA fixed-key point-cloud refreshes and downloads

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.venv/
 .pytest_cache/
 .ruff_cache/
 __pycache__/

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -188,6 +188,7 @@ def _download_point_cloud_content(
                     "The point-cloud download redirected to an insecure URL."
                 )
             content_length = response.headers.get("Content-Length")
+            declared_bytes: int | None = None
             if content_length is not None:
                 try:
                     declared_bytes = int(content_length)
@@ -201,7 +202,11 @@ def _download_point_cloud_content(
                     )
             content_parts: list[bytes] = []
             received_bytes = 0
-            while True:
+            # Once every declared byte has been read, http.client has already
+            # consumed and may auto-close the underlying socket, so stop
+            # before attempting one more (doomed) timeout-bounded read whose
+            # only purpose would be to observe an EOF we already know about.
+            while declared_bytes is None or received_bytes < declared_bytes:
                 remaining = deadline - time.monotonic()
                 if remaining <= 0:
                     raise DreameLawnMowerPointCloudError(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import json
 import math
 import time
@@ -9,6 +10,7 @@ import urllib.error
 import urllib.parse
 import urllib.request
 from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
 from io import BytesIO
 from typing import Any
 
@@ -36,6 +38,28 @@ from .models import (
 from .point_cloud import (
     DreameLawnMowerPointCloudError,
 )
+
+
+@dataclass(frozen=True, slots=True)
+class _PointCloudObjectIdentity:
+    """Stable response evidence used to detect a fixed-key object overwrite."""
+
+    content_sha256: str
+    etag: str | None
+    last_modified: str | None
+
+    def differs_from(self, other: _PointCloudObjectIdentity) -> bool:
+        """Return whether content or an object-store validator changed."""
+        if self.content_sha256 != other.content_sha256:
+            return True
+        if self.etag is not None and other.etag is not None:
+            if self.etag != other.etag:
+                return True
+        return (
+            self.last_modified is not None
+            and other.last_modified is not None
+            and self.last_modified != other.last_modified
+        )
 
 
 def _validate_app_map_chunk_size(value: int) -> int:
@@ -168,6 +192,20 @@ def _download_point_cloud_content(
     timeout: float,
     max_bytes: int,
 ) -> tuple[bytes, str]:
+    content, content_type, _ = _download_point_cloud_content_with_identity(
+        url,
+        timeout=timeout,
+        max_bytes=max_bytes,
+    )
+    return content, content_type
+
+
+def _download_point_cloud_content_with_identity(
+    url: str,
+    *,
+    timeout: float,
+    max_bytes: int,
+) -> tuple[bytes, str, _PointCloudObjectIdentity]:
     deadline = time.monotonic() + timeout
     request = urllib.request.Request(
         url,
@@ -213,7 +251,10 @@ def _download_point_cloud_content(
                         "The point-cloud download timed out."
                     )
                 _set_point_cloud_response_timeout(response, remaining)
-                chunk = response.read(min(64 * 1024, max_bytes + 1 - received_bytes))
+                read_bytes = min(64 * 1024, max_bytes + 1 - received_bytes)
+                if declared_bytes is not None:
+                    read_bytes = min(read_bytes, declared_bytes - received_bytes)
+                chunk = response.read(read_bytes)
                 if time.monotonic() >= deadline:
                     raise DreameLawnMowerPointCloudError(
                         "The point-cloud download timed out."
@@ -226,11 +267,20 @@ def _download_point_cloud_content(
                     raise DreameLawnMowerPointCloudError(
                         "The point-cloud download exceeds the configured size limit."
                     )
+            if declared_bytes is not None and received_bytes != declared_bytes:
+                raise DreameLawnMowerPointCloudError(
+                    "The point-cloud download ended before its declared size."
+                )
             content = b"".join(content_parts)
             content_type = (
                 response.headers.get_content_type()
                 if hasattr(response.headers, "get_content_type")
                 else "application/octet-stream"
+            )
+            identity = _PointCloudObjectIdentity(
+                content_sha256=hashlib.sha256(content).hexdigest(),
+                etag=response.headers.get("ETag"),
+                last_modified=response.headers.get("Last-Modified"),
             )
     except DreameLawnMowerPointCloudError:
         raise
@@ -247,7 +297,7 @@ def _download_point_cloud_content(
             "The point-cloud download could not be completed."
         ) from err
 
-    return content, content_type
+    return content, content_type, identity
 
 
 class _HttpsOnlyPointCloudRedirectHandler(urllib.request.HTTPRedirectHandler):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -30,7 +30,7 @@ from .client_map_helpers import (
     _app_maps_view_metadata,
     _app_object_extension,
     _coordinate_path_length_m,
-    _download_point_cloud_content,
+    _download_point_cloud_content_with_identity,
     _key_define_from_device_list_page,
     _key_define_from_mapping,
     _map_view_current_app_map_index,
@@ -39,6 +39,7 @@ from .client_map_helpers import (
     _point_cloud_action_data,
     _point_cloud_download_url,
     _point_cloud_object_name,
+    _PointCloudObjectIdentity,
     _render_app_map_payload_png,
     _runtime_blob_position,
     _select_app_map_payload,
@@ -93,9 +94,9 @@ from .vector_map import (
 if TYPE_CHECKING:
     from .map_visuals import MapRenderStyle
 
-# The 3dmap object is real PCD content either way; only the reported file
-# extension differs by cloud vendor (Dreame names it "*.pcd", MOVA "*.bin").
-_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
+# MOVA reports the fixed 3dmap object as "*.bin" even though the payload is PCD.
+_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd"})
+_MOVA_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
 
 
 class _DreameLawnMowerClientMapsMixin:
@@ -694,13 +695,6 @@ class _DreameLawnMowerClientMapsMixin:
             map_index,
         )
 
-        self._sync_call_point_cloud_action(
-            {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
-            operation="start point-cloud generation",
-            deadline=deadline,
-            require_data=False,
-        )
-
         cloud = self._sync_get_cloud_protocol(deadline=deadline)
         if not hasattr(cloud, "get_interim_file_url"):
             raise DreameLawnMowerPointCloudError(
@@ -714,8 +708,46 @@ class _DreameLawnMowerClientMapsMixin:
                 ),
             )
 
+        accepted_extensions = (
+            _MOVA_POINT_CLOUD_OBJECT_EXTENSIONS
+            if self._account_type == "mova"
+            else _POINT_CLOUD_OBJECT_EXTENSIONS
+        )
+        baseline_identity = None
+        baseline_extension = (
+            _app_object_extension(baseline_name)
+            if baseline_name is not None
+            else None
+        )
+        fixed_mova_baseline = (
+            self._account_type == "mova"
+            and baseline_name is not None
+            and baseline_extension is not None
+            and baseline_extension.casefold() in accepted_extensions
+        )
+        if fixed_mova_baseline:
+            try:
+                _, _, baseline_identity = self._sync_download_point_cloud_object(
+                    cloud,
+                    baseline_name,
+                    deadline=deadline,
+                    download_timeout=download_timeout,
+                    max_bytes=max_bytes,
+                )
+            except (DeviceException, DreameLawnMowerPointCloudError):
+                baseline_identity = None
+
+        self._sync_call_point_cloud_action(
+            {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
+            operation="start point-cloud generation",
+            deadline=deadline,
+            require_data=False,
+        )
+
         observed_clear = baseline_name is None
         saw_unusable_point_cloud = False
+        saw_stale_point_cloud = False
+        saw_unverified_fixed_object = False
         rejected_object_names: set[str] = set()
         object_download_attempts: dict[str, int] = {}
         while time.monotonic() < deadline:
@@ -734,65 +766,88 @@ class _DreameLawnMowerClientMapsMixin:
             object_extension = (
                 _app_object_extension(object_name) if object_name is not None else None
             )
-            # MOVA never renames the 3dmap object on generation, so it would
-            # never look "fresh" here; treat its unchanged baseline object as
-            # acceptable right away instead of waiting out the full timeout.
-            fresh_object = (
+            fixed_mova_object = (
+                self._account_type == "mova"
+                and object_name is not None
+                and object_name == baseline_name
+                and not observed_clear
+            )
+            object_ready = (
                 object_name != baseline_name
                 or observed_clear
-                or self._account_type == "mova"
+                or fixed_mova_object
+            )
+            attempt_allowed = fixed_mova_object or (
+                object_name not in rejected_object_names
+                and object_download_attempts.get(object_name, 0) < 2
             )
             if (
                 object_name is not None
                 and object_extension is not None
-                and object_extension.casefold() in _POINT_CLOUD_OBJECT_EXTENSIONS
-                and fresh_object
-                and object_name not in rejected_object_names
-                and object_download_attempts.get(object_name, 0) < 2
+                and object_extension.casefold() in accepted_extensions
+                and object_ready
+                and attempt_allowed
             ):
-                object_download_attempts[object_name] = (
-                    object_download_attempts.get(object_name, 0) + 1
-                )
-                try:
-                    raw_url = self._sync_get_point_cloud_download_url(
-                        cloud,
-                        object_name,
-                        deadline=deadline,
+                if not fixed_mova_object:
+                    object_download_attempts[object_name] = (
+                        object_download_attempts.get(object_name, 0) + 1
                     )
-                    url = _point_cloud_download_url(raw_url)
-                    remaining = deadline - time.monotonic()
-                    if remaining <= 0:
-                        raise DreameLawnMowerPointCloudError(
-                            "Point-cloud generation timed out."
+                try:
+                    content, content_type, object_identity = (
+                        self._sync_download_point_cloud_object(
+                            cloud,
+                            object_name,
+                            deadline=deadline,
+                            download_timeout=download_timeout,
+                            max_bytes=max_bytes,
                         )
-                    content, content_type = _download_point_cloud_content(
-                        url,
-                        timeout=min(download_timeout, remaining),
-                        max_bytes=max_bytes,
                     )
                 except (DeviceException, DreameLawnMowerPointCloudError):
                     saw_unusable_point_cloud = True
                 else:
-                    try:
-                        metadata = parse_pcd_metadata(
-                            content,
-                            max_bytes=max_bytes,
-                            deadline=deadline,
-                        )
-                    except DreameLawnMowerPointCloudError:
-                        saw_unusable_point_cloud = True
-                        rejected_object_names.add(object_name)
+                    if fixed_mova_object and baseline_identity is None:
+                        saw_unverified_fixed_object = True
+                    elif (
+                        fixed_mova_object
+                        and not object_identity.differs_from(baseline_identity)
+                    ):
+                        saw_stale_point_cloud = True
                     else:
-                        return DreameLawnMowerPointCloudDownload(
-                            map_index=map_index,
-                            content=content,
-                            metadata=metadata,
-                            content_type=content_type,
-                        )
+                        try:
+                            metadata = parse_pcd_metadata(
+                                content,
+                                max_bytes=max_bytes,
+                                deadline=deadline,
+                            )
+                        except DreameLawnMowerPointCloudError:
+                            saw_unusable_point_cloud = True
+                            if not fixed_mova_object:
+                                rejected_object_names.add(object_name)
+                        else:
+                            return DreameLawnMowerPointCloudDownload(
+                                map_index=map_index,
+                                content=content,
+                                metadata=metadata,
+                                content_type=content_type,
+                            )
 
             remaining = deadline - time.monotonic()
             if remaining > 0:
                 time.sleep(min(poll_interval, remaining))
+
+        if saw_unverified_fixed_object:
+            raise DreameLawnMowerPointCloudError(
+                "The MOVA fixed point-cloud object could not be compared with "
+                "its pre-generation version before the timeout.",
+                code="point_cloud_download_invalid",
+                stage="download_validation",
+                public_message=(
+                    "Home Assistant could not verify that the mower refreshed "
+                    f"its 3D map within {timeout:g} seconds."
+                ),
+                timeout_seconds=timeout,
+                retry_after_seconds=10,
+            )
 
         if saw_unusable_point_cloud:
             raise DreameLawnMowerPointCloudError(
@@ -807,6 +862,21 @@ class _DreameLawnMowerClientMapsMixin:
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
             )
+
+        if saw_stale_point_cloud:
+            raise DreameLawnMowerPointCloudError(
+                "The mower's fixed point-cloud object did not refresh before "
+                "the timeout.",
+                code="point_cloud_not_published",
+                stage="generation",
+                public_message=(
+                    f"The mower did not publish a fresh 3D map within {timeout:g} "
+                    "seconds."
+                ),
+                timeout_seconds=timeout,
+                retry_after_seconds=10,
+            )
+
         raise DreameLawnMowerPointCloudError(
             "The mower did not publish or refresh a point cloud before the timeout.",
             code="point_cloud_not_published",
@@ -816,6 +886,37 @@ class _DreameLawnMowerClientMapsMixin:
             ),
             timeout_seconds=timeout,
             retry_after_seconds=10,
+        )
+
+    def _sync_download_point_cloud_object(
+        self,
+        cloud: Any,
+        object_name: str,
+        *,
+        deadline: float,
+        download_timeout: float,
+        max_bytes: int,
+    ) -> tuple[bytes, str, _PointCloudObjectIdentity]:
+        raw_url = self._sync_get_point_cloud_download_url(
+            cloud,
+            object_name,
+            deadline=deadline,
+        )
+        url = _point_cloud_download_url(raw_url)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out.",
+                code="point_cloud_timeout",
+                stage="download",
+                public_message="The mower did not finish the 3D map request in time.",
+                timeout_seconds=download_timeout,
+                retry_after_seconds=10,
+            )
+        return _download_point_cloud_content_with_identity(
+            url,
+            timeout=min(download_timeout, remaining),
+            max_bytes=max_bytes,
         )
 
     def _sync_call_point_cloud_action(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -93,6 +93,10 @@ from .vector_map import (
 if TYPE_CHECKING:
     from .map_visuals import MapRenderStyle
 
+# The 3dmap object is real PCD content either way; only the reported file
+# extension differs by cloud vendor (Dreame names it "*.pcd", MOVA "*.bin").
+_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
+
 
 class _DreameLawnMowerClientMapsMixin:
     def _sync_switch_current_map(self, map_index: int) -> Any:
@@ -730,11 +734,18 @@ class _DreameLawnMowerClientMapsMixin:
             object_extension = (
                 _app_object_extension(object_name) if object_name is not None else None
             )
-            fresh_object = object_name != baseline_name or observed_clear
+            # MOVA never renames the 3dmap object on generation, so it would
+            # never look "fresh" here; treat its unchanged baseline object as
+            # acceptable right away instead of waiting out the full timeout.
+            fresh_object = (
+                object_name != baseline_name
+                or observed_clear
+                or self._account_type == "mova"
+            )
             if (
                 object_name is not None
                 and object_extension is not None
-                and object_extension.casefold() == "pcd"
+                and object_extension.casefold() in _POINT_CLOUD_OBJECT_EXTENSIONS
                 and fresh_object
                 and object_name not in rejected_object_names
                 and object_download_attempts.get(object_name, 0) < 2

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -258,6 +258,66 @@ def test_download_point_cloud_uses_a2_generation_flow(
     assert all(options["retry_count"] == 0 for options in interim_file_options)
     assert all(0 < options["timeout"] <= 5 for options in interim_file_options)
     assert result.map_index == 0
+
+
+def test_download_point_cloud_accepts_unchanged_baseline_for_mova(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = DreameLawnMowerClient(
+        username="user@example.invalid",
+        password="secret",
+        country="eu",
+        account_type="mova",
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-1",
+            name="Garage Mower",
+            model="mova.mower.g2408",
+            display_model="A2",
+            account_type="mova",
+            country="eu",
+        ),
+    )
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    signed_url = "https://downloads.example.invalid/object?private=signature"
+    cloud = type(
+        "Cloud",
+        (),
+        {"get_interim_file_url": lambda self, name, **kwargs: signed_url},
+    )()
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content, request.full_url
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    # The object never gets renamed (MOVA behavior), but it's downloaded on
+    # the very first poll iteration instead of waiting out the full timeout.
+    assert calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.map_index == 0
     assert result.content == content
     assert result.metadata.points == 1
     assert not hasattr(result, "url")

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -81,8 +81,32 @@ def _client() -> DreameLawnMowerClient:
     )
 
 
+def _mova_client() -> DreameLawnMowerClient:
+    return DreameLawnMowerClient(
+        username="user@example.invalid",
+        password="secret",
+        country="eu",
+        account_type="mova",
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-1",
+            name="Garage Mower",
+            model="mova.mower.g2408",
+            display_model="A2",
+            account_type="mova",
+            country="eu",
+        ),
+    )
+
+
 class _FakeResponse:
-    def __init__(self, content: bytes, url: str) -> None:
+    def __init__(
+        self,
+        content: bytes,
+        url: str,
+        *,
+        etag: str | None = None,
+        last_modified: str | None = None,
+    ) -> None:
         self._content = content
         self._offset = 0
         self._url = url
@@ -94,6 +118,10 @@ class _FakeResponse:
         self.headers = Message()
         self.headers["Content-Length"] = str(len(content))
         self.headers["Content-Type"] = "application/octet-stream"
+        if etag is not None:
+            self.headers["ETag"] = etag
+        if last_modified is not None:
+            self.headers["Last-Modified"] = last_modified
 
     def __enter__(self) -> _FakeResponse:
         return self
@@ -258,30 +286,23 @@ def test_download_point_cloud_uses_a2_generation_flow(
     assert all(options["retry_count"] == 0 for options in interim_file_options)
     assert all(0 < options["timeout"] <= 5 for options in interim_file_options)
     assert result.map_index == 0
+    assert result.content == content
+    assert result.metadata.points == 1
+    assert not hasattr(result, "url")
+    assert not hasattr(result, "object_name")
 
 
-def test_download_point_cloud_accepts_unchanged_baseline_for_mova(
+def test_download_point_cloud_waits_for_changed_mova_fixed_object(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = DreameLawnMowerClient(
-        username="user@example.invalid",
-        password="secret",
-        country="eu",
-        account_type="mova",
-        descriptor=DreameLawnMowerDescriptor(
-            did="device-1",
-            name="Garage Mower",
-            model="mova.mower.g2408",
-            display_model="A2",
-            account_type="mova",
-            country="eu",
-        ),
-    )
+    client = _mova_client()
     calls: list[dict[str, Any]] = []
     responses = iter(
         [
             {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
             {"r": 0},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
             {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
         ]
     )
@@ -296,7 +317,16 @@ def test_download_point_cloud_accepts_unchanged_baseline_for_mova(
         (),
         {"get_interim_file_url": lambda self, name, **kwargs: signed_url},
     )()
-    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    baseline_content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    refreshed_content = _binary_pcd((4.0, 5.0, 6.0, 0x654321))
+    downloads = iter(
+        [
+            baseline_content,
+            baseline_content,
+            baseline_content,
+            refreshed_content,
+        ]
+    )
     client._sync_call_app_action = call_app_action
     client._sync_get_cloud_protocol = lambda **kwargs: cloud
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
@@ -304,24 +334,175 @@ def test_download_point_cloud_accepts_unchanged_baseline_for_mova(
         _internal_client_module,
         "_open_point_cloud_response",
         lambda request, *, timeout, deadline: _FakeResponse(
-            content, request.full_url
+            next(downloads),
+            request.full_url,
         ),
     )
 
     result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
 
-    # The object never gets renamed (MOVA behavior), but it's downloaded on
-    # the very first poll iteration instead of waiting out the full timeout.
+    # The object never gets renamed (MOVA behavior), so unchanged valid
+    # baseline bytes are ignored until the overwritten content is observable.
     assert calls == [
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
     ]
     assert result.map_index == 0
-    assert result.content == content
+    assert result.content == refreshed_content
     assert result.metadata.points == 1
     assert not hasattr(result, "url")
     assert not hasattr(result, "object_name")
+
+
+def test_download_point_cloud_accepts_new_mova_object_validator(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client()
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+        ]
+    )
+    client._sync_call_app_action = lambda payload, **kwargs: next(responses)
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    downloads = iter(
+        [
+            _FakeResponse(
+                content,
+                "https://downloads.example.invalid/object",
+                etag='"baseline"',
+            ),
+            _FakeResponse(
+                content,
+                "https://downloads.example.invalid/object",
+                etag='"refreshed"',
+            ),
+        ]
+    )
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: next(downloads),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert result.content == content
+    assert result.metadata.points == 1
+
+
+def test_download_point_cloud_retries_mova_fixed_object_until_valid_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    baseline_content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    refreshed_content = _binary_pcd((4.0, 5.0, 6.0, 0x654321))
+    downloads: Any = iter(
+        [
+            _FakeResponse(
+                baseline_content,
+                "https://downloads.example.invalid/object",
+            ),
+            TimeoutError(),
+            _FakeResponse(
+                b"partially overwritten",
+                "https://downloads.example.invalid/object",
+            ),
+            _FakeResponse(
+                refreshed_content,
+                "https://downloads.example.invalid/object",
+            ),
+        ]
+    )
+
+    def open_response(request: Any, *, timeout: float, deadline: float) -> Any:
+        result = next(downloads)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        open_response,
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.content == refreshed_content
+    assert result.metadata.points == 1
+
+
+def test_download_point_cloud_does_not_accept_bin_extension_for_dreame(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    action_count = 0
+    download_url_calls = 0
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        nonlocal action_count
+        action_count += 1
+        if action_count == 1:
+            return {"r": 0, "d": {"name": ["private/existing-map.pcd"]}}
+        if action_count == 2:
+            return {"r": 0}
+        return {"r": 0, "d": {"name": ["private/generated-map.bin"]}}
+
+    def get_interim_file_url(name: str, **kwargs: Any) -> str:
+        nonlocal download_url_calls
+        download_url_calls += 1
+        return "https://downloads.example.invalid/object"
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=get_interim_file_url,
+    )
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+
+    with pytest.raises(DreameLawnMowerPointCloudError):
+        client._sync_download_app_map_point_cloud(0, 0.01, 0.001, 10, 1024)
+
+    assert download_url_calls == 0
 
 
 def test_download_point_cloud_error_does_not_expose_signed_url(
@@ -359,6 +540,59 @@ def test_download_point_cloud_error_does_not_expose_signed_url(
     assert "HTTP status 403" in str(captured.value)
     assert signed_url not in str(captured.value)
     assert signed_url not in repr(captured.value)
+
+
+def test_download_point_cloud_stops_at_declared_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signed_url = "https://downloads.example.invalid/private-object"
+    content = b"complete"
+    response = _FakeResponse(content, signed_url)
+    read_sizes: list[int] = []
+    original_read = response.read
+
+    def read(size: int) -> bytes:
+        read_sizes.append(size)
+        return original_read(size)
+
+    response.read = read
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: response,
+    )
+
+    downloaded, _ = _internal_client_module._download_point_cloud_content(
+        signed_url,
+        timeout=10,
+        max_bytes=1024,
+    )
+
+    assert downloaded == content
+    assert read_sizes == [len(content)]
+
+
+def test_download_point_cloud_rejects_truncated_content_length(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    signed_url = "https://downloads.example.invalid/private-object"
+    response = _FakeResponse(b"short", signed_url)
+    response.headers.replace_header("Content-Length", "10")
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: response,
+    )
+
+    with pytest.raises(
+        DreameLawnMowerPointCloudError,
+        match="ended before its declared size",
+    ):
+        _internal_client_module._download_point_cloud_content(
+            signed_url,
+            timeout=10,
+            max_bytes=1024,
+        )
 
 
 def test_download_point_cloud_rejects_insecure_redirect_before_following() -> None:


### PR DESCRIPTION
## What changed

MOVA exposes its generated 3D map through a fixed object key and may report the PCD payload with a `.bin` extension. The refresh flow now:

- captures the pre-generation object identity using its content hash and standard object-store validators;
- accepts the reused key only after its content or validators change, or after the object is observably cleared;
- keeps retrying transient downloads and partially overwritten fixed-key payloads until the shared deadline;
- limits `.bin` handling to MOVA while preserving Dreame's renamed `.pcd` flow.

The download reader also stops exactly at a declared `Content-Length` and rejects truncated bodies. This avoids the final-read socket race without treating incomplete data as a valid point cloud.

## Why

Waiting only for a renamed object makes MOVA generation time out, while accepting the unchanged key immediately can return the pre-generation map. Identity-based freshness handles the fixed-key behavior without weakening the existing Dreame contract.

The branch is rebased onto the current integration release and preserves its structured problem responses, privacy-safe diagnostics, timing, retry guidance, and distinct error stages for stale, unverifiable, invalid, or unavailable point clouds.

## Validation

- 996 repository tests, with one platform-specific skip
- 7 Home Assistant config-flow tests under Linux
- 66 focused point-cloud and diagnostics tests
- Ruff, diff, and packaged-wheel checks

A fresh run against physical MOVA hardware remains the final external validation gap.