### PR TITLE
Add ARM64 XP2P runtime compatibility diagnostics

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -42,3 +42,27 @@ jobs:
         env:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: pytest tests --ignore=tests/components/dreame_lawn_mower/test_config_flow.py
+
+  xp2p-runtime-arm64:
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v6
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.13"
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install -e .[test]
+
+      - name: Validate native managed XP2P worker
+        env:
+          DREAME_XP2P_REAL_RUNTIME_TEST: "1"
+          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
+        run: >-
+          pytest tests/test_xp2p_host_runtime.py
+          -k real_managed_worker_accepts_request_on_native_host

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -49,20 +49,19 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.13"
-
-      - name: Install dependencies
-        run: |
-          python -m pip install --upgrade pip
-          python -m pip install -e .[test]
-
-      - name: Validate native managed XP2P worker
+      - name: Validate native runtime in Home Assistant Container
         env:
-          DREAME_XP2P_REAL_RUNTIME_TEST: "1"
-          PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
-        run: >-
-          pytest tests/test_xp2p_host_runtime.py
-          -k real_managed_worker_accepts_request_on_native_host
+          HOME_ASSISTANT_IMAGE: >-
+            ghcr.io/home-assistant/home-assistant:2026.7.2
+        run: |
+          docker run --rm \
+            --volume "$PWD:/work" \
+            --workdir /work \
+            --env DREAME_XP2P_REAL_RUNTIME_TEST=1 \
+            --env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 \
+            "$HOME_ASSISTANT_IMAGE" \
+            bash -ceu '
+              python -m pip install --disable-pip-version-check pytest
+              python -m pytest tests/test_xp2p_host_runtime.py \
+                -k real_managed_worker_accepts_request_on_native_host
+            '

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_host_probe.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_host_probe.py
@@ -1,0 +1,75 @@
+"""Privacy-safe compatibility probe for the managed XP2P worker."""
+
+from __future__ import annotations
+
+import struct
+import subprocess
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .video_runner_diagnostics import safe_output_preview
+
+_PROBE_REQUEST = b"invalid request"
+_RESPONSE_MAGIC = b"DXR1"
+_EXPECTED_STATUS = 1
+
+
+def probe_xp2p_host_worker(
+    command: Sequence[str],
+    environment: Mapping[str, str],
+    *,
+    timeout: float = 10.0,
+) -> dict[str, Any]:
+    """Check that the isolated worker can read and answer on this host."""
+    try:
+        result = subprocess.run(
+            command,
+            input=_PROBE_REQUEST,
+            capture_output=True,
+            env=dict(environment),
+            timeout=timeout,
+            check=False,
+        )
+    except subprocess.TimeoutExpired:
+        return {
+            "ready": False,
+            "stage": "response_wait",
+            "exception": "TimeoutExpired",
+        }
+    except OSError as err:
+        return {
+            "ready": False,
+            "stage": "process_start",
+            "exception": type(err).__name__,
+            "errno": err.errno,
+        }
+
+    response_status = _response_status(result.stdout)
+    ready = result.returncode == _EXPECTED_STATUS and response_status == (
+        _EXPECTED_STATUS
+    )
+    diagnostics: dict[str, Any] = {
+        "ready": ready,
+        "stage": "response_decode" if result.stdout else "response_wait",
+        "returncode": result.returncode,
+        "exit": format_process_returncode(result.returncode),
+    }
+    if response_status is not None:
+        diagnostics["response_status"] = response_status
+    native_trace = safe_output_preview(result.stderr, ())
+    if native_trace:
+        diagnostics["native_trace"] = native_trace
+    return diagnostics
+
+
+def format_process_returncode(returncode: int) -> str:
+    """Return a stable description of a worker process exit."""
+    if returncode < 0:
+        return f"signal={-returncode}"
+    return f"exit_code={returncode}"
+
+
+def _response_status(payload: bytes) -> int | None:
+    if len(payload) < 12 or payload[:4] != _RESPONSE_MAGIC:
+        return None
+    return struct.unpack("!I", payload[4:8])[0]

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_host_runtime.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_host_runtime.py
@@ -10,7 +10,7 @@ import tempfile
 import threading
 import time
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, BinaryIO
 
