### PR TITLE
Improve live video and 3D map diagnostics

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -7,9 +7,15 @@ body:
   - type: markdown
     attributes:
       value: |
-        Reproduce the problem once, then download diagnostics before reloading Home Assistant. The report includes sanitized version, host, coordinator, entity, and recent failure information.
+        Update to the latest HACS release, restart Home Assistant, reproduce the problem once, then download diagnostics before reloading. The report includes sanitized version, host, coordinator, entity, and recent failure information.
 
-        Do not paste credentials, tokens, serial numbers, exact coordinates, or broad raw debug logs.
+        Drag the downloaded diagnostics JSON file into the form. Do not paste credentials, tokens, serial numbers, exact coordinates, or broad raw debug logs.
+  - type: input
+    id: related_issue
+    attributes:
+      label: Related or previous issue
+      description: Link an earlier report if this is a retest or the same symptom returned. Otherwise leave this blank.
+      placeholder: "#102 or https://github.com/EvotecIT/homeassistant-dreamelawnmower/issues/102"
   - type: input
     id: integration_version
     attributes:
@@ -97,6 +103,10 @@ body:
     attributes:
       label: Safety and privacy checks
       options:
+        - label: I updated to the latest HACS release and restarted Home Assistant before reproducing.
+          required: true
+        - label: I searched existing issues and linked any earlier report above instead of opening a disconnected duplicate.
+          required: true
         - label: I reproduced the problem immediately before downloading diagnostics.
           required: true
         - label: I removed credentials, tokens, serial numbers, exact coordinates, and other private data from anything added manually.

--- a/README.md
+++ b/README.md
@@ -222,6 +222,12 @@ external runner is required. The integration prepares the runtime during entity
 setup, starts it when Home Assistant requests the camera, verifies the local FLV
 source, and stops it when the camera is turned off or unloaded.
 
+The camera entity remains available while the mower is docked, returning, or in
+another state where Dreame blocks video. Its `video_block_reason` attribute
+explains what must change before a stream can start. Stream requests still fail
+closed until the mower reaches a permitted state; keeping the entity available
+only makes that state gate visible in Home Assistant and downloaded diagnostics.
+
 The first setup needs internet access. The integration downloads fixed versions
 of Tencent XP2P, the required AOSP Bionic libraries, and qemu-user-static on
 x86_64 hosts. Every file is pinned and SHA-256 verified before use, then cached
@@ -573,8 +579,10 @@ The report is sanitized by the integration and includes:
 - privacy-safe setup, foreground-refresh, and background-metadata timings,
   including bounded recent samples plus the latest and aggregate duration for
   each operation
-- on-demand `point_cloud_generation` timings and a stable failure code, stage,
-  retryability flag, and timeout when a 3D map request fails
+- on-demand `point_cloud_generation` timings plus coordinate-free completion or
+  failure events, including the source, point count, payload size, selected map,
+  stored-object eligibility, stable error code, safe numeric Dreame cloud error,
+  stage, retryability flag, and timeout when relevant
 - current state and diagnostic attributes for every entity belonging to the
   config entry, including the Live Video camera's last failure stage and a
   bounded, privacy-safe summary of each TX video cloud stage
@@ -604,9 +612,14 @@ slow without requiring broad protocol debug logging.
 
 For a 3D map report, retry once and download diagnostics before restarting Home
 Assistant. Include the visible `point_cloud_*` reference from the card. The
