### PR TITLE
Add actionable point-cloud diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -43,6 +43,7 @@ body:
         - Device availability or state
         - Mowing controls or services
         - Maps or zones
+        - 3D point cloud
         - Schedules or calendar
         - Live video or camera
         - Sensors or diagnostics

--- a/README.md
+++ b/README.md
@@ -477,6 +477,9 @@ this attribute and offers an on-demand 3D viewer. It does not generate or
 download garden geometry during an ordinary dashboard render. Select the Hero
 layout's **3D** tab or press **Load 3D map** in another layout when you want to
 fetch it. Point-cloud access is currently restricted to Home Assistant admins.
+The mower has up to 45 seconds to publish a fresh file. A failed request returns
+a privacy-safe problem code and stage instead of exposing the vendor object name
+or signed download URL.
 
 Current map support now includes:
 
@@ -558,6 +561,8 @@ The report is sanitized by the integration and includes:
 - privacy-safe setup, foreground-refresh, and background-metadata timings,
   including bounded recent samples plus the latest and aggregate duration for
   each operation
+- on-demand `point_cloud_generation` timings and a stable failure code, stage,
+  retryability flag, and timeout when a 3D map request fails
 - current state and diagnostic attributes for every entity belonging to the
   config entry, including the Live Video camera's last failure stage and a
   bounded, privacy-safe summary of each TX video cloud stage
@@ -570,11 +575,13 @@ Do not enable broad debug logging unless a maintainer asks for a specific logger
 Cloud protocol debug output can contain data that needs additional review before
 it is posted publicly.
 
-Startup and refresh measurements are also written as log lines beginning with
-`Dreame mower performance`. The first setup and metadata hydration are logged at
-info level, while unusually slow foreground or background refreshes are logged
-as warnings. Each line reports only operation names and elapsed time; it does
-not contain credentials, mower identifiers, map data, or coordinates.
+Startup, refresh, and on-demand 3D map measurements are also written as log
+lines beginning with `Dreame mower performance`. The first setup, metadata
+hydration, and successful point-cloud generation are logged at info level.
+Unusually slow refreshes and failed point-cloud generations are logged as
+warnings. Each line reports only operation names, outcome codes, stages, and
+elapsed time; it does not contain credentials, mower identifiers, map data,
+object names, URLs, or coordinates.
 
 For startup reports, include both the `setup` and `metadata_refresh` entries
 from downloaded diagnostics. `setup` is the blocking Home Assistant load path.
@@ -582,6 +589,12 @@ from downloaded diagnostics. `setup` is the blocking Home Assistant load path.
 maintenance, and preference metadata that continues in the background after
 the mower entity can load. The per-phase timings show which vendor endpoint is
 slow without requiring broad protocol debug logging.
