### PR TITLE
Support A2 app-map maintenance points

### DIFF
--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -20,6 +20,7 @@ from .coordinator import DreameLawnMowerCoordinator
 from .debug import build_debug_payload, sanitize_debug_data
 from .dreame_lawn_mower_client.maintenance import MAINTENANCE_ITEMS, MaintenanceItem
 from .entity import DreameLawnMowerEntity
+from .manual_control import remote_control_block_reason
 from .reporting import build_maintenance_point_diagnostics
 from .task_status_probe import TASK_STATUS_PROBE_KEYS, task_status_probe_payload
 
@@ -104,20 +105,33 @@ class DreameLawnMowerGoToMaintenancePointButton(
             return None
         return int(entries[0]["point_id"]) if entries else None
 
+    def _movement_block_reason(self) -> str | None:
+        """Return why maintenance-point movement is unsafe right now."""
+        snapshot = self.coordinator.data
+        block_reason = remote_control_block_reason(snapshot)
+        if block_reason is not None:
+            return block_reason
+        activity = str(getattr(snapshot, "activity", "") or "").casefold()
+        if activity not in {"idle", "docked"}:
+            return (
+                "The mower must be idle or docked before going to a "
+                "maintenance point."
+            )
+        return None
+
     @property
     def available(self) -> bool:
         """Allow the movement command only from a known idle state."""
-        snapshot = self.coordinator.data
-        activity = str(getattr(snapshot, "activity", "") or "").casefold()
         return (
-            snapshot is not None
-            and self._point_id() is not None
-            and activity in {"idle", "docked"}
+            self._point_id() is not None and self._movement_block_reason() is None
         )
 
     async def async_press(self) -> None:
         """Drive to the selected mower-configured maintenance point."""
         await self.coordinator.async_request_refresh()
+        block_reason = self._movement_block_reason()
+        if block_reason is not None:
+            raise ValueError(block_reason)
         app_maps_refreshed_at = self.coordinator.app_maps_refreshed_at
         vector_map_refreshed_at = self.coordinator.vector_map_details_refreshed_at
         await self.coordinator.async_refresh_app_maps(
@@ -141,12 +155,10 @@ class DreameLawnMowerGoToMaintenancePointButton(
             raise ValueError(
                 "No maintenance point is configured on the selected mower map."
             )
-        snapshot = self.coordinator.data
-        activity = str(getattr(snapshot, "activity", "") or "").casefold()
-        if snapshot is None or activity not in {"idle", "docked"}:
-            raise ValueError(
-                "The mower must be idle or docked before going to a maintenance point."
-            )
+        await self.coordinator.async_request_refresh()
+        block_reason = self._movement_block_reason()
+        if block_reason is not None:
+            raise ValueError(block_reason)
         await self.coordinator.client.async_go_to_maintenance_point(point_id)
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/dreame_lawn_mower/control_options.py
+++ b/custom_components/dreame_lawn_mower/control_options.py
@@ -308,13 +308,31 @@ def current_maintenance_point_entries(
     selected_map_index: int | None = None,
 ) -> list[dict[str, Any]]:
     """Return configured maintenance points for the selected map."""
-    if not isinstance(vector_map_details, Mapping):
-        return []
     current_idx = current_map_index(
         app_maps,
         batch_device_data,
         selected_map_index=selected_map_index,
     )
+    vector_entries = _current_vector_maintenance_point_entries(
+        vector_map_details,
+        current_idx,
+    )
+    if vector_entries:
+        return vector_entries
+    return _current_app_maintenance_point_entries(
+        app_maps,
+        batch_device_data,
+        current_idx,
+    )
+
+
+def _current_vector_maintenance_point_entries(
+    vector_map_details: Mapping[str, Any] | None,
+    map_index: int,
+) -> list[dict[str, Any]]:
+    """Return identified vector-map maintenance points for one map."""
+    if not isinstance(vector_map_details, Mapping):
+        return []
     maps = vector_map_details.get("maps")
     candidates = (
         maps
@@ -325,7 +343,7 @@ def current_maintenance_point_entries(
     for map_entry in candidates:
         if (
             not isinstance(map_entry, Mapping)
-            or map_entry.get("map_index") != current_idx
+            or map_entry.get("map_index") != map_index
         ):
             continue
         points = map_entry.get("clean_points")
@@ -341,14 +359,57 @@ def current_maintenance_point_entries(
                     point.get("label")
                     or f"Maintenance Point #{point['point_id']}"
                 ),
-                "map_index": current_idx,
+                "map_index": map_index,
             }
             for point in points
             if isinstance(point, Mapping)
             and isinstance(point.get("point_id"), int)
+            and not isinstance(point.get("point_id"), bool)
             and point["point_id"] > 0
         ]
     return []
+
+
+def _current_app_maintenance_point_entries(
+    app_maps: Mapping[str, Any] | None,
+    batch_device_data: Mapping[str, Any] | None,
+    map_index: int,
+) -> list[dict[str, Any]]:
+    """Return identified app-map point records when vector points are absent."""
+    map_entry = current_app_map_entry(
+        app_maps,
+        batch_device_data,
+        selected_map_index=map_index,
+    )
+    if not isinstance(map_entry, Mapping):
+        return []
+    summary = map_entry.get("summary")
+    if not isinstance(summary, Mapping):
+        return []
+    point_ids = summary.get("maintenance_point_ids")
+    if not isinstance(point_ids, Sequence) or isinstance(
+        point_ids,
+        str | bytes | bytearray,
+    ):
+        return []
+
+    result: list[dict[str, Any]] = []
+    for point_id in point_ids:
+        if (
+            not isinstance(point_id, int)
+            or isinstance(point_id, bool)
+            or point_id <= 0
+            or any(entry["point_id"] == point_id for entry in result)
+        ):
+            continue
+        result.append(
+            {
+                "point_id": point_id,
+                "label": f"Maintenance Point #{point_id}",
+                "map_index": map_index,
+            }
+        )
+    return result
 
 
 def find_spot_center(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -473,6 +473,8 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         "spot_boundary_point_count": spot_boundary_point_count,
         "point_count": len(point_entries),
         "point_entry_shapes": _app_map_point_entry_shapes(point_entries),
+        "maintenance_point_ids": _app_map_maintenance_point_ids(point_entries),
+        "point_type_codes": _app_map_point_type_codes(point_entries),
         "semantic_count": len(semantic),
         "semantic_boundary_point_count": semantic_boundary_point_count,
         "semantic_key_counts": dict(sorted(semantic_key_counts.items())),
@@ -515,6 +517,68 @@ def _app_map_point_entry_shapes(entries: Sequence[Any]) -> list[dict[str, Any]]:
             entry["item_types"] = list(shape[2])
         result.append(entry)
     return result
+
+
+def _app_map_maintenance_point_ids(entries: Sequence[Any]) -> list[int]:
+    """Return ids from the observed A2 maintenance-point record shape."""
+    result: list[int] = []
+    for entry in entries:
+        if not _is_app_map_maintenance_point_record(entry):
+            continue
+        point_id = entry.get("id")
+        if (
+            not isinstance(point_id, int)
+            or isinstance(point_id, bool)
+            or point_id <= 0
+            or point_id in result
+        ):
+            continue
+        result.append(point_id)
+    return result
+
+
+def _app_map_point_type_codes(entries: Sequence[Any]) -> list[int]:
+    """Return numeric vendor type codes from identified point records."""
+    result: list[int] = []
+    for entry in entries:
+        if not _is_app_map_maintenance_point_record(entry):
+            continue
+        point_type = entry.get("type")
+        if (
+            isinstance(point_type, int)
+            and not isinstance(point_type, bool)
+            and point_type not in result
+        ):
+            result.append(point_type)
+    return sorted(result)
+
+
+def _is_app_map_maintenance_point_record(value: object) -> bool:
+    """Recognize only the exact point-record structure observed on an A2 3000."""
+    if not isinstance(value, Mapping) or set(value) != {
+        "id",
+        "param",
+        "point",
+        "time",
+        "type",
+    }:
+        return False
+    point_type = value.get("type")
+    if not isinstance(point_type, int) or isinstance(point_type, bool):
+        return False
+    coordinates = value.get("point")
+    if (
+        not isinstance(coordinates, Sequence)
+        or isinstance(coordinates, str | bytes | bytearray)
+        or len(coordinates) != 2
+    ):
+        return False
+    return all(
+        isinstance(coordinate, int | float)
+        and not isinstance(coordinate, bool)
+        and math.isfinite(float(coordinate))
+        for coordinate in coordinates
+    )
 
 
 def _select_app_map_payload(app_maps: Mapping[str, Any]) -> Mapping[str, Any] | None:
@@ -614,6 +678,8 @@ def _app_map_entry_view_metadata(entry: Mapping[str, Any]) -> dict[str, Any]:
         "spot_count": summary.get("spot_count"),
         "point_count": summary.get("point_count"),
         "point_entry_shapes": summary.get("point_entry_shapes"),
+        "maintenance_point_ids": summary.get("maintenance_point_ids"),
+        "point_type_codes": summary.get("point_type_codes"),
         "trajectory_count": summary.get("trajectory_count"),
         "trajectory_point_count": summary.get("trajectory_point_count"),
         "trajectory_length_m": summary.get("trajectory_length_m"),

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -141,10 +141,16 @@ def build_maintenance_point_diagnostics(
     current_app_point_count = (
         current_app_entry.get("point_count") if current_app_entry else None
     )
+    current_app_point_ids = (
+        current_app_entry.get("maintenance_point_ids")
+        if current_app_entry
+        else []
+    )
     current_vector_point_ids = (
         current_vector_entry.get("point_ids") if current_vector_entry else []
     )
     mismatch = bool(current_app_point_count) and not current_vector_point_ids
+    control_point_ids = current_vector_point_ids or current_app_point_ids
 
     result = {
         "source": source,
@@ -152,7 +158,14 @@ def build_maintenance_point_diagnostics(
         "selected_point_id": _positive_int(
             getattr(coordinator, "selected_maintenance_point_id", None)
         ),
-        "control_ready": bool(current_vector_point_ids),
+        "control_ready": bool(control_point_ids),
+        "control_point_source": (
+            "vector_map"
+            if current_vector_point_ids
+            else "app_map"
+            if current_app_point_ids
+            else None
+        ),
         "app_points_without_vector_ids": mismatch,
         "app_maps": app_map_entries,
         "vector_maps": vector_map_entries,
@@ -179,6 +192,8 @@ def _maintenance_app_map_entries(value: object) -> list[dict[str, Any]]:
             summary = {}
         payload_keys = item.get("payload_keys")
         point_shapes = summary.get("point_entry_shapes")
+        point_ids = summary.get("maintenance_point_ids")
+        point_type_codes = summary.get("point_type_codes")
         result.append(
             {
                 "map_index": _map_index(item.get("idx")),
@@ -195,6 +210,30 @@ def _maintenance_app_map_entries(value: object) -> list[dict[str, Any]]:
                     list(point_shapes)
                     if isinstance(point_shapes, Sequence)
                     and not isinstance(point_shapes, str | bytes | bytearray)
+                    else []
+                ),
+                "maintenance_point_ids": (
+                    [
+                        point_id
+                        for point_id in point_ids
+                        if _positive_int(point_id) is not None
+                    ]
+                    if isinstance(point_ids, Sequence)
+                    and not isinstance(point_ids, str | bytes | bytearray)
+                    else []
+                ),
+                "point_type_codes": (
+                    [
+                        point_type
+                        for point_type in point_type_codes
+                        if isinstance(point_type, int)
+                        and not isinstance(point_type, bool)
+                    ]
+                    if isinstance(point_type_codes, Sequence)
+                    and not isinstance(
+                        point_type_codes,
+                        str | bytes | bytearray,
+                    )
                     else []
                 ),
             }

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -165,7 +165,31 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
             "total_area": 12.5,
             "map": [{"area": 12.5, "data": [[1, 2], [3, 4], [5, 6]]}],
             "spot": [{"id": 1}],
-            "point": [[7, 8]],
+            "point": [
+                {
+                    "id": 301,
+                    "param": 0,
+                    "point": [7, 8],
+                    "time": 0,
+                    "type": 1,
+                },
+                {
+                    "id": 302,
+                    "param": 0,
+                    "point": [9, 10],
+                    "time": 0,
+                    "type": 2,
+                },
+                {"id": 303, "type": "obstacle"},
+                {
+                    "id": 304,
+                    "param": 0,
+                    "point": [13, 14],
+                    "time": 0,
+                    "type": "BackGarden",
+                },
+                [11, 12],
+            ],
             "semantic": [
                 {"data": [[9, 9], [10, 9], [10, 10]], "type": "unknown"},
                 {"type": "unknown", "label": "future"},
@@ -196,15 +220,27 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
         "boundary_point_count": 3,
         "spot_count": 1,
         "spot_boundary_point_count": 0,
-        "point_count": 1,
+        "point_count": 5,
         "point_entry_shapes": [
             {
                 "kind": "array",
                 "count": 1,
                 "length": 2,
                 "item_types": ["number"],
-            }
+            },
+            {
+                "kind": "object",
+                "count": 3,
+                "keys": ["id", "param", "point", "time", "type"],
+            },
+            {
+                "kind": "object",
+                "count": 1,
+                "keys": ["id", "type"],
+            },
         ],
+        "maintenance_point_ids": [301, 302],
+        "point_type_codes": [1, 2],
         "semantic_count": 2,
         "semantic_boundary_point_count": 3,
         "semantic_key_counts": {"data": 1, "label": 1, "type": 2},

--- a/tests/test_maintenance_point_controls.py
+++ b/tests/test_maintenance_point_controls.py
@@ -18,7 +18,15 @@ from custom_components.dreame_lawn_mower.select import (
 
 def _coordinator(*, activity: str = "idle") -> SimpleNamespace:
     return SimpleNamespace(
-        data=SimpleNamespace(activity=activity),
+        data=SimpleNamespace(
+            activity=activity,
+            battery_level=80,
+            docked=activity == "docked",
+            mowing=activity == "mowing",
+            raw_attributes={},
+            returning=False,
+            state="charging" if activity == "docked" else "idle",
+        ),
         app_maps={"current_map_index": 0, "maps": [{"idx": 0, "current": True}]},
         batch_device_data={},
         vector_map_details={
@@ -48,6 +56,42 @@ def _coordinator(*, activity: str = "idle") -> SimpleNamespace:
         async_refresh_app_maps=AsyncMock(),
         async_refresh_vector_map_details=AsyncMock(),
     )
+
+
+def _a2_app_map_coordinator(*, activity: str = "idle") -> SimpleNamespace:
+    coordinator = _coordinator(activity=activity)
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [
+            {
+                "idx": 0,
+                "current": True,
+                "summary": {
+                    "point_count": 2,
+                    "maintenance_point_ids": [401, 402],
+                    "point_type_codes": [1],
+                },
+            },
+            {
+                "idx": 1,
+                "current": False,
+                "summary": {
+                    "point_count": 1,
+                    "maintenance_point_ids": [999],
+                    "point_type_codes": [1],
+                },
+            },
+        ],
+    }
+    coordinator.vector_map_details = {
+        "maps": [
+            {
+                "map_index": 0,
+                "clean_points": [],
+            }
+        ]
+    }
+    return coordinator
 
 
 def _complete_fresh_map_refresh(coordinator: SimpleNamespace) -> None:
@@ -84,6 +128,41 @@ def test_maintenance_point_select_uses_map_point_ids() -> None:
     assert entity.current_option == "Maintenance Point #302"
 
 
+def test_maintenance_point_select_falls_back_to_current_a2_app_map_ids() -> None:
+    coordinator = _a2_app_map_coordinator()
+    entity = object.__new__(DreameLawnMowerMaintenancePointSelect)
+    entity.coordinator = coordinator
+
+    assert entity.available is True
+    assert entity.options == [
+        "Maintenance Point #401",
+        "Maintenance Point #402",
+    ]
+    assert "Maintenance Point #999" not in entity.options
+
+    asyncio.run(entity.async_select_option("Maintenance Point #402"))
+
+    assert coordinator.selected_maintenance_point_id == 402
+    coordinator.async_update_listeners.assert_called_once()
+
+
+def test_vector_point_ids_remain_authoritative_over_app_map_fallback() -> None:
+    coordinator = _coordinator()
+    coordinator.app_maps["maps"][0]["summary"] = {
+        "point_count": 1,
+        "maintenance_point_ids": [999],
+        "point_type_codes": [1],
+    }
+    entity = object.__new__(DreameLawnMowerMaintenancePointSelect)
+    entity.coordinator = coordinator
+
+    assert entity.options == [
+        "Maintenance Point #301",
+        "Maintenance Point #302",
+    ]
+    assert "Maintenance Point #999" not in entity.options
+
+
 def test_go_to_maintenance_point_uses_selected_configured_id() -> None:
     coordinator = _coordinator(activity="docked")
     _complete_fresh_map_refresh(coordinator)
@@ -96,7 +175,86 @@ def test_go_to_maintenance_point_uses_selected_configured_id() -> None:
     asyncio.run(entity.async_press())
 
     coordinator.client.async_go_to_maintenance_point.assert_awaited_once_with(302)
+    assert coordinator.async_request_refresh.await_count == 3
+
+
+def test_go_to_maintenance_point_uses_fresh_a2_app_map_id() -> None:
+    coordinator = _a2_app_map_coordinator(activity="docked")
+    _complete_fresh_map_refresh(coordinator)
+    coordinator.selected_maintenance_point_id = 402
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    assert entity.available is True
+
+    asyncio.run(entity.async_press())
+
+    coordinator.client.async_go_to_maintenance_point.assert_awaited_once_with(402)
+    assert coordinator.async_request_refresh.await_count == 3
+
+
+@pytest.mark.parametrize(
+    ("data_change", "message"),
+    [
+        ({"battery_level": 10}, "battery is low"),
+        ({"raw_attributes": {"mapping": True}}, "while mapping"),
+    ],
+)
+def test_go_to_maintenance_point_applies_shared_movement_safety_gate(
+    data_change: dict[str, object],
+    message: str,
+) -> None:
+    coordinator = _a2_app_map_coordinator(activity="docked")
+    for name, value in data_change.items():
+        setattr(coordinator.data, name, value)
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    assert entity.available is False
+    with pytest.raises(ValueError, match=message):
+        asyncio.run(entity.async_press())
+
+    coordinator.async_refresh_app_maps.assert_not_awaited()
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
+
+
+def test_go_to_maintenance_point_revalidates_safety_after_map_refresh() -> None:
+    coordinator = _a2_app_map_coordinator(activity="docked")
+    _complete_fresh_map_refresh(coordinator)
+
+    original_vector_refresh = coordinator.async_refresh_vector_map_details.side_effect
+
+    async def refresh_vector_and_lower_battery(**kwargs):
+        result = await original_vector_refresh(**kwargs)
+        coordinator.data.battery_level = 10
+        return result
+
+    coordinator.async_refresh_vector_map_details.side_effect = (
+        refresh_vector_and_lower_battery
+    )
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    with pytest.raises(ValueError, match="battery is low"):
+        asyncio.run(entity.async_press())
+
     assert coordinator.async_request_refresh.await_count == 2
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
+
+
+def test_app_map_fallback_rejects_unidentified_point_records() -> None:
+    coordinator = _a2_app_map_coordinator()
+    coordinator.app_maps["maps"][0]["summary"]["maintenance_point_ids"] = [
+        True,
+        0,
+        -1,
+        "403",
+    ]
+    entity = object.__new__(DreameLawnMowerMaintenancePointSelect)
+    entity.coordinator = coordinator
+
+    assert entity.available is False
+    assert entity.options == []
 
 
 def test_go_to_maintenance_point_is_blocked_during_mowing() -> None:
@@ -106,7 +264,7 @@ def test_go_to_maintenance_point_is_blocked_during_mowing() -> None:
     entity.coordinator = coordinator
 
     assert entity.available is False
-    with pytest.raises(ValueError, match="idle or docked"):
+    with pytest.raises(ValueError, match="mower is active"):
         asyncio.run(entity.async_press())
 
     coordinator.client.async_go_to_maintenance_point.assert_not_awaited()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -113,6 +113,7 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
             "current_map_index": None,
             "selected_point_id": None,
             "control_ready": False,
+            "control_point_source": None,
             "app_points_without_vector_ids": False,
             "app_maps": [],
             "vector_maps": [],
@@ -188,16 +189,37 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
                         "payload_keys": ["map", "point"],
                         "summary": {
                             "point_count": 1,
-                            "point_entry_shapes": [
-                                {
-                                    "kind": "array",
-                                    "count": 1,
-                                    "length": 2,
-                                    "item_types": ["number"],
-                                }
+                            "maintenance_point_ids": [301],
+                            "point_type_codes": [
+                                1,
+                                "BackGarden",
+                                True,
                             ],
-                        },
-                        "payload": {"point": [[5910, 12400]]},
+                                "point_entry_shapes": [
+                                    {
+                                        "kind": "object",
+                                        "count": 1,
+                                        "keys": [
+                                            "id",
+                                            "param",
+                                            "point",
+                                            "time",
+                                            "type",
+                                        ],
+                                    }
+                                ],
+                            },
+                            "payload": {
+                                "point": [
+                                    {
+                                        "id": 301,
+                                        "param": 0,
+                                        "point": [5910, 12400],
+                                        "time": 0,
+                                        "type": 1,
+                                    }
+                                ]
+                            },
                     }
                 ],
             },
@@ -217,7 +239,8 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
         "source": "coordinator_cache",
         "current_map_index": 0,
         "selected_point_id": None,
-        "control_ready": False,
+        "control_ready": True,
+        "control_point_source": "app_map",
         "app_points_without_vector_ids": True,
         "app_maps": [
             {
@@ -226,14 +249,15 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
                 "available": True,
                 "point_payload_present": True,
                 "point_count": 1,
-                "point_entry_shapes": [
-                    {
-                        "kind": "array",
-                        "count": 1,
-                        "length": 2,
-                        "item_types": ["number"],
-                    }
-                ],
+                "maintenance_point_ids": [301],
+                "point_type_codes": [1],
+                    "point_entry_shapes": [
+                        {
+                            "kind": "object",
+                            "count": 1,
+                            "keys": ["id", "param", "point", "time", "type"],
+                        }
+                    ],
             }
         ],
         "vector_maps": [


### PR DESCRIPTION
## What changed

- discover A2 and A2 3000 maintenance points from the current app map when the vector map contains no identified points
- keep vector-map point IDs authoritative when Dreame provides them
- expose the existing maintenance-point selector and movement button for the app-map fallback
- add derived maintenance-point IDs and numeric vendor type codes to privacy-safe diagnostics

## Safety and privacy

Only the exact A2 record structure observed in issue diagnostics can become a movement destination: a positive integer ID, numeric type code, and finite coordinate pair inside the expected record keys. Coordinate-only entries, partial records, strings, booleans, and unknown shapes remain unavailable.

The button requires fresh app and vector metadata, an idle or docked mower, and the shared movement-safety checks. Mower state is revalidated after map refresh and immediately before dispatch, covering low battery, mapping, active errors, returning, and ambiguous active states.

Diagnostics contain counts, shapes, derived IDs, and numeric type codes. They do not include coordinates, raw map payloads, or symbolic vendor strings.

## Why

The v0.2.42 diagnostics attached to issue #79 show two A2 3000 maintenance-point records in the current app map and zero point IDs in its vector map. The previous implementation therefore kept both Home Assistant entities unavailable even though the Dreame app had two configured points.

Physical A2/A2 3000 confirmation is still required after installation before issue #79 can be closed.

Related to #79.