### PR TITLE
Support XP2P video on 16 KB ARM64 hosts

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_runtime_bootstrap.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_runtime_bootstrap.py
@@ -7,6 +7,7 @@ import gzip
 import hashlib
 import io
 import json
+import os
 import platform
 import shutil
 import struct
@@ -31,6 +32,7 @@ from .xp2p_host_worker_blob import (
 )
 
 RUNTIME_LAYOUT_VERSION = "1"
+LARGE_PAGE_RUNTIME_LAYOUT_VERSION = "2"
 TENCENT_XP2P_VERSION = "2.4.50"
 TENCENT_XP2P_AAR_URL = (
     "https://repo.maven.apache.org/maven2/com/tencent/iot/thirdparty/android/"
@@ -112,6 +114,17 @@ QEMU_X86_64_ARCHIVE_SHA256 = (
 QEMU_X86_64_BINARY_SHA256 = (
     "dce64b2dc6b005485c7aa735a7ea39cb0006bf7e5badc28b324b2cd0c73d883f"
 )
+QEMU_AARCH64_VERSION = "10.0.0-r1"
+QEMU_AARCH64_APK_URL = (
+    "https://dl-cdn.alpinelinux.org/alpine/v3.22/community/aarch64/"
+    "qemu-aarch64-10.0.0-r1.apk"
+)
+QEMU_AARCH64_APK_SHA256 = (
+    "59cdf1518f501c87f0397324bf97c807adac45fe70a50f5468fcb55280573758"
+)
+QEMU_AARCH64_BINARY_SHA256 = (
+    "4d1b11f85b7617ee9209d4e9224378ad8d96f757dc30ee7939f8097c1b65b13a"
+)
 
 _TENCENT_AAR_LIBRARY = "jni/arm64-v8a/libiot_video_demo.so"
 _MANIFEST_NAME = "runtime-manifest.json"
@@ -133,6 +146,7 @@ def ensure_xp2p_host_runtime(
     root: str | Path,
     *,
     machine: str | None = None,
+    page_size: int | None = None,
     http_client: _HttpClient | None = None,
     timeout: float = 60.0,
 ) -> DreameLawnMowerXp2pHostAssets:
@@ -143,10 +157,24 @@ def ensure_xp2p_host_runtime(
             "Managed XP2P video supports Linux aarch64 and x86_64 hosts; "
             f"this host reports {machine or platform.machine()!r}."
         )
+    host_page_size = _host_page_size() if page_size is None else page_size
+    use_aarch64_self_qemu = (
+        architecture == "aarch64" and host_page_size > 4096
+    )
+    layout_version = (
+        LARGE_PAGE_RUNTIME_LAYOUT_VERSION
+        if use_aarch64_self_qemu
+        else RUNTIME_LAYOUT_VERSION
+    )
     root_path = Path(root)
-    runtime_path = root_path / f"runtime-v{RUNTIME_LAYOUT_VERSION}-{architecture}"
+    runtime_path = root_path / f"runtime-v{layout_version}-{architecture}"
     with _INSTALL_LOCK:
-        assets = _validated_assets(runtime_path, architecture)
+        assets = _validated_assets(
+            runtime_path,
+            architecture,
+            layout_version=layout_version,
+            include_aarch64_qemu=use_aarch64_self_qemu,
+        )
         if assets is None:
             root_path.mkdir(parents=True, exist_ok=True)
             staging = Path(
@@ -159,10 +187,17 @@ def ensure_xp2p_host_runtime(
                 _install_runtime(
                     staging,
                     architecture,
+                    layout_version=layout_version,
+                    include_aarch64_qemu=use_aarch64_self_qemu,
                     http_client=http_client or requests,
                     timeout=timeout,
                 )
-                installed = _validated_assets(staging, architecture)
+                installed = _validated_assets(
+                    staging,
+                    architecture,
+                    layout_version=layout_version,
+                    include_aarch64_qemu=use_aarch64_self_qemu,
+                )
                 if installed is None:
                     raise DreameLawnMowerVideoRuntimeError(
                         "Installed XP2P host runtime failed integrity validation."
@@ -173,12 +208,25 @@ def ensure_xp2p_host_runtime(
             except Exception:
                 _remove_runtime_path(staging, root_path)
                 raise
-            assets = _validated_assets(runtime_path, architecture)
+            assets = _validated_assets(
+                runtime_path,
+                architecture,
+                layout_version=layout_version,
+                include_aarch64_qemu=use_aarch64_self_qemu,
+            )
             if assets is None:
                 raise DreameLawnMowerVideoRuntimeError(
                     "XP2P host runtime disappeared after installation."
                 )
     return _with_startup_probe(assets)
+
+
+def _host_page_size() -> int:
+    """Return the Linux host page size, or zero when it cannot be read."""
+    try:
+        return int(os.sysconf("SC_PAGE_SIZE"))
+    except (AttributeError, OSError, ValueError):
+        return 0
 
 
 def _with_startup_probe(
@@ -198,6 +246,8 @@ def _install_runtime(
     target: Path,
     architecture: str,
     *,
+    layout_version: str = RUNTIME_LAYOUT_VERSION,
+    include_aarch64_qemu: bool = False,
     http_client: _HttpClient,
     timeout: float,
 ) -> None:
@@ -300,15 +350,49 @@ def _install_runtime(
             QEMU_X86_64_BINARY_SHA256,
             mode=0o755,
         )
+    elif include_aarch64_qemu:
+        qemu_apk = _download_verified(
+            http_client,
+            QEMU_AARCH64_APK_URL,
+            QEMU_AARCH64_APK_SHA256,
+            timeout=timeout,
+            label="Alpine qemu-aarch64",
+        )
+        try:
+            with tarfile.open(
+                fileobj=io.BytesIO(qemu_apk),
+                mode="r:gz",
+            ) as archive:
+                stream = archive.extractfile("usr/bin/qemu-aarch64")
+                qemu = stream.read() if stream is not None else b""
+        except (KeyError, tarfile.TarError) as err:
+            raise DreameLawnMowerVideoRuntimeError(
+                "Alpine qemu-aarch64 package was malformed."
+            ) from err
+        _write_verified(
+            target / "bin/qemu-aarch64-static",
+            qemu,
+            QEMU_AARCH64_BINARY_SHA256,
+            mode=0o755,
+        )
 
     manifest = {
-        "layout_version": RUNTIME_LAYOUT_VERSION,
+        "layout_version": layout_version,
         "architecture": architecture,
         "tencent_xp2p_version": TENCENT_XP2P_VERSION,
         "aosp_runtime_commit": AOSP_RUNTIME_COMMIT,
         "aosp_vndk_commit": AOSP_VNDK_COMMIT,
-        "qemu_version": QEMU_VERSION if architecture == "x86_64" else None,
-        "files": _expected_installed_hashes(architecture),
+        "qemu_version": (
+            QEMU_VERSION
+            if architecture == "x86_64"
+            else QEMU_AARCH64_VERSION
+            if include_aarch64_qemu
+            else None
+        ),
+        "files": _expected_installed_hashes(
+            architecture,
+            include_aarch64_qemu=include_aarch64_qemu,
+        ),
     }
     manifest_path = target / _MANIFEST_NAME
     manifest_path.write_text(
@@ -320,6 +404,9 @@ def _install_runtime(
 def _validated_assets(
     runtime_path: Path,
     architecture: str,
+    *,
+    layout_version: str = RUNTIME_LAYOUT_VERSION,
+    include_aarch64_qemu: bool = False,
 ) -> DreameLawnMowerXp2pHostAssets | None:
     manifest_path = runtime_path / _MANIFEST_NAME
     try:
@@ -328,11 +415,14 @@ def _validated_assets(
         return None
     if not isinstance(manifest, Mapping):
         return None
-    if manifest.get("layout_version") != RUNTIME_LAYOUT_VERSION:
+    if manifest.get("layout_version") != layout_version:
         return None
     if manifest.get("architecture") != architecture:
         return None
-    expected = _expected_installed_hashes(architecture)
+    expected = _expected_installed_hashes(
+        architecture,
+        include_aarch64_qemu=include_aarch64_qemu,
+    )
     if manifest.get("files") != expected:
         return None
     for relative, expected_hash in expected.items():
@@ -350,7 +440,9 @@ def _validated_assets(
         library_path=library / "libiot_video_demo.so",
         library_search_paths=(library, library / "bionic"),
         qemu_path=(
-            binary / "qemu-aarch64-static" if architecture == "x86_64" else None
+            binary / "qemu-aarch64-static"
+            if architecture == "x86_64" or include_aarch64_qemu
+            else None
         ),
     )
     try:
@@ -360,7 +452,11 @@ def _validated_assets(
     return assets
 
 
-def _expected_installed_hashes(architecture: str) -> dict[str, str]:
+def _expected_installed_hashes(
+    architecture: str,
+    *,
+    include_aarch64_qemu: bool = False,
+) -> dict[str, str]:
     files = {
         "bin/dreame-xp2p-host-runner": WORKER_SHA256,
         "lib/libiot_video_demo.so": TENCENT_XP2P_LIBRARY_SHA256,
@@ -375,6 +471,8 @@ def _expected_installed_hashes(architecture: str) -> dict[str, str]:
     }
     if architecture == "x86_64":
         files["bin/qemu-aarch64-static"] = QEMU_X86_64_BINARY_SHA256
+    elif include_aarch64_qemu:
+        files["bin/qemu-aarch64-static"] = QEMU_AARCH64_BINARY_SHA256
     return dict(sorted(files.items()))
 
 

--- a/custom_components/dreame_lawn_mower/video_stream_helpers.py
+++ b/custom_components/dreame_lawn_mower/video_stream_helpers.py
@@ -105,18 +105,20 @@ def managed_runtime_environment() -> dict[str, str | bool | int]:
     else:
         normalized_machine = machine
     supported = system == "linux" and normalized_machine in {"x86_64", "aarch64"}
+    try:
+        page_size = int(os.sysconf("SC_PAGE_SIZE"))
+    except (AttributeError, OSError, ValueError):
+        page_size = 0
     execution_mode = (
         "qemu_aarch64"
         if supported and normalized_machine == "x86_64"
+        else "qemu_aarch64_self"
+        if supported and normalized_machine == "aarch64" and page_size > 4096
         else "native_aarch64"
         if supported
         else "unsupported"
     )
     libc_name, libc_version = platform.libc_ver()
-    try:
-        page_size = int(os.sysconf("SC_PAGE_SIZE"))
-    except (AttributeError, OSError, ValueError):
-        page_size = 0
     return {
         "system": system,
         "machine": normalized_machine,

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -238,6 +238,39 @@ def test_managed_runtime_environment_is_privacy_safe(
     }
 
 
+def test_managed_runtime_environment_reports_large_page_compatibility(
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(video_helpers_module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(
+        video_helpers_module.platform,
+        "machine",
+        lambda: "aarch64",
+    )
+    monkeypatch.setattr(
+        video_helpers_module.platform,
+        "release",
+        lambda: "6.12-test",
+    )
+    monkeypatch.setattr(
+        video_helpers_module.platform,
+        "libc_ver",
+        lambda: ("musl", "1"),
+    )
+    monkeypatch.setattr(
+        video_helpers_module.os,
+        "sysconf",
+        lambda _name: 16384,
+        raising=False,
+    )
+
+    environment = video_helpers_module.managed_runtime_environment()
+
+    assert environment["execution_mode"] == "qemu_aarch64_self"
+    assert environment["page_size"] == 16384
+    assert environment["supported"] is True
+
+
 def test_video_camera_facade_preserves_split_method_surface() -> None:
     """Keep reflection and direct module imports stable after decomposition."""
     split_methods = {

--- a/tests/test_xp2p_host_runtime.py
+++ b/tests/test_xp2p_host_runtime.py
@@ -211,7 +211,10 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
     assets = xp2p_runtime_bootstrap.ensure_xp2p_host_runtime(
         tmp_path,
         machine=platform.machine(),
+        page_size=16384,
     )
+    assert assets.qemu_path is not None
+    assert assets.command()[0] == str(assets.qemu_path)
     assert assets.startup_probe is not None
     assert assets.startup_probe["ready"] is True
     assert assets.startup_probe["stage"] == "response_decode"
@@ -237,6 +240,73 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
     assert runtime.last_failure is not None
     assert isinstance(runtime.last_failure.get("worker_status"), int)
     assert runtime.last_failure.get("returncode") != -11
+
+
+def test_runtime_bootstrap_adds_qemu_only_to_large_page_aarch64_layout() -> None:
+    native = xp2p_runtime_bootstrap._expected_installed_hashes("aarch64")
+    compatible = xp2p_runtime_bootstrap._expected_installed_hashes(
+        "aarch64",
+        include_aarch64_qemu=True,
+    )
+
+    assert "bin/qemu-aarch64-static" not in native
+    assert (
+        compatible["bin/qemu-aarch64-static"]
+        == xp2p_runtime_bootstrap.QEMU_AARCH64_BINARY_SHA256
+    )
+
+
+@pytest.mark.parametrize(
+    ("machine", "page_size", "expected_name", "include_aarch64_qemu"),
+    [
+        ("x86_64", 4096, "runtime-v1-x86_64", False),
+        ("aarch64", 4096, "runtime-v1-aarch64", False),
+        ("aarch64", 16384, "runtime-v2-aarch64", True),
+    ],
+)
+def test_runtime_bootstrap_preserves_existing_layouts_until_qemu_is_needed(
+    monkeypatch,
+    tmp_path,
+    machine,
+    page_size,
+    expected_name,
+    include_aarch64_qemu,
+) -> None:
+    calls = []
+
+    def validated(path, architecture, **options):
+        calls.append((path, architecture, options))
+        return DreameLawnMowerXp2pHostAssets(
+            worker_path=path / "bin" / "dreame-xp2p-host-runner",
+            linker_path=path / "bin" / "linker64",
+            library_path=path / "lib" / "libiot_video_demo.so",
+            library_search_paths=(path / "lib",),
+            qemu_path=(
+                path / "bin" / "qemu-aarch64-static"
+                if machine == "x86_64" or include_aarch64_qemu
+                else None
+            ),
+        )
+
+    monkeypatch.setattr(xp2p_runtime_bootstrap, "_validated_assets", validated)
+    monkeypatch.setattr(
+        xp2p_runtime_bootstrap,
+        "_with_startup_probe",
+        lambda assets: assets,
+    )
+
+    assets = xp2p_runtime_bootstrap.ensure_xp2p_host_runtime(
+        tmp_path,
+        machine=machine,
+        page_size=page_size,
+    )
+
+    assert assets.worker_path.parent.parent.name == expected_name
+    assert len(calls) == 1
+    assert calls[0][2] == {
+        "layout_version": expected_name.split("-")[1][1:],
+        "include_aarch64_qemu": include_aarch64_qemu,
+    }
 
 
 def test_host_probe_reports_signal_without_exposing_paths(
@@ -718,7 +788,7 @@ def test_runtime_bootstrap_repairs_file_shaped_cache(
             qemu_path=path / "bin" / "qemu-aarch64-static",
         )
 
-    def _validated(path, _architecture):
+    def _validated(path, _architecture, **_kwargs):
         if path == runtime_path and path.is_file():
             return None
         return _assets(path)


### PR DESCRIPTION
## What changed

- Detect Linux ARM64 hosts whose kernel page size is larger than 4 KB.
- Run the existing 4 KB-aligned Android/Bionic XP2P userspace through a pinned, statically linked ARM64 QEMU binary on those hosts.
- Download that compatibility asset only for large-page ARM64; x86_64 and ordinary 4 KB ARM64 keep their existing v1 runtime caches and launch behavior.
- Report `qemu_aarch64_self` in diagnostics when the compatibility path is active.
- Exercise the self-emulated worker contract in the native ARM Home Assistant container CI lane.

## Why

Issue #94 supplies the missing host detail from the earlier video investigation: Raspberry Pi 5 uses a 16,384-byte kernel page size. The bundled XP2P worker and Tencent library are 64 KB-aligned, but the pinned Android linker and Bionic libc are only 4 KB-aligned. Launching that loader natively on the reported host exits with signal 11 before any mower credentials are sent.

The pinned Alpine `qemu-aarch64` executable is statically linked, has no package dependencies, and its load segments are 64 KB-aligned. Self-emulation gives the Android userspace its expected 4 KB target page model without changing the Tencent SDK.

## Validation

- 1,010 repository tests passed; the opt-in real-runtime test skipped locally as expected.
- Ruff, compileall, and diff checks passed.
- Focused runtime/video suite: 95 passed and one opt-in test skipped locally.
- One risk-focused local review found a cache migration/download regression; it was fixed, and targeted confirmation found no remaining issue.

The native ARM CI lane proves the pinned self-QEMU command inside the exact Home Assistant 2026.7.2 ARM64 container. Its runner still has a 4 KB kernel, so an actual Raspberry Pi 5 / 16 KB-page retest remains the final acceptance gate. This PR does not claim physical playback is confirmed yet, and issue #94 should remain open until that retest succeeds.

Related to #94.