-matching recent event explains whether the mower failed to publish a fresh
-object, the object could not be downloaded and validated, another generation
-was already running, or the integration reloaded during the request.
+matching recent event shows whether a later request completed or the mower
+failed to publish a fresh object, the object could not be downloaded and
+validated, another generation was already running, or the integration reloaded
+during the request.
+
+`App Map Count` reports maps the mower has actually created; reserved cloud
+slots with `created: false` are excluded. Raw slot count remains available as
+the mower entity's `app_map_slot_count` diagnostic attribute.
 
 The staged cloud summaries retain field names, value types, safe status codes,
 required-field presence, and sanitized error messages. They do not retain raw

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -53,6 +53,7 @@ from .client_shared_helpers import (
 )
 from .exceptions import (
     DeviceException,
+    DreameLawnMowerCloudAPIError,
     DreameLawnMowerConnectionError,
 )
 from .exceptions import (
@@ -558,6 +559,9 @@ class _DreameLawnMowerClientMapsMixin:
             "source": "app_action_map",
             "available": False,
             "map_count": len(map_entries),
+            "created_map_count": sum(
+                1 for entry in map_entries if entry.get("created") is not False
+            ),
             "current_map_index": None,
             "raw_map_list": _json_safe(map_list_result, max_depth=5),
             "maps": [],
@@ -1391,10 +1395,20 @@ class _DreameLawnMowerClientMapsMixin:
                 "timeout": remaining,
                 "deadline": deadline,
                 "redact_response": True,
+                "raise_on_api_error": True,
             }
             if on_dispatch is not None:
                 action_options["on_dispatch"] = on_dispatch
             response = self._sync_call_app_action(payload, **action_options)
+        except DreameLawnMowerCloudAPIError as err:
+            raise DreameLawnMowerPointCloudError(
+                f"The Dreame cloud rejected the {operation} request.",
+                code="point_cloud_mower_request_rejected",
+                stage="mower_request",
+                public_message="The Dreame cloud rejected the mower 3D map request.",
+                retry_after_seconds=10,
+                vendor_error_code=err.code,
+            ) from err
         except DreameLawnMowerConnectionError as err:
             if time.monotonic() >= deadline:
                 raise DreameLawnMowerPointCloudError(
@@ -1516,6 +1530,7 @@ class _DreameLawnMowerClientMapsMixin:
         deadline: float | None = None,
         redact_response: bool = False,
         on_dispatch: Callable[[], None] | None = None,
+        raise_on_api_error: bool = False,
     ) -> Any:
         cloud = (
             self._sync_get_cloud_protocol(deadline=deadline)
@@ -1562,6 +1577,8 @@ class _DreameLawnMowerClientMapsMixin:
                 request_options["redact_response"] = True
             if on_dispatch is not None:
                 request_options["on_dispatch"] = on_dispatch
+            if raise_on_api_error:
+                request_options["raise_on_api_error"] = True
             if hasattr(cloud, "call_app_action"):
                 response = cloud.call_app_action(
                     payload,
@@ -1580,6 +1597,8 @@ class _DreameLawnMowerClientMapsMixin:
                     },
                     **request_options,
                 )
+        except DreameLawnMowerCloudAPIError:
+            raise
         except DeviceException as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import time
 import urllib.error
 import urllib.parse
 import urllib.request
@@ -84,6 +85,8 @@ from .schedule import (
     schedule_task_summary,
 )
 
+SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS = 5.0
+
 
 class _DreameLawnMowerClientSettingsMixin:
     def _sync_get_app_schedules(
@@ -105,8 +108,14 @@ class _DreameLawnMowerClientSettingsMixin:
         }
 
         try:
+            current_task_deadline = (
+                time.monotonic() + SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS
+            )
             task_result = self._sync_call_app_action(
-                {"m": "g", "t": "SCHDT", "d": {"t": 0}}
+                {"m": "g", "t": "SCHDT", "d": {"t": 0}},
+                retry_count=0,
+                timeout=SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS,
+                deadline=current_task_deadline,
             )
             result["raw_current_task"] = _json_safe(task_result, max_depth=4)
             task_data = _app_action_data(task_result)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/exceptions.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/exceptions.py
@@ -26,6 +26,14 @@ class DreameLawnMowerConnectionError(DreameLawnMowerError):
     """Connection or update failure."""
 
 