+
+For a 3D map report, retry once and download diagnostics before restarting Home
+Assistant. Include the visible `point_cloud_*` reference from the card. The
+matching recent event explains whether the mower failed to publish a fresh
+object, the object could not be downloaded and validated, another generation
+was already running, or the integration reloaded during the request.
 
 The staged cloud summaries retain field names, value types, safe status codes,
 required-field presence, and sanitized error messages. They do not retain raw

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1057,7 +1057,15 @@ class DreameLawnMowerClient(
                 )
         except TimeoutError as err:
             raise DreameLawnMowerPointCloudError(
-                "Point-cloud generation timed out."
+                "Point-cloud generation timed out.",
+                code="point_cloud_timeout",
+                stage="generation",
+                public_message=(
+                    f"The mower did not finish the 3D map request within "
+                    f"{timeout:g} seconds."
+                ),
+                timeout_seconds=timeout,
+                retry_after_seconds=10,
             ) from err
 
     async def async_get_cloud_properties(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -94,7 +94,11 @@ def _point_cloud_object_name(value: Any, map_index: int) -> str | None:
 def _validate_point_cloud_map_index(value: int) -> int:
     if isinstance(value, bool) or not isinstance(value, int) or not 0 <= value <= 255:
         raise DreameLawnMowerPointCloudError(
-            "Point-cloud map index must be an integer between 0 and 255."
+            "Point-cloud map index must be an integer between 0 and 255.",
+            code="point_cloud_invalid_request",
+            stage="request",
+            retryable=False,
+            public_message="The 3D map request contains an invalid map index.",
         )
     return value
 
@@ -102,12 +106,20 @@ def _validate_point_cloud_map_index(value: int) -> int:
 def _validate_positive_number(value: float, label: str) -> float:
     if isinstance(value, bool) or not isinstance(value, int | float):
         raise DreameLawnMowerPointCloudError(
-            f"Point-cloud {label} must be a positive number."
+            f"Point-cloud {label} must be a positive number.",
+            code="point_cloud_invalid_request",
+            stage="request",
+            retryable=False,
+            public_message=f"The 3D map request contains an invalid {label}.",
         )
     normalized = float(value)
     if not math.isfinite(normalized) or normalized <= 0:
         raise DreameLawnMowerPointCloudError(
-            f"Point-cloud {label} must be a positive number."
+            f"Point-cloud {label} must be a positive number.",
+            code="point_cloud_invalid_request",
+            stage="request",
+            retryable=False,
+            public_message=f"The 3D map request contains an invalid {label}.",
         )
     return normalized
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -659,12 +659,26 @@ class _DreameLawnMowerClientMapsMixin:
             or max_bytes <= 0
         ):
             raise DreameLawnMowerPointCloudError(
-                "Point-cloud maximum size must be a positive integer."
+                "Point-cloud maximum size must be a positive integer.",
+                code="point_cloud_invalid_request",
+                stage="request",
+                retryable=False,
+                public_message="The 3D map request contains an invalid size limit.",
             )
 
         deadline = time.monotonic() + timeout if deadline is None else deadline
         if time.monotonic() >= deadline:
