### PR TITLE
Publish realtime mower pose updates immediately

### DIFF
--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -198,6 +198,11 @@ class DreameLawnMowerMapCamera(
             image_cached=self._map_cache.last_image is not None,
             refreshed_at=self._map_cache.last_refresh_at,
             last_error=self._map_cache.last_error,
+            runtime_status_blob=getattr(
+                self.coordinator,
+                "runtime_status_blob",
+                None,
+            ),
         )
         attributes["point_cloud_api_path"] = current_point_cloud_api_path(
             self.coordinator.entry.entry_id,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
@@ -14,7 +14,11 @@ from random import randrange
 from threading import RLock, Timer
 from typing import Any, Optional
 
-from .app_protocol import mower_realtime_property_name
+from .app_protocol import (
+    MOWER_BLUETOOTH_PROPERTY_KEY,
+    MOWER_RUNTIME_STATUS_PROPERTY_KEY,
+    mower_realtime_property_name,
+)
 from .device_code_semantics import (
     MowerDeviceCodeTier,
     mower_device_code_definition,
@@ -146,6 +150,14 @@ from .map_decoder import DreameMowerMapDecoder
 
 _LOGGER = logging.getLogger(__name__)
 
+_EXTERNAL_REALTIME_UPDATE_KEYS = frozenset(
+    {
+        MOWER_RUNTIME_STATUS_PROPERTY_KEY,
+        MOWER_BLUETOOTH_PROPERTY_KEY,
+    }
+)
+
+
 class _DreameMowerDeviceStateMixin:
     def _connected_callback(self):
         if not self._ready:
@@ -166,6 +178,7 @@ class _DreameMowerDeviceStateMixin:
                 if message["method"] == "properties_changed" and "params" in message:
                     params = []
                     map_params = []
+                    external_realtime_changed = False
                     for param in message["params"]:
                         matched_property = None
                         properties = [prop for prop in DreameMowerProperty]
@@ -191,11 +204,19 @@ class _DreameMowerDeviceStateMixin:
                                     ):
                                         map_params.append(param)
                                     break
-                        self._remember_realtime_property(param, matched_property)
+                        external_realtime_changed = (
+                            self._remember_realtime_property(
+                                param,
+                                matched_property,
+                            )
+                            or external_realtime_changed
+                        )
                     if len(map_params) and self._map_manager:
                         self._map_manager.handle_properties(map_params)
 
-                    self._handle_properties(params)
+                    known_property_changed = self._handle_properties(params)
+                    if external_realtime_changed and not known_property_changed:
+                        self._property_changed()
 
     def _handle_properties(self, properties) -> bool:
         if not isinstance(properties, list | tuple):
@@ -387,14 +408,21 @@ class _DreameMowerDeviceStateMixin:
         self,
         payload: dict[str, Any],
         property_enum: DreameMowerProperty | None,
-    ) -> None:
-        """Store realtime MQTT property payloads, even when not yet decoded."""
+    ) -> bool:
+        """Store an MQTT property and report relevant external state changes."""
         siid = payload.get("siid")
         piid = payload.get("piid")
         if siid is None or piid is None:
-            return
+            return False
 
         key = f"{siid}.{piid}"
+        previous_entry = self.realtime_properties.get(key)
+        previous_value = (
+            previous_entry.get("value")
+            if isinstance(previous_entry, dict)
+            else None
+        )
+        value = copy.deepcopy(payload.get("value"))
         property_name = (
             property_enum.name
             if property_enum is not None
@@ -410,7 +438,7 @@ class _DreameMowerDeviceStateMixin:
             "piid": piid,
             "did": payload.get("did"),
             "code": payload.get("code"),
-            "value": copy.deepcopy(payload.get("value")),
+            "value": value,
             "property_name": property_name,
             "last_seen": (
                 received_at
@@ -418,6 +446,7 @@ class _DreameMowerDeviceStateMixin:
                 else time.time()
             ),
         }
+        return key in _EXTERNAL_REALTIME_UPDATE_KEYS and previous_value != value
 
     def _request_properties(self, properties: list[DreameMowerProperty] = None) -> bool:
         """Request properties from the device."""

--- a/custom_components/dreame_lawn_mower/map_attributes.py
+++ b/custom_components/dreame_lawn_mower/map_attributes.py
@@ -50,6 +50,7 @@ def map_camera_attributes(
     image_cached: bool,
     refreshed_at: datetime | None,
     last_error: str | None,
+    runtime_status_blob: Any = None,
 ) -> dict[str, Any]:
     """Return Home Assistant attributes for a cached map camera view."""
     summary = map_summary_to_dict(None if view is None else view.summary)