+class DreameLawnMowerCloudAPIError(DeviceException):
+    """A privacy-safe numeric error returned by the Dreame cloud API."""
+
+    def __init__(self, code: int) -> None:
+        super().__init__(f"Dreame cloud API request failed with code {code}.")
+        self.code = code
+
+
 class DreameLawnMowerTwoFactorRequiredError(DreameLawnMowerAuthError):
     """Two-factor authentication is required."""
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -33,6 +33,7 @@ class DreameLawnMowerPointCloudError(ValueError):
         public_message: str = "The mower point cloud is temporarily unavailable.",
         timeout_seconds: float | None = None,
         retry_after_seconds: int | None = None,
+        vendor_error_code: int | None = None,
     ) -> None:
         super().__init__(message)
         self.code = code
@@ -41,6 +42,7 @@ class DreameLawnMowerPointCloudError(ValueError):
         self.public_message = public_message
         self.timeout_seconds = timeout_seconds
         self.retry_after_seconds = retry_after_seconds
+        self.vendor_error_code = vendor_error_code
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, Mapping, Optional, Tuple
 from Crypto.Cipher import ARC4
 from miio.miioprotocol import MiIOProtocol
 
-from .exceptions import DeviceException
+from .exceptions import DeviceException, DreameLawnMowerCloudAPIError
 from .const import DREAME_STRINGS, MOVA_STRINGS
 from .deadline import DeadlineExceededError, run_with_deadline
 from .mqtt_tls import create_cloud_mqtt_ssl_context
@@ -840,6 +840,7 @@ class DreameMowerDreameHomeCloudProtocol:
         deadline: float | None = None,
         redact_response: bool = False,
         on_dispatch: Callable[[], None] | None = None,
+        raise_on_api_error: bool = False,
     ) -> Any:
         with self._operation_lock():
             return self._send_unlocked(
@@ -850,6 +851,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 deadline=deadline,
                 redact_response=redact_response,
                 on_dispatch=on_dispatch,
+                raise_on_api_error=raise_on_api_error,
             )
 
     def _send_unlocked(
@@ -862,6 +864,7 @@ class DreameMowerDreameHomeCloudProtocol:
         deadline: float | None = None,
         redact_response: bool = False,
         on_dispatch: Callable[[], None] | None = None,
+        raise_on_api_error: bool = False,
     ) -> Any:
         host = ""
         if self._host and len(self._host):
@@ -894,6 +897,16 @@ class DreameMowerDreameHomeCloudProtocol:
             logged_response,
         )
         self._id = self._id + 1
+        response_code = (
+            api_response.get("code") if isinstance(api_response, Mapping) else None
+        )
+        if (
+            raise_on_api_error
+            and isinstance(response_code, int)
+            and not isinstance(response_code, bool)
+            and response_code != 0
+        ):
+            raise DreameLawnMowerCloudAPIError(response_code)
         if isinstance(api_response, Mapping) and api_response.get("code") == 80001:
             # Seems to be a valid error message from the server which translates to:
             #   "The device may be offline and the command sending timed out."
@@ -942,6 +955,7 @@ class DreameMowerDreameHomeCloudProtocol:
         deadline: float | None = None,
         redact_response: bool = False,
         on_dispatch: Callable[[], None] | None = None,
