### PR TITLE
Expose maintenance-point API evidence in diagnostics

### DIFF
--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -20,6 +20,7 @@ from .coordinator import DreameLawnMowerCoordinator
 from .debug import build_debug_payload, sanitize_debug_data
 from .dreame_lawn_mower_client.maintenance import MAINTENANCE_ITEMS, MaintenanceItem
 from .entity import DreameLawnMowerEntity
+from .reporting import build_maintenance_point_diagnostics
 from .task_status_probe import TASK_STATUS_PROBE_KEYS, task_status_probe_payload
 
 _LOGGER = logging.getLogger(__name__)
@@ -257,6 +258,10 @@ class DreameLawnMowerCaptureMapProbeButton(
         """Probe known read-only map sources and log the structured result."""
         await self.coordinator.async_request_refresh()
         payload = await self.coordinator.client.async_probe_map_sources()
+        self.coordinator.last_map_probe_result = build_maintenance_point_diagnostics(
+            self.coordinator,
+            map_probe_payload=payload,
+        )
         _LOGGER.info(
             "Captured Dreame lawn mower map probe for %s: %s",
             self.coordinator.client.descriptor.title,
@@ -265,8 +270,9 @@ class DreameLawnMowerCaptureMapProbeButton(
         persistent_notification.async_create(
             self.coordinator.hass,
             (
-                "Captured a Dreame lawn mower map probe. Enable info logging "
-                "for this integration to view the JSON payload."
+                "Captured a Dreame lawn mower map probe. Privacy-safe "
+                "maintenance-point evidence is now included in downloaded "
+                "diagnostics; enable info logging for the full JSON payload."
             ),
             title="Dreame Lawn Mower Map Probe",
             notification_id=(

--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -261,6 +261,7 @@ class DreameLawnMowerCaptureMapProbeButton(
         self.coordinator.last_map_probe_result = build_maintenance_point_diagnostics(
             self.coordinator,
             map_probe_payload=payload,
+            captured_at=datetime.now(UTC).isoformat(),
         )
         _LOGGER.info(
             "Captured Dreame lawn mower map probe for %s: %s",

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -123,6 +123,7 @@ class DreameLawnMowerCoordinator(
         self.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
         self.performance = DreameLawnMowerPerformanceTracker()
         self.last_batch_device_data_probe_result: dict[str, Any] | None = None
+        self.last_map_probe_result: dict[str, Any] | None = None
         self.last_preference_probe_result: dict[str, Any] | None = None
         self.last_preference_write_result: dict[str, Any] | None = None
         self.last_schedule_probe_result: dict[str, Any] | None = None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -472,6 +472,7 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         "spot_count": len(spots),
         "spot_boundary_point_count": spot_boundary_point_count,
         "point_count": len(point_entries),
+        "point_entry_shapes": _app_map_point_entry_shapes(point_entries),
         "semantic_count": len(semantic),
         "semantic_boundary_point_count": semantic_boundary_point_count,
         "semantic_key_counts": dict(sorted(semantic_key_counts.items())),
@@ -480,6 +481,40 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         "trajectory_length_m": round(trajectory_length_m, 2),
         "cut_relation_count": len(cut_relation),
     }
+
+
+def _app_map_point_entry_shapes(entries: Sequence[Any]) -> list[dict[str, Any]]:
+    """Describe maintenance-point records without exposing coordinates."""
+    grouped: dict[tuple[Any, ...], int] = {}
+    for entry in entries:
+        if isinstance(entry, Mapping):
+            shape: tuple[Any, ...] = (
+                "object",
+                tuple(sorted(str(key) for key in entry)),
+            )
+        elif isinstance(entry, Sequence) and not isinstance(
+            entry,
+            str | bytes | bytearray,
+        ):
+            shape = (
+                "array",
+                len(entry),
+                tuple(sorted({_operation_value_type(item) for item in entry})),
+            )
+        else:
+            shape = (_operation_value_type(entry),)
+        grouped[shape] = grouped.get(shape, 0) + 1
+
+    result: list[dict[str, Any]] = []
+    for shape, count in sorted(grouped.items(), key=lambda item: repr(item[0])):
+        entry: dict[str, Any] = {"kind": shape[0], "count": count}
+        if shape[0] == "object":
+            entry["keys"] = list(shape[1])
+        elif shape[0] == "array":
+            entry["length"] = shape[1]
+            entry["item_types"] = list(shape[2])
+        result.append(entry)
+    return result
 
 
 def _select_app_map_payload(app_maps: Mapping[str, Any]) -> Mapping[str, Any] | None:
@@ -578,6 +613,7 @@ def _app_map_entry_view_metadata(entry: Mapping[str, Any]) -> dict[str, Any]:
         "boundary_point_count": summary.get("boundary_point_count"),
         "spot_count": summary.get("spot_count"),
         "point_count": summary.get("point_count"),
+        "point_entry_shapes": summary.get("point_entry_shapes"),
         "trajectory_count": summary.get("trajectory_count"),
         "trajectory_point_count": summary.get("trajectory_point_count"),
         "trajectory_length_m": summary.get("trajectory_length_m"),

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -79,10 +79,9 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
         "performance": (
             performance.as_dict() if hasattr(performance, "as_dict") else None
         ),
-        "maintenance_points": (
-            dict(last_map_probe)
-            if isinstance(last_map_probe, Mapping)
-            else build_maintenance_point_diagnostics(coordinator)
+        "maintenance_points": build_maintenance_point_diagnostics(coordinator),
+        "last_maintenance_point_probe": (
+            dict(last_map_probe) if isinstance(last_map_probe, Mapping) else None
         ),
     }
 
@@ -91,6 +90,7 @@ def build_maintenance_point_diagnostics(
     coordinator: object,
     *,
     map_probe_payload: Mapping[str, Any] | None = None,
+    captured_at: str | None = None,
 ) -> dict[str, Any]:
     """Return point availability evidence without map coordinates or payloads."""
     app_maps = getattr(coordinator, "app_maps", None)
@@ -110,11 +110,17 @@ def build_maintenance_point_diagnostics(
 
     app_map_entries = _maintenance_app_map_entries(app_maps)
     vector_map_entries = _maintenance_vector_map_entries(vector_details)
-    current_map_index = _map_index(
-        getattr(coordinator, "selected_map_index", None)
-    )
+    current_map_index = None
+    if isinstance(map_probe_payload, Mapping) and isinstance(app_maps, Mapping):
+        current_map_index = _map_index(app_maps.get("current_map_index"))
+    if current_map_index is None:
+        current_map_index = _map_index(
+            getattr(coordinator, "selected_map_index", None)
+        )
     if current_map_index is None and isinstance(app_maps, Mapping):
         current_map_index = _map_index(app_maps.get("current_map_index"))
+    if current_map_index is None and isinstance(vector_details, Mapping):
+        current_map_index = _map_index(vector_details.get("map_index"))
 
     current_app_entry = next(
         (
@@ -140,7 +146,7 @@ def build_maintenance_point_diagnostics(
     )
     mismatch = bool(current_app_point_count) and not current_vector_point_ids
 
-    return {
+    result = {
         "source": source,
         "current_map_index": current_map_index,
         "selected_point_id": _positive_int(
@@ -151,6 +157,9 @@ def build_maintenance_point_diagnostics(
         "app_maps": app_map_entries,
         "vector_maps": vector_map_entries,
     }
+    if source == "map_probe":
+        result["captured_at"] = captured_at
+    return result
 
 
 def _maintenance_app_map_entries(value: object) -> list[dict[str, Any]]:

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable, Iterable, Mapping
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
 
 from .debug import sanitize_debug_data, sanitize_diagnostic_text
@@ -60,6 +60,7 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
     update_interval = getattr(coordinator, "update_interval", None)
     last_exception = getattr(coordinator, "last_exception", None)
     performance = getattr(coordinator, "performance", None)
+    last_map_probe = getattr(coordinator, "last_map_probe_result", None)
     return {
         "last_update_success": getattr(coordinator, "last_update_success", None),
         "last_exception_type": (
@@ -78,7 +79,175 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
         "performance": (
             performance.as_dict() if hasattr(performance, "as_dict") else None
         ),
+        "maintenance_points": (
+            dict(last_map_probe)
+            if isinstance(last_map_probe, Mapping)
+            else build_maintenance_point_diagnostics(coordinator)
+        ),
     }
+
+
+def build_maintenance_point_diagnostics(
+    coordinator: object,
+    *,
+    map_probe_payload: Mapping[str, Any] | None = None,
+) -> dict[str, Any]:
+    """Return point availability evidence without map coordinates or payloads."""
+    app_maps = getattr(coordinator, "app_maps", None)
+    vector_details = getattr(coordinator, "vector_map_details", None)
+    source = "coordinator_cache"
+
+    if isinstance(map_probe_payload, Mapping):
+        probed_app_maps = map_probe_payload.get("app_maps")
+        if isinstance(probed_app_maps, Mapping):
+            app_maps = probed_app_maps
+        vector_view = map_probe_payload.get("batch_vector_map")
+        if isinstance(vector_view, Mapping):
+            probed_vector_details = vector_view.get("details")
+            if isinstance(probed_vector_details, Mapping):
+                vector_details = probed_vector_details
+        source = "map_probe"
+
+    app_map_entries = _maintenance_app_map_entries(app_maps)
+    vector_map_entries = _maintenance_vector_map_entries(vector_details)
+    current_map_index = _map_index(
+        getattr(coordinator, "selected_map_index", None)
+    )
+    if current_map_index is None and isinstance(app_maps, Mapping):
+        current_map_index = _map_index(app_maps.get("current_map_index"))
+
+    current_app_entry = next(
+        (
+            entry
+            for entry in app_map_entries
+            if entry.get("map_index") == current_map_index
+        ),
+        None,
+    )
+    current_vector_entry = next(
+        (
+            entry
+            for entry in vector_map_entries
+            if entry.get("map_index") == current_map_index
+        ),
+        None,
+    )
+    current_app_point_count = (
+        current_app_entry.get("point_count") if current_app_entry else None
+    )
+    current_vector_point_ids = (
+        current_vector_entry.get("point_ids") if current_vector_entry else []
+    )
+    mismatch = bool(current_app_point_count) and not current_vector_point_ids
+
+    return {
+        "source": source,
+        "current_map_index": current_map_index,
+        "selected_point_id": _positive_int(
+            getattr(coordinator, "selected_maintenance_point_id", None)
+        ),
+        "control_ready": bool(current_vector_point_ids),
+        "app_points_without_vector_ids": mismatch,
+        "app_maps": app_map_entries,
+        "vector_maps": vector_map_entries,
+    }
+
+
+def _maintenance_app_map_entries(value: object) -> list[dict[str, Any]]:
+    maps = value.get("maps") if isinstance(value, Mapping) else None
+    if not isinstance(maps, Sequence) or isinstance(
+        maps,
+        str | bytes | bytearray,
+    ):
+        return []
+
+    result: list[dict[str, Any]] = []
+    for item in maps:
+        if not isinstance(item, Mapping):
+            continue
+        summary = item.get("summary")
+        if not isinstance(summary, Mapping):
+            summary = {}
+        payload_keys = item.get("payload_keys")
+        point_shapes = summary.get("point_entry_shapes")
+        result.append(
+            {
+                "map_index": _map_index(item.get("idx")),
+                "current": bool(item.get("current")),
+                "available": bool(item.get("available")),
+                "point_payload_present": (
+                    "point" in payload_keys
+                    if isinstance(payload_keys, Sequence)
+                    and not isinstance(payload_keys, str | bytes | bytearray)
+                    else None
+                ),
+                "point_count": _non_negative_int(summary.get("point_count")),
+                "point_entry_shapes": (
+                    list(point_shapes)
+                    if isinstance(point_shapes, Sequence)
+                    and not isinstance(point_shapes, str | bytes | bytearray)
+                    else []
+                ),
+            }
+        )
+    return result
+
+
+def _maintenance_vector_map_entries(value: object) -> list[dict[str, Any]]:
+    maps = value.get("maps") if isinstance(value, Mapping) else None
+    if not isinstance(maps, Sequence) or isinstance(
+        maps,
+        str | bytes | bytearray,
+    ):
+        maps = [value] if isinstance(value, Mapping) else []
+
+    result: list[dict[str, Any]] = []
+    for item in maps:
+        if not isinstance(item, Mapping):
+            continue
+        point_ids = item.get("clean_point_ids")
+        safe_point_ids = (
+            [
+                point_id
+                for point_id in point_ids
+                if _positive_int(point_id) is not None
+            ]
+            if isinstance(point_ids, Sequence)
+            and not isinstance(point_ids, str | bytes | bytearray)
+            else []
+        )
+        result.append(
+            {
+                "map_index": _map_index(item.get("map_index")),
+                "point_count": _non_negative_int(item.get("clean_point_count")),
+                "point_ids": safe_point_ids,
+            }
+        )
+    return result
+
+
+def _map_index(value: object) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else None
+    )
+
+
+def _positive_int(value: object) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value > 0
+        else None
+    )
+
+
+def _non_negative_int(value: object) -> int | None:
+    return (
+        value
+        if isinstance(value, int) and not isinstance(value, bool) and value >= 0
+        else None
+    )
 
 
 def build_entity_diagnostics(

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -196,6 +196,14 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
         "spot_count": 1,
         "spot_boundary_point_count": 0,
         "point_count": 1,
+        "point_entry_shapes": [
+            {
+                "kind": "array",
+                "count": 1,
+                "length": 2,
+                "item_types": ["number"],
+            }
+        ],
         "semantic_count": 2,
         "semantic_boundary_point_count": 3,
         "semantic_key_counts": {"data": 1, "label": 1, "type": 2},
@@ -383,6 +391,14 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
                 "boundary_point_count": 4,
                 "spot_count": 1,
                 "point_count": 1,
+                "point_entry_shapes": [
+                    {
+                        "kind": "array",
+                        "count": 1,
+                        "length": 2,
+                        "item_types": ["number"],
+                    }
+                ],
                 "trajectory_count": 1,
                 "trajectory_point_count": 3,
                 "trajectory_length_m": 1.41,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -9,6 +9,7 @@ from custom_components.dreame_lawn_mower.performance import (
 from custom_components.dreame_lawn_mower.reporting import (
     build_coordinator_diagnostics,
     build_entity_diagnostics,
+    build_maintenance_point_diagnostics,
     build_report_context,
 )
 
@@ -107,6 +108,15 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
         "last_exception": "refresh failed token=**REDACTED**",
         "update_interval_seconds": 30.0,
         "performance": None,
+        "maintenance_points": {
+            "source": "coordinator_cache",
+            "current_map_index": None,
+            "selected_point_id": None,
+            "control_ready": False,
+            "app_points_without_vector_ids": False,
+            "app_maps": [],
+            "vector_maps": [],
+        },
     }
 
 
@@ -134,6 +144,105 @@ def test_coordinator_diagnostics_include_privacy_safe_performance_history() -> N
         "outcomes": {"completed": 1},
     }
     assert diagnostics["performance"]["samples"][0]["phases_ms"] == {}
+
+
+def test_coordinator_diagnostics_prefer_captured_map_probe_evidence() -> None:
+    captured = {
+        "source": "map_probe",
+        "current_map_index": 1,
+        "selected_point_id": None,
+        "control_ready": False,
+        "app_points_without_vector_ids": True,
+        "app_maps": [],
+        "vector_maps": [],
+    }
+
+    diagnostics = build_coordinator_diagnostics(
+        SimpleNamespace(
+            last_update_success=True,
+            last_exception=None,
+            update_interval=timedelta(seconds=30),
+            last_map_probe_result=captured,
+        )
+    )
+
+    assert diagnostics["maintenance_points"] == captured
+    assert diagnostics["maintenance_points"] is not captured
+
+
+def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -> None:
+    diagnostics = build_maintenance_point_diagnostics(
+        SimpleNamespace(
+            selected_map_index=0,
+            selected_maintenance_point_id=None,
+            app_maps={
+                "current_map_index": 0,
+                "maps": [
+                    {
+                        "idx": 0,
+                        "current": True,
+                        "available": True,
+                        "payload_keys": ["map", "point"],
+                        "summary": {
+                            "point_count": 1,
+                            "point_entry_shapes": [
+                                {
+                                    "kind": "array",
+                                    "count": 1,
+                                    "length": 2,
+                                    "item_types": ["number"],
+                                }
+                            ],
+                        },
+                        "payload": {"point": [[5910, 12400]]},
+                    }
+                ],
+            },
+            vector_map_details={
+                "maps": [
+                    {
+                        "map_index": 0,
+                        "clean_point_count": 0,
+                        "clean_point_ids": [],
+                    }
+                ]
+            },
+        )
+    )
+
+    assert diagnostics == {
+        "source": "coordinator_cache",
+        "current_map_index": 0,
+        "selected_point_id": None,
+        "control_ready": False,
+        "app_points_without_vector_ids": True,
+        "app_maps": [
+            {
+                "map_index": 0,
+                "current": True,
+                "available": True,
+                "point_payload_present": True,
+                "point_count": 1,
+                "point_entry_shapes": [
+                    {
+                        "kind": "array",
+                        "count": 1,
+                        "length": 2,
+                        "item_types": ["number"],
+                    }
+                ],
+            }
+        ],
+        "vector_maps": [
+            {
+                "map_index": 0,
+                "point_count": 0,
+                "point_ids": [],
+            }
+        ],
+    }
+    assert "5910" not in repr(diagnostics)
+    assert "12400" not in repr(diagnostics)
 
 
 def test_entity_diagnostics_redact_runtime_map_coordinates() -> None:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -117,6 +117,7 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
             "app_maps": [],
             "vector_maps": [],
         },
+        "last_maintenance_point_probe": None,
     }
 
 
@@ -146,9 +147,10 @@ def test_coordinator_diagnostics_include_privacy_safe_performance_history() -> N
     assert diagnostics["performance"]["samples"][0]["phases_ms"] == {}
 
 
-def test_coordinator_diagnostics_prefer_captured_map_probe_evidence() -> None:
+def test_coordinator_diagnostics_keep_current_and_captured_probe_evidence() -> None:
     captured = {
         "source": "map_probe",
+        "captured_at": "2026-07-26T14:30:00+00:00",
         "current_map_index": 1,
         "selected_point_id": None,
         "control_ready": False,
@@ -166,8 +168,9 @@ def test_coordinator_diagnostics_prefer_captured_map_probe_evidence() -> None:
         )
     )
 
-    assert diagnostics["maintenance_points"] == captured
-    assert diagnostics["maintenance_points"] is not captured
+    assert diagnostics["maintenance_points"]["source"] == "coordinator_cache"
+    assert diagnostics["last_maintenance_point_probe"] == captured
+    assert diagnostics["last_maintenance_point_probe"] is not captured
 
 
 def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -> None:
@@ -243,6 +246,71 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
     }
     assert "5910" not in repr(diagnostics)
     assert "12400" not in repr(diagnostics)
+
+
+def test_map_probe_uses_probed_current_map_over_stale_coordinator_selection() -> None:
+    diagnostics = build_maintenance_point_diagnostics(
+        SimpleNamespace(
+            selected_map_index=0,
+            selected_maintenance_point_id=None,
+            app_maps=None,
+            vector_map_details=None,
+        ),
+        map_probe_payload={
+            "app_maps": {
+                "current_map_index": 1,
+                "maps": [
+                    {
+                        "idx": 0,
+                        "current": False,
+                        "available": True,
+                        "payload_keys": ["point"],
+                        "summary": {"point_count": 0},
+                    },
+                    {
+                        "idx": 1,
+                        "current": True,
+                        "available": True,
+                        "payload_keys": ["point"],
+                        "summary": {
+                            "point_count": 1,
+                            "point_entry_shapes": [
+                                {
+                                    "kind": "array",
+                                    "count": 1,
+                                    "length": 2,
+                                    "item_types": ["number"],
+                                }
+                            ],
+                        },
+                    },
+                ],
+            },
+            "batch_vector_map": {
+                "details": {
+                    "maps": [
+                        {
+                            "map_index": 0,
+                            "clean_point_count": 1,
+                            "clean_point_ids": [301],
+                        },
+                        {
+                            "map_index": 1,
+                            "clean_point_count": 0,
+                            "clean_point_ids": [],
+                        },
+                    ]
+                }
+            },
+        },
+        captured_at="2026-07-26T14:30:00+00:00",
+    )
+
+    assert diagnostics["source"] == "map_probe"
+    assert diagnostics["captured_at"] == "2026-07-26T14:30:00+00:00"
+    assert diagnostics["current_map_index"] == 1
+    assert diagnostics["control_ready"] is False
+    assert diagnostics["app_points_without_vector_ids"] is True
 
 
 def test_entity_diagnostics_redact_runtime_map_coordinates() -> None:


### PR DESCRIPTION
## What changed

- describe app maintenance-point records by privacy-safe shape and count, without coordinates or raw map payloads
- include current maintenance-point readiness in downloaded Home Assistant diagnostics
- retain the last Capture Map Probe result separately with its UTC capture time
- prefer the probe's own current-map index so a stale cached selection cannot mislabel the evidence

## Why

An A2 1200 owner can configure a maintenance point in the Dreame app while the integration receives no vector-map point ID, leaving both entities unavailable. We need to distinguish that API mismatch before changing any movement payload.

This PR does not loosen movement safety or add a coordinate fallback. The button still requires a fresh, positive vector point ID and an idle or docked mower.

Related to #79.

## Validation

- Ruff: clean
- Tests: 1,056 passed, 1 skipped under WSL
- Independent read-only review: two diagnostic consistency findings fixed; targeted confirmation found no remaining P0-P2 issues