### PR TITLE
Make LiDAR point-cloud downloads reliable and fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -466,10 +466,12 @@ need source, counts, and parser evidence.
 
 The map camera also advertises a local `point_cloud_api_path` attribute. A
 Home Assistant administrator can sign that path for a short-lived download.
-The integration asks the mower to generate the selected app map, immediately
-captures the transient object, validates the returned PCD file, and serves it
-with `private, no-store` caching. Vendor filenames, cloud-signed URLs, and point
-coordinates are never written to entity state or logs.
+The integration asks the mower to upload the selected app map, immediately
+captures its LiDAR object announcement, validates the returned PCD file, and
+serves it with `private, no-store` caching. It retains the older transient-object
+lookup as a fallback for firmware that does not publish the announcement.
+Vendor filenames, cloud-signed URLs, and point coordinates are never written to
+entity state or logs.
 
 The companion
 [Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card) detects

--- a/README.md
+++ b/README.md
@@ -125,8 +125,8 @@ region/account details are especially helpful for moving a device from
   coordinated light/dark themes, line and marker scaling, and per-map rotation
 - optional custom mower marker loaded only from Home Assistant's `config/www`
   folder, with path, type, size, and image-dimension limits
-- on-demand PCD point-cloud generation through an authenticated, admin-only
-  Home Assistant download endpoint
+- on-demand stored-or-fresh PCD point-cloud download through an authenticated,
+  admin-only Home Assistant endpoint
 - disabled-by-default all-maps and map-diagnostics cameras
 - live video camera with a managed XP2P runtime on Linux x86_64 and aarch64 hosts
 - runtime telemetry sensors for mission progress, mission area, mower pose, and live-track length
@@ -466,10 +466,13 @@ need source, counts, and parser evidence.
 
 The map camera also advertises a local `point_cloud_api_path` attribute. A
 Home Assistant administrator can sign that path for a short-lived download.
-The integration asks the mower to upload the selected app map, immediately
-captures its LiDAR object announcement, validates the returned PCD file, and
-serves it with `private, no-store` caching. It retains the older transient-object
-lookup as a fallback for firmware that does not publish the announcement.
+For the verified active map, the integration first tries the mower's stored
+LiDAR object so an existing 3D map can display without another upload. If that
+object is absent, expired, or invalid, it asks the mower to upload the selected
+app map, immediately captures the new announcement, and validates the returned
+PCD file. Other map indices always use fresh generation, and firmware without
+the announcement retains the older transient-object lookup as a fallback.
+Responses use `private, no-store` caching.
 Vendor filenames, cloud-signed URLs, and point coordinates are never written to
 entity state or logs.
 
@@ -479,8 +482,9 @@ this attribute and offers an on-demand 3D viewer. It does not generate or
 download garden geometry during an ordinary dashboard render. Select the Hero
 layout's **3D** tab or press **Load 3D map** in another layout when you want to
 fetch it. Point-cloud access is currently restricted to Home Assistant admins.
-The mower has up to 45 seconds to publish a fresh file. A failed request returns
-a privacy-safe problem code and stage instead of exposing the vendor object name
+A stored active-map file normally avoids mower generation; otherwise the mower
+has up to 45 seconds to publish a fresh file. A failed request returns a
+privacy-safe problem code and stage instead of exposing the vendor object name
 or signed download URL.
 
 Current map support now includes:

--- a/README.md
+++ b/README.md
@@ -466,13 +466,14 @@ need source, counts, and parser evidence.
 
 The map camera also advertises a local `point_cloud_api_path` attribute. A
 Home Assistant administrator can sign that path for a short-lived download.
-For the verified active map, the integration first tries the mower's stored
-LiDAR object so an existing 3D map can display without another upload. If that
-object is absent, expired, or invalid, it asks the mower to upload the selected
-app map, immediately captures the new announcement, and validates the returned
-PCD file. Other map indices always use fresh generation, and firmware without
-the announcement retains the older transient-object lookup as a fallback.
-Responses use `private, no-store` caching.
+When the mower has exactly one verified map, the integration first tries its
+stored LiDAR object so an existing 3D map can display without another upload.
+If that object is absent, expired, or invalid, it asks the mower to upload the
+selected app map, immediately captures the new announcement, and validates the
+returned PCD file. Multi-map requests always use fresh generation because the
+stored announcement does not identify its map. Firmware without the
+announcement retains the older transient-object lookup as a fallback. Responses
+use `private, no-store` caching.
 Vendor filenames, cloud-signed URLs, and point coordinates are never written to
 entity state or logs.
 
@@ -482,7 +483,7 @@ this attribute and offers an on-demand 3D viewer. It does not generate or
 download garden geometry during an ordinary dashboard render. Select the Hero
 layout's **3D** tab or press **Load 3D map** in another layout when you want to
 fetch it. Point-cloud access is currently restricted to Home Assistant admins.
-A stored active-map file normally avoids mower generation; otherwise the mower
+A stored single-map file normally avoids mower generation; otherwise the mower
 has up to 45 seconds to publish a fresh file. A failed request returns a
 privacy-safe problem code and stage instead of exposing the vendor object name
 or signed download URL.
@@ -503,7 +504,7 @@ Current map support now includes:
 - services for switching the active mower map and starting explicit zone, spot,
   or edge jobs
 - runtime live-track telemetry surfaced through sensors and map-camera attributes
-- an admin-only, transient PCD point-cloud download for the selected app map
+- an admin-only, stored-or-fresh PCD point-cloud download for the selected app map
 - circular and rotated rectangular forbidden areas rendered from their compact
   mower map representation
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1036,12 +1036,13 @@ class DreameLawnMowerClient(
         self,
         *,
         map_index: int = 0,
+        allow_stored: bool = False,
         timeout: float = 45.0,
         poll_interval: float = 2.0,
         download_timeout: float = 60.0,
         max_bytes: int = DEFAULT_POINT_CLOUD_MAX_BYTES,
     ) -> DreameLawnMowerPointCloudDownload:
-        """Generate, download, and validate a mower app-map point cloud."""
+        """Download a stored or freshly generated mower app-map point cloud."""
         timeout = _validate_positive_number(timeout, "generation timeout")
         deadline = time.monotonic() + timeout
         try:
@@ -1054,6 +1055,7 @@ class DreameLawnMowerClient(
                     download_timeout,
                     max_bytes,
                     deadline,
+                    allow_stored,
                 )
         except TimeoutError as err:
             raise DreameLawnMowerPointCloudError(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -75,7 +75,10 @@ from .client_core_helpers import (
 from .client_core_helpers import (
     _FIRMWARE_DESCRIPTION_PREFERRED_KEYS as _FIRMWARE_DESCRIPTION_PREFERRED_KEYS,
 )
-from .client_maps import _DreameLawnMowerClientMapsMixin
+from .client_maps import (
+    _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS,
+    _DreameLawnMowerClientMapsMixin,
+)
 from .client_settings import _DreameLawnMowerClientSettingsMixin
 from .deadline import DeadlineExceededError as DeadlineExceededError
 from .deadline import run_with_deadline as run_with_deadline
@@ -1044,9 +1047,14 @@ class DreameLawnMowerClient(
     ) -> DreameLawnMowerPointCloudDownload:
         """Download a stored or freshly generated mower app-map point cloud."""
         timeout = _validate_positive_number(timeout, "generation timeout")
-        deadline = time.monotonic() + timeout
+        operation_timeout = timeout + (
+            _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS
+            if allow_stored
+            else 0.0
+        )
+        deadline = time.monotonic() + operation_timeout
         try:
-            async with asyncio.timeout(timeout):
+            async with asyncio.timeout(operation_timeout):
                 return await asyncio.to_thread(
                     self._sync_download_app_map_point_cloud,
                     map_index,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -104,6 +104,10 @@ _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 2.0
 _POINT_CLOUD_ANNOUNCEMENT_INITIAL_BUDGET_FRACTION = 0.05
 _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS = 8.0
 _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
+_POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS = (
+    _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS
+    + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS
+)
 
 
 class _DreameLawnMowerClientMapsMixin:
@@ -757,6 +761,8 @@ class _DreameLawnMowerClientMapsMixin:
                     metadata=metadata,
                     content_type=content_type,
                 )
+        if allow_stored:
+            deadline = min(deadline, time.monotonic() + timeout)
         baseline_name = None
         if not use_announcement_path:
             baseline_result = self._sync_call_point_cloud_action(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -102,6 +102,8 @@ _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
 _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
 _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 2.0
 _POINT_CLOUD_ANNOUNCEMENT_INITIAL_BUDGET_FRACTION = 0.05
+_POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS = 3
+_POINT_CLOUD_ANNOUNCEMENT_REPROBE_TIMEOUT_SECONDS = 0.5
 _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS = 8.0
 _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
 _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS = (
@@ -820,6 +822,7 @@ class _DreameLawnMowerClientMapsMixin:
         rejected_object_names: set[str] = set()
         object_download_attempts: dict[str, int] = {}
         announcement_download_attempts: dict[tuple[str, int], int] = {}
+        announcement_reprobe_attempts = 0
         while time.monotonic() < deadline:
             announced_name = None
             announced_identity = None
@@ -832,6 +835,34 @@ class _DreameLawnMowerClientMapsMixin:
                         deadline=deadline,
                     )
                 )
+            elif (
+                announcement_reprobe_attempts
+                < _POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS
+            ):
+                # A transient cloud timeout during the preflight probe must not
+                # permanently select the legacy OBJ route. Keep that fallback
+                # active while briefly re-probing the dedicated announcement
+                # property after generation has started.
+                announcement_reprobe_attempts += 1
+                remaining = max(0.0, deadline - time.monotonic())
+                reprobe_budget = min(
+                    _POINT_CLOUD_ANNOUNCEMENT_REPROBE_TIMEOUT_SECONDS,
+                    remaining,
+                )
+                announcement_supported, announced_name, announced_identity = (
+                    self._sync_get_announced_point_cloud_object(
+                        cloud,
+                        requested_after_ms=generation_requested_at_ms,
+                        baseline=announcement_baseline,
+                        fallback_reserve_seconds=max(
+                            0.0,
+                            remaining - reprobe_budget,
+                        ),
+                        deadline=deadline,
+                    )
+                )
+                if announcement_supported:
+                    use_announcement_path = True
             if announced_name is not None:
                 attempt_key = announced_identity or (announced_name, 0)
                 attempts = announcement_download_attempts.get(attempt_key, 0)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -764,6 +764,7 @@ class _DreameLawnMowerClientMapsMixin:
                     content=content,
                     metadata=metadata,
                     content_type=content_type,
+                    source="stored",
                 )
         if allow_stored:
             deadline = min(deadline, time.monotonic() + timeout)
@@ -831,13 +832,13 @@ class _DreameLawnMowerClientMapsMixin:
             except (DeviceException, DreameLawnMowerPointCloudError):
                 baseline_identity = None
 
-        generation_requested_at_ms = int(time.time() * 1000)
         self._sync_call_point_cloud_action(
             {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
             operation="start point-cloud generation",
             deadline=deadline,
             require_data=False,
         )
+        generation_requested_at_ms = int(time.time() * 1000)
 
         observed_clear = baseline_known and baseline_name is None
         saw_unusable_point_cloud = False
@@ -1189,7 +1190,7 @@ class _DreameLawnMowerClientMapsMixin:
                         normalized_name != baseline[0]
                         or updated_at_ms > baseline[1]
                     )
-                    and updated_at_ms >= requested_after_ms
+                    and updated_at_ms > requested_after_ms
                 )
                 if baseline is not None
                 else (

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -102,9 +102,10 @@ _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
 _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
 _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 2.0
 _POINT_CLOUD_ANNOUNCEMENT_INITIAL_BUDGET_FRACTION = 0.05
-_POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS = 3
 _POINT_CLOUD_ANNOUNCEMENT_REPROBE_TIMEOUT_SECONDS = 0.5
+_POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS = 3
 _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS = 8.0
+_POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS = 2.0
 _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
 _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS = (
     _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS
@@ -720,7 +721,7 @@ class _DreameLawnMowerClientMapsMixin:
             ),
             remaining,
         )