+        raise_on_api_error: bool = False,
     ) -> Any:
         """Call the mobile-app action bridge used by mower plugin commands."""
         return self.send(
@@ -957,6 +971,7 @@ class DreameMowerDreameHomeCloudProtocol:
             deadline=deadline,
             redact_response=redact_response,
             on_dispatch=on_dispatch,
+            raise_on_api_error=raise_on_api_error,
         )
 
     def get_file(self, url: str, retry_count: int = 4) -> Any:

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -351,6 +351,11 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 active_app_map_index,
             ),
             "app_map_count": (
+                self.coordinator.app_maps.get("created_map_count")
+                if isinstance(self.coordinator.app_maps, dict)
+                else None
+            ),
+            "app_map_slot_count": (
                 self.coordinator.app_maps.get("map_count")
                 if isinstance(self.coordinator.app_maps, dict)
                 else None

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -43,6 +43,7 @@ _POINT_CLOUD_PROBLEM_STATUS = {
     "point_cloud_download_invalid": 504,
     "point_cloud_entry_reloaded": 503,
     "point_cloud_download_unsupported": 503,
+    "point_cloud_mower_request_rejected": 502,
 }
 _POINT_CLOUD_PROBLEM_TITLE = {
     "point_cloud_generation_in_progress": "3D map generation already in progress",
@@ -53,6 +54,7 @@ _POINT_CLOUD_PROBLEM_TITLE = {
     "point_cloud_entry_reloaded": "The mower integration was reloaded",
     "point_cloud_download_unsupported": "3D map download is unavailable",
     "point_cloud_mower_request_failed": "The mower rejected the 3D map request",
+    "point_cloud_mower_request_rejected": "The cloud rejected the 3D map request",
     "point_cloud_mower_response_invalid": "The mower returned an invalid response",
     "point_cloud_failed": "3D map unavailable",
 }
@@ -271,6 +273,7 @@ class DreameLawnMowerPointCloudAPI:
             if hasattr(performance, "start")
             else None
         )
+        sample = None
         try:
             if self._entry_epochs.get(key[0], 0) != epoch:
                 raise DreameLawnMowerPointCloudError(
@@ -311,7 +314,13 @@ class DreameLawnMowerPointCloudAPI:
                 )
         except DreameLawnMowerPointCloudError as err:
             sample = cycle.finish(outcome=err.code) if cycle is not None else None
-            self._record_generation_failure(coordinator, err, sample)
+            self._record_generation_failure(
+                coordinator,
+                err,
+                sample,
+                map_index=key[1],
+                allow_stored=allow_stored,
+            )
             raise
         except Exception as err:
             public_error = DreameLawnMowerPointCloudError(
@@ -326,7 +335,13 @@ class DreameLawnMowerPointCloudAPI:
                 if cycle is not None
                 else None
             )
-            self._record_generation_failure(coordinator, public_error, sample)
+            self._record_generation_failure(
+                coordinator,
+                public_error,
+                sample,
+                map_index=key[1],
+                allow_stored=allow_stored,
+            )
             raise public_error from err
         else:
             if cycle is not None:
@@ -338,6 +353,11 @@ class DreameLawnMowerPointCloudAPI:
                     total,
                     phases,
                 )
+            self._record_generation_success(
+                coordinator,
+                download,
+                sample,
+            )
 
         created_at = time.monotonic()
         self._remove_cache_entry(key)
@@ -356,6 +376,31 @@ class DreameLawnMowerPointCloudAPI:
             oldest_key = next(iter(self._cache))
             self._remove_cache_entry(oldest_key)
         return download
+
+    def _record_generation_success(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        download: DreameLawnMowerPointCloudDownload,
+        sample: Any,
+    ) -> None:
+        """Keep coordinate-free evidence that 3D generation recovered."""
+        context: dict[str, Any] = {
+            "map_index": download.map_index,
+            "source": download.source,
+            "point_count": download.metadata.points,
+            "total_bytes": download.metadata.total_bytes,
+            "data_encoding": download.metadata.data_encoding,
+        }
+        if sample is not None:
+            context["duration_ms"] = round(sample.total_seconds * 1000, 1)
+        record_diagnostic_event(
+            coordinator,
+            code="point_cloud_completed",
+            source="point_cloud_api",
+            severity="info",
+            message="The mower 3D map request completed successfully.",
+            context=context,
+        )
 
     def _reject_request(
         self,
@@ -387,6 +432,9 @@ class DreameLawnMowerPointCloudAPI:
         coordinator: DreameLawnMowerCoordinator,
         error: DreameLawnMowerPointCloudError,
         sample: Any,
+        *,
+        map_index: int,
+        allow_stored: bool,
     ) -> None:
         """Keep one privacy-safe failure event and benchmark sample."""
         context: dict[str, Any] = {
@@ -394,6 +442,9 @@ class DreameLawnMowerPointCloudAPI:
             "retryable": error.retryable,
             "retry_after_seconds": error.retry_after_seconds,
             "timeout_seconds": error.timeout_seconds,
+            "vendor_error_code": error.vendor_error_code,
+            "map_index": map_index,
+            "allow_stored": allow_stored,
         }
         if sample is not None:
             context["duration_ms"] = round(sample.total_seconds * 1000, 1)