-            raise DreameLawnMowerPointCloudError("Point-cloud generation timed out.")
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out.",
+                code="point_cloud_timeout",
+                stage="generation",
+                public_message=(
+                    f"The mower did not finish the 3D map request within "
+                    f"{timeout:g} seconds."
+                ),
+                timeout_seconds=timeout,
+                retry_after_seconds=10,
+            )
         baseline_result = self._sync_call_point_cloud_action(
             {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
             operation="read the existing point-cloud object state",
@@ -686,7 +700,14 @@ class _DreameLawnMowerClientMapsMixin:
         cloud = self._sync_get_cloud_protocol(deadline=deadline)
         if not hasattr(cloud, "get_interim_file_url"):
             raise DreameLawnMowerPointCloudError(
-                "The configured cloud protocol cannot download interim files."
+                "The configured cloud protocol cannot download interim files.",
+                code="point_cloud_download_unsupported",
+                stage="download",
+                retryable=False,
+                public_message=(
+                    "This Home Assistant connection cannot download the mower's "
+                    "generated 3D map."
+                ),
             )
 
         observed_clear = baseline_name is None
@@ -765,10 +786,25 @@ class _DreameLawnMowerClientMapsMixin:
         if saw_unusable_point_cloud:
             raise DreameLawnMowerPointCloudError(
                 "The mower published a point cloud, but it could not be downloaded "
-                "and validated before the timeout."
+                "and validated before the timeout.",
+                code="point_cloud_download_invalid",
+                stage="download_validation",
+                public_message=(
+                    "The mower published a 3D map, but Home Assistant could not "
+                    f"download and validate it within {timeout:g} seconds."
+                ),
+                timeout_seconds=timeout,
+                retry_after_seconds=10,
             )
         raise DreameLawnMowerPointCloudError(
-            "The mower did not publish or refresh a point cloud before the timeout."
+            "The mower did not publish or refresh a point cloud before the timeout.",
+            code="point_cloud_not_published",
+            stage="generation",
+            public_message=(
+                f"The mower did not publish a fresh 3D map within {timeout:g} seconds."
+            ),
+            timeout_seconds=timeout,
+            retry_after_seconds=10,
         )
 
     def _sync_call_point_cloud_action(
@@ -782,7 +818,13 @@ class _DreameLawnMowerClientMapsMixin:
         """Call one point-cloud action within the shared generation deadline."""
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise DreameLawnMowerPointCloudError("Point-cloud generation timed out.")
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out.",
+                code="point_cloud_timeout",
+                stage="mower_request",
+                public_message="The mower did not finish the 3D map request in time.",
+                retry_after_seconds=10,
+            )
         try:
             response = self._sync_call_app_action(
                 payload,
@@ -794,18 +836,47 @@ class _DreameLawnMowerClientMapsMixin:
         except DreameLawnMowerConnectionError as err:
             if time.monotonic() >= deadline:
                 raise DreameLawnMowerPointCloudError(
-                    "Point-cloud generation timed out."
+                    "Point-cloud generation timed out.",
+                    code="point_cloud_timeout",
+                    stage="mower_request",
+                    public_message=(
+                        "The mower did not finish the 3D map request in time."
+                    ),
+                    retry_after_seconds=10,
                 ) from err
             raise DreameLawnMowerPointCloudError(
-                f"The mower could not {operation}."
+                f"The mower could not {operation}.",
+                code="point_cloud_mower_request_failed",
+                stage="mower_request",
+                public_message=(
+                    "The mower rejected or could not complete the 3D map request."
+                ),
+                retry_after_seconds=10,
             ) from err
         if time.monotonic() >= deadline:
-            raise DreameLawnMowerPointCloudError("Point-cloud generation timed out.")
-        return _point_cloud_action_data(
-            response,
-            operation,
-            require_data=require_data,
-        )
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud generation timed out.",
+                code="point_cloud_timeout",
+                stage="mower_request",
+                public_message="The mower did not finish the 3D map request in time.",
+                retry_after_seconds=10,
+            )
+        try:
+            return _point_cloud_action_data(
+                response,
+                operation,
+                require_data=require_data,
+            )
+        except DreameLawnMowerPointCloudError as err:
+            raise DreameLawnMowerPointCloudError(
+                str(err),
+                code="point_cloud_mower_response_invalid",
+                stage="mower_response",
+                public_message=(
+                    "The mower returned an invalid response for the 3D map request."
+                ),
+                retry_after_seconds=10,
+            ) from err
 
     def _sync_get_point_cloud_download_url(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -21,7 +21,26 @@ _VALIDATION_DEADLINE_CHECK_BYTES = 64 * 1024
 
 
 class DreameLawnMowerPointCloudError(ValueError):
-    """Raised when a downloaded point cloud is invalid or unsupported."""
+    """Describe a point-cloud failure without exposing private cloud details."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        code: str = "point_cloud_failed",
+        stage: str = "point_cloud",
+        retryable: bool = True,
+        public_message: str = "The mower point cloud is temporarily unavailable.",
+        timeout_seconds: float | None = None,
+        retry_after_seconds: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.code = code
+        self.stage = stage
+        self.retryable = retryable
+        self.public_message = public_message
+        self.timeout_seconds = timeout_seconds
+        self.retry_after_seconds = retry_after_seconds
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -8,7 +8,7 @@ import time
 from collections import OrderedDict
 from collections.abc import Mapping
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, NoReturn
 
 from aiohttp import web
 from homeassistant.components.http import HomeAssistantView
@@ -17,10 +17,12 @@ from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
 from .control_options import current_map_index
+from .diagnostic_events import record_diagnostic_event
 from .dreame_lawn_mower_client import (
     DreameLawnMowerPointCloudDownload,
     DreameLawnMowerPointCloudError,
 )
+from .performance import format_performance_sample
 
 if TYPE_CHECKING:
     from .coordinator import DreameLawnMowerCoordinator
@@ -31,6 +33,29 @@ POINT_CLOUD_API_DATA_KEY = "point_cloud_api"
 POINT_CLOUD_API_PATH = f"/api/{DOMAIN}/point-cloud"
 POINT_CLOUD_CACHE_TTL_SECONDS = 60.0
 POINT_CLOUD_CACHE_MAX_ENTRIES = 4
+POINT_CLOUD_PROBLEM_SCHEMA_VERSION = 1
+
+_POINT_CLOUD_PROBLEM_STATUS = {
+    "point_cloud_generation_in_progress": 409,
+    "point_cloud_invalid_request": 400,
+    "point_cloud_timeout": 504,
+    "point_cloud_not_published": 504,
+    "point_cloud_download_invalid": 504,
+    "point_cloud_entry_reloaded": 503,
+    "point_cloud_download_unsupported": 503,
+}
+_POINT_CLOUD_PROBLEM_TITLE = {
+    "point_cloud_generation_in_progress": "3D map generation already in progress",
+    "point_cloud_invalid_request": "Invalid 3D map request",
+    "point_cloud_timeout": "3D map generation timed out",
+    "point_cloud_not_published": "The mower did not publish a fresh 3D map",
+    "point_cloud_download_invalid": "The generated 3D map could not be used",
+    "point_cloud_entry_reloaded": "The mower integration was reloaded",
+    "point_cloud_download_unsupported": "3D map download is unavailable",
+    "point_cloud_mower_request_failed": "The mower rejected the 3D map request",
+    "point_cloud_mower_response_invalid": "The mower returned an invalid response",
+    "point_cloud_failed": "3D map unavailable",
+}
 
 
 def point_cloud_api_path(entry_id: str, map_index: int) -> str:
@@ -128,9 +153,18 @@ class DreameLawnMowerPointCloudAPI:
             if inflight.epoch != epoch:
                 await self._async_discard_stale_generation(other_key, inflight)
                 return await self.async_get(entry_id, map_index, refresh=refresh)
-            raise DreameLawnMowerPointCloudError(
-                "Another point-cloud generation is already in progress "
-                "for this mower."
+            self._reject_request(
+                coordinator,
+                DreameLawnMowerPointCloudError(
+                    "Another point-cloud generation is already in progress "
+                    "for this mower.",
+                    code="point_cloud_generation_in_progress",
+                    stage="queue",
+                    public_message=(
+                        "A 3D map is already being generated for this mower."
+                    ),
+                    retry_after_seconds=5,
+                ),
             )
 
         generation = self._async_generate(
@@ -191,17 +225,78 @@ class DreameLawnMowerPointCloudAPI:
         epoch: int,
     ) -> DreameLawnMowerPointCloudDownload:
         """Run and cache one generation independently of HTTP waiters."""
-        if self._entry_epochs.get(key[0], 0) != epoch:
-            raise DreameLawnMowerPointCloudError(
-                "The mower entry changed before point-cloud generation started."
-            )
-        download = await coordinator.client.async_download_app_map_point_cloud(
-            map_index=key[1]
+        performance = getattr(coordinator, "performance", None)
+        cycle = (
+            performance.start("point_cloud_generation")
+            if hasattr(performance, "start")
+            else None
         )
-        if self._entry_epochs.get(key[0], 0) != epoch:
-            raise DreameLawnMowerPointCloudError(
-                "The mower entry changed during point-cloud generation."
+        try:
+            if self._entry_epochs.get(key[0], 0) != epoch:
+                raise DreameLawnMowerPointCloudError(
+                    "The mower entry changed before point-cloud generation started.",
+                    code="point_cloud_entry_reloaded",
+                    stage="lifecycle",
+                    public_message=(
+                        "The mower integration was reloaded before the 3D map "
+                        "request started."
+                    ),
+                    retry_after_seconds=2,
+                )
+            if cycle is not None:
+                download = await cycle.measure(
+                    "generate_download_validate",
+                    lambda: coordinator.client.async_download_app_map_point_cloud(
+                        map_index=key[1]
+                    ),
+                )
+            else:
+                download = (
+                    await coordinator.client.async_download_app_map_point_cloud(
+                        map_index=key[1]
+                    )
+                )
+            if self._entry_epochs.get(key[0], 0) != epoch:
+                raise DreameLawnMowerPointCloudError(
+                    "The mower entry changed during point-cloud generation.",
+                    code="point_cloud_entry_reloaded",
+                    stage="lifecycle",
+                    public_message=(
+                        "The mower integration was reloaded while generating the "
+                        "3D map."
+                    ),
+                    retry_after_seconds=2,
+                )
+        except DreameLawnMowerPointCloudError as err:
+            sample = cycle.finish(outcome=err.code) if cycle is not None else None
+            self._record_generation_failure(coordinator, err, sample)
+            raise
+        except Exception as err:
+            public_error = DreameLawnMowerPointCloudError(
+                "Unexpected point-cloud generation failure.",
+                code="point_cloud_failed",
+                stage="generation",
+                public_message="The mower point cloud is temporarily unavailable.",
+                retry_after_seconds=10,
             )
+            sample = (
+                cycle.finish(outcome=public_error.code)
+                if cycle is not None
+                else None
+            )
+            self._record_generation_failure(coordinator, public_error, sample)
+            raise public_error from err
+        else:
+            if cycle is not None:
+                sample = cycle.finish()
+                total, phases = format_performance_sample(sample)
+                _LOGGER.info(
+                    "Dreame mower performance: operation=point_cloud_generation "
+                    "outcome=completed total=%.3fs phases=%s",
+                    total,
+                    phases,
+                )
+
         created_at = time.monotonic()
         self._remove_cache_entry(key)
         self._cache[key] = _CacheEntry(
@@ -219,6 +314,66 @@ class DreameLawnMowerPointCloudAPI:
             oldest_key = next(iter(self._cache))
             self._remove_cache_entry(oldest_key)
         return download
+
+    def _reject_request(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        error: DreameLawnMowerPointCloudError,
+    ) -> NoReturn:
+        """Record and raise a safe request-level point-cloud failure."""
+        record_diagnostic_event(
+            coordinator,
+            code=error.code,
+            source="point_cloud_api",
+            message=error.public_message,
+            context={
+                "stage": error.stage,
+                "retryable": error.retryable,
+                "retry_after_seconds": error.retry_after_seconds,
+            },
+        )
+        _LOGGER.warning(
+            "Dreame point-cloud request failed: code=%s stage=%s retryable=%s",
+            error.code,
+            error.stage,
+            error.retryable,
+        )
+        raise error
+
+    def _record_generation_failure(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        error: DreameLawnMowerPointCloudError,
+        sample: Any,
+    ) -> None:
+        """Keep one privacy-safe failure event and benchmark sample."""
+        context: dict[str, Any] = {
+            "stage": error.stage,
+            "retryable": error.retryable,
+            "retry_after_seconds": error.retry_after_seconds,
+            "timeout_seconds": error.timeout_seconds,
+        }
+        if sample is not None:
+            context["duration_ms"] = round(sample.total_seconds * 1000, 1)
+            total, phases = format_performance_sample(sample)
+        else:
+            total, phases = 0.0, "none"
+        record_diagnostic_event(
+            coordinator,
+            code=error.code,
+            source="point_cloud_api",
+            message=error.public_message,
+            context=context,
+        )
+        _LOGGER.warning(
+            "Dreame mower performance: operation=point_cloud_generation "
+            "outcome=%s total=%.3fs phases=%s stage=%s retryable=%s",
+            error.code,
+            total,
+            phases,
+            error.stage,
+            error.retryable,
+        )
 
     @callback
     def _generation_done(
@@ -291,12 +446,31 @@ class DreameLawnMowerPointCloudView(HomeAssistantView):
         map_index: str,
     ) -> web.Response:
         """Generate and return one private PCD download."""
+        started_at = time.monotonic()
         try:
             normalized_index = int(map_index)
-        except ValueError as err:
-            raise web.HTTPBadRequest(text="Invalid point-cloud map index.") from err
+        except ValueError:
+            return _point_cloud_problem_response(
+                DreameLawnMowerPointCloudError(
+                    "Invalid point-cloud map index.",
+                    code="point_cloud_invalid_request",
+                    stage="request",
+                    retryable=False,
+                    public_message="The 3D map request contains an invalid map index.",
+                ),
+                elapsed_seconds=time.monotonic() - started_at,
+            )
         if not 0 <= normalized_index <= 255:
-            raise web.HTTPBadRequest(text="Invalid point-cloud map index.")
+            return _point_cloud_problem_response(
+                DreameLawnMowerPointCloudError(
+                    "Invalid point-cloud map index.",
+                    code="point_cloud_invalid_request",
+                    stage="request",
+                    retryable=False,
+                    public_message="The 3D map request contains an invalid map index.",
+                ),
+                elapsed_seconds=time.monotonic() - started_at,
+            )
 
         refresh = request.query.get("refresh") == "1"
         try:
@@ -308,16 +482,31 @@ class DreameLawnMowerPointCloudView(HomeAssistantView):
         except web.HTTPException:
             raise
         except DreameLawnMowerPointCloudError as err:
-            _LOGGER.warning("Dreame point-cloud generation or validation failed")
-            raise web.HTTPBadGateway(
-                text="The mower point cloud is temporarily unavailable."
-            ) from err
-        except Exception as err:  # noqa: BLE001 - keep private cloud details private.
-            _LOGGER.warning("Unexpected Dreame point-cloud generation failure")
-            raise web.HTTPBadGateway(
-                text="The mower point cloud is temporarily unavailable."
-            ) from err
+            return _point_cloud_problem_response(
+                err,
+                elapsed_seconds=time.monotonic() - started_at,
+            )
+        except Exception:  # noqa: BLE001 - keep private cloud details private.
+            elapsed_seconds = time.monotonic() - started_at
+            _LOGGER.warning(
+                "Dreame point-cloud request failed: code=point_cloud_failed "
+                "stage=delivery elapsed=%.3fs retryable=True",
+                elapsed_seconds,
+            )
+            return _point_cloud_problem_response(
+                DreameLawnMowerPointCloudError(
+                    "Unexpected point-cloud delivery failure.",
+                    code="point_cloud_failed",
+                    stage="delivery",
+                    public_message=(
+                        "The mower point cloud is temporarily unavailable."
+                    ),
+                    retry_after_seconds=10,
+                ),
+                elapsed_seconds=elapsed_seconds,
+            )
 
+        elapsed_ms = round((time.monotonic() - started_at) * 1000, 1)
         return web.Response(
             body=download.content,
             content_type="application/octet-stream",
@@ -327,8 +516,50 @@ class DreameLawnMowerPointCloudView(HomeAssistantView):
                     f'attachment; filename="dreame-map-{normalized_index}.pcd"'
                 ),
                 "X-Content-Type-Options": "nosniff",
+                "X-Dreame-Operation-Elapsed-Ms": str(elapsed_ms),
+                "Server-Timing": f"dreame-point-cloud;dur={elapsed_ms}",
             },
         )
+
+
+def _point_cloud_problem_response(
+    error: DreameLawnMowerPointCloudError,
+    *,
+    elapsed_seconds: float,
+) -> web.Response:
+    """Return a bounded, machine-readable, privacy-safe failure response."""
+    status = _POINT_CLOUD_PROBLEM_STATUS.get(error.code, 502)
+    elapsed_ms = round(max(0.0, elapsed_seconds) * 1000, 1)
+    headers = {
+        "Cache-Control": "private, no-store",
+        "X-Content-Type-Options": "nosniff",
+        "X-Dreame-Problem-Code": error.code,
+        "X-Dreame-Problem-Stage": error.stage,
+        "X-Dreame-Operation-Elapsed-Ms": str(elapsed_ms),
+        "Server-Timing": f"dreame-point-cloud;dur={elapsed_ms}",
+    }
+    if error.retry_after_seconds is not None:
+        headers["Retry-After"] = str(error.retry_after_seconds)
+    return web.json_response(
+        {
+            "schema_version": POINT_CLOUD_PROBLEM_SCHEMA_VERSION,
+            "title": _POINT_CLOUD_PROBLEM_TITLE.get(
+                error.code,
+                "3D map unavailable",
+            ),
+            "status": status,
+            "detail": error.public_message,
+            "code": error.code,
+            "stage": error.stage,
+            "retryable": error.retryable,
+            "retry_after_seconds": error.retry_after_seconds,
+            "elapsed_ms": elapsed_ms,
+            "timeout_seconds": error.timeout_seconds,
+        },
+        status=status,
+        content_type="application/problem+json",
+        headers=headers,
+    )
 
 
 @callback

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -847,8 +847,12 @@ def test_point_cloud_generation_deadline_includes_executor_queue_time(
         with pytest.raises(
             DreameLawnMowerPointCloudError,
             match="generation timed out",
-        ):
+        ) as captured:
             await client.async_download_app_map_point_cloud(timeout=0.01)
+        assert captured.value.code == "point_cloud_timeout"
+        assert captured.value.stage == "generation"
+        assert captured.value.timeout_seconds == 0.01
+        assert captured.value.retryable is True
         assert queued.is_set()
 
     asyncio.run(run())
@@ -1029,5 +1033,40 @@ def test_download_point_cloud_rejects_ambiguous_failed_object_poll(
     with pytest.raises(
         DreameLawnMowerPointCloudError,
         match="could not read the generated point-cloud object state",
-    ):
+    ) as captured:
         client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+    assert captured.value.code == "point_cloud_mower_response_invalid"
+    assert captured.value.stage == "mower_response"
+
+
+@pytest.mark.parametrize(
+    ("map_index", "timeout", "poll_interval", "download_timeout", "max_bytes"),
+    [
+        (-1, 5, 0.1, 10, 1024),
+        (0, 0, 0.1, 10, 1024),
+        (0, 5, 0, 10, 1024),
+        (0, 5, 0.1, 0, 1024),
+        (0, 5, 0.1, 10, 0),
+    ],
+)
+def test_download_point_cloud_classifies_invalid_request_values(
+    map_index: int,
+    timeout: float,
+    poll_interval: float,
+    download_timeout: float,
+    max_bytes: int,
+) -> None:
+    client = _client()
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(
+            map_index,
+            timeout,
+            poll_interval,
+            download_timeout,
+            max_bytes,
+        )
+
+    assert captured.value.code == "point_cloud_invalid_request"
+    assert captured.value.stage == "request"
+    assert captured.value.retryable is False

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -3,17 +3,23 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
 from types import SimpleNamespace
 from typing import Any
 
 import pytest
-from aiohttp import web
 from homeassistant.exceptions import Unauthorized
 
 from custom_components.dreame_lawn_mower.const import DOMAIN
+from custom_components.dreame_lawn_mower.diagnostic_events import (
+    DreameLawnMowerDiagnosticEventStore,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     DreameLawnMowerPointCloudError,
+)
+from custom_components.dreame_lawn_mower.performance import (
+    DreameLawnMowerPerformanceTracker,
 )
 from custom_components.dreame_lawn_mower.point_cloud_api import (
     POINT_CLOUD_API_DATA_KEY,
@@ -334,6 +340,50 @@ def test_point_cloud_api_purges_unloaded_entry() -> None:
     assert calls == 2
 
 
+def test_point_cloud_api_records_safe_failure_and_timing() -> None:
+    private_detail = "https://downloads.example.invalid/map?token=private"
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        raise DreameLawnMowerPointCloudError(
+            private_detail,
+            code="point_cloud_not_published",
+            stage="generation",
+            public_message=(
+                "The mower did not publish a fresh 3D map within 45 seconds."
+            ),
+            timeout_seconds=45,
+            retry_after_seconds=10,
+        )
+
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(async_download_app_map_point_cloud=download),
+        diagnostic_events=DreameLawnMowerDiagnosticEventStore(),
+        performance=DreameLawnMowerPerformanceTracker(),
+    )
+    hass = SimpleNamespace(data={DOMAIN: {"entry-1": coordinator}})
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        with pytest.raises(DreameLawnMowerPointCloudError):
+            await api.async_get("entry-1", 0)
+
+    asyncio.run(run())
+
+    event = coordinator.diagnostic_events.as_list()[0]
+    assert event["code"] == "point_cloud_not_published"
+    assert event["source"] == "point_cloud_api"
+    assert event["context"]["stage"] == "generation"
+    assert event["context"]["timeout_seconds"] == 45
+    assert private_detail not in repr(event)
+    performance = coordinator.performance.as_dict()
+    assert performance["summary"]["point_cloud_generation"]["outcomes"] == {
+        "point_cloud_not_published": 1
+    }
+    assert performance["latest_by_operation"]["point_cloud_generation"][
+        "phases_ms"
+    ].keys() == {"generate_download_validate"}
+
+
 def test_point_cloud_api_registration_is_idempotent() -> None:
     registered: list[object] = []
     hass = SimpleNamespace(
@@ -420,6 +470,65 @@ def test_point_cloud_view_requires_admin() -> None:
     asyncio.run(run())
 
 
+@pytest.mark.parametrize("map_index", ["invalid", "-1", "256"])
+def test_point_cloud_view_returns_structured_invalid_request(
+    map_index: str,
+) -> None:
+    view = DreameLawnMowerPointCloudView(SimpleNamespace())
+
+    response = asyncio.run(
+        view.get(_FakeRequest(is_admin=True), "entry-1", map_index)
+    )
+    payload = json.loads(response.text)
+
+    assert response.status == 400
+    assert response.content_type == "application/problem+json"
+    assert payload["code"] == "point_cloud_invalid_request"
+    assert payload["stage"] == "request"
+    assert payload["retryable"] is False
+    assert "map index" in payload["detail"]
+
+
+def test_point_cloud_view_returns_actionable_problem_details() -> None:
+    async def get(*args: Any, **kwargs: Any) -> None:
+        raise DreameLawnMowerPointCloudError(
+            "Internal point-cloud polling detail.",
+            code="point_cloud_not_published",
+            stage="generation",
+            public_message=(
+                "The mower did not publish a fresh 3D map within 45 seconds."
+            ),
+            timeout_seconds=45,
+            retry_after_seconds=10,
+        )
+
+    view = DreameLawnMowerPointCloudView(SimpleNamespace(async_get=get))
+    response = asyncio.run(
+        view.get(_FakeRequest(is_admin=True), "entry-1", "0")
+    )
+    payload = json.loads(response.text)
+
+    assert response.status == 504
+    assert response.content_type == "application/problem+json"
+    assert response.headers["Cache-Control"] == "private, no-store"
+    assert response.headers["Retry-After"] == "10"
+    assert response.headers["X-Dreame-Problem-Code"] == (
+        "point_cloud_not_published"
+    )
+    assert payload == {
+        "schema_version": 1,
+        "title": "The mower did not publish a fresh 3D map",
+        "status": 504,
+        "detail": "The mower did not publish a fresh 3D map within 45 seconds.",
+        "code": "point_cloud_not_published",
+        "stage": "generation",
+        "retryable": True,
+        "retry_after_seconds": 10,
+        "elapsed_ms": pytest.approx(0, abs=10),
+        "timeout_seconds": 45,
+    }
+
+
 def test_point_cloud_view_does_not_log_private_exception_details(
     caplog: pytest.LogCaptureFixture,
 ) -> None:
@@ -432,13 +541,14 @@ def test_point_cloud_view_does_not_log_private_exception_details(
 
     view = DreameLawnMowerPointCloudView(SimpleNamespace(async_get=get))
 
-    async def run() -> None:
-        with pytest.raises(web.HTTPBadGateway):
-            await view.get(_FakeRequest(is_admin=True), "entry-1", "0")
-
     with caplog.at_level(logging.WARNING):
-        asyncio.run(run())
+        response = asyncio.run(
+            view.get(_FakeRequest(is_admin=True), "entry-1", "0")
+        )
 
-    assert "point-cloud generation failure" in caplog.text
+    assert response.status == 502
+    assert json.loads(response.text)["code"] == "point_cloud_failed"
+    assert "code=point_cloud_failed" in caplog.text
     assert private_detail not in caplog.text
     assert "do-not-log" not in caplog.text
+    assert private_detail not in response.text


### PR DESCRIPTION
## What changed

- return a stable `application/problem+json` response for point-cloud failures, including a safe code, stage, retryability, elapsed time, and retry guidance
- record point-cloud generation timing through the integration's shared performance tracker and add privacy-safe recent diagnostic events
- distinguish invalid requests, mower request/response failures, generation timeouts, unpublished objects, download validation failures, reloads, and unsupported downloads
- keep private object names, URLs, coordinates, credentials, and exception details out of responses and logs
- document the 45-second generation window, troubleshooting workflow, and useful diagnostics; add 3D point cloud to the bug-report area selector

## User experience

A generic HTTP 502 can now be diagnosed from the response, Home Assistant logs, or downloaded integration diagnostics without enabling unsafe verbose logging. Invalid requests use the same structured contract instead of falling back to plain text.

## Compatibility

The endpoint remains authenticated and administrator-only. Successful PCD downloads are unchanged, and older cards continue to receive a normal HTTP failure if they do not understand the richer problem response.

## Validation

- full Python regression suite and Ruff
- Home Assistant config-flow lane on Linux
- focused point-cloud, diagnostics, privacy, and concurrency contracts
- packaged wheel content