@@ -104,6 +104,11 @@ class DreameLawnMowerXp2pHostAssets:
     library_path: Path
     library_search_paths: tuple[Path, ...]
     qemu_path: Path | None = None
+    startup_probe: dict[str, Any] | None = field(
+        default=None,
+        compare=False,
+        hash=False,
+    )
 
     def command(self) -> tuple[str, ...]:
         """Return the non-secret worker command."""
@@ -200,6 +205,7 @@ class DreameLawnMowerXp2pHostRuntime:
         """Start a host-owned local HTTP-FLV session."""
         self.last_failure = None
         self.assets.validate()
+        self.require_compatible_worker()
         request = DreameLawnMowerXp2pLiveStreamRequest.from_runtime_inputs(inputs)
         device_config = self.config_fetcher(inputs)
         stun_file = _write_stun_file(_stun_servers(device_config))
@@ -231,6 +237,7 @@ class DreameLawnMowerXp2pHostRuntime:
         """Start direct same-LAN HTTP-FLV without cloud config or credentials."""
         self.last_failure = None
         self.assets.validate()
+        self.require_compatible_worker()
         request = DreameLawnMowerXp2pLiveStreamRequest.from_lan_runtime_inputs(inputs)
         if endpoint is None:
             endpoint = self.lan_discoverer(
@@ -414,6 +421,8 @@ class DreameLawnMowerXp2pHostRuntime:
                 failure["exit"] = _format_worker_returncode(failure_returncode)
             if native_detail:
                 failure["native_trace"] = native_detail
+            if self.assets.startup_probe is not None:
+                failure["startup_probe"] = self.assets.startup_probe
             self.last_failure = failure
             if isinstance(err, DreameLawnMowerVideoRuntimeError):
                 if startup_stage != "response_wait":
@@ -425,6 +434,20 @@ class DreameLawnMowerXp2pHostRuntime:
             raise DreameLawnMowerVideoRuntimeError(
                 "XP2P host worker could not start (" + ", ".join(details) + ")."
             ) from err
+
+    def require_compatible_worker(self) -> None:
+        """Stop before a real request when the safe startup probe failed."""
+        probe = self.assets.startup_probe
+        if probe is None or probe.get("ready") is True:
+            return
+        self.last_failure = {
+            "stage": "runtime_probe",
+            "startup_probe": probe,
+        }
+        exit_detail = probe.get("exit", "unknown exit")
+        raise DreameLawnMowerVideoRuntimeError(
+            f"XP2P host worker compatibility probe failed ({exit_detail})."
+        )
 
     def stop_live_stream(self, session: DreameLawnMowerXp2pLiveStreamSession) -> None:
         """Stop the worker and remove its transient STUN configuration."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_runtime_bootstrap.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_runtime_bootstrap.py
@@ -15,12 +15,14 @@ import tempfile
 import threading
 import zipfile
 from collections.abc import Mapping
+from dataclasses import replace
 from pathlib import Path, PurePosixPath
 from typing import Protocol
 
 import requests
 
 from .video_runtime import DreameLawnMowerVideoRuntimeError
+from .xp2p_host_probe import probe_xp2p_host_worker
 from .xp2p_host_runtime import DreameLawnMowerXp2pHostAssets
 from .xp2p_host_worker_blob import (
     WORKER_GZIP_BASE64,
@@ -145,39 +147,51 @@ def ensure_xp2p_host_runtime(
     runtime_path = root_path / f"runtime-v{RUNTIME_LAYOUT_VERSION}-{architecture}"
     with _INSTALL_LOCK:
         assets = _validated_assets(runtime_path, architecture)
-        if assets is not None:
-            return assets
-        root_path.mkdir(parents=True, exist_ok=True)
-        staging = Path(
-            tempfile.mkdtemp(
-                prefix=f".{runtime_path.name}-",
-                dir=root_path,
-            )
-        )
-        try:
-            _install_runtime(
-                staging,
-                architecture,
-                http_client=http_client or requests,
-                timeout=timeout,
-            )
-            installed = _validated_assets(staging, architecture)
-            if installed is None:
-                raise DreameLawnMowerVideoRuntimeError(
-                    "Installed XP2P host runtime failed integrity validation."
-                )
-            if runtime_path.exists():
-                _remove_runtime_path(runtime_path, root_path)
-            staging.replace(runtime_path)
-        except Exception:
-            _remove_runtime_path(staging, root_path)
-            raise
-        assets = _validated_assets(runtime_path, architecture)
         if assets is None:
-            raise DreameLawnMowerVideoRuntimeError(
-                "XP2P host runtime disappeared after installation."
+            root_path.mkdir(parents=True, exist_ok=True)
+            staging = Path(
+                tempfile.mkdtemp(
+                    prefix=f".{runtime_path.name}-",
+                    dir=root_path,
+                )
             )
-        return assets
+            try:
+                _install_runtime(
+                    staging,
+                    architecture,
+                    http_client=http_client or requests,
+                    timeout=timeout,
+                )
+                installed = _validated_assets(staging, architecture)
+                if installed is None:
+                    raise DreameLawnMowerVideoRuntimeError(
+                        "Installed XP2P host runtime failed integrity validation."
+                    )
+                if runtime_path.exists():
+                    _remove_runtime_path(runtime_path, root_path)
+                staging.replace(runtime_path)
+            except Exception:
+                _remove_runtime_path(staging, root_path)
+                raise
+            assets = _validated_assets(runtime_path, architecture)
+            if assets is None:
+                raise DreameLawnMowerVideoRuntimeError(
+                    "XP2P host runtime disappeared after installation."
+                )
+    return _with_startup_probe(assets)
+
+
+def _with_startup_probe(
+    assets: DreameLawnMowerXp2pHostAssets,
+) -> DreameLawnMowerXp2pHostAssets:
+    """Attach one safe worker-launch result to the prepared runtime."""
+    return replace(
+        assets,
+        startup_probe=probe_xp2p_host_worker(
+            assets.command(),
+            assets.environment(),
+        ),
+    )
 
 
 def _install_runtime(

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -857,8 +857,16 @@ class DreameLawnMowerVideoCamera(
                 ensure_xp2p_host_runtime(runtime_root),
                 config_fetcher=self._resolve_xp2p_config,
             )
+            try:
+                runtime.require_compatible_worker()
+            except DreameLawnMowerVideoRuntimeError:
+                self._last_managed_runtime_diagnostics = (
+                    video_helpers.safe_state_attribute(runtime.last_failure)
+                )
+                raise
             self._prepared_runtime = runtime
             self._last_native_runtime_diagnostics = None
+            self._last_managed_runtime_diagnostics = None
             return runtime
 
         raise DreameLawnMowerVideoRuntimeError(

--- a/custom_components/dreame_lawn_mower/video_stream_helpers.py
+++ b/custom_components/dreame_lawn_mower/video_stream_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import os
 import platform
 import shlex
 from collections.abc import Callable
@@ -93,7 +94,7 @@ def managed_runtime_supported() -> bool:
     return managed_runtime_environment()["supported"]
 
 
-def managed_runtime_environment() -> dict[str, str | bool]:
+def managed_runtime_environment() -> dict[str, str | bool | int]:
     """Return privacy-safe host facts needed to diagnose managed XP2P startup."""
     system = platform.system().strip().casefold() or "unknown"
     machine = platform.machine().strip().casefold() or "unknown"
@@ -111,11 +112,20 @@ def managed_runtime_environment() -> dict[str, str | bool]:
         if supported
         else "unsupported"
     )
+    libc_name, libc_version = platform.libc_ver()
+    try:
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+    except (AttributeError, OSError, ValueError):
+        page_size = 0
     return {
         "system": system,
         "machine": normalized_machine,
         "execution_mode": execution_mode,
         "supported": supported,
+        "kernel_release": platform.release().strip() or "unknown",
+        "page_size": page_size,
+        "libc": libc_name.strip().casefold() or "unknown",
+        "libc_version": libc_version.strip() or "unknown",
     }
 
 

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -51,6 +51,9 @@ from custom_components.dreame_lawn_mower.const import (
 from custom_components.dreame_lawn_mower.diagnostic_events import (
     DreameLawnMowerDiagnosticEventStore,
 )
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    DreameLawnMowerXp2pHostAssets,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
     DreameLawnMowerCameraStreamRuntimeInputs,
 )
@@ -210,12 +213,28 @@ def test_managed_runtime_environment_is_privacy_safe(
 ) -> None:
     monkeypatch.setattr(video_helpers_module.platform, "system", lambda: "Linux")
     monkeypatch.setattr(video_helpers_module.platform, "machine", lambda: "AMD64")
+    monkeypatch.setattr(video_helpers_module.platform, "release", lambda: "6.12-test")
+    monkeypatch.setattr(
+        video_helpers_module.platform,
+        "libc_ver",
+        lambda: ("glibc", "2.39"),
+    )
+    monkeypatch.setattr(
+        video_helpers_module.os,
+        "sysconf",
+        lambda _name: 4096,
+        raising=False,
+    )
 
     assert video_helpers_module.managed_runtime_environment() == {
         "system": "linux",
         "machine": "x86_64",
         "execution_mode": "qemu_aarch64",
         "supported": True,
+        "kernel_release": "6.12-test",
+        "page_size": 4096,
+        "libc": "glibc",
+        "libc_version": "2.39",
     }
 
 
@@ -1123,6 +1142,73 @@ def test_native_library_runtime_receives_device_config_fetcher() -> None:
     config_fetcher = runtime_type.call_args.kwargs["config_fetcher"]
     assert config_fetcher.__self__ is entity
     assert config_fetcher.__func__ is DreameLawnMowerVideoCamera._resolve_xp2p_config
+
+
+def test_managed_runtime_retries_after_transient_probe_failure(
+    monkeypatch,
+    tmp_path,
+) -> None:
+    entity = _uninitialized_entity()
+    entity._entry.options.pop(CONF_XP2P_RUNNER_COMMAND)
+    entity.hass = SimpleNamespace(
+        config=SimpleNamespace(path=lambda *parts: str(tmp_path.joinpath(*parts)))
+    )
+    failed_assets = DreameLawnMowerXp2pHostAssets(
+        worker_path=tmp_path / "worker",
+        linker_path=tmp_path / "linker64",
+        library_path=tmp_path / "libiot_video_demo.so",
+        library_search_paths=(tmp_path,),
+        startup_probe={
+            "ready": False,
+            "stage": "response_wait",
+            "exception": "TimeoutExpired",
+        },
+    )
+    ready_assets = DreameLawnMowerXp2pHostAssets(
+        worker_path=tmp_path / "worker",
+        linker_path=tmp_path / "linker64",
+        library_path=tmp_path / "libiot_video_demo.so",
+        library_search_paths=(tmp_path,),
+        startup_probe={
+            "ready": True,
+            "returncode": 1,
+            "exit": "exit_code=1",
+            "response_status": 1,
+        },
+    )
+    prepared = iter((failed_assets, ready_assets))
+    monkeypatch.setattr(
+        video_helpers_module,
+        "managed_runtime_supported",
+        lambda: True,
+    )
+    monkeypatch.setattr(
+        video_camera_module,
+        "ensure_xp2p_host_runtime",
+        lambda _root: next(prepared),
+    )
+
+    with pytest.raises(
+        DreameLawnMowerVideoRuntimeError,
+        match="compatibility probe failed",
+    ):
+        entity._create_runtime()
+
+    assert entity._prepared_runtime is None
+    assert entity._last_managed_runtime_diagnostics == {
+        "stage": "runtime_probe",
+        "startup_probe": {
+            "ready": False,
+            "stage": "response_wait",
+            "exception": "TimeoutExpired",
+        },
+    }
+
+    runtime = entity._create_runtime()
+
+    assert runtime is entity._prepared_runtime
+    assert runtime.assets is ready_assets
+    assert entity._last_managed_runtime_diagnostics is None
 
 
 def test_video_camera_serializes_concurrent_stream_starts() -> None:

--- a/tests/test_xp2p_host_runtime.py
+++ b/tests/test_xp2p_host_runtime.py
@@ -6,6 +6,8 @@ import base64
 import gzip
 import hashlib
 import io
+import os
+import platform
 import struct
 import subprocess
 import threading
@@ -194,6 +196,31 @@ def test_embedded_worker_matches_reproducible_hashes() -> None:
     assert hashlib.sha256(compressed).hexdigest() == WORKER_GZIP_SHA256
     assert hashlib.sha256(worker).hexdigest() == WORKER_SHA256
     assert worker.startswith(b"\x7fELF")
+
+
+def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
+    """Prove the installed worker starts on the architecture used by CI."""
+    if (
+        platform.system().casefold() != "linux"
+        or os.environ.get("DREAME_XP2P_REAL_RUNTIME_TEST") != "1"
+    ):
+        pytest.skip("real managed runtime validation is opt-in")
+
+    assets = xp2p_runtime_bootstrap.ensure_xp2p_host_runtime(
+        tmp_path,
+        machine=platform.machine(),
+    )
+    result = subprocess.run(
+        assets.command(),
+        input=b"invalid request",
+        capture_output=True,
+        env=assets.environment(),
+        timeout=30,
+        check=False,
+    )
+
+    assert result.returncode == 1
+    assert result.stdout.startswith(b"DXR1" + struct.pack("!I", 1))
 
 
 def test_host_worker_success_payload_reports_direct_or_relay_route() -> None:

--- a/tests/test_xp2p_host_runtime.py
+++ b/tests/test_xp2p_host_runtime.py
@@ -28,6 +28,7 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import 
     DreameLawnMowerCameraStreamRuntimeInputs,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.video_runtime import (
+    DreameLawnMowerVideoRuntimeError,
     DreameLawnMowerXp2pLiveStreamRequest,
     DreameLawnMowerXp2pLiveStreamSession,
 )
@@ -221,6 +222,25 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
 
     assert result.returncode == 1
     assert result.stdout.startswith(b"DXR1" + struct.pack("!I", 1))
+
+    runtime = xp2p_host_runtime.DreameLawnMowerXp2pHostRuntime(
+        assets,
+        startup_timeout=10,
+        config_fetcher=lambda _inputs: DreameLawnMowerXp2pDeviceConfig(),
+    )
+    with pytest.raises(DreameLawnMowerVideoRuntimeError):
+        runtime.start_live_stream(
+            _inputs(),
+            command_timeout_us=100_000,
+            device_status_attempts=1,
+            device_status_retry_interval=0,
+            delegate_attempts=1,
+            delegate_retry_interval=0,
+        )
+
+    assert runtime.last_failure is not None
+    assert isinstance(runtime.last_failure.get("worker_status"), int)
+    assert runtime.last_failure.get("returncode") != -11
 
 
 def test_host_worker_success_payload_reports_direct_or_relay_route() -> None:

--- a/tests/test_xp2p_host_runtime.py
+++ b/tests/test_xp2p_host_runtime.py
@@ -17,6 +17,7 @@ import pytest
 import requests
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    xp2p_host_probe,
     xp2p_host_runtime,
     xp2p_host_worker_blob,
     xp2p_runtime_bootstrap,
@@ -211,17 +212,12 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
         tmp_path,
         machine=platform.machine(),
     )
-    result = subprocess.run(
-        assets.command(),
-        input=b"invalid request",
-        capture_output=True,
-        env=assets.environment(),
-        timeout=30,
-        check=False,
-    )
-
-    assert result.returncode == 1
-    assert result.stdout.startswith(b"DXR1" + struct.pack("!I", 1))
+    assert assets.startup_probe is not None
+    assert assets.startup_probe["ready"] is True
+    assert assets.startup_probe["stage"] == "response_decode"
+    assert assets.startup_probe["returncode"] == 1
+    assert assets.startup_probe["exit"] == "exit_code=1"
+    assert assets.startup_probe["response_status"] == 1
 
     runtime = xp2p_host_runtime.DreameLawnMowerXp2pHostRuntime(
         assets,
@@ -241,6 +237,82 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
     assert runtime.last_failure is not None
     assert isinstance(runtime.last_failure.get("worker_status"), int)
     assert runtime.last_failure.get("returncode") != -11
+
+
+def test_host_probe_reports_signal_without_exposing_paths(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(
+        subprocess,
+        "run",
+        lambda *_args, **_kwargs: subprocess.CompletedProcess(
+            args=(),
+            returncode=-11,
+            stdout=b"",
+            stderr=b"/config/.storage/dreame-xp2p/linker64 crashed",
+        ),
+    )
+
+    assert xp2p_host_probe.probe_xp2p_host_worker(("worker",), {}) == {
+        "ready": False,
+        "stage": "response_wait",
+        "returncode": -11,
+        "exit": "signal=11",
+        "native_trace": "[redacted-path] crashed",
+    }
+
+
+def test_host_runtime_rejects_failed_compatibility_probe(tmp_path) -> None:
+    runtime = xp2p_host_runtime.DreameLawnMowerXp2pHostRuntime(
+        DreameLawnMowerXp2pHostAssets(
+            worker_path=tmp_path / "worker",
+            linker_path=tmp_path / "linker64",
+            library_path=tmp_path / "libiot_video_demo.so",
+            library_search_paths=(tmp_path,),
+            startup_probe={
+                "ready": False,
+                "returncode": -11,
+                "exit": "signal=11",
+            },
+        )
+    )
+    for path in (
+        runtime.assets.worker_path,
+        runtime.assets.linker_path,
+        runtime.assets.library_path,
+    ):
+        path.touch(mode=0o755)
+
+    with pytest.raises(
+        DreameLawnMowerVideoRuntimeError,
+        match=r"compatibility probe failed \(signal=11\)",
+    ):
+        runtime.start_live_stream(_inputs())
+
+    assert runtime.last_failure == {
+        "stage": "runtime_probe",
+        "startup_probe": {
+            "ready": False,
+            "returncode": -11,
+            "exit": "signal=11",
+        },
+    }
+
+
+def test_host_assets_remain_hashable_with_probe_diagnostics(tmp_path) -> None:
+    assets = DreameLawnMowerXp2pHostAssets(
+        worker_path=tmp_path / "worker",
+        linker_path=tmp_path / "linker64",
+        library_path=tmp_path / "libiot_video_demo.so",
+        library_search_paths=(tmp_path,),
+        startup_probe={
+            "ready": True,
+            "returncode": 1,
+            "exit": "exit_code=1",
+        },
+    )
+
+    assert hash(assets) == hash(replace(assets, startup_probe=None))
 
 
 def test_host_worker_success_payload_reports_direct_or_relay_route() -> None:
@@ -481,6 +553,12 @@ def test_host_runtime_reports_abnormal_worker_exit_without_secrets(
         linker_path=tmp_path / "linker64",
         library_path=tmp_path / "libiot_video_demo.so",
         library_search_paths=(tmp_path / "lib",),
+        startup_probe={
+            "ready": True,
+            "returncode": 1,
+            "exit": "exit_code=1",
+            "response_status": 1,
+        },
     )
     runtime = xp2p_host_runtime.DreameLawnMowerXp2pHostRuntime(
         assets,
@@ -513,6 +591,7 @@ def test_host_runtime_reports_abnormal_worker_exit_without_secrets(
     assert runtime.last_failure is not None
     assert runtime.last_failure["stage"] == "request_write"
     assert runtime.last_failure["returncode"] == -11
+    assert runtime.last_failure["startup_probe"]["ready"] is True
     native_trace = runtime.last_failure["native_trace"]
     assert "[redacted]" in native_trace
     assert long_secret[-64:] not in native_trace


### PR DESCRIPTION
## What changed

- Probe the managed XP2P worker during runtime preparation with a non-secret invalid request and require the expected framed rejection before any mower credentials are sent.
- Report privacy-safe host compatibility facts: architecture, execution mode, kernel release, page size, and libc version.
- Preserve the successful startup probe beside later request-stage crash diagnostics, while leaving transient probe failures retryable instead of caching them until reload.
- Run the full managed-worker request contract inside the exact `ghcr.io/home-assistant/home-assistant:2026.7.2` ARM64 container on native ARM CI.

## Why

Issue #84 reports a native `aarch64` worker crash with signal 11 at `request_write` even though all cloud inputs are present. The native ARM runner and the exact Home Assistant 2026.7.2 ARM64 container both complete the startup contract, so architecture alone is not the cause. These changes separate host/loader startup failures from real-request crashes and collect the smallest additional host facts needed to compare the reporter environment.

This PR does not claim that physical A2 playback is fixed. Issue #84 should remain open until the reporter confirms playback or supplies the new diagnostics from the affected host.

## Validation

- 981 repository tests passed; one opt-in real-runtime test skipped in the normal lane.
- Ruff and diff checks passed.
- The opt-in real managed-runtime startup/full-request test passed under WSL x86_64.
- Native ARM and exact Home Assistant 2026.7.2 ARM64 container jobs passed on GitHub Actions.
- One risk-focused local review found two P2 recovery/compatibility issues; both were fixed and the targeted confirmation found no remaining regression.

Related to #84.