--- a/custom_components/dreame_lawn_mower/sensor_map_data.py
+++ b/custom_components/dreame_lawn_mower/sensor_map_data.py
@@ -140,7 +140,7 @@ def _app_map_count(result: dict[str, Any] | None) -> int | None:
     summary = _app_maps_summary(result)
     if not isinstance(summary, dict):
         return None
-    value = summary.get("map_count")
+    value = summary.get("created_map_count")
     return value if isinstance(value, int) else None
 
 
@@ -742,6 +742,9 @@ def _app_maps_summary(
         "source": value.get("source"),
         "available": value.get("available"),
         "map_count": len(maps),
+        "created_map_count": sum(
+            1 for entry in maps if entry.get("created") is not False
+        ),
         "current_map_index": selected_current_map_index(value, batch_device_data),
         "maps": maps,
     }

--- a/custom_components/dreame_lawn_mower/video_camera_state.py
+++ b/custom_components/dreame_lawn_mower/video_camera_state.py
@@ -88,8 +88,6 @@ class DreameLawnMowerVideoStateMixin:
         if not self._runtime_configured:
             return False
         snapshot = self.coordinator.data
-        if camera_stream_block_reason(snapshot) is not None:
-            return False
         if snapshot is not None and not getattr(snapshot, "available", True):
             return False
         cached_lan_ready = (

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -180,6 +180,7 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
 
     assert result["available"] is True
     assert result["map_count"] == 2
+    assert result["created_map_count"] == 1
     assert result["current_map_index"] == 0
     assert result["objects"]["object_count"] == 1
     assert result["objects"]["urls_included"] is False

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -19,6 +19,7 @@ class _FakeAppScheduleCloud:
 
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
+        self.request_options: list[dict[str, object]] = []
         self._pending_uploads: dict[int, dict[str, object]] = {}
         self.payloads = {
             -1: {"version": 31345, "text": '{"d":[[0,1,"","EODBJwAAADDgwScAAAA="]]}'},
@@ -38,10 +39,21 @@ class _FakeAppScheduleCloud:
         *,
         siid: int = 2,
         aiid: int = 50,
+        retry_count: int | None = None,
+        timeout: float | None = None,
+        deadline: float | None = None,
     ) -> dict[str, object]:
         assert siid == 2
         assert aiid == 50
         self.calls.append(payload)
+        self.request_options.append(
+            {
+                "command": payload.get("t"),
+                "retry_count": retry_count,
+                "timeout": timeout,
+                "deadline": deadline,
+            }
+        )
         command = payload.get("t")
         if command == "MAPL":
             return {
@@ -138,7 +150,7 @@ def _client() -> DreameLawnMowerClient:
 def test_app_schedules_decode_plans_and_current_task() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     result = client._sync_get_app_schedules(chunk_size=40)
 
@@ -177,12 +189,23 @@ def test_app_schedules_decode_plans_and_current_task() -> None:
     }
     assert "raw_text" not in map_0
     assert [call["t"] for call in cloud.calls[:3]] == ["SCHDT", "MAPL", "SCHDIV2"]
+    assert cloud.request_options[0]["command"] == "SCHDT"
+    assert cloud.request_options[0]["retry_count"] == 0
+    assert 0 < cloud.request_options[0]["timeout"] <= 5.0
+    assert isinstance(cloud.request_options[0]["deadline"], float)
+    assert cloud.request_options[0]["deadline"] > 0
+    assert cloud.request_options[1] == {
+        "command": "MAPL",
+        "retry_count": None,
+        "timeout": None,
+        "deadline": None,
+    }
 
 
 def test_app_schedules_can_include_raw_payload_text() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     result = client._sync_get_app_schedules(
         include_raw=True,
@@ -244,7 +267,7 @@ def test_schedule_upload_requests_do_not_split_utf8_characters() -> None:
 def test_set_app_schedule_plan_enabled_builds_dry_run_request() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     result = client._sync_set_app_schedule_plan_enabled(
         map_index=0,
@@ -287,7 +310,7 @@ def test_set_app_schedule_plan_enabled_builds_dry_run_request() -> None:
 def test_set_app_schedule_plan_enabled_requires_confirmation_to_execute() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     with pytest.raises(ValueError, match="confirm_write=True"):
         client._sync_set_app_schedule_plan_enabled(
@@ -301,7 +324,7 @@ def test_set_app_schedule_plan_enabled_requires_confirmation_to_execute() -> Non
 def test_set_app_schedule_plan_enabled_can_execute_when_confirmed() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     result = client._sync_set_app_schedule_plan_enabled(
         map_index=0,
@@ -327,7 +350,7 @@ def test_set_app_schedule_plan_enabled_can_execute_when_confirmed() -> None:
 def test_set_app_schedule_plan_enabled_rejects_failed_write_response() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     def failing_call(payload: dict[str, object]) -> dict[str, object]:
         if payload["t"] == "SCHDSV2":
@@ -349,7 +372,7 @@ def test_set_app_schedule_plan_enabled_rejects_failed_write_response() -> None:
 def test_plan_app_schedule_upload_builds_dry_run_sequence() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     result = client._sync_plan_app_schedule_upload(
         map_index=0,
@@ -417,7 +440,7 @@ def test_plan_app_schedule_upload_builds_dry_run_sequence() -> None:
 def test_plan_app_schedule_upload_requires_confirmation_to_execute() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     with pytest.raises(ValueError, match="confirm_write=True"):
         client._sync_plan_app_schedule_upload(
@@ -430,7 +453,7 @@ def test_plan_app_schedule_upload_requires_confirmation_to_execute() -> None:
 def test_plan_app_schedule_upload_can_execute_when_confirmed() -> None:
     client = _client()
     cloud = _FakeAppScheduleCloud()
-    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
     result = client._sync_plan_app_schedule_upload(
         map_index=0,

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -1251,8 +1251,8 @@ def test_app_map_count_sensor_uses_cached_app_map_state() -> None:
                 {
                     "idx": 1,
                     "current": False,
-                    "available": True,
-                    "created": True,
+                    "available": False,
+                    "created": False,
                     "summary": {
                         "total_area": 550,
                         "map_area_total": 550.0,
@@ -1269,13 +1269,14 @@ def test_app_map_count_sensor_uses_cached_app_map_state() -> None:
     )
 
     assert entity.available is True
-    assert entity.native_value == 2
+    assert entity.native_value == 1
     assert entity.extra_state_attributes == {
         "source": "app_maps_auto",
         "app_maps": {
             "source": "app_maps_auto",
             "available": True,
             "map_count": 2,
+            "created_map_count": 1,
             "current_map_index": 0,
             "maps": [
                 {
@@ -1296,8 +1297,8 @@ def test_app_map_count_sensor_uses_cached_app_map_state() -> None:
                 {
                     "idx": 1,
                     "current": False,
-                    "available": True,
-                    "created": True,
+                    "available": False,
+                    "created": False,
                     "total_area": 550,
                     "map_area_total": 550.0,
                     "map_area_count": 2,

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -28,6 +28,7 @@ from dreame_lawn_mower_client.models import DreameLawnMowerDescriptor
 _internal_client_module = load_internal_module("client_map_helpers")
 _internal_client_facade_module = load_internal_module("client")
 _internal_deadline_module = load_internal_module("deadline")
+_internal_exceptions_module = load_internal_module("exceptions")
 _internal_point_cloud_module = load_internal_module("point_cloud")
 _internal_protocol_module = load_internal_module("protocol_cloud")
 
@@ -1936,10 +1937,11 @@ def test_point_cloud_app_action_uses_and_enforces_remaining_deadline(
         {
             "retry_count": 0,
             "timeout": pytest.approx(0.8),
-            "deadline": 101.0,
-            "redact_response": True,
-        }
-    ]
+                "deadline": 101.0,
+                "redact_response": True,
+                "raise_on_api_error": True,
+            }
+        ]
 
 
 def test_point_cloud_action_response_enforces_overall_deadline(
@@ -2005,6 +2007,55 @@ def test_point_cloud_action_marks_dispatch_before_waiting_for_response() -> None
 
     assert events == ["dispatch", "post"]
     assert result == {"out": [{"value": {"r": 0}}]}
+
+
+def test_point_cloud_action_can_raise_safe_cloud_api_code() -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    cloud._request_lock = threading.RLock()
+    cloud._strings = [f"value-{index}" for index in range(57)]
+    cloud._host = "host.example.invalid"
+    cloud._did = "device-1"
+    cloud._id = 1
+    cloud._api_call = lambda *args, **kwargs: {
+        "code": 80001,
+        "success": False,
+        "data": None,
+    }
+
+    with pytest.raises(
+        _internal_exceptions_module.DreameLawnMowerCloudAPIError
+    ) as captured:
+        cloud.call_app_action(
+            {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+            retry_count=0,
+            redact_response=True,
+            raise_on_api_error=True,
+        )
+
+    assert captured.value.code == 80001
+    assert "80001" in str(captured.value)
+
+
+def test_point_cloud_wraps_safe_cloud_api_rejection() -> None:
+    client = _client()
+
+    def rejected(*args: Any, **kwargs: Any) -> None:
+        raise _internal_exceptions_module.DreameLawnMowerCloudAPIError(80001)
+
+    client._sync_call_app_action = rejected
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_call_point_cloud_action(
+            {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+            operation="start point-cloud generation",
+            deadline=time.monotonic() + 5,
+            require_data=False,
+        )
+
+    assert captured.value.code == "point_cloud_mower_request_rejected"
+    assert captured.value.stage == "mower_request"
+    assert captured.value.vendor_error_code == 80001
 
 
 def test_point_cloud_dispatch_waits_for_network_worker_slot() -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -73,19 +73,21 @@ def test_point_cloud_api_caches_recent_downloads() -> None:
         options.append(kwargs)
         return _download(kwargs["map_index"])
 
+    coordinator = SimpleNamespace(
+        app_maps={
+            "current_map_index": 0,
+            "maps": [{"idx": 0}],
+        },
+        selected_map_index=0,
+        client=SimpleNamespace(
+            async_download_app_map_point_cloud=download,
+        ),
+        diagnostic_events=DreameLawnMowerDiagnosticEventStore(),
+    )
     hass = SimpleNamespace(
         data={
             DOMAIN: {
-                "entry-1": SimpleNamespace(
-                    app_maps={
-                        "current_map_index": 0,
-                        "maps": [{"idx": 0}],
-                    },
-                    selected_map_index=0,
-                    client=SimpleNamespace(
-                        async_download_app_map_point_cloud=download,
-                    )
-                )
+                "entry-1": coordinator
             }
         }
     )
@@ -100,6 +102,16 @@ def test_point_cloud_api_caches_recent_downloads() -> None:
 
     assert calls == 1
     assert options == [{"map_index": 0, "allow_stored": True}]
+    event = coordinator.diagnostic_events.as_list()[0]
+    assert event["code"] == "point_cloud_completed"
+    assert event["severity"] == "info"
+    assert event["context"] == {
+        "map_index": 0,
+        "source": "generated",
+        "point_count": 1,
+        "total_bytes": 112,
+        "data_encoding": "binary",
+    }
 
 
 def test_point_cloud_api_does_not_use_stored_object_for_inactive_map() -> None:
@@ -685,6 +697,9 @@ def test_point_cloud_api_records_safe_failure_and_timing() -> None:
     assert event["source"] == "point_cloud_api"
     assert event["context"]["stage"] == "generation"
     assert event["context"]["timeout_seconds"] == 45
+    assert event["context"]["map_index"] == 0
+    assert event["context"]["allow_stored"] is False
+    assert event["context"]["vendor_error_code"] is None
     assert private_detail not in repr(event)
     performance = coordinator.performance.as_dict()
     assert performance["summary"]["point_cloud_generation"]["outcomes"] == {

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -730,7 +730,15 @@ def test_video_camera_restores_support_from_healthy_cache_after_docked_reload() 
 
 
 def test_video_camera_dock_transition_recovers_from_stale_raw_returning() -> None:
-    async def _run() -> tuple[int, int, bool, bool, list[str], str | None]:
+    async def _run() -> tuple[
+        int,
+        int,
+        bool,
+        str | None,
+        bool,
+        list[str],
+        str | None,
+    ]:
         snapshot = SimpleNamespace(
             available=True,
             state="mowing",
@@ -799,7 +807,10 @@ def test_video_camera_dock_transition_recovers_from_stale_raw_returning() -> Non
             assert cleanup_task is not None
             await cleanup_task
 
-            unavailable_while_docked = not entity.available
+            available_while_docked = entity.available
+            docked_block_reason = entity.extra_state_attributes[
+                "video_block_reason"
+            ]
             entity.coordinator.data = SimpleNamespace(
                 available=True,
                 state="mowing",
@@ -821,7 +832,8 @@ def test_video_camera_dock_transition_recovers_from_stale_raw_returning() -> Non
         return (
             runtime_stops,
             camera_disables,
-            unavailable_while_docked,
+            available_while_docked,
+            docked_block_reason,
             entity.available,
             [event["code"] for event in events],
             entity._last_stream_cleanup_error_stage,
@@ -831,6 +843,11 @@ def test_video_camera_dock_transition_recovers_from_stale_raw_returning() -> Non
         1,
         1,
         True,
+        (
+            "Camera stream handshake probe is blocked while the mower is "
+            "docked. The Dreame app requires moving the mower out of the "
+            "station before remote video monitoring can start."
+        ),
         True,
         [
             "video_state_gate_cleanup",


### PR DESCRIPTION
## What changed

- Keeps the video camera entity available while the mower is docked or returning, so Home Assistant can show the real `video_block_reason` instead of hiding the diagnostic state. Stream start remains fail-closed when the mower cannot provide video.
- Records coordinate-free 3D point-cloud success and failure diagnostics, including source, map index, point/byte counts, duration, stage, and safe numeric vendor error codes.
- Treats only created maps as real maps while preserving the raw map-slot count for diagnosis. This covers the reserved `created: false` slot reported in #108.
- Applies one five-second absolute deadline to the optional current-schedule task probe, including cloud login and device preflight.
- Improves the bug-report form and README guidance for video and 3D-map investigations.

## Issue #108

This does not guess a different undocumented point-cloud action payload. The reported `80001` response is now surfaced as a mower-side rejection with safe diagnostic context, while existing stored-object fallback remains available when the cloud exposes an object URL. That gives the next report enough evidence to distinguish payload rejection, cloud setup delay, download failure, and an absent stored object.

## Validation

- Full pytest suite passed (one existing skip)
- Ruff passed for `custom_components` and `tests`
- Focused map, point-cloud, schedule, entity, and video tests passed
- Independent cross-repository review completed with no remaining P0/P1/P2 findings

Addresses #108.