### PR TITLE
Fix 16 KB video runtime and stored 3D map fallback

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/android_build_artifact.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/android_build_artifact.py
@@ -1,0 +1,169 @@
+"""Read selected files from a public Android build artifact over HTTP ranges."""
+
+from __future__ import annotations
+
+import io
+import re
+import zipfile
+from collections.abc import Mapping, Sequence
+from typing import Protocol
+
+from .video_runtime import DreameLawnMowerVideoRuntimeError
+
+_CONTENT_RANGE = re.compile(r"bytes (\d+)-(\d+)/(\d+)")
+
+
+class _HttpResponse(Protocol):
+    status_code: int
+    content: bytes
+    headers: Mapping[str, str]
+    url: str
+
+
+class _HttpClient(Protocol):
+    def get(
+        self,
+        url: str,
+        *,
+        headers: Mapping[str, str],
+        timeout: float,
+    ) -> _HttpResponse: ...
+
+
+class _HttpRangeReader(io.RawIOBase):
+    """Expose one immutable HTTP resource as a seekable binary stream."""
+
+    def __init__(
+        self,
+        client: _HttpClient,
+        url: str,
+        size: int,
+        *,
+        timeout: float,
+    ) -> None:
+        super().__init__()
+        self._client = client
+        self._url = url
+        self._size = size
+        self._timeout = timeout
+        self._position = 0
+
+    def readable(self) -> bool:
+        return True
+
+    def seekable(self) -> bool:
+        return True
+
+    def tell(self) -> int:
+        return self._position
+
+    def seek(self, offset: int, whence: int = io.SEEK_SET) -> int:
+        if whence == io.SEEK_SET:
+            position = offset
+        elif whence == io.SEEK_CUR:
+            position = self._position + offset
+        elif whence == io.SEEK_END:
+            position = self._size + offset
+        else:
+            raise ValueError(f"Unsupported seek mode: {whence}")
+        if position < 0:
+            raise ValueError("Cannot seek before the start of an HTTP resource.")
+        self._position = min(position, self._size)
+        return self._position
+
+    def read(self, size: int = -1) -> bytes:
+        if self._position >= self._size or size == 0:
+            return b""
+        end = (
+            self._size - 1
+            if size < 0
+            else min(self._size - 1, self._position + size - 1)
+        )
+        start = self._position
+        response = self._client.get(
+            self._url,
+            headers={
+                "Accept-Encoding": "identity",
+                "Range": f"bytes={start}-{end}",
+            },
+            timeout=self._timeout,
+        )
+        content = bytes(response.content)
+        _require_range_response(
+            response,
+            expected_start=start,
+            expected_end=end,
+            expected_size=self._size,
+            content_length=len(content),
+        )
+        self._position += len(content)
+        return content
+
+
+def read_android_build_zip_entries(
+    artifact_url: str,
+    entry_names: Sequence[str],
+    *,
+    expected_size: int,
+    http_client: _HttpClient,
+    timeout: float,
+) -> dict[str, bytes]:
+    """Return selected entries without downloading the complete build archive."""
+    probe = http_client.get(
+        artifact_url,
+        headers={
+            "Accept-Encoding": "identity",
+            "Range": "bytes=0-0",
+        },
+        timeout=timeout,
+    )
+    _require_range_response(
+        probe,
+        expected_start=0,
+        expected_end=0,
+        expected_size=expected_size,
+        content_length=len(probe.content),
+    )
+    reader = _HttpRangeReader(
+        http_client,
+        probe.url,
+        expected_size,
+        timeout=timeout,
+    )
+    try:
+        with zipfile.ZipFile(reader) as archive:
+            return {name: archive.read(name) for name in entry_names}
+    except (KeyError, OSError, zipfile.BadZipFile) as err:
+        raise DreameLawnMowerVideoRuntimeError(
+            "Android build runtime artifact was malformed."
+        ) from err
+
+
+def _require_range_response(
+    response: _HttpResponse,
+    *,
+    expected_start: int,
+    expected_end: int,
+    expected_size: int,
+    content_length: int,
+) -> None:
+    if response.status_code != 206:
+        raise DreameLawnMowerVideoRuntimeError(
+            "Android build runtime did not support HTTP range downloads."
+        )
+    match = _CONTENT_RANGE.fullmatch(response.headers.get("Content-Range", ""))
+    if match is None:
+        raise DreameLawnMowerVideoRuntimeError(
+            "Android build runtime returned an invalid Content-Range."
+        )
+    start, end, total = (int(value) for value in match.groups())
+    expected_length = expected_end - expected_start + 1
+    if (
+        start != expected_start
+        or end != expected_end
+        or total != expected_size
+        or content_length != expected_length
+    ):
+        raise DreameLawnMowerVideoRuntimeError(
+            "Android build runtime returned an unexpected byte range."
+        )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -94,10 +94,8 @@ from .vector_map import (
 if TYPE_CHECKING:
     from .map_visuals import MapRenderStyle
 
-# MOVA reports the fixed 3dmap object as "*.bin" even though the payload is PCD.
-_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd"})
-_MOVA_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
-_POINT_CLOUD_ANNOUNCEMENT_EXTENSIONS = frozenset({"pcd", "bin"})
+# Dreame and MOVA can report 3D-map PCD payloads with a "*.bin" object name.
+_POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
 _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
 _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
 _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 2.0
@@ -735,37 +733,16 @@ class _DreameLawnMowerClientMapsMixin:
         use_announcement_path = announcement_capability is True
         announcement_probe_pending = announcement_capability is None
         if allow_stored and stored_name is not None:
-            stored_deadline = min(
-                deadline,
-                time.monotonic()
-                + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+            stored = self._sync_try_download_stored_point_cloud(
+                cloud,
+                stored_name,
+                map_index=map_index,
+                deadline=deadline,
+                download_timeout=download_timeout,
+                max_bytes=max_bytes,
             )
-            try:
-                content, content_type, _ = self._sync_download_point_cloud_object(
-                    cloud,
-                    stored_name,
-                    deadline=stored_deadline,
-                    download_timeout=min(
-                        download_timeout,
-                        _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
-                    ),
-                    max_bytes=max_bytes,
-                )
-                metadata = parse_pcd_metadata(
-                    content,
-                    max_bytes=max_bytes,
-                    deadline=stored_deadline,
-                )
-            except (DeviceException, DreameLawnMowerPointCloudError):
-                pass
-            else:
-                return DreameLawnMowerPointCloudDownload(
-                    map_index=map_index,
-                    content=content,
-                    metadata=metadata,
-                    content_type=content_type,
-                    source="stored",
-                )
+            if stored is not None:
+                return stored
         if allow_stored:
             deadline = min(deadline, time.monotonic() + timeout)
         baseline_name = None
@@ -802,25 +779,31 @@ class _DreameLawnMowerClientMapsMixin:
                 baseline_result,
                 map_index,
             )
+            if allow_stored and baseline_name is not None:
+                stored = self._sync_try_download_stored_point_cloud(
+                    cloud,
+                    baseline_name,
+                    map_index=map_index,
+                    deadline=deadline,
+                    download_timeout=download_timeout,
+                    max_bytes=max_bytes,
+                )
+                if stored is not None:
+                    return stored
 
-        accepted_extensions = (
-            _MOVA_POINT_CLOUD_OBJECT_EXTENSIONS
-            if self._account_type == "mova"
-            else _POINT_CLOUD_OBJECT_EXTENSIONS
-        )
+        accepted_extensions = _POINT_CLOUD_OBJECT_EXTENSIONS
         baseline_identity = None
         baseline_extension = (
             _app_object_extension(baseline_name)
             if baseline_name is not None
             else None
         )
-        fixed_mova_baseline = (
-            self._account_type == "mova"
-            and baseline_name is not None
+        fixed_object_baseline = (
+            baseline_name is not None
             and baseline_extension is not None
-            and baseline_extension.casefold() in accepted_extensions
+            and baseline_extension.casefold() == "bin"
         )
-        if fixed_mova_baseline:
+        if fixed_object_baseline:
             try:
                 _, _, baseline_identity = self._sync_download_point_cloud_object(
                     cloud,
@@ -1006,18 +989,19 @@ class _DreameLawnMowerClientMapsMixin:
             object_extension = (
                 _app_object_extension(object_name) if object_name is not None else None
             )
-            fixed_mova_object = (
-                self._account_type == "mova"
-                and object_name is not None
+            fixed_object = (
+                object_name is not None
                 and object_name == baseline_name
                 and not observed_clear
+                and object_extension is not None
+                and object_extension.casefold() == "bin"
             )
             object_ready = (
                 object_name != baseline_name
                 or observed_clear
-                or fixed_mova_object
+                or fixed_object
             )
-            attempt_allowed = fixed_mova_object or (
+            attempt_allowed = fixed_object or (
                 object_name not in rejected_object_names
                 and object_download_attempts.get(object_name, 0) < 2
             )
@@ -1028,7 +1012,7 @@ class _DreameLawnMowerClientMapsMixin:
                 and object_ready
                 and attempt_allowed
             ):
-                if not fixed_mova_object:
+                if not fixed_object:
                     object_download_attempts[object_name] = (
                         object_download_attempts.get(object_name, 0) + 1
                     )
@@ -1045,10 +1029,10 @@ class _DreameLawnMowerClientMapsMixin:
                 except (DeviceException, DreameLawnMowerPointCloudError):
                     saw_unusable_point_cloud = True
                 else:
-                    if fixed_mova_object and baseline_identity is None:
+                    if fixed_object and baseline_identity is None:
                         saw_unverified_fixed_object = True
                     elif (
-                        fixed_mova_object
+                        fixed_object
                         and not object_identity.differs_from(baseline_identity)
                     ):
                         saw_stale_point_cloud = True
@@ -1061,7 +1045,7 @@ class _DreameLawnMowerClientMapsMixin:
                             )
                         except DreameLawnMowerPointCloudError:
                             saw_unusable_point_cloud = True
-                            if not fixed_mova_object:
+                            if not fixed_object:
                                 rejected_object_names.add(object_name)
                         else:
                             return DreameLawnMowerPointCloudDownload(
@@ -1077,7 +1061,7 @@ class _DreameLawnMowerClientMapsMixin:
 
         if saw_unverified_fixed_object:
             raise DreameLawnMowerPointCloudError(
-                "The MOVA fixed point-cloud object could not be compared with "
+                "The fixed point-cloud object could not be compared with "
                 "its pre-generation version before the timeout.",
                 code="point_cloud_download_invalid",
                 stage="download_validation",
@@ -1126,6 +1110,53 @@ class _DreameLawnMowerClientMapsMixin:
             ),
             timeout_seconds=timeout,
             retry_after_seconds=10,
+        )
+
+    def _sync_try_download_stored_point_cloud(
+        self,
+        cloud: Any,
+        object_name: str,
+        *,
+        map_index: int,
+        deadline: float,
+        download_timeout: float,
+        max_bytes: int,
+    ) -> DreameLawnMowerPointCloudDownload | None:
+        """Return one valid stored PCD from either object-discovery route."""
+        extension = _app_object_extension(object_name)
+        if (
+            extension is None
+            or extension.casefold() not in _POINT_CLOUD_OBJECT_EXTENSIONS
+        ):
+            return None
+        stored_deadline = min(
+            deadline,
+            time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+        try:
+            content, content_type, _ = self._sync_download_point_cloud_object(
+                cloud,
+                object_name,
+                deadline=stored_deadline,
+                download_timeout=min(
+                    download_timeout,
+                    _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+                ),
+                max_bytes=max_bytes,
+            )
+            metadata = parse_pcd_metadata(
+                content,
+                max_bytes=max_bytes,
+                deadline=stored_deadline,
+            )
+        except (DeviceException, DreameLawnMowerPointCloudError):
+            return None
+        return DreameLawnMowerPointCloudDownload(
+            map_index=map_index,
+            content=content,
+            metadata=metadata,
+            content_type=content_type,
+            source="stored",
         )
 
     def _sync_get_announced_point_cloud_object(
@@ -1190,7 +1221,7 @@ class _DreameLawnMowerClientMapsMixin:
             if (
                 extension is None
                 or extension.casefold()
-                not in _POINT_CLOUD_ANNOUNCEMENT_EXTENSIONS
+                not in _POINT_CLOUD_OBJECT_EXTENSIONS
             ):
                 return True, None, None
             normalized_name = object_name.strip()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_runtime_bootstrap.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/xp2p_runtime_bootstrap.py
@@ -22,6 +22,7 @@ from typing import Protocol
 
 import requests
 
+from .android_build_artifact import read_android_build_zip_entries
 from .video_runtime import DreameLawnMowerVideoRuntimeError
 from .xp2p_host_probe import probe_xp2p_host_worker
 from .xp2p_host_runtime import DreameLawnMowerXp2pHostAssets
@@ -32,7 +33,7 @@ from .xp2p_host_worker_blob import (
 )
 
 RUNTIME_LAYOUT_VERSION = "1"
-LARGE_PAGE_RUNTIME_LAYOUT_VERSION = "2"
+LARGE_PAGE_RUNTIME_LAYOUT_VERSION = "3"
 TENCENT_XP2P_VERSION = "2.4.50"
 TENCENT_XP2P_AAR_URL = (
     "https://repo.maven.apache.org/maven2/com/tencent/iot/thirdparty/android/"
@@ -103,6 +104,63 @@ AOSP_VNDK_FILES = {
     ),
 }
 
+LARGE_PAGE_ANDROID_BUILD_ID = "15885347"
+LARGE_PAGE_ANDROID_BUILD_TARGET = "aosp_cf_arm64_only_phone-userdebug"
+LARGE_PAGE_ANDROID_BUILD_ARTIFACT = (
+    "aosp_cf_arm64_only_phone-target_files-15885347.zip"
+)
+LARGE_PAGE_ANDROID_BUILD_ARTIFACT_SIZE = 2_223_019_107
+LARGE_PAGE_ANDROID_BUILD_ARTIFACT_URL = (
+    "https://androidbuildinternal.googleapis.com/android/internal/build/v3/"
+    f"builds/{LARGE_PAGE_ANDROID_BUILD_ID}/"
+    f"{LARGE_PAGE_ANDROID_BUILD_TARGET}/attempts/latest/artifacts/"
+    f"{LARGE_PAGE_ANDROID_BUILD_ARTIFACT}/url"
+)
+LARGE_PAGE_ANDROID_RUNTIME_APEX = "SYSTEM/apex/com.android.runtime.apex"
+LARGE_PAGE_ANDROID_RUNTIME_APEX_SHA256 = (
+    "6e320d2a2537a66dfb24812b84d5ecd3be536df91e534a6a472cfbc20ba8a8f9"
+)
+LARGE_PAGE_AOSP_RUNTIME_FILES = {
+    "bin/linker64": (
+        "bin/linker64",
+        "fdf3b18b361fbe341785694d2f3fea9319990fc4094da3b0c18ad8d9f093015a",
+        0o755,
+    ),
+    "lib64/bionic/libc.so": (
+        "lib/bionic/libc.so",
+        "ca50882f8f3dd01821378d529740096f177f272f68bcb701759c727d50bcdae6",
+        0o644,
+    ),
+    "lib64/bionic/libm.so": (
+        "lib/bionic/libm.so",
+        "fdc7c200502aed34a521437c6d47034f3e472262de6435e554ce5c52c034dc7d",
+        0o644,
+    ),
+    "lib64/bionic/libdl.so": (
+        "lib/bionic/libdl.so",
+        "ce8156bace0ce59e220f69666bd1d6bb4ba275d66ec8052f04c674a415eb99fc",
+        0o644,
+    ),
+}
+LARGE_PAGE_AOSP_SYSTEM_FILES = {
+    "SYSTEM/lib64/ld-android.so": (
+        "lib/ld-android.so",
+        "5dbbe8389b417d3abea5f022cf630cf79bc6909b8404a8765c271978c7bd655e",
+    ),
+    "SYSTEM/lib64/libc++.so": (
+        "lib/libstdc++.so",
+        "cb118e98c74d3454858921123b9b51ba13df9cad7dfa141dd892c453661a4d78",
+    ),
+    "SYSTEM/lib64/liblog.so": (
+        "lib/liblog.so",
+        "a3833794cd68202018930e130e238b206cd5a0c322050ccb8af8fe4e58f3e4b3",
+    ),
+    "SYSTEM/lib64/libz.so": (
+        "lib/libz.so",
+        "0d85c66c4db2364393205cdb8adaed01ade4d89443347ea867c8a91c32d30270",
+    ),
+}
+
 QEMU_VERSION = "7.2.0-1"
 QEMU_X86_64_URL = (
     "https://github.com/multiarch/qemu-user-static/releases/download/"
@@ -113,17 +171,6 @@ QEMU_X86_64_ARCHIVE_SHA256 = (
 )
 QEMU_X86_64_BINARY_SHA256 = (
     "dce64b2dc6b005485c7aa735a7ea39cb0006bf7e5badc28b324b2cd0c73d883f"
-)
-QEMU_AARCH64_VERSION = "10.0.0-r1"
-QEMU_AARCH64_APK_URL = (
-    "https://dl-cdn.alpinelinux.org/alpine/v3.22/community/aarch64/"
-    "qemu-aarch64-10.0.0-r1.apk"
-)
-QEMU_AARCH64_APK_SHA256 = (
-    "59cdf1518f501c87f0397324bf97c807adac45fe70a50f5468fcb55280573758"
-)
-QEMU_AARCH64_BINARY_SHA256 = (
-    "4d1b11f85b7617ee9209d4e9224378ad8d96f757dc30ee7939f8097c1b65b13a"
 )
 
 _TENCENT_AAR_LIBRARY = "jni/arm64-v8a/libiot_video_demo.so"
@@ -158,12 +205,10 @@ def ensure_xp2p_host_runtime(
             f"this host reports {machine or platform.machine()!r}."
         )
     host_page_size = _host_page_size() if page_size is None else page_size
-    use_aarch64_self_qemu = (
-        architecture == "aarch64" and host_page_size > 4096
-    )
+    use_large_page_runtime = architecture == "aarch64" and host_page_size > 4096
     layout_version = (
         LARGE_PAGE_RUNTIME_LAYOUT_VERSION
-        if use_aarch64_self_qemu
+        if use_large_page_runtime
         else RUNTIME_LAYOUT_VERSION
     )
     root_path = Path(root)
@@ -173,7 +218,7 @@ def ensure_xp2p_host_runtime(
             runtime_path,
             architecture,
             layout_version=layout_version,
-            include_aarch64_qemu=use_aarch64_self_qemu,
+            use_large_page_runtime=use_large_page_runtime,
         )
         if assets is None:
             root_path.mkdir(parents=True, exist_ok=True)
@@ -188,7 +233,7 @@ def ensure_xp2p_host_runtime(
                     staging,
                     architecture,
                     layout_version=layout_version,
-                    include_aarch64_qemu=use_aarch64_self_qemu,
+                    use_large_page_runtime=use_large_page_runtime,
                     http_client=http_client or requests,
                     timeout=timeout,
                 )
@@ -196,7 +241,7 @@ def ensure_xp2p_host_runtime(
                     staging,
                     architecture,
                     layout_version=layout_version,
-                    include_aarch64_qemu=use_aarch64_self_qemu,
+                    use_large_page_runtime=use_large_page_runtime,
                 )
                 if installed is None:
                     raise DreameLawnMowerVideoRuntimeError(
@@ -212,7 +257,7 @@ def ensure_xp2p_host_runtime(
                 runtime_path,
                 architecture,
                 layout_version=layout_version,
-                include_aarch64_qemu=use_aarch64_self_qemu,
+                use_large_page_runtime=use_large_page_runtime,
             )
             if assets is None:
                 raise DreameLawnMowerVideoRuntimeError(
@@ -247,7 +292,7 @@ def _install_runtime(
     architecture: str,
     *,
     layout_version: str = RUNTIME_LAYOUT_VERSION,
-    include_aarch64_qemu: bool = False,
+    use_large_page_runtime: bool = False,
     http_client: _HttpClient,
     timeout: float,
 ) -> None:
@@ -281,51 +326,18 @@ def _install_runtime(
         TENCENT_XP2P_LIBRARY_SHA256,
     )
 
-    apex_encoded = _download_verified(
-        http_client,
-        AOSP_RUNTIME_APEX_URL,
-        None,
-        timeout=timeout,
-        label="AOSP Bionic runtime",
-    )
-    try:
-        apex = _decode_gitiles(apex_encoded)
-    except ValueError as err:
-        raise DreameLawnMowerVideoRuntimeError(
-            "AOSP Bionic runtime download was not valid Gitiles base64."
-        ) from err
-    _require_hash(apex, AOSP_RUNTIME_APEX_SHA256, "AOSP Bionic runtime")
-    try:
-        with zipfile.ZipFile(io.BytesIO(apex)) as archive:
-            filesystem_image = archive.read("apex_payload.img")
-    except (KeyError, zipfile.BadZipFile) as err:
-        raise DreameLawnMowerVideoRuntimeError(
-            "AOSP Bionic APEX did not contain apex_payload.img."
-        ) from err
-    filesystem = _ExtFilesystem(filesystem_image)
-    for source, (relative_target, expected_hash, mode) in AOSP_RUNTIME_FILES.items():
-        _write_verified(
-            target / relative_target,
-            filesystem.read_file(source),
-            expected_hash,
-            mode=mode,
-        )
-
-    for relative_target, (url, expected_hash) in AOSP_VNDK_FILES.items():
-        encoded = _download_verified(
-            http_client,
-            url,
-            None,
+    if use_large_page_runtime:
+        _install_large_page_aosp_runtime(
+            target,
+            http_client=http_client,
             timeout=timeout,
-            label=Path(relative_target).name,
         )
-        try:
-            content = _decode_gitiles(encoded)
-        except ValueError as err:
-            raise DreameLawnMowerVideoRuntimeError(
-                f"AOSP {Path(relative_target).name} was not valid Gitiles base64."
-            ) from err
-        _write_verified(target / relative_target, content, expected_hash)
+    else:
+        _install_legacy_aosp_runtime(
+            target,
+            http_client=http_client,
+            timeout=timeout,
+        )
 
     if architecture == "x86_64":
         qemu_archive = _download_verified(
@@ -350,48 +362,22 @@ def _install_runtime(
             QEMU_X86_64_BINARY_SHA256,
             mode=0o755,
         )
-    elif include_aarch64_qemu:
-        qemu_apk = _download_verified(
-            http_client,
-            QEMU_AARCH64_APK_URL,
-            QEMU_AARCH64_APK_SHA256,
-            timeout=timeout,
-            label="Alpine qemu-aarch64",
-        )
-        try:
-            with tarfile.open(
-                fileobj=io.BytesIO(qemu_apk),
-                mode="r:gz",
-            ) as archive:
-                stream = archive.extractfile("usr/bin/qemu-aarch64")
-                qemu = stream.read() if stream is not None else b""
-        except (KeyError, tarfile.TarError) as err:
-            raise DreameLawnMowerVideoRuntimeError(
-                "Alpine qemu-aarch64 package was malformed."
-            ) from err
-        _write_verified(
-            target / "bin/qemu-aarch64-static",
-            qemu,
-            QEMU_AARCH64_BINARY_SHA256,
-            mode=0o755,
-        )
 
     manifest = {
         "layout_version": layout_version,
         "architecture": architecture,
         "tencent_xp2p_version": TENCENT_XP2P_VERSION,
-        "aosp_runtime_commit": AOSP_RUNTIME_COMMIT,
-        "aosp_vndk_commit": AOSP_VNDK_COMMIT,
-        "qemu_version": (
-            QEMU_VERSION
-            if architecture == "x86_64"
-            else QEMU_AARCH64_VERSION
-            if include_aarch64_qemu
-            else None
+        "aosp_runtime_commit": (
+            None if use_large_page_runtime else AOSP_RUNTIME_COMMIT
         ),
+        "aosp_vndk_commit": None if use_large_page_runtime else AOSP_VNDK_COMMIT,
+        "android_build_id": (
+            LARGE_PAGE_ANDROID_BUILD_ID if use_large_page_runtime else None
+        ),
+        "qemu_version": QEMU_VERSION if architecture == "x86_64" else None,
         "files": _expected_installed_hashes(
             architecture,
-            include_aarch64_qemu=include_aarch64_qemu,
+            use_large_page_runtime=use_large_page_runtime,
         ),
     }
     manifest_path = target / _MANIFEST_NAME
@@ -401,12 +387,103 @@ def _install_runtime(
     )
 
 
+def _install_legacy_aosp_runtime(
+    target: Path,
+    *,
+    http_client: _HttpClient,
+    timeout: float,
+) -> None:
+    apex_encoded = _download_verified(
+        http_client,
+        AOSP_RUNTIME_APEX_URL,
+        None,
+        timeout=timeout,
+        label="AOSP Bionic runtime",
+    )
+    try:
+        apex = _decode_gitiles(apex_encoded)
+    except ValueError as err:
+        raise DreameLawnMowerVideoRuntimeError(
+            "AOSP Bionic runtime download was not valid Gitiles base64."
+        ) from err
+    _require_hash(apex, AOSP_RUNTIME_APEX_SHA256, "AOSP Bionic runtime")
+    _install_apex_files(target, apex, AOSP_RUNTIME_FILES)
+
+    for relative_target, (url, expected_hash) in AOSP_VNDK_FILES.items():
+        encoded = _download_verified(
+            http_client,
+            url,
+            None,
+            timeout=timeout,
+            label=Path(relative_target).name,
+        )
+        try:
+            content = _decode_gitiles(encoded)
+        except ValueError as err:
+            raise DreameLawnMowerVideoRuntimeError(
+                f"AOSP {Path(relative_target).name} was not valid Gitiles base64."
+            ) from err
+        _write_verified(target / relative_target, content, expected_hash)
+
+
+def _install_large_page_aosp_runtime(
+    target: Path,
+    *,
+    http_client: _HttpClient,
+    timeout: float,
+) -> None:
+    entry_names = (
+        LARGE_PAGE_ANDROID_RUNTIME_APEX,
+        *LARGE_PAGE_AOSP_SYSTEM_FILES,
+    )
+    entries = read_android_build_zip_entries(
+        LARGE_PAGE_ANDROID_BUILD_ARTIFACT_URL,
+        entry_names,
+        expected_size=LARGE_PAGE_ANDROID_BUILD_ARTIFACT_SIZE,
+        http_client=http_client,
+        timeout=timeout,
+    )
+    apex = entries[LARGE_PAGE_ANDROID_RUNTIME_APEX]
+    _require_hash(
+        apex,
+        LARGE_PAGE_ANDROID_RUNTIME_APEX_SHA256,
+        "large-page AOSP Bionic runtime",
+    )
+    _install_apex_files(target, apex, LARGE_PAGE_AOSP_RUNTIME_FILES)
+    for source, (relative_target, expected_hash) in (
+        LARGE_PAGE_AOSP_SYSTEM_FILES.items()
+    ):
+        _write_verified(target / relative_target, entries[source], expected_hash)
+
+
+def _install_apex_files(
+    target: Path,
+    apex: bytes,
+    files: Mapping[str, tuple[str, str, int]],
+) -> None:
+    try:
+        with zipfile.ZipFile(io.BytesIO(apex)) as archive:
+            filesystem_image = archive.read("apex_payload.img")
+    except (KeyError, zipfile.BadZipFile) as err:
+        raise DreameLawnMowerVideoRuntimeError(
+            "AOSP Bionic APEX did not contain apex_payload.img."
+        ) from err
+    filesystem = _ExtFilesystem(filesystem_image)
+    for source, (relative_target, expected_hash, mode) in files.items():
+        _write_verified(
+            target / relative_target,
+            filesystem.read_file(source),
+            expected_hash,
+            mode=mode,
+        )
+
+
 def _validated_assets(
     runtime_path: Path,
     architecture: str,
     *,
     layout_version: str = RUNTIME_LAYOUT_VERSION,
-    include_aarch64_qemu: bool = False,
+    use_large_page_runtime: bool = False,
 ) -> DreameLawnMowerXp2pHostAssets | None:
     manifest_path = runtime_path / _MANIFEST_NAME
     try:
@@ -421,7 +498,7 @@ def _validated_assets(
         return None
     expected = _expected_installed_hashes(
         architecture,
-        include_aarch64_qemu=include_aarch64_qemu,
+        use_large_page_runtime=use_large_page_runtime,
     )
     if manifest.get("files") != expected:
         return None
@@ -440,9 +517,7 @@ def _validated_assets(
         library_path=library / "libiot_video_demo.so",
         library_search_paths=(library, library / "bionic"),
         qemu_path=(
-            binary / "qemu-aarch64-static"
-            if architecture == "x86_64" or include_aarch64_qemu
-            else None
+            binary / "qemu-aarch64-static" if architecture == "x86_64" else None
         ),
     )
     try:
@@ -455,24 +530,37 @@ def _validated_assets(
 def _expected_installed_hashes(
     architecture: str,
     *,
-    include_aarch64_qemu: bool = False,
+    use_large_page_runtime: bool = False,
 ) -> dict[str, str]:
+    runtime_files = (
+        LARGE_PAGE_AOSP_RUNTIME_FILES
+        if use_large_page_runtime
+        else AOSP_RUNTIME_FILES
+    )
+    system_hashes = (
+        {
+            relative_target: expected_hash
+            for relative_target, expected_hash in (
+                LARGE_PAGE_AOSP_SYSTEM_FILES.values()
+            )
+        }
+        if use_large_page_runtime
+        else {
+            relative_target: expected_hash
+            for relative_target, (_url, expected_hash) in AOSP_VNDK_FILES.items()
+        }
+    )
     files = {
         "bin/dreame-xp2p-host-runner": WORKER_SHA256,
         "lib/libiot_video_demo.so": TENCENT_XP2P_LIBRARY_SHA256,
         **{
             relative_target: expected_hash
-            for relative_target, expected_hash, _mode in AOSP_RUNTIME_FILES.values()
+            for relative_target, expected_hash, _mode in runtime_files.values()
         },
-        **{
-            relative_target: expected_hash
-            for relative_target, (_url, expected_hash) in AOSP_VNDK_FILES.items()
-        },
+        **system_hashes,
     }
     if architecture == "x86_64":
         files["bin/qemu-aarch64-static"] = QEMU_X86_64_BINARY_SHA256
-    elif include_aarch64_qemu:
-        files["bin/qemu-aarch64-static"] = QEMU_AARCH64_BINARY_SHA256
     return dict(sorted(files.items()))
 
 

--- a/custom_components/dreame_lawn_mower/video_stream_helpers.py
+++ b/custom_components/dreame_lawn_mower/video_stream_helpers.py
@@ -112,7 +112,7 @@ def managed_runtime_environment() -> dict[str, str | bool | int]:
     execution_mode = (
         "qemu_aarch64"
         if supported and normalized_machine == "x86_64"
-        else "qemu_aarch64_self"
+        else "native_aarch64_large_page"
         if supported and normalized_machine == "aarch64" and page_size > 4096
         else "native_aarch64"
         if supported

--- a/tests/test_android_build_artifact.py
+++ b/tests/test_android_build_artifact.py
@@ -1,0 +1,110 @@
+"""Contracts for selective Android build artifact downloads."""
+
+from __future__ import annotations
+
+import io
+import zipfile
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    android_build_artifact,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.video_runtime import (
+    DreameLawnMowerVideoRuntimeError,
+)
+
+
+class _Response:
+    def __init__(
+        self,
+        content: bytes,
+        *,
+        content_range: str,
+        url: str,
+        status_code: int = 206,
+    ) -> None:
+        self.content = content
+        self.headers = {"Content-Range": content_range}
+        self.status_code = status_code
+        self.url = url
+
+
+class _RangeClient:
+    def __init__(self, content: bytes, *, status_code: int = 206) -> None:
+        self.content = content
+        self.status_code = status_code
+        self.requests: list[tuple[str, str]] = []
+
+    def get(self, url, *, headers, timeout):
+        assert timeout == 10
+        byte_range = headers["Range"]
+        self.requests.append((url, byte_range))
+        start, end = (
+            int(value) for value in byte_range.removeprefix("bytes=").split("-")
+        )
+        return _Response(
+            self.content[start : end + 1],
+            content_range=f"bytes {start}-{end}/{len(self.content)}",
+            url="https://signed.example.test/android-build.zip",
+            status_code=self.status_code,
+        )
+
+
+def _build_zip() -> bytes:
+    buffer = io.BytesIO()
+    with zipfile.ZipFile(buffer, "w", zipfile.ZIP_DEFLATED) as archive:
+        archive.writestr("SYSTEM/apex/com.android.runtime.apex", b"runtime-apex")
+        archive.writestr("SYSTEM/lib64/liblog.so", b"android-log")
+        archive.writestr("unrelated-large-image.img", b"ignored" * 1000)
+    return buffer.getvalue()
+
+
+def test_selected_entries_are_read_with_http_ranges() -> None:
+    content = _build_zip()
+    client = _RangeClient(content)
+
+    entries = android_build_artifact.read_android_build_zip_entries(
+        "https://build.example.test/artifact/url",
+        (
+            "SYSTEM/apex/com.android.runtime.apex",
+            "SYSTEM/lib64/liblog.so",
+        ),
+        expected_size=len(content),
+        http_client=client,
+        timeout=10,
+    )
+
+    assert entries == {
+        "SYSTEM/apex/com.android.runtime.apex": b"runtime-apex",
+        "SYSTEM/lib64/liblog.so": b"android-log",
+    }
+    assert client.requests[0] == (
+        "https://build.example.test/artifact/url",
+        "bytes=0-0",
+    )
+    assert all(
+        url == "https://signed.example.test/android-build.zip"
+        for url, _range in client.requests[1:]
+    )
+    assert sum(
+        int(end) - int(start) + 1
+        for _url, byte_range in client.requests
+        for start, end in [byte_range.removeprefix("bytes=").split("-")]
+    ) < len(content)
+
+
+def test_range_reader_rejects_servers_without_partial_content() -> None:
+    content = _build_zip()
+
+    with pytest.raises(
+        DreameLawnMowerVideoRuntimeError,
+        match="did not support HTTP range downloads",
+    ):
+        android_build_artifact.read_android_build_zip_entries(
+            "https://build.example.test/artifact/url",
+            ("SYSTEM/apex/com.android.runtime.apex",),
+            expected_size=len(content),
+            http_client=_RangeClient(content, status_code=200),
+            timeout=10,
+        )

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -455,6 +455,50 @@ def test_download_point_cloud_uses_stored_active_map_when_allowed(
     assert result.source == "stored"
 
 
+def test_download_point_cloud_uses_legacy_stored_bin_after_property_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    client._sync_call_app_action = lambda payload, **kwargs: (
+        actions.append(payload)
+        or {"r": 0, "d": {"name": ["private/fixed-map.bin", ""]}}
+    )
+    signed_names: list[str] = []
+
+    def get_interim_file_url(name: str, **options: Any) -> str:
+        signed_names.append(name)
+        return "https://downloads.example.invalid/stored"
+
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_properties=lambda key, **options: None,
+        get_interim_file_url=get_interim_file_url,
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        45,
+        1,
+        10,
+        1024,
+        allow_stored=True,
+    )
+
+    assert actions == [{"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}]
+    assert signed_names == ["private/fixed-map.bin"]
+    assert result.content == content
+    assert result.source == "stored"
+
+
 def test_download_point_cloud_regenerates_when_stored_object_is_invalid(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -1518,37 +1562,56 @@ def test_download_point_cloud_retries_mova_fixed_object_until_valid_refresh(
     assert result.metadata.points == 1
 
 
-def test_download_point_cloud_does_not_accept_bin_extension_for_dreame(
+def test_download_point_cloud_accepts_dreame_bin_when_announcement_is_unavailable(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _client()
     action_count = 0
     download_url_calls = 0
+    property_calls = 0
+    baseline_content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    refreshed_content = _binary_pcd((4.0, 5.0, 6.0, 0x654321))
 
     def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         nonlocal action_count
         action_count += 1
         if action_count == 1:
-            return {"r": 0, "d": {"name": ["private/existing-map.pcd"]}}
+            return {"r": 0, "d": {"name": ["private/fixed-map.bin"]}}
         if action_count == 2:
             return {"r": 0}
-        return {"r": 0, "d": {"name": ["private/generated-map.bin"]}}
+        return {"r": 0, "d": {"name": ["private/fixed-map.bin"]}}
 
     def get_interim_file_url(name: str, **kwargs: Any) -> str:
         nonlocal download_url_calls
         download_url_calls += 1
         return "https://downloads.example.invalid/object"
 
+    def get_properties(*args: Any, **kwargs: Any) -> None:
+        nonlocal property_calls
+        property_calls += 1
+
     client._sync_call_app_action = call_app_action
     client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
         get_interim_file_url=get_interim_file_url,
+        get_properties=get_properties,
     )
     monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    downloads = iter((baseline_content, refreshed_content))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            next(downloads),
+            request.full_url,
+        ),
+    )
 
-    with pytest.raises(DreameLawnMowerPointCloudError):
-        client._sync_download_app_map_point_cloud(0, 0.01, 0.001, 10, 1024)
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
 
-    assert download_url_calls == 0
+    assert result.content == refreshed_content
+    assert result.metadata.points == 1
+    assert property_calls == 2
+    assert download_url_calls == 2
 
 
 def test_download_point_cloud_error_does_not_expose_signed_url(

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -266,7 +266,7 @@ def test_managed_runtime_environment_reports_large_page_compatibility(
 
     environment = video_helpers_module.managed_runtime_environment()
 
-    assert environment["execution_mode"] == "qemu_aarch64_self"
+    assert environment["execution_mode"] == "native_aarch64_large_page"
     assert environment["page_size"] == 16384
     assert environment["supported"] is True
 

--- a/tests/test_xp2p_host_runtime.py
+++ b/tests/test_xp2p_host_runtime.py
@@ -213,8 +213,8 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
         machine=platform.machine(),
         page_size=16384,
     )
-    assert assets.qemu_path is not None
-    assert assets.command()[0] == str(assets.qemu_path)
+    assert assets.qemu_path is None
+    assert assets.command()[0] == str(assets.linker_path)
     assert assets.startup_probe is not None
     assert assets.startup_probe["ready"] is True
     assert assets.startup_probe["stage"] == "response_decode"
@@ -242,35 +242,42 @@ def test_real_managed_worker_accepts_request_on_native_host(tmp_path) -> None:
     assert runtime.last_failure.get("returncode") != -11
 
 
-def test_runtime_bootstrap_adds_qemu_only_to_large_page_aarch64_layout() -> None:
+def test_runtime_bootstrap_uses_native_large_page_aarch64_layout() -> None:
     native = xp2p_runtime_bootstrap._expected_installed_hashes("aarch64")
-    compatible = xp2p_runtime_bootstrap._expected_installed_hashes(
+    large_page = xp2p_runtime_bootstrap._expected_installed_hashes(
         "aarch64",
-        include_aarch64_qemu=True,
+        use_large_page_runtime=True,
     )
 
     assert "bin/qemu-aarch64-static" not in native
+    assert "bin/qemu-aarch64-static" not in large_page
     assert (
-        compatible["bin/qemu-aarch64-static"]
-        == xp2p_runtime_bootstrap.QEMU_AARCH64_BINARY_SHA256
+        native["lib/liblog.so"]
+        == xp2p_runtime_bootstrap.AOSP_VNDK_FILES["lib/liblog.so"][1]
     )
+    assert not any(path.startswith("http") for path in native)
+    assert (
+        large_page["bin/linker64"]
+        == xp2p_runtime_bootstrap.LARGE_PAGE_AOSP_RUNTIME_FILES["bin/linker64"][1]
+    )
+    assert large_page["bin/linker64"] != native["bin/linker64"]
 
 
 @pytest.mark.parametrize(
-    ("machine", "page_size", "expected_name", "include_aarch64_qemu"),
+    ("machine", "page_size", "expected_name", "use_large_page_runtime"),
     [
         ("x86_64", 4096, "runtime-v1-x86_64", False),
         ("aarch64", 4096, "runtime-v1-aarch64", False),
-        ("aarch64", 16384, "runtime-v2-aarch64", True),
+        ("aarch64", 16384, "runtime-v3-aarch64", True),
     ],
 )
-def test_runtime_bootstrap_preserves_existing_layouts_until_qemu_is_needed(
+def test_runtime_bootstrap_preserves_existing_layouts_until_large_pages_need_it(
     monkeypatch,
     tmp_path,
     machine,
     page_size,
     expected_name,
-    include_aarch64_qemu,
+    use_large_page_runtime,
 ) -> None:
     calls = []
 
@@ -283,7 +290,7 @@ def test_runtime_bootstrap_preserves_existing_layouts_until_qemu_is_needed(
             library_search_paths=(path / "lib",),
             qemu_path=(
                 path / "bin" / "qemu-aarch64-static"
-                if machine == "x86_64" or include_aarch64_qemu
+                if machine == "x86_64"
                 else None
             ),
         )
@@ -305,7 +312,7 @@ def test_runtime_bootstrap_preserves_existing_layouts_until_qemu_is_needed(
     assert len(calls) == 1
     assert calls[0][2] == {
         "layout_version": expected_name.split("-")[1][1:],
-        "include_aarch64_qemu": include_aarch64_qemu,
+        "use_large_page_runtime": use_large_page_runtime,
     }
 
 


### PR DESCRIPTION
## What changed

- replace ARM64 self-emulation on hosts with 16 KiB pages with a pinned, 16 KiB-aligned Android runtime; the installer reads only the required files from the verified AOSP build artifact
- preserve the existing x86_64 and 4 KiB ARM64 runtime layouts
- when point-cloud property `99.20` is unavailable, reuse a valid legacy `.bin` PCD for the single active map instead of forcing a generation timeout
- compare fixed-name `.bin` objects before and after refresh so stale geometry is not accepted

## Why

QEMU user mode cannot run a 4 KiB guest userspace on a 16 KiB host page size, which caused live video startup to fail before the XP2P worker could respond. Separately, A2 firmware can expose its 3D map as a `.bin` object through the legacy route when the preferred cloud-property lookup times out.

## Validation

- Ruff and the full Linux test suite
- verified public AOSP range download, hashes, installed cache, and worker startup probe
- verified the unchanged legacy x86_64 runtime still installs and starts
- focused stored-map, fixed-object refresh, diagnostics, and runtime-layout contracts

Physical confirmation is still needed from the reporter's 16 KiB ARM64 host for live video and A2 for the 3D map.

Related to #99
Related to #100