-        announcement_supported, stored_name, announcement_baseline = (
+        announcement_capability, stored_name, announcement_baseline = (
             self._sync_get_announced_point_cloud_object(
                 cloud,
                 requested_after_ms=0,
@@ -731,7 +732,8 @@ class _DreameLawnMowerClientMapsMixin:
                 deadline=deadline,
             )
         )
-        use_announcement_path = announcement_supported
+        use_announcement_path = announcement_capability is True
+        announcement_probe_pending = announcement_capability is None
         if allow_stored and stored_name is not None:
             stored_deadline = min(
                 deadline,
@@ -766,13 +768,35 @@ class _DreameLawnMowerClientMapsMixin:
         if allow_stored:
             deadline = min(deadline, time.monotonic() + timeout)
         baseline_name = None
+        baseline_known = use_announcement_path
         if not use_announcement_path:
-            baseline_result = self._sync_call_point_cloud_action(
-                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
-                operation="read the existing point-cloud object state",
-                deadline=deadline,
-                require_data=True,
-            )
+            baseline_deadline = deadline
+            if announcement_probe_pending:
+                baseline_deadline = min(
+                    deadline,
+                    time.monotonic()
+                    + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
+                )
+            try:
+                baseline_result = self._sync_call_point_cloud_action(
+                    {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+                    operation="read the existing point-cloud object state",
+                    deadline=baseline_deadline,
+                    require_data=True,
+                )
+            except DreameLawnMowerPointCloudError as err:
+                if not (
+                    announcement_probe_pending
+                    and err.code
+                    in {
+                        "point_cloud_timeout",
+                        "point_cloud_mower_request_failed",
+                    }
+                ):
+                    raise
+                baseline_result = None
+            else:
+                baseline_known = True
             baseline_name = _point_cloud_object_name(
                 baseline_result,
                 map_index,
@@ -815,7 +839,7 @@ class _DreameLawnMowerClientMapsMixin:
             require_data=False,
         )
 
-        observed_clear = baseline_name is None
+        observed_clear = baseline_known and baseline_name is None
         saw_unusable_point_cloud = False
         saw_stale_point_cloud = False
         saw_unverified_fixed_object = False
@@ -832,28 +856,30 @@ class _DreameLawnMowerClientMapsMixin:
                         cloud,
                         requested_after_ms=generation_requested_at_ms,
                         baseline=announcement_baseline,
+                        require_post_request=announcement_baseline is None,
                         deadline=deadline,
                     )
                 )
-            elif (
-                announcement_reprobe_attempts
-                < _POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS
-            ):
+            elif announcement_probe_pending:
                 # A transient cloud timeout during the preflight probe must not
                 # permanently select the legacy OBJ route. Keep that fallback
-                # active while briefly re-probing the dedicated announcement
-                # property after generation has started.
-                announcement_reprobe_attempts += 1
+                # active while re-probing the dedicated announcement property
+                # after generation has started.
                 remaining = max(0.0, deadline - time.monotonic())
                 reprobe_budget = min(
                     _POINT_CLOUD_ANNOUNCEMENT_REPROBE_TIMEOUT_SECONDS,
                     remaining,
                 )
-                announcement_supported, announced_name, announced_identity = (
+                (
+                    announcement_capability,
+                    announced_name,
+                    announced_identity,
+                ) = (
                     self._sync_get_announced_point_cloud_object(
                         cloud,
                         requested_after_ms=generation_requested_at_ms,
                         baseline=announcement_baseline,
+                        require_post_request=announcement_baseline is None,
                         fallback_reserve_seconds=max(
                             0.0,
                             remaining - reprobe_budget,
@@ -861,8 +887,19 @@ class _DreameLawnMowerClientMapsMixin:
                         deadline=deadline,
                     )
                 )
-                if announcement_supported:
+                announcement_reprobe_attempts += 1
+                if announcement_capability is True:
                     use_announcement_path = True
+                    announcement_probe_pending = False
+                elif announcement_capability is False:
+                    announcement_probe_pending = False
+                elif (
+                    announcement_reprobe_attempts
+                    >= _POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS
+                ):
+                    # Do not keep constraining a valid but slower legacy OBJ
+                    # route when the dedicated property remains inconclusive.
+                    announcement_probe_pending = False
             if announced_name is not None:
                 attempt_key = announced_identity or (announced_name, 0)
                 attempts = announcement_download_attempts.get(attempt_key, 0)
@@ -914,16 +951,44 @@ class _DreameLawnMowerClientMapsMixin:
                     time.sleep(min(poll_interval, remaining))
                 continue
 
-            object_result = self._sync_call_point_cloud_action(
-                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
-                operation="read the generated point-cloud object state",
-                deadline=deadline,
-                require_data=True,
-            )
+            object_deadline = deadline
+            if announcement_probe_pending:
+                object_deadline = min(
+                    deadline,
+                    time.monotonic()
+                    + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
+                )
+                if object_deadline <= time.monotonic():
+                    continue
+            try:
+                object_result = self._sync_call_point_cloud_action(
+                    {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+                    operation="read the generated point-cloud object state",
+                    deadline=object_deadline,
+                    require_data=True,
+                )
+            except DreameLawnMowerPointCloudError as err:
+                if announcement_probe_pending and err.code in {
+                    "point_cloud_timeout",
+                    "point_cloud_mower_request_failed",
+                }:
+                    continue
+                raise
             object_name = _point_cloud_object_name(
                 object_result,
                 map_index,
             )
+            if not baseline_known:
+                # A bounded preflight timeout is not proof that the prior OBJ
+                # state was empty. Establish the missing baseline from the
+                # first successful legacy response before accepting a change.
+                baseline_name = object_name
+                baseline_known = True
+                observed_clear = object_name is None
+                remaining = deadline - time.monotonic()
+                if remaining > 0:
+                    time.sleep(min(poll_interval, remaining))
+                continue
             if object_name is None:
                 observed_clear = True
             object_extension = (
@@ -1057,14 +1122,19 @@ class _DreameLawnMowerClientMapsMixin:
         *,
         requested_after_ms: int,
         baseline: tuple[str, int] | None = None,
+        require_post_request: bool = False,
         fallback_reserve_seconds: float = 0,
         deadline: float,
-    ) -> tuple[bool, str | None, tuple[str, int] | None]:
-        """Return support state and a fresh cloud-property 99.20 LiDAR object."""
+    ) -> tuple[bool | None, str | None, tuple[str, int] | None]:
+        """Return capability state and a fresh cloud-property 99.20 object.
+
+        A ``None`` capability means the probe was inconclusive, so callers may
+        retry it without treating the firmware as unsupported.
+        """
         remaining = deadline - time.monotonic()
         probe_budget = remaining - max(0.0, fallback_reserve_seconds)
         if probe_budget <= 0:
-            return False, None, None
+            return None, None, None
         get_properties = getattr(cloud, "get_properties", None)
         if not callable(get_properties):
             return False, None, None
@@ -1084,7 +1154,9 @@ class _DreameLawnMowerClientMapsMixin:
                 deadline=probe_deadline,
             )
         except (DeviceException, json.JSONDecodeError):
-            return False, None, None
+            return None, None, None
+        if payload is None:
+            return None, None, None
 
         for entry in self._normalize_cloud_property_entries(payload):
             if entry.get("key") != _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY:
@@ -1100,7 +1172,7 @@ class _DreameLawnMowerClientMapsMixin:
                 return True, None, None
             try:
                 updated_at_ms = int(updated_at)
-            except (TypeError, ValueError):
+            except (TypeError, ValueError, OverflowError):
                 return True, None, None
             extension = _app_object_extension(object_name)
             if (
@@ -1121,9 +1193,15 @@ class _DreameLawnMowerClientMapsMixin:
                 )
                 if baseline is not None
                 else (
-                    updated_at_ms
-                    >= requested_after_ms
-                    - _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS
+                    updated_at_ms > requested_after_ms
+                    if require_post_request
+                    else (
+                        updated_at_ms
+                        >= (
+                            requested_after_ms
+                            - _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS
+                        )
+                    )
                 )
             )
             return True, normalized_name if fresh else None, observed

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -102,6 +102,7 @@ _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
 _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
 _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 8.0
 _POINT_CLOUD_ANNOUNCEMENT_MAX_DOWNLOAD_ATTEMPTS = 3
+_POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
 
 
 class _DreameLawnMowerClientMapsMixin:
@@ -655,6 +656,7 @@ class _DreameLawnMowerClientMapsMixin:
         download_timeout: float,
         max_bytes: int,
         deadline: float | None = None,
+        allow_stored: bool = False,
     ) -> DreameLawnMowerPointCloudDownload:
         map_index = _validate_point_cloud_map_index(map_index)
         timeout = _validate_positive_number(timeout, "generation timeout")
@@ -702,7 +704,7 @@ class _DreameLawnMowerClientMapsMixin:
                 ),
             )
 
-        announcement_supported, _, announcement_baseline = (
+        announcement_supported, stored_name, announcement_baseline = (
             self._sync_get_announced_point_cloud_object(
                 cloud,
                 requested_after_ms=0,
@@ -711,6 +713,37 @@ class _DreameLawnMowerClientMapsMixin:
             )
         )
         use_announcement_path = announcement_supported
+        if allow_stored and stored_name is not None:
+            stored_deadline = min(
+                deadline,
+                time.monotonic()
+                + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+            )
+            try:
+                content, content_type, _ = self._sync_download_point_cloud_object(
+                    cloud,
+                    stored_name,
+                    deadline=stored_deadline,
+                    download_timeout=min(
+                        download_timeout,
+                        _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+                    ),
+                    max_bytes=max_bytes,
+                )
+                metadata = parse_pcd_metadata(
+                    content,
+                    max_bytes=max_bytes,
+                    deadline=stored_deadline,
+                )
+            except (DeviceException, DreameLawnMowerPointCloudError):
+                pass
+            else:
+                return DreameLawnMowerPointCloudDownload(
+                    map_index=map_index,
+                    content=content,
+                    metadata=metadata,
+                    content_type=content_type,
+                )
         baseline_name = None
         if not use_announcement_path:
             baseline_result = self._sync_call_point_cloud_action(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -1107,11 +1107,22 @@ class _DreameLawnMowerClientMapsMixin:
         download_timeout: float,
         max_bytes: int,
     ) -> tuple[bytes, str, _PointCloudObjectIdentity]:
-        raw_url = self._sync_get_point_cloud_download_url(
-            cloud,
-            object_name,
-            deadline=deadline,
-        )
+        try:
+            raw_url = self._sync_get_point_cloud_download_url(
+                cloud,
+                object_name,
+                deadline=deadline,
+            )
+        except json.JSONDecodeError as err:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud signer returned an invalid response.",
+                code="point_cloud_download_invalid",
+                stage="download",
+                public_message=(
+                    "The mower's generated 3D map is not ready to download."
+                ),
+                retry_after_seconds=2,
+            ) from err
         url = _point_cloud_download_url(raw_url)
         remaining = deadline - time.monotonic()
         if remaining <= 0:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -97,6 +97,11 @@ if TYPE_CHECKING:
 # MOVA reports the fixed 3dmap object as "*.bin" even though the payload is PCD.
 _POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd"})
 _MOVA_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
+_POINT_CLOUD_ANNOUNCEMENT_EXTENSIONS = frozenset({"pcd", "bin"})
+_POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
+_POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
+_POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 8.0
+_POINT_CLOUD_ANNOUNCEMENT_MAX_DOWNLOAD_ATTEMPTS = 3
 
 
 class _DreameLawnMowerClientMapsMixin:
@@ -684,17 +689,6 @@ class _DreameLawnMowerClientMapsMixin:
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
             )
-        baseline_result = self._sync_call_point_cloud_action(
-            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
-            operation="read the existing point-cloud object state",
-            deadline=deadline,
-            require_data=True,
-        )
-        baseline_name = _point_cloud_object_name(
-            baseline_result,
-            map_index,
-        )
-
         cloud = self._sync_get_cloud_protocol(deadline=deadline)
         if not hasattr(cloud, "get_interim_file_url"):
             raise DreameLawnMowerPointCloudError(
@@ -706,6 +700,28 @@ class _DreameLawnMowerClientMapsMixin:
                     "This Home Assistant connection cannot download the mower's "
                     "generated 3D map."
                 ),