@@ -127,4 +128,42 @@ def map_camera_attributes(
     )
     if summary is not None and attributes.get("map_id") is None:
         attributes["map_id"] = summary["map_id"]
+    runtime_pose_x = getattr(
+        runtime_status_blob,
+        "candidate_runtime_pose_x",
+        None,
+    )
+    runtime_pose_y = getattr(
+        runtime_status_blob,
+        "candidate_runtime_pose_y",
+        None,
+    )
+    if runtime_pose_x is not None and runtime_pose_y is not None:
+        runtime_heading = getattr(
+            runtime_status_blob,
+            "candidate_runtime_heading_deg",
+            None,
+        )
+        runtime_region = getattr(
+            runtime_status_blob,
+            "candidate_runtime_region_id",
+            None,
+        )
+        runtime_updated_at = getattr(runtime_status_blob, "received_at", None)
+        attributes.update(
+            {
+                "runtime_pose_x": runtime_pose_x,
+                "runtime_pose_y": runtime_pose_y,
+                "runtime_heading_deg": runtime_heading,
+                "runtime_region_id": runtime_region,
+                "runtime_position_updated_at": runtime_updated_at,
+                "position_x": runtime_pose_x,
+                "position_y": runtime_pose_y,
+                "position_heading": runtime_heading,
+                "position_segment": runtime_region,
+                "position_updated_at": runtime_updated_at,
+            }
+        )
+        if runtime_updated_at != details.get("runtime_position_updated_at"):
+            attributes["runtime_position_valid"] = None
     return attributes

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -266,6 +266,45 @@ def test_status_blob_decoder_accepts_a3_awd_pro_22_byte_frame() -> None:
     assert decoded.candidate_runtime_pose_y == 0
 
 
+def test_status_blob_decoder_does_not_treat_heartbeat_bytes_as_pose() -> None:
+    decoded = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            202,
+            69,
+            36,
+            0,
+            4,
+            128,
+            167,
+            126,
+            0,
+            128,
+            206,
+        ]
+    )
+
+    assert decoded is not None
+    assert decoded.candidate_battery_level == 74
+    assert decoded.candidate_runtime_pose_x == 0
+    assert decoded.candidate_runtime_pose_y == 0
+    assert decoded.candidate_runtime_heading_deg == 0.0
+    assert decoded.main_state is None
+    assert decoded.sub_state is None
+    assert decoded.task_status is None
+    assert decoded.mowing_session_active is None
+
+
 def test_status_blob_decoder_exposes_paused_resumable_session_at_dock() -> None:
     decoded = decode_mower_status_blob(
         [206, 0, 0, 0, 0, 0, 0, 0, 128, 0, 128, 100, 21, 36, 0, 0, 128, 211, 196, 206]

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -275,6 +275,50 @@ def test_map_camera_attributes_include_live_path_metadata() -> None:
     }
 
 
+def test_map_camera_attributes_overlay_latest_realtime_pose() -> None:
+    """Camera position attributes must not wait for a map-view refresh."""
+    view = DreameLawnMowerMapView(
+        source="batch_vector_map",
+        details={
+            "runtime_pose_x": -2240,
+            "runtime_pose_y": -140,
+            "runtime_heading_deg": 207.53,
+            "runtime_region_id": 7,
+            "runtime_position_updated_at": "2026-07-16T09:45:12+00:00",
+            "runtime_position_valid": True,
+        },
+    )
+    realtime_blob = SimpleNamespace(
+        candidate_runtime_pose_x=-1800,
+        candidate_runtime_pose_y=250,
+        candidate_runtime_heading_deg=91.25,
+        candidate_runtime_region_id=8,
+        received_at="2026-07-25T11:58:00+00:00",
+    )
+
+    attributes = map_camera_attributes(
+        view,
+        image_cached=True,
+        refreshed_at=None,
+        last_error=None,
+        runtime_status_blob=realtime_blob,
+    )
+
+    assert attributes["runtime_pose_x"] == -1800
+    assert attributes["runtime_pose_y"] == 250
+    assert attributes["runtime_heading_deg"] == 91.25
+    assert attributes["runtime_region_id"] == 8
+    assert attributes["runtime_position_updated_at"] == (
+        "2026-07-25T11:58:00+00:00"
+    )
+    assert attributes["position_x"] == -1800
+    assert attributes["position_y"] == 250
+    assert attributes["position_heading"] == 91.25
+    assert attributes["position_segment"] == 8
+    assert attributes["position_updated_at"] == "2026-07-25T11:58:00+00:00"
+    assert attributes["runtime_position_valid"] is None
+
+
 def test_map_camera_attributes_include_app_trajectory_details() -> None:
     """App-map trajectory metadata is promoted into camera attributes."""
     view = DreameLawnMowerMapView(

--- a/tests/test_unknown_properties.py
+++ b/tests/test_unknown_properties.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from threading import RLock
 from types import SimpleNamespace
 
+import pytest
+
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device import (
     DreameMowerDevice,
 )
@@ -174,6 +176,94 @@ def test_message_callback_tracks_realtime_properties_and_unmapped_pairs() -> Non
             for entry in device.realtime_properties.values()
         }
     ) == 1