+            )
+
+        announcement_supported, _, announcement_baseline = (
+            self._sync_get_announced_point_cloud_object(
+                cloud,
+                requested_after_ms=0,
+                fallback_reserve_seconds=min(15.0, timeout / 2),
+                deadline=deadline,
+            )
+        )
+        use_announcement_path = announcement_supported
+        baseline_name = None
+        if not use_announcement_path:
+            baseline_result = self._sync_call_point_cloud_action(
+                {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+                operation="read the existing point-cloud object state",
+                deadline=deadline,
+                require_data=True,
+            )
+            baseline_name = _point_cloud_object_name(
+                baseline_result,
+                map_index,
             )
 
         accepted_extensions = (
@@ -737,6 +753,7 @@ class _DreameLawnMowerClientMapsMixin:
             except (DeviceException, DreameLawnMowerPointCloudError):
                 baseline_identity = None
 
+        generation_requested_at_ms = int(time.time() * 1000)
         self._sync_call_point_cloud_action(
             {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
             operation="start point-cloud generation",
@@ -750,7 +767,74 @@ class _DreameLawnMowerClientMapsMixin:
         saw_unverified_fixed_object = False
         rejected_object_names: set[str] = set()
         object_download_attempts: dict[str, int] = {}
+        announcement_download_attempts: dict[tuple[str, int], int] = {}
         while time.monotonic() < deadline:
+            announced_name = None
+            announced_identity = None
+            if use_announcement_path:
+                _, announced_name, announced_identity = (
+                    self._sync_get_announced_point_cloud_object(
+                        cloud,
+                        requested_after_ms=generation_requested_at_ms,
+                        baseline=announcement_baseline,
+                        deadline=deadline,
+                    )
+                )
+            if announced_name is not None:
+                attempt_key = announced_identity or (announced_name, 0)
+                attempts = announcement_download_attempts.get(attempt_key, 0)
+                if (
+                    attempts
+                    >= _POINT_CLOUD_ANNOUNCEMENT_MAX_DOWNLOAD_ATTEMPTS
+                ):
+                    saw_unusable_point_cloud = True
+                    remaining = deadline - time.monotonic()
+                    if remaining > 0:
+                        time.sleep(min(poll_interval, remaining))
+                    continue
+                announcement_download_attempts[attempt_key] = attempts + 1
+                try:
+                    content, content_type, _ = (
+                        self._sync_download_point_cloud_object(
+                            cloud,
+                            announced_name,
+                            deadline=deadline,
+                            download_timeout=download_timeout,
+                            max_bytes=max_bytes,
+                        )
+                    )
+                    metadata = parse_pcd_metadata(
+                        content,
+                        max_bytes=max_bytes,
+                        deadline=deadline,
+                    )
+                except (DeviceException, DreameLawnMowerPointCloudError):
+                    # The mower announces the object before upload progress
+                    # reaches 100%, so the signer can briefly return no URL.
+                    saw_unusable_point_cloud = True
+                else:
+                    return DreameLawnMowerPointCloudDownload(
+                        map_index=map_index,
+                        content=content,
+                        metadata=metadata,
+                        content_type=content_type,
+                    )
+
+                remaining = deadline - time.monotonic()
+                if remaining > 0:
+                    time.sleep(min(poll_interval, remaining))
+                continue
+
+            remaining = deadline - time.monotonic()
+            if use_announcement_path:
+                # A2-class firmware can take a few seconds to upload the LiDAR
+                # object after accepting o:10. Avoid slow routed OBJ reads while
+                # its dedicated announcement channel is active. Do not accept
+                # an unverified legacy OBJ as fresh when no OBJ baseline exists.
+                if remaining > 0:
+                    time.sleep(min(poll_interval, remaining))
+                continue
+
             object_result = self._sync_call_point_cloud_action(
                 {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
                 operation="read the generated point-cloud object state",
@@ -887,6 +971,81 @@ class _DreameLawnMowerClientMapsMixin:
             timeout_seconds=timeout,
             retry_after_seconds=10,
         )
+
+    def _sync_get_announced_point_cloud_object(
+        self,
+        cloud: Any,
+        *,
+        requested_after_ms: int,
+        baseline: tuple[str, int] | None = None,
+        fallback_reserve_seconds: float = 0,
+        deadline: float,
+    ) -> tuple[bool, str | None, tuple[str, int] | None]:
+        """Return support state and a fresh cloud-property 99.20 LiDAR object."""
+        remaining = deadline - time.monotonic()
+        probe_budget = remaining - max(0.0, fallback_reserve_seconds)
+        if probe_budget <= 0:
+            return False, None, None
+        get_properties = getattr(cloud, "get_properties", None)
+        if not callable(get_properties):
+            return False, None, None
+        probe_timeout = min(
+            probe_budget,
+            _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS,
+        )
+        probe_deadline = min(
+            deadline,
+            time.monotonic() + probe_timeout,
+        )
+        try:
+            payload = get_properties(
+                _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY,
+                retry_count=0,
+                timeout=probe_timeout,
+                deadline=probe_deadline,
+            )
+        except DeviceException:
+            return False, None, None
+
+        for entry in self._normalize_cloud_property_entries(payload):
+            if entry.get("key") != _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY:
+                continue
+            object_name = entry.get("value")
+            updated_at = entry.get("updateDate")
+            if (
+                not isinstance(object_name, str)
+                or not object_name.strip()
+                or isinstance(updated_at, bool)
+                or not isinstance(updated_at, int | float | str)
+            ):
+                continue
+            try:
+                updated_at_ms = int(updated_at)
+            except (TypeError, ValueError):
+                continue
+            extension = _app_object_extension(object_name)
+            if (
+                extension is None
+                or extension.casefold()
+                not in _POINT_CLOUD_ANNOUNCEMENT_EXTENSIONS
+            ):
+                continue
+            normalized_name = object_name.strip()
+            observed = (normalized_name, updated_at_ms)
+            fresh = (
+                (
+                    normalized_name != baseline[0]
+                    or updated_at_ms > baseline[1]
+                )
+                if baseline is not None
+                else (
+                    updated_at_ms
+                    >= requested_after_ms
+                    - _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS
+                )
+            )
+            return True, normalized_name if fresh else None, observed
+        return False, None, None
 
     def _sync_download_point_cloud_object(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 import time
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
@@ -832,13 +832,24 @@ class _DreameLawnMowerClientMapsMixin:
             except (DeviceException, DreameLawnMowerPointCloudError):
                 baseline_identity = None
 
+        generation_requested_at_ms: int | None = None
+
+        def mark_generation_dispatched() -> None:
+            nonlocal generation_requested_at_ms
+            if generation_requested_at_ms is None:
+                generation_requested_at_ms = int(time.time() * 1000)
+
         self._sync_call_point_cloud_action(
             {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
             operation="start point-cloud generation",
             deadline=deadline,
             require_data=False,
+            on_dispatch=mark_generation_dispatched,
         )
-        generation_requested_at_ms = int(time.time() * 1000)
+        if generation_requested_at_ms is None:
+            # Preserve compatibility with alternate/mock cloud transports that
+            # do not expose the dispatch hook.
+            mark_generation_dispatched()
 
         observed_clear = baseline_known and baseline_name is None
         saw_unusable_point_cloud = False
@@ -1257,6 +1268,7 @@ class _DreameLawnMowerClientMapsMixin:
         operation: str,
         deadline: float,
         require_data: bool,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         """Call one point-cloud action within the shared generation deadline."""
         remaining = deadline - time.monotonic()
@@ -1269,13 +1281,15 @@ class _DreameLawnMowerClientMapsMixin:
                 retry_after_seconds=10,
             )
         try:
-            response = self._sync_call_app_action(
-                payload,
-                retry_count=0,
-                timeout=remaining,
-                deadline=deadline,
-                redact_response=True,
-            )
+            action_options: dict[str, Any] = {
+                "retry_count": 0,
+                "timeout": remaining,
+                "deadline": deadline,
+                "redact_response": True,
+            }
+            if on_dispatch is not None:
+                action_options["on_dispatch"] = on_dispatch
+            response = self._sync_call_app_action(payload, **action_options)
         except DreameLawnMowerConnectionError as err:
             if time.monotonic() >= deadline:
                 raise DreameLawnMowerPointCloudError(
@@ -1396,6 +1410,7 @@ class _DreameLawnMowerClientMapsMixin:
         timeout: float | None = None,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         cloud = (
             self._sync_get_cloud_protocol(deadline=deadline)
@@ -1440,6 +1455,8 @@ class _DreameLawnMowerClientMapsMixin:
                 request_options["deadline"] = deadline
             if redact_response:
                 request_options["redact_response"] = True
+            if on_dispatch is not None:
+                request_options["on_dispatch"] = on_dispatch
             if hasattr(cloud, "call_app_action"):
                 response = cloud.call_app_action(
                     payload,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -1046,7 +1046,7 @@ class _DreameLawnMowerClientMapsMixin:
                 timeout=probe_timeout,
                 deadline=probe_deadline,
             )
-        except DeviceException:
+        except (DeviceException, json.JSONDecodeError):
             return False, None, None
 
         for entry in self._normalize_cloud_property_entries(payload):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -100,8 +100,9 @@ _MOVA_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
 _POINT_CLOUD_ANNOUNCEMENT_EXTENSIONS = frozenset({"pcd", "bin"})
 _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
 _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
-_POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 8.0
-_POINT_CLOUD_ANNOUNCEMENT_MAX_DOWNLOAD_ATTEMPTS = 3
+_POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 2.0
+_POINT_CLOUD_ANNOUNCEMENT_INITIAL_BUDGET_FRACTION = 0.05
+_POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS = 8.0
 _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
 
 
@@ -704,11 +705,23 @@ class _DreameLawnMowerClientMapsMixin:
                 ),
             )
 
+        remaining = max(0.0, deadline - time.monotonic())
+        initial_probe_budget = min(
+            _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS,
+            max(
+                0.005,
+                timeout * _POINT_CLOUD_ANNOUNCEMENT_INITIAL_BUDGET_FRACTION,
+            ),
+            remaining,
+        )
         announcement_supported, stored_name, announcement_baseline = (
             self._sync_get_announced_point_cloud_object(
                 cloud,
                 requested_after_ms=0,
-                fallback_reserve_seconds=min(15.0, timeout / 2),
+                fallback_reserve_seconds=max(
+                    0.0,
+                    remaining - initial_probe_budget,
+                ),
                 deadline=deadline,
             )
         )
@@ -816,15 +829,6 @@ class _DreameLawnMowerClientMapsMixin:
             if announced_name is not None:
                 attempt_key = announced_identity or (announced_name, 0)
                 attempts = announcement_download_attempts.get(attempt_key, 0)
-                if (
-                    attempts
-                    >= _POINT_CLOUD_ANNOUNCEMENT_MAX_DOWNLOAD_ATTEMPTS
-                ):
-                    saw_unusable_point_cloud = True
-                    remaining = deadline - time.monotonic()
-                    if remaining > 0:
-                        time.sleep(min(poll_interval, remaining))
-                    continue
                 announcement_download_attempts[attempt_key] = attempts + 1
                 try:
                     content, content_type, _ = (
@@ -845,6 +849,11 @@ class _DreameLawnMowerClientMapsMixin:
                     # The mower announces the object before upload progress
                     # reaches 100%, so the signer can briefly return no URL.
                     saw_unusable_point_cloud = True
+                    retry_delay = min(
+                        _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS,
+                        max(poll_interval, 0.5)
+                        * (2 ** min(attempts, 4)),
+                    )
                 else:
                     return DreameLawnMowerPointCloudDownload(
                         map_index=map_index,
@@ -855,7 +864,7 @@ class _DreameLawnMowerClientMapsMixin:
 
                 remaining = deadline - time.monotonic()
                 if remaining > 0:
-                    time.sleep(min(poll_interval, remaining))
+                    time.sleep(min(retry_delay, remaining))
                 continue
 
             remaining = deadline - time.monotonic()
@@ -1051,24 +1060,27 @@ class _DreameLawnMowerClientMapsMixin:
                 or isinstance(updated_at, bool)
                 or not isinstance(updated_at, int | float | str)
             ):
-                continue
+                return True, None, None
             try:
                 updated_at_ms = int(updated_at)
             except (TypeError, ValueError):
-                continue
+                return True, None, None
             extension = _app_object_extension(object_name)
             if (
                 extension is None
                 or extension.casefold()
                 not in _POINT_CLOUD_ANNOUNCEMENT_EXTENSIONS
             ):
-                continue
+                return True, None, None
             normalized_name = object_name.strip()
             observed = (normalized_name, updated_at_ms)
             fresh = (
                 (
-                    normalized_name != baseline[0]
-                    or updated_at_ms > baseline[1]
+                    (
+                        normalized_name != baseline[0]
+                        or updated_at_ms > baseline[1]
+                    )
+                    and updated_at_ms >= requested_after_ms
                 )
                 if baseline is not None
                 else (

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -7,7 +7,7 @@ import struct
 import time
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import Any
+from typing import Any, Literal
 
 DEFAULT_POINT_CLOUD_MAX_BYTES = 64 * 1024 * 1024
 MAX_POINT_CLOUD_HEADER_BYTES = 64 * 1024
@@ -96,6 +96,7 @@ class DreameLawnMowerPointCloudDownload:
     metadata: DreameLawnMowerPointCloudMetadata
     content_type: str = "application/octet-stream"
     file_extension: str = "pcd"
+    source: Literal["generated", "stored"] = "generated"
 
 
 def parse_pcd_metadata(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -118,13 +118,19 @@ def _post_cloud_response(
     request_options: dict[str, Any],
     *,
     deadline: float | None,
+    on_dispatch: Callable[[], None] | None = None,
 ) -> Any:
     """Post while bounding the response-header phase by an absolute deadline."""
-    if deadline is None:
+    def post() -> Any:
+        if on_dispatch is not None:
+            on_dispatch()
         return session.post(url, **request_options)
+
+    if deadline is None:
+        return post()
     try:
         return run_with_deadline(
-            lambda: session.post(url, **request_options),
+            post,
             deadline=deadline,
         )
     except DeadlineExceededError as err:
@@ -1169,13 +1175,14 @@ class DreameMowerDreameHomeCloudProtocol:
                         )
                     request_options["timeout"] = min(timeout, remaining)
                     request_options["stream"] = True
+                post_options: dict[str, Any] = {"deadline": deadline}
                 if on_dispatch is not None:
-                    on_dispatch()
+                    post_options["on_dispatch"] = on_dispatch
                 response = _post_cloud_response(
                     self._session,
                     url,
                     request_options,
-                    deadline=deadline,
+                    **post_options,
                 )
                 if deadline is not None:
                     try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -9,6 +9,7 @@ import hmac
 import requests
 import zlib
 import queue
+from collections.abc import Callable
 from threading import RLock, Thread, Timer
 from time import sleep
 import time
@@ -201,6 +202,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ):
         return self.request(
             f"{self.get_api_url()}/{url}",
@@ -210,6 +212,7 @@ class DreameMowerDreameHomeCloudProtocol:
             timeout,
             deadline=deadline,
             redact_response=redact_response,
+            on_dispatch=on_dispatch,
         )
 
     def get_api_url(self) -> str:
@@ -830,6 +833,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         with self._operation_lock():
             return self._send_unlocked(
@@ -839,6 +843,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 timeout,
                 deadline=deadline,
                 redact_response=redact_response,
+                on_dispatch=on_dispatch,
             )
 
     def _send_unlocked(
@@ -850,6 +855,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         host = ""
         if self._host and len(self._host):
@@ -871,6 +877,7 @@ class DreameMowerDreameHomeCloudProtocol:
             timeout,
             deadline=deadline,
             redact_response=redact_response,
+            on_dispatch=on_dispatch,
         )
         logged_response = _app_action_response_log_value(
             api_response,
@@ -928,6 +935,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         """Call the mobile-app action bridge used by mower plugin commands."""
         return self.send(
@@ -942,6 +950,7 @@ class DreameMowerDreameHomeCloudProtocol:
             timeout=timeout,
             deadline=deadline,
             redact_response=redact_response,
+            on_dispatch=on_dispatch,
         )
 
     def get_file(self, url: str, retry_count: int = 4) -> Any:
@@ -1079,6 +1088,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         with self._operation_lock():
             return self._request_unlocked(
@@ -1088,6 +1098,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 timeout,
                 deadline=deadline,
                 redact_response=redact_response,
+                on_dispatch=on_dispatch,
             )
 
     def _request_unlocked(
@@ -1099,6 +1110,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
         redact_response: bool = False,
+        on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
         _LOGGER.debug(
             "DreameMowerDreameHomeCloudProtocol.request %s %s",
@@ -1157,6 +1169,8 @@ class DreameMowerDreameHomeCloudProtocol:
                         )
                     request_options["timeout"] = min(timeout, remaining)
                     request_options["stream"] = True
+                if on_dispatch is not None:
+                    on_dispatch()
                 response = _post_cloud_response(
                     self._session,
                     url,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -29,6 +29,8 @@ _TX_VIDEO_API_PATH = "/dreame-third-video/tx/"
 _REDACTED_TX_VIDEO_PAYLOAD = "<redacted TX video payload>"
 _INTERIM_FILE_API_PATH = "/dreame-user-iot/iotfile/getDownloadUrl"
 _REDACTED_INTERIM_FILE_PAYLOAD = "<redacted interim file payload>"
+_CLOUD_PROPERTIES_API_PATH = "/dreame-user-iot/iotstatus/props"
+_REDACTED_CLOUD_PROPERTIES_PAYLOAD = "<redacted cloud properties payload>"
 _REDACTED_APP_ACTION_RESPONSE = "<redacted app action response>"
 _DEADLINE_RESPONSE_CHUNK_BYTES = 8 * 1024
 _MAX_DEADLINE_RESPONSE_BYTES = 1024 * 1024
@@ -41,6 +43,8 @@ def _cloud_request_log_value(url: str, value: Any) -> Any:
         return _REDACTED_TX_VIDEO_PAYLOAD
     if _INTERIM_FILE_API_PATH in url and value is not None:
         return _REDACTED_INTERIM_FILE_PAYLOAD
+    if _CLOUD_PROPERTIES_API_PATH in url and value is not None:
+        return _REDACTED_CLOUD_PROPERTIES_PAYLOAD
     return value
 def _app_action_response_log_value(value: Any, *, redact: bool) -> Any:
     """Hide private point-cloud object names from app-action response logs."""
@@ -996,10 +1000,22 @@ class DreameMowerDreameHomeCloudProtocol:
 
         return api_response["data"]
 
-    def get_properties(self, keys):
+    def get_properties(
+        self,
+        keys,
+        retry_count: int = 2,
+        timeout: float = 20,
+        *,
+        deadline: float | None = None,
+    ):
         params = {"did": str(self._did), "keys": keys}
         api_response = self._api_call(
-            f"{self._strings[23]}/{self._strings[25]}/{self._strings[41]}", params)
+            f"{self._strings[23]}/{self._strings[25]}/{self._strings[41]}",
+            params,
+            retry_count=retry_count,
+            timeout=timeout,
+            deadline=deadline,
+        )
         if api_response is None or "data" not in api_response:
             return None
 

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -6,7 +6,7 @@ import asyncio
 import logging
 import time
 from collections import OrderedDict
-from collections.abc import Mapping
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any, NoReturn
 
@@ -243,17 +243,7 @@ class DreameLawnMowerPointCloudAPI:
                     ),
                     retry_after_seconds=2,
                 )
-            allow_stored = (
-                active_map_index(
-                    getattr(coordinator, "app_maps", None),
-                    selected_map_index=getattr(
-                        coordinator,
-                        "selected_map_index",
-                        None,
-                    ),
-                )
-                == key[1]
-            )
+            allow_stored = _single_active_map_index(coordinator) == key[1]
             if cycle is not None:
                 download = await cycle.measure(
                     "generate_download_validate",
@@ -439,6 +429,41 @@ class DreameLawnMowerPointCloudAPI:
         handle = self._cache_expiry_handles.pop(key, None)
         if handle is not None:
             handle.cancel()
+
+
+def _single_active_map_index(
+    coordinator: DreameLawnMowerCoordinator,
+) -> int | None:
+    """Return the active map only when stored-object identity is unambiguous."""
+    app_maps = getattr(coordinator, "app_maps", None)
+    if not isinstance(app_maps, Mapping):
+        return None
+    maps = app_maps.get("maps")
+    if not isinstance(maps, Sequence) or isinstance(
+        maps,
+        str | bytes | bytearray,
+    ):
+        return None
+    indices = {
+        entry.get("idx")
+        for entry in maps
+        if isinstance(entry, Mapping)
+        and isinstance(entry.get("idx"), int)
+        and not isinstance(entry.get("idx"), bool)
+        and entry["idx"] >= 0
+    }
+    if len(indices) != 1:
+        return None
+    only_index = next(iter(indices))
+    active_index = active_map_index(
+        app_maps,
+        selected_map_index=getattr(
+            coordinator,
+            "selected_map_index",
+            None,
+        ),
+    )
+    return only_index if active_index == only_index else None
 
 
 class DreameLawnMowerPointCloudView(HomeAssistantView):

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -171,6 +171,7 @@ class DreameLawnMowerPointCloudAPI:
             key,
             coordinator,
             epoch=epoch,
+            refresh=refresh,
         )
         create_task = getattr(self._hass, "async_create_task", None)
         if callable(create_task):
@@ -223,6 +224,7 @@ class DreameLawnMowerPointCloudAPI:
         coordinator: DreameLawnMowerCoordinator,
         *,
         epoch: int,
+        refresh: bool,
     ) -> DreameLawnMowerPointCloudDownload:
         """Run and cache one generation independently of HTTP waiters."""
         performance = getattr(coordinator, "performance", None)
@@ -243,7 +245,10 @@ class DreameLawnMowerPointCloudAPI:
                     ),
                     retry_after_seconds=2,
                 )
-            allow_stored = _single_active_map_index(coordinator) == key[1]
+            allow_stored = (
+                not refresh
+                and _single_active_map_index(coordinator) == key[1]
+            )
             if cycle is not None:
                 download = await cycle.measure(
                     "generate_download_validate",
@@ -451,6 +456,10 @@ def _single_active_map_index(
         and isinstance(entry.get("idx"), int)
         and not isinstance(entry.get("idx"), bool)
         and entry["idx"] >= 0
+        and not (
+            entry.get("created") is False
+            and entry.get("available") is False
+        )
     }
     if len(indices) != 1:
         return None

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -230,7 +230,10 @@ class DreameLawnMowerPointCloudAPI:
         except Exception:  # noqa: BLE001 - the refresh starts independently.
             return None
         finally:
-            if self._inflight.get(key) is inflight:
+            if (
+                inflight.task.done()
+                and self._inflight.get(key) is inflight
+            ):
                 self._inflight.pop(key, None)
 
     async def _async_discard_stale_generation(

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -94,6 +94,7 @@ class _InflightGeneration:
     """Track one generation and the config-entry lifetime that started it."""
 
     epoch: int
+    allow_stored: bool
     task: asyncio.Task[DreameLawnMowerPointCloudDownload]
 
 
@@ -136,6 +137,13 @@ class DreameLawnMowerPointCloudAPI:
         inflight = self._inflight.get(key)
         if inflight is not None:
             if inflight.epoch == epoch:
+                if refresh and inflight.allow_stored:
+                    await self._async_wait_for_stored_generation(key, inflight)
+                    return await self.async_get(
+                        entry_id,
+                        map_index,
+                        refresh=True,
+                    )
                 return await asyncio.shield(inflight.task)
             await self._async_discard_stale_generation(key, inflight)
             return await self.async_get(entry_id, map_index, refresh=refresh)
@@ -167,11 +175,15 @@ class DreameLawnMowerPointCloudAPI:
                 ),
             )
 
+        allow_stored = (
+            not refresh
+            and _single_active_map_index(coordinator) == map_index
+        )
         generation = self._async_generate(
             key,
             coordinator,
             epoch=epoch,
-            refresh=refresh,
+            allow_stored=allow_stored,
         )
         create_task = getattr(self._hass, "async_create_task", None)
         if callable(create_task):
@@ -184,7 +196,11 @@ class DreameLawnMowerPointCloudAPI:
                 generation,
                 name=f"{DOMAIN} point cloud {entry_id}:{map_index}",
             )
-        inflight = _InflightGeneration(epoch=epoch, task=task)
+        inflight = _InflightGeneration(
+            epoch=epoch,
+            allow_stored=allow_stored,
+            task=task,
+        )
         self._inflight[key] = inflight
         task.add_done_callback(
             lambda completed, *, inflight_key=key: self._generation_done(
@@ -197,6 +213,19 @@ class DreameLawnMowerPointCloudAPI:
         # Shield the shared generation so another request joins it instead of
         # launching a second mower-side job.
         return await asyncio.shield(task)
+
+    async def _async_wait_for_stored_generation(
+        self,
+        key: tuple[str, int],
+        inflight: _InflightGeneration,
+    ) -> None:
+        """Wait for stored-capable work before starting a forced refresh."""
+        try:
+            await asyncio.shield(inflight.task)
+        except Exception:  # noqa: BLE001 - the refresh starts independently.
+            pass
+        if self._inflight.get(key) is inflight:
+            self._inflight.pop(key, None)
 
     async def _async_discard_stale_generation(
         self,
@@ -224,7 +253,7 @@ class DreameLawnMowerPointCloudAPI:
         coordinator: DreameLawnMowerCoordinator,
         *,
         epoch: int,
-        refresh: bool,
+        allow_stored: bool,
     ) -> DreameLawnMowerPointCloudDownload:
         """Run and cache one generation independently of HTTP waiters."""
         performance = getattr(coordinator, "performance", None)
@@ -245,10 +274,6 @@ class DreameLawnMowerPointCloudAPI:
                     ),
                     retry_after_seconds=2,
                 )
-            allow_stored = (
-                not refresh
-                and _single_active_map_index(coordinator) == key[1]
-            )
             if cycle is not None:
                 download = await cycle.measure(
                     "generate_download_validate",
@@ -456,10 +481,7 @@ def _single_active_map_index(
         and isinstance(entry.get("idx"), int)
         and not isinstance(entry.get("idx"), bool)
         and entry["idx"] >= 0
-        and not (
-            entry.get("created") is False
-            and entry.get("available") is False
-        )
+        and entry.get("created") is not False
     }
     if len(indices) != 1:
         return None

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -16,7 +16,7 @@ from homeassistant.components.http.decorators import require_admin
 from homeassistant.core import HomeAssistant, callback
 
 from .const import DOMAIN
-from .control_options import current_map_index
+from .control_options import active_map_index, current_map_index
 from .diagnostic_events import record_diagnostic_event
 from .dreame_lawn_mower_client import (
     DreameLawnMowerPointCloudDownload,
@@ -243,17 +243,30 @@ class DreameLawnMowerPointCloudAPI:
                     ),
                     retry_after_seconds=2,
                 )
+            allow_stored = (
+                active_map_index(
+                    getattr(coordinator, "app_maps", None),
+                    selected_map_index=getattr(
+                        coordinator,
+                        "selected_map_index",
+                        None,
+                    ),
+                )
+                == key[1]
+            )
             if cycle is not None:
                 download = await cycle.measure(
                     "generate_download_validate",
                     lambda: coordinator.client.async_download_app_map_point_cloud(
-                        map_index=key[1]
+                        map_index=key[1],
+                        allow_stored=allow_stored,
                     ),
                 )
             else:
                 download = (
                     await coordinator.client.async_download_app_map_point_cloud(
-                        map_index=key[1]
+                        map_index=key[1],
+                        allow_stored=allow_stored,
                     )
                 )
             if self._entry_epochs.get(key[0], 0) != epoch:

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -138,7 +138,12 @@ class DreameLawnMowerPointCloudAPI:
         if inflight is not None:
             if inflight.epoch == epoch:
                 if refresh and inflight.allow_stored:
-                    await self._async_wait_for_stored_generation(key, inflight)
+                    completed = await self._async_wait_for_stored_generation(
+                        key,
+                        inflight,
+                    )
+                    if completed is not None and completed.source == "generated":
+                        return completed
                     return await self.async_get(
                         entry_id,
                         map_index,
@@ -218,14 +223,15 @@ class DreameLawnMowerPointCloudAPI:
         self,
         key: tuple[str, int],
         inflight: _InflightGeneration,
-    ) -> None:
+    ) -> DreameLawnMowerPointCloudDownload | None:
         """Wait for stored-capable work before starting a forced refresh."""
         try:
-            await asyncio.shield(inflight.task)
+            return await asyncio.shield(inflight.task)
         except Exception:  # noqa: BLE001 - the refresh starts independently.
-            pass
-        if self._inflight.get(key) is inflight:
-            self._inflight.pop(key, None)
+            return None
+        finally:
+            if self._inflight.get(key) is inflight:
+                self._inflight.pop(key, None)
 
     async def _async_discard_stale_generation(
         self,

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -145,13 +145,18 @@ Last updated: 2026-04-21
   camera still renders the current map image, but its attributes expose compact
   all-map metadata (`app_map_count`, `app_current_map_index`, `app_maps`, etc.).
 - The generated 3D-map path is now solved on the live A2. App action
-  `{"m":"a","p":0,"o":10,"d":{"idx":0}}` requests map generation; polling
-  `OBJ type=3dmap` then exposes a short-lived object name that must be resolved
-  immediately through `getDownloadUrl`.
+  `{"m":"a","p":0,"o":10,"d":{"idx":0}}` requests the upload. The mower
+  announces the short-lived object through cloud property `99.20`; it must be
+  resolved immediately through `getDownloadUrl`. Polling `OBJ type=3dmap`
+  remains the fallback for firmware without that announcement.
 - A 2026-07-23 A2 run returned a standard binary PCD 0.7 file with
   `x y z rgb`, 152,318 points, and 2,437,272 bytes. The public
   `async_download_app_map_point_cloud()` API reproduced the same result while
   the mower remained docked at `charging_completed`.
+- A 2026-07-25 A2 run reproduced the old 45-second timeout while the mower was
+  mowing. Capturing fresh property `99.20` instead of waiting on `OBJ` returned
+  the same validated 2,437,272-byte PCD through the public API in 12.5 seconds,
+  without pausing or docking the mower.
 - `examples/point_cloud_probe.py` prints coordinate-free PCD metadata and writes
   geometry only when `--out` is explicitly supplied. The older
   `app_map_probe.py --probe-object-downloads` path remains useful only for

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -350,6 +350,12 @@ The successful map path is the app action bridge described above. On
   `/dreame-user-iot/iotfile/getDownloadUrl`; the returned HTTPS URL needs no
   custom download headers. `OBJ type=3dmap` remains a compatibility fallback
   but can miss the object's short publication window.
+- Property `99.20` can keep the last generated object signable after the upload.
+  A read-only A2 check on 2026-07-25 resolved that stored object in 0.03 seconds
+  and downloaded and validated the 2,437,272-byte PCD in another 0.38 seconds.
+  Home Assistant uses this stored path only for its verified active map because
+  the property does not carry a map index; absent, expired, invalid, and
+  non-active-map requests retain fresh generation.
 - The generated file was a standard PCD 0.7 binary with fields `x y z rgb`,
   152,318 finite points, 991 observed colors, and 2,437,272 total bytes.
   Repeating the flow through the new public client returned the same validated

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -353,9 +353,9 @@ The successful map path is the app action bridge described above. On
 - Property `99.20` can keep the last generated object signable after the upload.
   A read-only A2 check on 2026-07-25 resolved that stored object in 0.03 seconds
   and downloaded and validated the 2,437,272-byte PCD in another 0.38 seconds.
-  Home Assistant uses this stored path only for its verified active map because
-  the property does not carry a map index; absent, expired, invalid, and
-  non-active-map requests retain fresh generation.
+  Home Assistant uses this stored path only when the mower has exactly one
+  verified map because the property does not carry a map index; absent, expired,
+  invalid, and multi-map requests retain fresh generation.
 - The generated file was a standard PCD 0.7 binary with fields `x y z rgb`,
   152,318 finite points, 991 observed colors, and 2,437,272 total bytes.
   Repeating the flow through the new public client returned the same validated

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -343,17 +343,23 @@ The successful map path is the app action bridge described above. On
   switching the rendered camera frame.
 - Historical `OBJ type=3dmap` reads returned stale `.bin` metadata whose signed
   URLs failed with `403`/`404`. Those objects are not the generated PCD flow.
-- A live A2 run on 2026-07-23 confirmed the complete sequence:
-  `{"m":"a","p":0,"o":10,"d":{"idx":0}}` requests generation, then
-  `{"m":"g","t":"OBJ","d":{"type":"3dmap"}}` briefly publishes the generated
-  object name. The client must resolve that name immediately through
+- Live A2 runs confirmed that
+  `{"m":"a","p":0,"o":10,"d":{"idx":0}}` requests the upload. The reliable
+  completion signal is cloud property `99.20`, which carries the short-lived
+  LiDAR object name. The client must resolve it immediately through
   `/dreame-user-iot/iotfile/getDownloadUrl`; the returned HTTPS URL needs no
-  custom download headers.
+  custom download headers. `OBJ type=3dmap` remains a compatibility fallback
+  but can miss the object's short publication window.
 - The generated file was a standard PCD 0.7 binary with fields `x y z rgb`,
   152,318 finite points, 991 observed colors, and 2,437,272 total bytes.
   Repeating the flow through the new public client returned the same validated
   format and counts while the mower remained docked at
   `charging_completed`.
+- On 2026-07-25, the `OBJ`-only flow timed out at 45 and 120 seconds while the
+  A2 was mowing even though property `99.20` and upload progress `2.54` had
+  updated. Capturing the fresh announcement directly returned the same
+  2,437,272-byte PCD through the public API in 12.5 seconds without changing
+  the mower's activity.
 - `async_download_app_map_point_cloud()` now owns the generation, transient
   object capture, bounded HTTPS download, and PCD validation. It returns bytes
   plus coordinate-free metadata and deliberately omits the vendor filename and

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -125,7 +125,7 @@ from pathlib import Path
 
 download = await client.async_download_app_map_point_cloud(
     map_index=0,
-    allow_stored=True,  # Only when map 0 is known to be the active map.
+    allow_stored=True,  # Only when map 0 is the mower's sole known map.
 )
 print(download.metadata.as_dict())
 
@@ -135,13 +135,13 @@ Path("garden-map.pcd").write_bytes(download.content)
 
 With `allow_stored=True`, the method first validates the object currently
 announced through cloud property `99.20`. Callers should enable this only when
-the requested index is known to be the mower's active map, because the
-announcement does not identify its map. If that object is absent, expired, or
-invalid, the client triggers app action `o:10`, captures the fresh LiDAR object,
-and resolves its short-lived download immediately. Firmware without that
-announcement continues through the transient `OBJ` 3D-map fallback. Every path
-enforces HTTPS, time, and size limits and validates PCD 0.7 before returning.
-The result deliberately does not expose the vendor filename or cloud-signed URL.
+the requested index is the mower's sole known map, because the announcement
+does not identify its map. If that object is absent, expired, or invalid, the
+client triggers app action `o:10`, captures the fresh LiDAR object, and resolves
+its short-lived download immediately. Firmware without that announcement
+continues through the transient `OBJ` 3D-map fallback. Every path enforces
+HTTPS, time, and size limits and validates PCD 0.7 before returning. The result
+deliberately does not expose the vendor filename or cloud-signed URL.
 
 Use `python examples/point_cloud_probe.py` to print coordinate-free metadata.
 Add `--out garden-map.pcd` only when you intentionally want to persist private

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -123,19 +123,25 @@ from automations.
 ```python
 from pathlib import Path
 
-download = await client.async_download_app_map_point_cloud(map_index=0)
+download = await client.async_download_app_map_point_cloud(
+    map_index=0,
+    allow_stored=True,  # Only when map 0 is known to be the active map.
+)
 print(download.metadata.as_dict())
 
 # Persist geometry only when you explicitly need a local PCD file.
 Path("garden-map.pcd").write_bytes(download.content)
 ```
 
-The method triggers app action `o:10`, captures the fresh LiDAR object announced
-through cloud property `99.20`, and resolves its short-lived download
-immediately. Firmware without that announcement continues through the
-transient `OBJ` 3D-map fallback. Both paths enforce HTTPS, time, and size limits
-and validate PCD 0.7 before returning. The result deliberately does not expose
-the vendor filename or cloud-signed URL.
+With `allow_stored=True`, the method first validates the object currently
+announced through cloud property `99.20`. Callers should enable this only when
+the requested index is known to be the mower's active map, because the
+announcement does not identify its map. If that object is absent, expired, or
+invalid, the client triggers app action `o:10`, captures the fresh LiDAR object,
+and resolves its short-lived download immediately. Firmware without that
+announcement continues through the transient `OBJ` 3D-map fallback. Every path
+enforces HTTPS, time, and size limits and validates PCD 0.7 before returning.
+The result deliberately does not expose the vendor filename or cloud-signed URL.
 
 Use `python examples/point_cloud_probe.py` to print coordinate-free metadata.
 Add `--out garden-map.pcd` only when you intentionally want to persist private

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -130,10 +130,12 @@ print(download.metadata.as_dict())
 Path("garden-map.pcd").write_bytes(download.content)
 ```
 
-The method triggers app action `o:10`, polls the transient `OBJ` 3D-map slot,
-resolves its short-lived cloud download immediately, enforces HTTPS, time, and
-size limits, and validates PCD 0.7 before returning. The result deliberately
-does not expose the vendor filename or cloud-signed URL.
+The method triggers app action `o:10`, captures the fresh LiDAR object announced
+through cloud property `99.20`, and resolves its short-lived download
+immediately. Firmware without that announcement continues through the
+transient `OBJ` 3D-map fallback. Both paths enforce HTTPS, time, and size limits
+and validate PCD 0.7 before returning. The result deliberately does not expose
+the vendor filename or cloud-signed URL.
 
 Use `python examples/point_cloud_probe.py` to print coordinate-free metadata.
 Add `--out garden-map.pcd` only when you intentionally want to persist private

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -304,7 +304,8 @@ def test_download_point_cloud_uses_fresh_lidar_announcement(
         return next(responses)
 
     property_options: list[dict[str, Any]] = []
-    update_dates = iter([1_000, 2_000])
+    now_ms = int(time.time() * 1000)
+    update_dates = iter([now_ms - 1_000, now_ms + 1_000])
 
     def get_properties(key: str, **kwargs: Any) -> list[dict[str, Any]]:
         property_options.append(kwargs)
@@ -402,7 +403,8 @@ def test_download_point_cloud_regenerates_when_stored_object_is_invalid(
         actions.append(payload)
         return next(responses)
 
-    update_dates = iter([1_000, 1_000, 2_000])
+    now_ms = int(time.time() * 1000)
+    update_dates = iter([now_ms - 1_000, now_ms - 1_000, now_ms + 1_000])
 
     def get_properties(key: str, **options: Any) -> list[dict[str, Any]]:
         updated_at = next(update_dates)
@@ -411,7 +413,7 @@ def test_download_point_cloud_regenerates_when_stored_object_is_invalid(
                 "key": key,
                 "value": (
                     "private/stored-map.bin"
-                    if updated_at == 1_000
+                    if updated_at < now_ms
                     else "private/fresh-map.bin"
                 ),
                 "updateDate": updated_at,
@@ -459,16 +461,20 @@ def test_download_point_cloud_retries_announced_object_until_signable(
     signed_urls = iter(
         [
             None,
+            None,
+            None,
+            None,
             "https://downloads.example.invalid/object",
         ]
     )
-    update_dates = iter([1_000, 2_000])
+    now_ms = int(time.time() * 1000)
+    update_dates = iter([now_ms - 1_000, now_ms + 1_000])
     cloud = SimpleNamespace(
         get_properties=lambda key, **options: [
             {
                 "key": key,
                 "value": "private/generated-map.bin",
-                "updateDate": next(update_dates, 2_000),
+                "updateDate": next(update_dates, now_ms + 1_000),
             }
         ],
         get_interim_file_url=lambda name, **options: next(signed_urls),
@@ -575,7 +581,7 @@ def test_download_point_cloud_caps_optional_announcement_probe(
 
     assert len(property_options) == 1
     assert property_options[0]["retry_count"] == 0
-    assert property_options[0]["timeout"] == 8.0
+    assert 1.9 < property_options[0]["timeout"] <= 2.0
     assert property_options[0]["deadline"] > time.monotonic()
     assert calls == [
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
@@ -593,8 +599,8 @@ def test_download_point_cloud_caps_optional_announcement_probe(
         "expected_probe_deadline",
     ),
     [
-        (145.0, 15.0, 8.0, 108.0),
-        (105.0, 2.5, 2.5, 102.5),
+        (145.0, 15.0, 2.0, 102.0),
+        (105.0, 2.5, 2.0, 102.0),
     ],
 )
 def test_announcement_probe_uses_reserved_absolute_sub_deadline(
@@ -630,18 +636,121 @@ def test_announcement_probe_uses_reserved_absolute_sub_deadline(
     ]
 
 
+def test_announcement_probe_preserves_support_when_value_is_empty() -> None:
+    client = _client()
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(
+            get_properties=lambda key, **kwargs: [
+                {
+                    "key": key,
+                    "value": None,
+                    "updateDate": None,
+                }
+            ]
+        ),
+        requested_after_ms=0,
+        deadline=time.monotonic() + 1,
+    )
+
+    assert result == (True, None, None)
+
+
+def test_announcement_probe_rejects_changed_object_from_before_request() -> None:
+    client = _client()
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(
+            get_properties=lambda key, **kwargs: [
+                {
+                    "key": key,
+                    "value": "private/other-map.bin",
+                    "updateDate": 2_000,
+                }
+            ]
+        ),
+        requested_after_ms=3_000,
+        baseline=("private/baseline-map.bin", 1_000),
+        deadline=time.monotonic() + 1,
+    )
+
+    assert result == (
+        True,
+        None,
+        ("private/other-map.bin", 2_000),
+    )
+
+
+def test_download_point_cloud_follows_initially_empty_announcement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    now_ms = int(time.time() * 1000)
+    property_values = iter(
+        [
+            (None, None),
+            ("private/fresh-map.bin", now_ms + 1_000),
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        actions.append(payload)
+        return {"r": 0}
+
+    def get_properties(key: str, **kwargs: Any) -> list[dict[str, Any]]:
+        value, updated_at = next(property_values)
+        return [
+            {
+                "key": key,
+                "value": value,
+                "updateDate": updated_at,
+            }
+        ]
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        5,
+        0.1,
+        10,
+        1024,
+    )
+
+    assert actions == [{"m": "a", "p": 0, "o": 10, "d": {"idx": 0}}]
+    assert result.content == content
+
+
 def test_download_point_cloud_bounds_invalid_announced_object_downloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _client()
     client._sync_call_app_action = lambda payload, **kwargs: {"r": 0}
-    update_dates = iter([1_000, 2_000])
+    now_ms = int(time.time() * 1000)
+    update_dates = iter([now_ms - 1_000, now_ms + 1_000])
     cloud = SimpleNamespace(
         get_properties=lambda key, **options: [
             {
                 "key": key,
                 "value": "private/generated-map.bin",
-                "updateDate": next(update_dates, 2_000),
+                "updateDate": next(update_dates, now_ms + 1_000),
             }
         ],
         get_interim_file_url=lambda name, **options: (
@@ -661,7 +770,6 @@ def test_download_point_cloud_bounds_invalid_announced_object_downloads(
         download_count += 1
         return _FakeResponse(b"not a pcd", request.full_url)
 
-    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
     monkeypatch.setattr(
         _internal_client_module,
         "_open_point_cloud_response",
@@ -678,7 +786,7 @@ def test_download_point_cloud_bounds_invalid_announced_object_downloads(
         )
 
     assert captured.value.code == "point_cloud_download_invalid"
-    assert download_count == 3
+    assert download_count == 1
 
 
 def test_download_point_cloud_waits_for_changed_mova_fixed_object(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -628,16 +628,71 @@ def test_download_point_cloud_caps_optional_announcement_probe(
 
     result = client._sync_download_app_map_point_cloud(0, 45, 0.1, 10, 1024)
 
-    assert len(property_options) == 1
+    assert len(property_options) == 2
     assert property_options[0]["retry_count"] == 0
     assert 1.9 < property_options[0]["timeout"] <= 2.0
     assert property_options[0]["deadline"] > time.monotonic()
+    assert property_options[1]["retry_count"] == 0
+    assert 0 < property_options[1]["timeout"] <= 0.5
     assert calls == [
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
     ]
     assert result.content == content
+
+
+def test_download_point_cloud_recovers_from_transient_announcement_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    client._sync_call_app_action = lambda payload, **kwargs: (
+        actions.append(payload)
+        or (
+            {"r": 0, "d": {"name": ["private/stale-map.pcd"]}}
+            if payload.get("m") == "g"
+            else {"r": 0}
+        )
+    )
+    now_ms = int(time.time() * 1000)
+    property_results = iter(
+        [
+            None,
+            [
+                {
+                    "key": "99.20",
+                    "value": "private/generated-map.bin",
+                    "updateDate": now_ms + 1_000,
+                }
+            ],
+        ]
+    )
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: next(property_results),
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert actions == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+    ]
+    assert result.content == content
+    assert result.metadata.points == 1
 
 
 @pytest.mark.parametrize(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -347,6 +347,109 @@ def test_download_point_cloud_uses_fresh_lidar_announcement(
     assert result.metadata.points == 1
 
 
+def test_download_point_cloud_uses_stored_active_map_when_allowed(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    client._sync_call_app_action = lambda payload, **kwargs: actions.append(payload)
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stored-map.bin",
+                "updateDate": 1_000,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/stored"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        5,
+        0.1,
+        10,
+        1024,
+        allow_stored=True,
+    )
+
+    assert actions == []
+    assert result.map_index == 0
+    assert result.content == content
+    assert result.metadata.points == 1
+
+
+def test_download_point_cloud_regenerates_when_stored_object_is_invalid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    responses = iter([{"r": 0}])
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        actions.append(payload)
+        return next(responses)
+
+    update_dates = iter([1_000, 1_000, 2_000])
+
+    def get_properties(key: str, **options: Any) -> list[dict[str, Any]]:
+        updated_at = next(update_dates)
+        return [
+            {
+                "key": key,
+                "value": (
+                    "private/stored-map.bin"
+                    if updated_at == 1_000
+                    else "private/fresh-map.bin"
+                ),
+                "updateDate": updated_at,
+            }
+        ]
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    fresh_content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    downloads = iter([b"not a pcd", fresh_content])
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            next(downloads),
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        5,
+        0.1,
+        10,
+        1024,
+        allow_stored=True,
+    )
+
+    assert actions == [{"m": "a", "p": 0, "o": 10, "d": {"idx": 0}}]
+    assert result.content == fresh_content
+
+
 def test_download_point_cloud_retries_announced_object_until_signable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -695,6 +695,308 @@ def test_download_point_cloud_recovers_from_transient_announcement_probe(
     assert result.metadata.points == 1
 
 
+def test_download_point_cloud_preserves_time_for_later_announcement_reprobe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    property_calls = 0
+    legacy_poll_deadlines: list[float] = []
+    action_calls: list[dict[str, Any]] = []
+
+    def get_properties(key: str, **options: Any) -> Any:
+        nonlocal property_calls
+        property_calls += 1
+        if property_calls < 3:
+            return None
+        return [
+            {
+                "key": key,
+                "value": "private/generated-map.bin",
+                "updateDate": 101_000,
+            }
+        ]
+
+    def call_point_cloud_action(
+        payload: dict[str, Any],
+        *,
+        operation: str,
+        deadline: float,
+        require_data: bool,
+    ) -> Any:
+        action_calls.append(payload)
+        if payload.get("m") == "a":
+            return None
+        if len(action_calls) == 1:
+            return {"name": ["private/stale-map.pcd"]}
+        legacy_poll_deadlines.append(deadline)
+        clock[0] = deadline
+        raise DreameLawnMowerPointCloudError(
+            "bounded legacy poll timed out",
+            code="point_cloud_timeout",
+        )
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    client._sync_call_point_cloud_action = call_point_cloud_action
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(client_module.time, "time", lambda: 100.0)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        10,
+        0.1,
+        10,
+        1024,
+        deadline=110.0,
+    )
+
+    assert property_calls == 3
+    assert legacy_poll_deadlines == [102.0]
+    assert action_calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.content == content
+
+
+def test_download_point_cloud_eventually_allows_slow_legacy_fallback(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    action_calls: list[dict[str, Any]] = []
+    legacy_poll_deadlines: list[float] = []
+
+    def call_point_cloud_action(
+        payload: dict[str, Any],
+        *,
+        operation: str,
+        deadline: float,
+        require_data: bool,
+    ) -> Any:
+        action_calls.append(payload)
+        if payload.get("m") == "a":
+            return None
+        if len(action_calls) == 1:
+            return {"name": ["private/stale-map.pcd"]}
+        legacy_poll_deadlines.append(deadline)
+        if len(legacy_poll_deadlines) < 3:
+            clock[0] = deadline
+            raise DreameLawnMowerPointCloudError(
+                "bounded legacy poll timed out",
+                code="point_cloud_timeout",
+            )
+        return {"name": ["private/generated-map.pcd"]}
+
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: None,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    client._sync_call_point_cloud_action = call_point_cloud_action
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(client_module.time, "time", lambda: 100.0)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        15,
+        0.1,
+        10,
+        1024,
+        deadline=115.0,
+    )
+
+    assert legacy_poll_deadlines == [102.0, 104.0, 115.0]
+    assert action_calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.content == content
+
+
+def test_download_point_cloud_bounds_inconclusive_legacy_baseline(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    action_calls: list[dict[str, Any]] = []
+    baseline_deadlines: list[float] = []
+    property_calls = 0
+
+    def get_properties(key: str, **options: Any) -> Any:
+        nonlocal property_calls
+        property_calls += 1
+        if property_calls == 1:
+            return None
+        return [
+            {
+                "key": key,
+                "value": "private/generated-map.bin",
+                "updateDate": 103_000,
+            }
+        ]
+
+    def call_point_cloud_action(
+        payload: dict[str, Any],
+        *,
+        operation: str,
+        deadline: float,
+        require_data: bool,
+    ) -> Any:
+        action_calls.append(payload)
+        if payload.get("m") == "g":
+            baseline_deadlines.append(deadline)
+            clock[0] = deadline
+            raise DreameLawnMowerPointCloudError(
+                "bounded baseline timed out",
+                code="point_cloud_timeout",
+            )
+        return None
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    client._sync_call_point_cloud_action = call_point_cloud_action
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(client_module.time, "time", lambda: 100.0)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        15,
+        0.1,
+        10,
+        1024,
+        deadline=115.0,
+    )
+
+    assert baseline_deadlines == [102.0]
+    assert action_calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+    ]
+    assert result.content == content
+
+
+def test_download_point_cloud_does_not_treat_timed_out_baseline_as_clear(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    legacy_results = iter(
+        [
+            DreameLawnMowerPointCloudError(
+                "baseline timed out",
+                code="point_cloud_timeout",
+            ),
+            DreameLawnMowerPointCloudError(
+                "bounded poll timed out",
+                code="point_cloud_timeout",
+            ),
+            DreameLawnMowerPointCloudError(
+                "bounded poll timed out",
+                code="point_cloud_timeout",
+            ),
+            {"name": ["private/stale-map.pcd"]},
+            {"name": ["private/generated-map.pcd"]},
+        ]
+    )
+    returned_names: list[str] = []
+
+    def call_point_cloud_action(
+        payload: dict[str, Any],
+        *,
+        operation: str,
+        deadline: float,
+        require_data: bool,
+    ) -> Any:
+        if payload.get("m") == "a":
+            return None
+        result = next(legacy_results)
+        if isinstance(result, DreameLawnMowerPointCloudError):
+            clock[0] = deadline
+            raise result
+        returned_names.extend(result["name"])
+        return result
+
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: None,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    client._sync_call_point_cloud_action = call_point_cloud_action
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+    monkeypatch.setattr(client_module.time, "time", lambda: 100.0)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        15,
+        0.1,
+        10,
+        1024,
+        deadline=115.0,
+    )
+
+    assert returned_names == [
+        "private/stale-map.pcd",
+        "private/generated-map.pcd",
+    ]
+    assert result.content == content
+
+
 @pytest.mark.parametrize(
     (
         "deadline",
@@ -730,7 +1032,7 @@ def test_announcement_probe_uses_reserved_absolute_sub_deadline(
         deadline=deadline,
     )
 
-    assert result == (False, None, None)
+    assert result == (None, None, None)
     assert options == [
         {
             "retry_count": 0,
@@ -760,7 +1062,7 @@ def test_announcement_probe_preserves_support_when_value_is_empty() -> None:
     assert result == (True, None, None)
 
 
-def test_announcement_probe_treats_malformed_json_as_unsupported() -> None:
+def test_announcement_probe_treats_malformed_json_as_inconclusive() -> None:
     client = _client()
 
     def get_properties(key: str, **kwargs: Any) -> None:
@@ -768,6 +1070,18 @@ def test_announcement_probe_treats_malformed_json_as_unsupported() -> None:
 
     result = client._sync_get_announced_point_cloud_object(
         SimpleNamespace(get_properties=get_properties),
+        requested_after_ms=0,
+        deadline=time.monotonic() + 1,
+    )
+
+    assert result == (None, None, None)
+
+
+def test_announcement_probe_treats_absent_property_as_unsupported() -> None:
+    client = _client()
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(get_properties=lambda key, **kwargs: []),
         requested_after_ms=0,
         deadline=time.monotonic() + 1,
     )
@@ -798,6 +1112,52 @@ def test_announcement_probe_rejects_changed_object_from_before_request() -> None
         None,
         ("private/other-map.bin", 2_000),
     )
+
+
+def test_announcement_probe_requires_post_request_time_without_baseline() -> None:
+    client = _client()
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(
+            get_properties=lambda key, **kwargs: [
+                {
+                    "key": key,
+                    "value": "private/recent-other-map.bin",
+                    "updateDate": 3_000,
+                }
+            ]
+        ),
+        requested_after_ms=3_000,
+        require_post_request=True,
+        deadline=time.monotonic() + 1,
+    )
+
+    assert result == (
+        True,
+        None,
+        ("private/recent-other-map.bin", 3_000),
+    )
+
+
+def test_announcement_probe_treats_overflowing_timestamp_as_unusable() -> None:
+    client = _client()
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(
+            get_properties=lambda key, **kwargs: [
+                {
+                    "key": key,
+                    "value": "private/generated-map.bin",
+                    "updateDate": float("inf"),
+                }
+            ]
+        ),
+        requested_after_ms=3_000,
+        require_post_request=True,
+        deadline=time.monotonic() + 1,
+    )
+
+    assert result == (True, None, None)
 
 
 def test_download_point_cloud_follows_initially_empty_announcement(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -292,6 +292,292 @@ def test_download_point_cloud_uses_a2_generation_flow(
     assert not hasattr(result, "object_name")
 
 
+def test_download_point_cloud_uses_fresh_lidar_announcement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+    responses = iter([{"r": 0}])
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    property_options: list[dict[str, Any]] = []
+    update_dates = iter([1_000, 2_000])
+
+    def get_properties(key: str, **kwargs: Any) -> list[dict[str, Any]]:
+        property_options.append(kwargs)
+        return [
+            {
+                "key": key,
+                "value": "private/generated-map.bin",
+                "updateDate": next(update_dates, 2_000),
+            }
+        ]
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+    ]
+    assert property_options
+    assert property_options[0]["retry_count"] == 0
+    assert 0 < property_options[0]["timeout"] <= 5
+    assert property_options[0]["deadline"] > time.monotonic()
+    assert result.content == content
+    assert result.metadata.points == 1
+
+
+def test_download_point_cloud_retries_announced_object_until_signable(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    responses = iter([{"r": 0}])
+    client._sync_call_app_action = lambda payload, **kwargs: next(responses)
+    signed_urls = iter(
+        [
+            None,
+            "https://downloads.example.invalid/object",
+        ]
+    )
+    update_dates = iter([1_000, 2_000])
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/generated-map.bin",
+                "updateDate": next(update_dates, 2_000),
+            }
+        ],
+        get_interim_file_url=lambda name, **options: next(signed_urls),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert result.content == content
+    assert result.metadata.points == 1
+
+
+def test_download_point_cloud_does_not_fallback_from_stale_announcement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+    responses = iter([{"r": 0}])
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stale-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    with pytest.raises(DreameLawnMowerPointCloudError):
+        client._sync_download_app_map_point_cloud(
+            0,
+            0.05,
+            0.001,
+            10,
+            1024,
+        )
+
+    assert calls == [
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+    ]
+
+
+def test_download_point_cloud_caps_optional_announcement_probe(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    property_options: list[dict[str, Any]] = []
+
+    def get_properties(key: str, **options: Any) -> None:
+        property_options.append(options)
+        return None
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 45, 0.1, 10, 1024)
+
+    assert len(property_options) == 1
+    assert property_options[0]["retry_count"] == 0
+    assert property_options[0]["timeout"] == 8.0
+    assert property_options[0]["deadline"] > time.monotonic()
+    assert calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.content == content
+
+
+@pytest.mark.parametrize(
+    (
+        "deadline",
+        "fallback_reserve_seconds",
+        "expected_timeout",
+        "expected_probe_deadline",
+    ),
+    [
+        (145.0, 15.0, 8.0, 108.0),
+        (105.0, 2.5, 2.5, 102.5),
+    ],
+)
+def test_announcement_probe_uses_reserved_absolute_sub_deadline(
+    monkeypatch: pytest.MonkeyPatch,
+    deadline: float,
+    fallback_reserve_seconds: float,
+    expected_timeout: float,
+    expected_probe_deadline: float,
+) -> None:
+    client = _client()
+    options: list[dict[str, Any]] = []
+
+    def get_properties(key: str, **kwargs: Any) -> None:
+        options.append(kwargs)
+        return None
+
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: 100.0)
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(get_properties=get_properties),
+        requested_after_ms=0,
+        fallback_reserve_seconds=fallback_reserve_seconds,
+        deadline=deadline,
+    )
+
+    assert result == (False, None, None)
+    assert options == [
+        {
+            "retry_count": 0,
+            "timeout": expected_timeout,
+            "deadline": expected_probe_deadline,
+        }
+    ]
+
+
+def test_download_point_cloud_bounds_invalid_announced_object_downloads(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload, **kwargs: {"r": 0}
+    update_dates = iter([1_000, 2_000])
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/generated-map.bin",
+                "updateDate": next(update_dates, 2_000),
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    download_count = 0
+
+    def open_invalid_response(
+        request: Any,
+        *,
+        timeout: float,
+        deadline: float,
+    ) -> _FakeResponse:
+        nonlocal download_count
+        download_count += 1
+        return _FakeResponse(b"not a pcd", request.full_url)
+
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        open_invalid_response,
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(
+            0,
+            0.02,
+            0.001,
+            10,
+            1024,
+        )
+
+    assert captured.value.code == "point_cloud_download_invalid"
+    assert download_count == 3
+
+
 def test_download_point_cloud_waits_for_changed_mova_fixed_object(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -629,6 +915,26 @@ def test_interim_file_cloud_logs_redact_request_and_response() -> None:
             '{"data":"https://downloads.example.invalid/object?secret=signature"}',
         )
         == "<redacted interim file payload>"
+    )
+
+
+def test_cloud_property_logs_redact_request_and_response() -> None:
+    url = "https://eu.example.invalid/dreame-user-iot/iotstatus/props"
+    private_name = "ali_dreame/private-device/generated-map.bin"
+
+    assert (
+        _internal_protocol_module._cloud_request_log_value(
+            url,
+            '{"did":"private-device","keys":"99.20"}',
+        )
+        == "<redacted cloud properties payload>"
+    )
+    assert (
+        _internal_protocol_module._cloud_request_log_value(
+            url,
+            f'{{"data":[{{"key":"99.20","value":"{private_name}"}}]}}',
+        )
+        == "<redacted cloud properties payload>"
     )
 
 
@@ -1220,6 +1526,40 @@ def test_interim_file_protocol_forwards_absolute_deadline() -> None:
         )
         == "https://downloads.example.invalid/object"
     )
+    assert options == [
+        {
+            "retry_count": 0,
+            "timeout": 0.8,
+            "deadline": 101.0,
+        }
+    ]
+
+
+def test_cloud_property_lookup_forwards_absolute_deadline() -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [""] * 42
+    strings[23] = "iot"
+    strings[25] = "status"
+    strings[41] = "props"
+    cloud._strings = strings
+    cloud._did = "device-1"
+    options: list[dict[str, Any]] = []
+
+    def api_call(*args: Any, **kwargs: Any) -> dict[str, Any]:
+        options.append(kwargs)
+        return {"data": [{"key": "99.20", "value": "private/map.bin"}]}
+
+    cloud._api_call = api_call
+
+    result = cloud.get_properties(
+        "99.20",
+        retry_count=0,
+        timeout=0.8,
+        deadline=101.0,
+    )
+
+    assert result == [{"key": "99.20", "value": "private/map.bin"}]
     assert options == [
         {
             "retry_count": 0,

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1685,6 +1685,73 @@ def test_point_cloud_generation_deadline_includes_executor_queue_time(
     asyncio.run(run())
 
 
+def test_stored_point_cloud_preflight_has_a_separate_time_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    captured: dict[str, Any] = {}
+
+    async def capture_to_thread(function: Any, *args: Any) -> Any:
+        captured["function"] = function
+        captured["args"] = args
+        return SimpleNamespace(content=b"pcd")
+
+    monkeypatch.setattr(
+        _internal_client_facade_module.asyncio,
+        "to_thread",
+        capture_to_thread,
+    )
+
+    async def run() -> None:
+        result = await client.async_download_app_map_point_cloud(
+            timeout=5,
+            allow_stored=True,
+        )
+        assert result.content
+
+    started = time.monotonic()
+    asyncio.run(run())
+
+    assert captured["function"] == client._sync_download_app_map_point_cloud
+    assert captured["args"][-1] is True
+    assert captured["args"][-2] - started == pytest.approx(12, abs=0.25)
+
+
+def test_stored_point_cloud_fallback_receives_full_generation_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    captured_deadlines: list[float] = []
+    cloud = SimpleNamespace(get_interim_file_url=lambda name: None)
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+
+    def probe(*args: Any, **kwargs: Any) -> tuple[bool, None, None]:
+        clock[0] = 106.0
+        return False, None, None
+
+    def stop_at_baseline(payload: dict[str, Any], **kwargs: Any) -> Any:
+        captured_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after deadline capture")
+
+    client._sync_get_announced_point_cloud_object = probe
+    client._sync_call_point_cloud_action = stop_at_baseline
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+
+    with pytest.raises(RuntimeError, match="deadline capture"):
+        client._sync_download_app_map_point_cloud(
+            0,
+            5,
+            0.1,
+            10,
+            1024,
+            deadline=112.0,
+            allow_stored=True,
+        )
+
+    assert captured_deadlines == [111.0]
+
+
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -349,7 +349,7 @@ def test_download_point_cloud_uses_fresh_lidar_announcement(
     assert result.metadata.points == 1
 
 
-def test_download_point_cloud_rejects_announcement_from_during_action(
+def test_download_point_cloud_uses_action_dispatch_as_freshness_boundary(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _client()
@@ -367,6 +367,8 @@ def test_download_point_cloud_rejects_announcement_from_during_action(
     def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         actions.append(payload)
         clock[0] = 2.0
+        kwargs["on_dispatch"]()
+        clock[0] = 3.0
         return {"r": 0}
 
     def get_properties(key: str, **kwargs: Any) -> list[dict[str, Any]]:
@@ -783,9 +785,11 @@ def test_download_point_cloud_preserves_time_for_later_announcement_reprobe(
         operation: str,
         deadline: float,
         require_data: bool,
+        on_dispatch: Any = None,
     ) -> Any:
         action_calls.append(payload)
         if payload.get("m") == "a":
+            on_dispatch()
             return None
         if len(action_calls) == 1:
             return {"name": ["private/stale-map.pcd"]}
@@ -849,9 +853,11 @@ def test_download_point_cloud_eventually_allows_slow_legacy_fallback(
         operation: str,
         deadline: float,
         require_data: bool,
+        on_dispatch: Any = None,
     ) -> Any:
         action_calls.append(payload)
         if payload.get("m") == "a":
+            on_dispatch()
             return None
         if len(action_calls) == 1:
             return {"name": ["private/stale-map.pcd"]}
@@ -932,6 +938,7 @@ def test_download_point_cloud_bounds_inconclusive_legacy_baseline(
         operation: str,
         deadline: float,
         require_data: bool,
+        on_dispatch: Any = None,
     ) -> Any:
         action_calls.append(payload)
         if payload.get("m") == "g":
@@ -941,6 +948,7 @@ def test_download_point_cloud_bounds_inconclusive_legacy_baseline(
                 "bounded baseline timed out",
                 code="point_cloud_timeout",
             )
+        on_dispatch()
         return None
 
     cloud = SimpleNamespace(
@@ -1011,8 +1019,10 @@ def test_download_point_cloud_does_not_treat_timed_out_baseline_as_clear(
         operation: str,
         deadline: float,
         require_data: bool,
+        on_dispatch: Any = None,
     ) -> Any:
         if payload.get("m") == "a":
+            on_dispatch()
             return None
         result = next(legacy_results)
         if isinstance(result, DreameLawnMowerPointCloudError):
@@ -1794,6 +1804,59 @@ def test_point_cloud_action_response_enforces_overall_deadline(
         )
 
     assert applied_timeouts == pytest.approx([0.8])
+
+
+def test_point_cloud_action_marks_dispatch_before_waiting_for_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    cloud._request_lock = threading.RLock()
+    cloud._strings = [f"value-{index}" for index in range(57)]
+    cloud._country = "eu"
+    cloud._host = "host.example.invalid"
+    cloud._did = "device-1"
+    cloud._id = 1
+    cloud._key_expire = None
+    cloud._secondary_key = None
+    cloud._session = SimpleNamespace()
+    cloud._connected = True
+    cloud._fail_count = 0
+    cloud._ti = ""
+    cloud._key = "key"
+    events: list[str] = []
+    response = SimpleNamespace(
+        status_code=200,
+        text=(
+            '{"code":0,"data":{"result":{"out":'
+            '[{"value":{"r":0}}]}}}'
+        ),
+    )
+
+    def post_response(
+        session: Any,
+        url: str,
+        request_options: dict[str, Any],
+        *,
+        deadline: float | None,
+    ) -> Any:
+        events.append("post")
+        return response
+
+    monkeypatch.setattr(
+        _internal_protocol_module,
+        "_post_cloud_response",
+        post_response,
+    )
+
+    result = cloud.call_app_action(
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        retry_count=0,
+        on_dispatch=lambda: events.append("dispatch"),
+    )
+
+    assert events == ["dispatch", "post"]
+    assert result == {"out": [{"value": {"r": 0}}]}
 
 
 def test_point_cloud_401_reauthentication_uses_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import json
 import struct
 import threading
 import time
@@ -654,6 +655,21 @@ def test_announcement_probe_preserves_support_when_value_is_empty() -> None:
     )
 
     assert result == (True, None, None)
+
+
+def test_announcement_probe_treats_malformed_json_as_unsupported() -> None:
+    client = _client()
+
+    def get_properties(key: str, **kwargs: Any) -> None:
+        raise json.JSONDecodeError("Expecting value", "", 0)
+
+    result = client._sync_get_announced_point_cloud_object(
+        SimpleNamespace(get_properties=get_properties),
+        requested_after_ms=0,
+        deadline=time.monotonic() + 1,
+    )
+
+    assert result == (False, None, None)
 
 
 def test_announcement_probe_rejects_changed_object_from_before_request() -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -349,6 +349,65 @@ def test_download_point_cloud_uses_fresh_lidar_announcement(
     assert result.metadata.points == 1
 
 
+def test_download_point_cloud_rejects_announcement_from_during_action(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [1.0]
+    actions: list[dict[str, Any]] = []
+    announced_names = iter(
+        [
+            ("private/baseline-map.bin", 500),
+            ("private/other-upload.bin", 1_500),
+            ("private/generated-map.bin", 2_500),
+        ]
+    )
+    signed_names: list[str] = []
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        actions.append(payload)
+        clock[0] = 2.0
+        return {"r": 0}
+
+    def get_properties(key: str, **kwargs: Any) -> list[dict[str, Any]]:
+        name, updated_at = next(announced_names)
+        return [
+            {
+                "key": key,
+                "value": name,
+                "updateDate": updated_at,
+            }
+        ]
+
+    def get_interim_file_url(name: str, **kwargs: Any) -> str:
+        signed_names.append(name)
+        return "https://downloads.example.invalid/object"
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=get_interim_file_url,
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "time", lambda: clock[0])
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert actions == [{"m": "a", "p": 0, "o": 10, "d": {"idx": 0}}]
+    assert signed_names == ["private/generated-map.bin"]
+    assert result.source == "generated"
+
+
 def test_download_point_cloud_uses_stored_active_map_when_allowed(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -391,6 +450,7 @@ def test_download_point_cloud_uses_stored_active_map_when_allowed(
     assert result.map_index == 0
     assert result.content == content
     assert result.metadata.points == 1
+    assert result.source == "stored"
 
 
 def test_download_point_cloud_regenerates_when_stored_object_is_invalid(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1807,7 +1807,6 @@ def test_point_cloud_action_response_enforces_overall_deadline(
 
 
 def test_point_cloud_action_marks_dispatch_before_waiting_for_response(
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
     cloud = object.__new__(protocol_type)
@@ -1819,7 +1818,6 @@ def test_point_cloud_action_marks_dispatch_before_waiting_for_response(
     cloud._id = 1
     cloud._key_expire = None
     cloud._secondary_key = None
-    cloud._session = SimpleNamespace()
     cloud._connected = True
     cloud._fail_count = 0
     cloud._ti = ""
@@ -1833,20 +1831,8 @@ def test_point_cloud_action_marks_dispatch_before_waiting_for_response(
         ),
     )
 
-    def post_response(
-        session: Any,
-        url: str,
-        request_options: dict[str, Any],
-        *,
-        deadline: float | None,
-    ) -> Any:
-        events.append("post")
-        return response
-
-    monkeypatch.setattr(
-        _internal_protocol_module,
-        "_post_cloud_response",
-        post_response,
+    cloud._session = SimpleNamespace(
+        post=lambda url, **request_options: events.append("post") or response,
     )
 
     result = cloud.call_app_action(
@@ -1857,6 +1843,53 @@ def test_point_cloud_action_marks_dispatch_before_waiting_for_response(
 
     assert events == ["dispatch", "post"]
     assert result == {"out": [{"value": {"r": 0}}]}
+
+
+def test_point_cloud_dispatch_waits_for_network_worker_slot() -> None:
+    operation_slots = _internal_deadline_module._operation_slots
+    acquired_slots = 0
+    caller_started = threading.Event()
+    events: list[str] = []
+    result: list[Any] = []
+    response = SimpleNamespace(status_code=200)
+    session = SimpleNamespace(
+        post=lambda url, **request_options: events.append("post") or response,
+    )
+    def post_with_deadline() -> None:
+        caller_started.set()
+        result.append(
+            _internal_protocol_module._post_cloud_response(
+                session,
+                "https://cloud.example.invalid/action",
+                {"timeout": 1, "stream": True},
+                deadline=time.monotonic() + 1,
+                on_dispatch=lambda: events.append("dispatch"),
+            )
+        )
+
+    caller = threading.Thread(
+        target=post_with_deadline,
+    )
+
+    try:
+        for _ in range(_internal_deadline_module._MAX_ABANDONED_OPERATIONS):
+            assert operation_slots.acquire(timeout=1)
+            acquired_slots += 1
+        caller.start()
+        assert caller_started.wait(timeout=1)
+        time.sleep(0.05)
+        assert events == []
+
+        operation_slots.release()
+        acquired_slots -= 1
+        caller.join(timeout=1)
+    finally:
+        for _ in range(acquired_slots):
+            operation_slots.release()
+
+    assert not caller.is_alive()
+    assert events == ["dispatch", "post"]
+    assert result == [response]
 
 
 def test_point_cloud_401_reauthentication_uses_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -498,6 +498,54 @@ def test_download_point_cloud_retries_announced_object_until_signable(
     assert result.metadata.points == 1
 
 
+def test_download_point_cloud_retries_malformed_signer_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    client._sync_call_app_action = lambda payload, **kwargs: {"r": 0}
+    now_ms = int(time.time() * 1000)
+    update_dates = iter([now_ms - 1_000, now_ms + 1_000])
+    signer_results: Any = iter(
+        [
+            json.JSONDecodeError("Expecting value", "", 0),
+            "https://downloads.example.invalid/object",
+        ]
+    )
+
+    def get_interim_file_url(name: str, **options: Any) -> str:
+        result = next(signer_results)
+        if isinstance(result, Exception):
+            raise result
+        return result
+
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/generated-map.bin",
+                "updateDate": next(update_dates, now_ms + 1_000),
+            }
+        ],
+        get_interim_file_url=get_interim_file_url,
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert result.content == content
+    assert result.metadata.points == 1
+
+
 def test_download_point_cloud_does_not_fallback_from_stale_announcement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -60,16 +60,20 @@ def _download(map_index: int = 0) -> DreameLawnMowerPointCloudDownload:
 
 def test_point_cloud_api_caches_recent_downloads() -> None:
     calls = 0
+    options: list[dict[str, Any]] = []
 
     async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
         nonlocal calls
         calls += 1
+        options.append(kwargs)
         return _download(kwargs["map_index"])
 
     hass = SimpleNamespace(
         data={
             DOMAIN: {
                 "entry-1": SimpleNamespace(
+                    app_maps={"current_map_index": 0},
+                    selected_map_index=0,
                     client=SimpleNamespace(
                         async_download_app_map_point_cloud=download,
                     )
@@ -87,6 +91,34 @@ def test_point_cloud_api_caches_recent_downloads() -> None:
     asyncio.run(run())
 
     assert calls == 1
+    assert options == [{"map_index": 0, "allow_stored": True}]
+
+
+def test_point_cloud_api_does_not_use_stored_object_for_inactive_map() -> None:
+    options: list[dict[str, Any]] = []
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        options.append(kwargs)
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={"current_map_index": 0},
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    asyncio.run(api.async_get("entry-1", 1))
+
+    assert options == [{"map_index": 1, "allow_stored": False}]
 
 
 def test_point_cloud_api_evicts_downloads_when_ttl_expires() -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -184,7 +184,6 @@ def test_point_cloud_api_ignores_empty_trailing_map_slots() -> None:
                                 "idx": 1,
                                 "current": False,
                                 "created": False,
-                                "available": False,
                             },
                         ],
                     },
@@ -308,6 +307,57 @@ def test_point_cloud_api_deduplicates_concurrent_refreshes() -> None:
     asyncio.run(run())
 
     assert calls == 1
+
+
+def test_point_cloud_api_refresh_does_not_join_stored_capable_request() -> None:
+    options: list[dict[str, Any]] = []
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        options.append(kwargs)
+        if len(options) == 1:
+            first_started.set()
+            await release_first.wait()
+        return _download(len(options) - 1)
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [{"idx": 0, "created": True}],
+                    },
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        stored = asyncio.create_task(api.async_get("entry-1", 0))
+        await first_started.wait()
+        refreshed = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await asyncio.sleep(0)
+        assert len(options) == 1
+        release_first.set()
+        stored_result, refresh_result = await asyncio.gather(stored, refreshed)
+        assert stored_result.map_index == 0
+        assert refresh_result.map_index == 1
+
+    asyncio.run(run())
+
+    assert options == [
+        {"map_index": 0, "allow_stored": True},
+        {"map_index": 0, "allow_stored": False},
+    ]
 
 
 def test_point_cloud_api_keeps_generation_alive_after_waiter_cancellation() -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -72,7 +72,10 @@ def test_point_cloud_api_caches_recent_downloads() -> None:
         data={
             DOMAIN: {
                 "entry-1": SimpleNamespace(
-                    app_maps={"current_map_index": 0},
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [{"idx": 0}],
+                    },
                     selected_map_index=0,
                     client=SimpleNamespace(
                         async_download_app_map_point_cloud=download,
@@ -105,7 +108,10 @@ def test_point_cloud_api_does_not_use_stored_object_for_inactive_map() -> None:
         data={
             DOMAIN: {
                 "entry-1": SimpleNamespace(
-                    app_maps={"current_map_index": 0},
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [{"idx": 0}],
+                    },
                     selected_map_index=0,
                     client=SimpleNamespace(
                         async_download_app_map_point_cloud=download,
@@ -119,6 +125,36 @@ def test_point_cloud_api_does_not_use_stored_object_for_inactive_map() -> None:
     asyncio.run(api.async_get("entry-1", 1))
 
     assert options == [{"map_index": 1, "allow_stored": False}]
+
+
+def test_point_cloud_api_does_not_use_stored_object_with_multiple_maps() -> None:
+    options: list[dict[str, Any]] = []
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        options.append(kwargs)
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [{"idx": 0}, {"idx": 1}],
+                    },
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    asyncio.run(api.async_get("entry-1", 0))
+
+    assert options == [{"map_index": 0, "allow_stored": False}]
 
 
 def test_point_cloud_api_evicts_downloads_when_ttl_expires() -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -413,6 +413,64 @@ def test_point_cloud_api_refresh_joins_stored_fallback_generation() -> None:
     assert options == [{"map_index": 0, "allow_stored": True}]
 
 
+def test_point_cloud_api_cancelled_refresh_keeps_stored_work_inflight() -> None:
+    calls = 0
+    started = asyncio.Event()
+    release = asyncio.Event()
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        nonlocal calls
+        calls += 1
+        started.set()
+        await release.wait()
+        return _download(source="generated")
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [{"idx": 0, "created": True}],
+                    },
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        first = asyncio.create_task(api.async_get("entry-1", 0))
+        await started.wait()
+        cancelled_refresh = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await asyncio.sleep(0)
+        cancelled_refresh.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await cancelled_refresh
+
+        replacement = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await asyncio.sleep(0)
+        assert calls == 1
+        release.set()
+        first_result, replacement_result = await asyncio.gather(
+            first,
+            replacement,
+        )
+        assert replacement_result is first_result
+
+    asyncio.run(run())
+
+    assert calls == 1
+
+
 def test_point_cloud_api_keeps_generation_alive_after_waiter_cancellation() -> None:
     calls = 0
     started = asyncio.Event()

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -157,6 +157,88 @@ def test_point_cloud_api_does_not_use_stored_object_with_multiple_maps() -> None
     assert options == [{"map_index": 0, "allow_stored": False}]
 
 
+def test_point_cloud_api_ignores_empty_trailing_map_slots() -> None:
+    options: list[dict[str, Any]] = []
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        options.append(kwargs)
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={
+                        "current_map_index": 0,
+                        "available_map_count": 1,
+                        "created_map_count": 1,
+                        "map_count": 2,
+                        "maps": [
+                            {
+                                "idx": 0,
+                                "current": True,
+                                "created": True,
+                                "available": True,
+                            },
+                            {
+                                "idx": 1,
+                                "current": False,
+                                "created": False,
+                                "available": False,
+                            },
+                        ],
+                    },
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    asyncio.run(api.async_get("entry-1", 0))
+
+    assert options == [{"map_index": 0, "allow_stored": True}]
+
+
+def test_point_cloud_api_refresh_forces_fresh_generation() -> None:
+    options: list[dict[str, Any]] = []
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        options.append(kwargs)
+        return _download(kwargs["map_index"])
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [
+                            {
+                                "idx": 0,
+                                "created": True,
+                                "available": True,
+                            }
+                        ],
+                    },
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    asyncio.run(api.async_get("entry-1", 0, refresh=True))
+
+    assert options == [{"map_index": 0, "allow_stored": False}]
+
+
 def test_point_cloud_api_evicts_downloads_when_ttl_expires() -> None:
     calls = 0
 

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -35,7 +35,11 @@ from dreame_lawn_mower_client import (
 )
 
 
-def _download(map_index: int = 0) -> DreameLawnMowerPointCloudDownload:
+def _download(
+    map_index: int = 0,
+    *,
+    source: str = "generated",
+) -> DreameLawnMowerPointCloudDownload:
     content = b"private-pcd"
     return DreameLawnMowerPointCloudDownload(
         map_index=map_index,
@@ -55,6 +59,7 @@ def _download(map_index: int = 0) -> DreameLawnMowerPointCloudDownload:
             payload_bytes=12,
             total_bytes=112,
         ),
+        source=source,
     )
 
 
@@ -319,7 +324,8 @@ def test_point_cloud_api_refresh_does_not_join_stored_capable_request() -> None:
         if len(options) == 1:
             first_started.set()
             await release_first.wait()
-        return _download(len(options) - 1)
+            return _download(0, source="stored")
+        return _download(1)
 
     hass = SimpleNamespace(
         data={
@@ -358,6 +364,53 @@ def test_point_cloud_api_refresh_does_not_join_stored_capable_request() -> None:
         {"map_index": 0, "allow_stored": True},
         {"map_index": 0, "allow_stored": False},
     ]
+
+
+def test_point_cloud_api_refresh_joins_stored_fallback_generation() -> None:
+    options: list[dict[str, Any]] = []
+    first_started = asyncio.Event()
+    release_first = asyncio.Event()
+
+    async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
+        options.append(kwargs)
+        first_started.set()
+        await release_first.wait()
+        return _download(0, source="generated")
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    app_maps={
+                        "current_map_index": 0,
+                        "maps": [{"idx": 0, "created": True}],
+                    },
+                    selected_map_index=0,
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    ),
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        first = asyncio.create_task(api.async_get("entry-1", 0))
+        await first_started.wait()
+        refreshed = asyncio.create_task(
+            api.async_get("entry-1", 0, refresh=True)
+        )
+        await asyncio.sleep(0)
+        assert len(options) == 1
+        release_first.set()
+        first_result, refresh_result = await asyncio.gather(first, refreshed)
+        assert refresh_result is first_result
+        assert refresh_result.source == "generated"
+
+    asyncio.run(run())
+
+    assert options == [{"map_index": 0, "allow_stored": True}]
 
 
 def test_point_cloud_api_keeps_generation_alive_after_waiter_cancellation() -> None:


### PR DESCRIPTION
## What changed

- reuse the stored LiDAR point cloud when app metadata identifies one real, active map, while ignoring reserved map slots
- generate and capture a fresh object through cloud property `99.20` when the stored copy is unavailable, invalid, or bypassed with `refresh=1`
- keep fresh generation serialized across concurrent and cancelled requests so one mower does not start duplicate uploads
- measure announcement freshness from the actual cloud network dispatch, excluding authentication, lock, worker-queue, and response delays
- retry temporarily unavailable signed objects within the request deadline and retain the older `OBJ type=3dmap` fallback for firmware without `99.20`
- always generate multi-map requests because the announcement does not identify which garden produced the stored object
- redact cloud-property payloads that can contain device IDs or private object names

## Result

Single-garden mowers can return an existing point cloud without waiting for another upload, while `refresh=1` still requests new geometry. Multi-map mowers remain conservative so one garden cannot be returned under another map index.

Physical Dreame A2 validation produced a valid 2,437,272-byte, 152,318-point PCD in about 6.5 seconds. Warm stored downloads completed in 0.456 and 0.473 seconds. The Q2501A reporter confirmed display in 1.84 seconds. Focused coverage, the full non-component suite, Ruff, compile checks, ARM64 CI, Hassfest, and HACS validation pass.

A physical MOVA LiDAX Ultra 1600 AWD retest remains useful because its fixed-object firmware path differs from the A2 and Q2501A paths.

Fixes #89
Fixes #90