+
+
+@pytest.mark.parametrize("piid", [4, 53])
+def test_message_callback_publishes_external_realtime_property_changes(
+    piid: int,
+) -> None:
+    device, updates = _device_stub()
+
+    DreameMowerDevice._message_callback(
+        device,
+        {
+            "method": "properties_changed",
+            "params": [{"siid": 1, "piid": piid, "value": [206, 1, 206]}],
+        },
+    )
+    DreameMowerDevice._message_callback(
+        device,
+        {
+            "method": "properties_changed",
+            "params": [{"siid": 1, "piid": piid, "value": [206, 2, 206]}],
+        },
+    )
+    DreameMowerDevice._message_callback(
+        device,
+        {
+            "method": "properties_changed",
+            "params": [{"siid": 1, "piid": piid, "value": [206, 2, 206]}],
+        },
+    )
+
+    assert updates == ["changed", "changed"]
+
+
+def test_message_callback_does_not_publish_raw_heartbeat_as_pose() -> None:
+    device, updates = _device_stub()
+
+    DreameMowerDevice._message_callback(
+        device,
+        {
+            "method": "properties_changed",
+            "params": [
+                {
+                    "siid": 1,
+                    "piid": 1,
+                    "value": [
+                        206,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        0,
+                        202,
+                        69,
+                        36,
+                        0,
+                        4,
+                        128,
+                        167,
+                        126,
+                        0,
+                        128,
+                        206,
+                    ],
+                }
+            ],
+        },
+    )
+
+    assert updates == []
+
+
+def test_message_callback_does_not_publish_unmapped_diagnostic_changes() -> None:
+    device, updates = _device_stub()
+
+    DreameMowerDevice._message_callback(
+        device,
+        {
+            "method": "properties_changed",
+            "params": [{"siid": 9, "piid": 4, "value": {"blob": 123}}],
+        },
+    )
+
+    assert updates == []
 
 
 def test_message_callback_applies_known_and_realtime_state_under_one_lock() -> None:


### PR DESCRIPTION
## What changed

- publish changed raw `1.4` runtime-pose packets to Home Assistant immediately instead of waiting for an unrelated mapped property update
- expose disabled-by-default diagnostic sensors for Runtime Position X, Runtime Position Y, and Runtime Heading
- update the map camera's lightweight `position_*` and `runtime_*` attributes directly from the latest decoded MQTT pose rather than waiting for an asynchronous map refresh/render
- keep rendered map generation coalesced; cards can move their marker at the native pose cadence without forcing a heavy render for every packet
- publish at most once when a packet also changes a normal mapped property, ignore identical repeat payloads, and retain immediate `1.53` Bluetooth updates

## Packet correction

The 22-byte `1.1` packet from #91 is a battery/heartbeat frame, not a position frame. Byte 11 (`202`) encodes battery level 74 plus the charging flag; bytes 11-12 must not be decoded as little-endian X. Runtime pose remains the first six payload bytes of property `1.4`.

## Validation

- Q2501A reporter confirmation: camera position attributes changed 18 times over 120 seconds at a 3.6-second mean cadence, down from 20-48 seconds before the fix
- physical A2 while mowing: nine distinct `1.4` poses arrived at a 5.000-second mean cadence; raw receipt to callback was at most 0.169 ms and camera-attribute projection at most 0.029 ms
- coordinator-equivalent confirmation: six more moving poses arrived every 5.002 seconds; cached snapshot, runtime decode, Bluetooth read, and camera attribute projection averaged 0.958 ms and peaked at 1.304 ms
- all live samples replaced deliberately stale map-view coordinates and preserved their matching `position_updated_at`
- 131 focused device-state, protocol, coordinator, entity, and map-camera tests
- exact issue packet covered as zero pose with intentionally unavailable state fields
- full CI, Ruff, compile, and whitespace checks pass

The runtime sensors are disabled by default to avoid adding three entities for users who do not need coordinate automations. Enable them from the mower device's entity list.

Fixes #91
Fixes #96