### PR TITLE
Improve maintenance point record diagnostics

### DIFF
--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -25,7 +25,7 @@ from .dreame_lawn_mower_client.models import (
     remote_control_state_safe,
 )
 
-DIAGNOSTIC_SCHEMA_VERSION = 7
+DIAGNOSTIC_SCHEMA_VERSION = 8
 UNKNOWN_REALTIME_PREFIX = "UNKNOWN_REALTIME_"
 
 REDACT_KEYS = {

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -23,6 +23,11 @@ from .deadline import DeadlineExceededError, run_with_deadline
 from .exceptions import (
     DreameLawnMowerError as DreameLawnMowerError,
 )
+from .maintenance_point_records import (
+    app_map_maintenance_point_ids,
+    app_map_point_record_diagnostics,
+    app_map_point_type_codes,
+)
 from .map_visuals import (
     MapRenderStyle,
     line_width,
@@ -473,8 +478,9 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         "spot_boundary_point_count": spot_boundary_point_count,
         "point_count": len(point_entries),
         "point_entry_shapes": _app_map_point_entry_shapes(point_entries),
-        "maintenance_point_ids": _app_map_maintenance_point_ids(point_entries),
-        "point_type_codes": _app_map_point_type_codes(point_entries),
+        "maintenance_point_ids": app_map_maintenance_point_ids(point_entries),
+        "point_type_codes": app_map_point_type_codes(point_entries),
+        "point_record_validation": app_map_point_record_diagnostics(point_entries),
         "semantic_count": len(semantic),
         "semantic_boundary_point_count": semantic_boundary_point_count,
         "semantic_key_counts": dict(sorted(semantic_key_counts.items())),
@@ -517,68 +523,6 @@ def _app_map_point_entry_shapes(entries: Sequence[Any]) -> list[dict[str, Any]]:
             entry["item_types"] = list(shape[2])
         result.append(entry)
     return result
-
-
-def _app_map_maintenance_point_ids(entries: Sequence[Any]) -> list[int]:
-    """Return ids from the observed A2 maintenance-point record shape."""
-    result: list[int] = []
-    for entry in entries:
-        if not _is_app_map_maintenance_point_record(entry):
-            continue
-        point_id = entry.get("id")
-        if (
-            not isinstance(point_id, int)
-            or isinstance(point_id, bool)
-            or point_id <= 0
-            or point_id in result
-        ):
-            continue
-        result.append(point_id)
-    return result
-
-
-def _app_map_point_type_codes(entries: Sequence[Any]) -> list[int]:
-    """Return numeric vendor type codes from identified point records."""
-    result: list[int] = []
-    for entry in entries:
-        if not _is_app_map_maintenance_point_record(entry):
-            continue
-        point_type = entry.get("type")
-        if (
-            isinstance(point_type, int)
-            and not isinstance(point_type, bool)
-            and point_type not in result
-        ):
-            result.append(point_type)
-    return sorted(result)
-
-
-def _is_app_map_maintenance_point_record(value: object) -> bool:
-    """Recognize only the exact point-record structure observed on an A2 3000."""
-    if not isinstance(value, Mapping) or set(value) != {
-        "id",
-        "param",
-        "point",
-        "time",
-        "type",
-    }:
-        return False
-    point_type = value.get("type")
-    if not isinstance(point_type, int) or isinstance(point_type, bool):
-        return False
-    coordinates = value.get("point")
-    if (
-        not isinstance(coordinates, Sequence)
-        or isinstance(coordinates, str | bytes | bytearray)
-        or len(coordinates) != 2
-    ):
-        return False
-    return all(
-        isinstance(coordinate, int | float)
-        and not isinstance(coordinate, bool)
-        and math.isfinite(float(coordinate))
-        for coordinate in coordinates
-    )
 
 
 def _select_app_map_payload(app_maps: Mapping[str, Any]) -> Mapping[str, Any] | None:
@@ -680,6 +624,7 @@ def _app_map_entry_view_metadata(entry: Mapping[str, Any]) -> dict[str, Any]:
         "point_entry_shapes": summary.get("point_entry_shapes"),
         "maintenance_point_ids": summary.get("maintenance_point_ids"),
         "point_type_codes": summary.get("point_type_codes"),
+        "point_record_validation": summary.get("point_record_validation"),
         "trajectory_count": summary.get("trajectory_count"),
         "trajectory_point_count": summary.get("trajectory_point_count"),
         "trajectory_length_m": summary.get("trajectory_length_m"),

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance_point_records.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance_point_records.py
@@ -1,0 +1,190 @@
+"""Parse and describe mower-native app-map maintenance-point records."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+from .client_shared_helpers import _operation_value_type
+
+_REQUIRED_KEYS = frozenset({"id", "param", "point", "time", "type"})
+
+
+def app_map_maintenance_point_ids(entries: Sequence[Any]) -> list[int]:
+    """Return positive ids from recognized app-map maintenance-point records."""
+    result: list[int] = []
+    for entry in entries:
+        if not is_app_map_maintenance_point_record(entry):
+            continue
+        point_id = entry.get("id")
+        if (
+            not isinstance(point_id, int)
+            or isinstance(point_id, bool)
+            or point_id <= 0
+            or point_id in result
+        ):
+            continue
+        result.append(point_id)
+    return result
+
+
+def app_map_point_type_codes(entries: Sequence[Any]) -> list[int]:
+    """Return numeric vendor type codes from recognized point records."""
+    result: list[int] = []
+    for entry in entries:
+        if not is_app_map_maintenance_point_record(entry):
+            continue
+        point_type = entry.get("type")
+        if (
+            isinstance(point_type, int)
+            and not isinstance(point_type, bool)
+            and point_type not in result
+        ):
+            result.append(point_type)
+    return sorted(result)
+
+
+def app_map_point_record_diagnostics(
+    entries: Sequence[Any],
+) -> dict[str, Any]:
+    """Describe rejected point value shapes without exposing values."""
+    exact_shape_count = 0
+    parser_accepted_count = 0
+    identified_count = 0
+    rejection_counts: dict[str, int] = {}
+    grouped_shapes: dict[tuple[Any, ...], int] = {}
+
+    for entry in entries:
+        reasons = _maintenance_point_rejection_reasons(entry)
+        for reason in reasons:
+            rejection_counts[reason] = rejection_counts.get(reason, 0) + 1
+
+        if not isinstance(entry, Mapping) or set(entry) != _REQUIRED_KEYS:
+            continue
+        exact_shape_count += 1
+        shape = _maintenance_point_value_shape(entry)
+        grouped_shapes[shape] = grouped_shapes.get(shape, 0) + 1
+        if is_app_map_maintenance_point_record(entry):
+            parser_accepted_count += 1
+            point_id = entry.get("id")
+            if (
+                isinstance(point_id, int)
+                and not isinstance(point_id, bool)
+                and point_id > 0
+            ):
+                identified_count += 1
+
+    value_shapes: list[dict[str, Any]] = []
+    for shape, count in sorted(grouped_shapes.items(), key=lambda item: repr(item[0])):
+        (
+            id_type,
+            param_type,
+            point_type,
+            time_type,
+            vendor_type,
+            point_length,
+            point_item_types,
+        ) = shape
+        value_shape: dict[str, Any] = {
+            "count": count,
+            "id_type": id_type,
+            "param_type": param_type,
+            "point_type": point_type,
+            "time_type": time_type,
+            "type_type": vendor_type,
+        }
+        if point_length is not None:
+            value_shape["point_length"] = point_length
+            value_shape["point_item_types"] = list(point_item_types)
+        value_shapes.append(value_shape)
+
+    return {
+        "total_count": len(entries),
+        "exact_shape_count": exact_shape_count,
+        "parser_accepted_count": parser_accepted_count,
+        "identified_count": identified_count,
+        "rejection_reason_counts": [
+            {"reason": reason, "count": count}
+            for reason, count in sorted(rejection_counts.items())
+        ],
+        "value_type_shapes": value_shapes,
+    }
+
+
+def is_app_map_maintenance_point_record(value: object) -> bool:
+    """Recognize only the exact point-record structure observed on an A2 3000."""
+    if not isinstance(value, Mapping) or set(value) != _REQUIRED_KEYS:
+        return False
+    point_type = value.get("type")
+    if not isinstance(point_type, int) or isinstance(point_type, bool):
+        return False
+    coordinates = value.get("point")
+    if (
+        not isinstance(coordinates, Sequence)
+        or isinstance(coordinates, str | bytes | bytearray)
+        or len(coordinates) != 2
+    ):
+        return False
+    return all(
+        isinstance(coordinate, int | float)
+        and not isinstance(coordinate, bool)
+        and math.isfinite(float(coordinate))
+        for coordinate in coordinates
+    )
+
+
+def _maintenance_point_rejection_reasons(value: object) -> list[str]:
+    if not isinstance(value, Mapping):
+        return ["not_object"]
+    if set(value) != _REQUIRED_KEYS:
+        return ["unexpected_keys"]
+
+    reasons: list[str] = []
+    point_id = value.get("id")
+    if not isinstance(point_id, int) or isinstance(point_id, bool) or point_id <= 0:
+        reasons.append("id_not_positive_integer")
+
+    point_type = value.get("type")
+    if not isinstance(point_type, int) or isinstance(point_type, bool):
+        reasons.append("type_not_integer")
+
+    coordinates = value.get("point")
+    if (
+        not isinstance(coordinates, Sequence)
+        or isinstance(coordinates, str | bytes | bytearray)
+        or len(coordinates) != 2
+    ):
+        reasons.append("point_not_coordinate_pair")
+    elif not all(
+        isinstance(coordinate, int | float)
+        and not isinstance(coordinate, bool)
+        and math.isfinite(float(coordinate))
+        for coordinate in coordinates
+    ):
+        reasons.append("point_coordinates_not_finite_numbers")
+    return reasons
+
+
+def _maintenance_point_value_shape(value: Mapping[str, Any]) -> tuple[Any, ...]:
+    coordinates = value.get("point")
+    if isinstance(coordinates, Sequence) and not isinstance(
+        coordinates,
+        str | bytes | bytearray,
+    ):
+        point_length: int | None = len(coordinates)
+        point_item_types = tuple(
+            sorted({_operation_value_type(item) for item in coordinates})
+        )
+    else:
+        point_length = None
+        point_item_types = ()
+    return (
+        _operation_value_type(value.get("id")),
+        _operation_value_type(value.get("param")),
+        _operation_value_type(coordinates),
+        _operation_value_type(value.get("time")),
+        _operation_value_type(value.get("type")),
+        point_length,
+        point_item_types,
+    )

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -33,6 +33,20 @@ _SENSITIVE_ENTITY_STATE_NAMES = frozenset(
     }
 )
 
+_MAINTENANCE_POINT_REJECTION_REASONS = frozenset(
+    {
+        "id_not_positive_integer",
+        "not_object",
+        "point_coordinates_not_finite_numbers",
+        "point_not_coordinate_pair",
+        "type_not_integer",
+        "unexpected_keys",
+    }
+)
+_MAINTENANCE_POINT_VALUE_TYPES = frozenset(
+    {"array", "bool", "null", "number", "object", "string"}
+)
+
 
 def build_report_context(
     *,
@@ -194,50 +208,141 @@ def _maintenance_app_map_entries(value: object) -> list[dict[str, Any]]:
         point_shapes = summary.get("point_entry_shapes")
         point_ids = summary.get("maintenance_point_ids")
         point_type_codes = summary.get("point_type_codes")
-        result.append(
+        record_validation = _maintenance_point_record_validation(
+            summary.get("point_record_validation")
+        )
+        entry = {
+            "map_index": _map_index(item.get("idx")),
+            "current": bool(item.get("current")),
+            "available": bool(item.get("available")),
+            "point_payload_present": (
+                "point" in payload_keys
+                if isinstance(payload_keys, Sequence)
+                and not isinstance(payload_keys, str | bytes | bytearray)
+                else None
+            ),
+            "point_count": _non_negative_int(summary.get("point_count")),
+            "point_entry_shapes": (
+                list(point_shapes)
+                if isinstance(point_shapes, Sequence)
+                and not isinstance(point_shapes, str | bytes | bytearray)
+                else []
+            ),
+            "maintenance_point_ids": (
+                [
+                    point_id
+                    for point_id in point_ids
+                    if _positive_int(point_id) is not None
+                ]
+                if isinstance(point_ids, Sequence)
+                and not isinstance(point_ids, str | bytes | bytearray)
+                else []
+            ),
+            "point_type_codes": (
+                [
+                    point_type
+                    for point_type in point_type_codes
+                    if isinstance(point_type, int)
+                    and not isinstance(point_type, bool)
+                ]
+                if isinstance(point_type_codes, Sequence)
+                and not isinstance(
+                    point_type_codes,
+                    str | bytes | bytearray,
+                )
+                else []
+            ),
+        }
+        if record_validation is not None:
+            entry["point_record_validation"] = record_validation
+        result.append(entry)
+    return result
+
+
+def _maintenance_point_record_validation(
+    value: object,
+) -> dict[str, Any] | None:
+    if not isinstance(value, Mapping):
+        return None
+
+    result: dict[str, Any] = {
+        key: _non_negative_int(value.get(key))
+        for key in (
+            "total_count",
+            "exact_shape_count",
+            "parser_accepted_count",
+            "identified_count",
+        )
+    }
+    reasons = value.get("rejection_reason_counts")
+    result["rejection_reason_counts"] = (
+        [
             {
-                "map_index": _map_index(item.get("idx")),
-                "current": bool(item.get("current")),
-                "available": bool(item.get("available")),
-                "point_payload_present": (
-                    "point" in payload_keys
-                    if isinstance(payload_keys, Sequence)
-                    and not isinstance(payload_keys, str | bytes | bytearray)
-                    else None
-                ),
-                "point_count": _non_negative_int(summary.get("point_count")),
-                "point_entry_shapes": (
-                    list(point_shapes)
-                    if isinstance(point_shapes, Sequence)
-                    and not isinstance(point_shapes, str | bytes | bytearray)
-                    else []
-                ),
-                "maintenance_point_ids": (
-                    [
-                        point_id
-                        for point_id in point_ids
-                        if _positive_int(point_id) is not None
-                    ]
-                    if isinstance(point_ids, Sequence)
-                    and not isinstance(point_ids, str | bytes | bytearray)
-                    else []
-                ),
-                "point_type_codes": (
-                    [
-                        point_type
-                        for point_type in point_type_codes
-                        if isinstance(point_type, int)
-                        and not isinstance(point_type, bool)
-                    ]
-                    if isinstance(point_type_codes, Sequence)
+                "reason": reason,
+                "count": count,
+            }
+            for item in reasons
+            if isinstance(item, Mapping)
+            and isinstance((reason := item.get("reason")), str)
+            and reason in _MAINTENANCE_POINT_REJECTION_REASONS
+            and (count := _positive_int(item.get("count"))) is not None
+        ]
+        if isinstance(reasons, Sequence)
+        and not isinstance(
+            reasons,
+            str | bytes | bytearray,
+        )
+        else []
+    )
+
+    shapes = value.get("value_type_shapes")
+    safe_shapes: list[dict[str, Any]] = []
+    if isinstance(shapes, Sequence) and not isinstance(
+        shapes,
+        str | bytes | bytearray,
+    ):
+        for shape in shapes:
+            if not isinstance(shape, Mapping):
+                continue
+            count = _positive_int(shape.get("count"))
+            if count is None:
+                continue
+            safe_shape: dict[str, Any] = {"count": count}
+            for key in (
+                "id_type",
+                "param_type",
+                "point_type",
+                "time_type",
+                "type_type",
+            ):
+                value_type = shape.get(key)
+                if (
+                    isinstance(value_type, str)
+                    and value_type in _MAINTENANCE_POINT_VALUE_TYPES
+                ):
+                    safe_shape[key] = value_type
+            point_length = _non_negative_int(shape.get("point_length"))
+            if point_length is not None:
+                safe_shape["point_length"] = point_length
+                point_item_types = shape.get("point_item_types")
+                safe_shape["point_item_types"] = (
+                    sorted(
+                        {
+                            item_type
+                            for item_type in point_item_types
+                            if isinstance(item_type, str)
+                            and item_type in _MAINTENANCE_POINT_VALUE_TYPES
+                        }
+                    )
+                    if isinstance(point_item_types, Sequence)
                     and not isinstance(
-                        point_type_codes,
+                        point_item_types,
                         str | bytes | bytearray,
                     )
                     else []
-                ),
-            }
-        )
+                )
+            safe_shapes.append(safe_shape)
+    result["value_type_shapes"] = safe_shapes
     return result
 
 

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -241,6 +241,39 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
         ],
         "maintenance_point_ids": [301, 302],
         "point_type_codes": [1, 2],
+        "point_record_validation": {
+            "total_count": 5,
+            "exact_shape_count": 3,
+            "parser_accepted_count": 2,
+            "identified_count": 2,
+            "rejection_reason_counts": [
+                {"reason": "not_object", "count": 1},
+                {"reason": "type_not_integer", "count": 1},
+                {"reason": "unexpected_keys", "count": 1},
+            ],
+            "value_type_shapes": [
+                {
+                    "count": 2,
+                    "id_type": "number",
+                    "param_type": "number",
+                    "point_type": "array",
+                    "time_type": "number",
+                    "type_type": "number",
+                    "point_length": 2,
+                    "point_item_types": ["number"],
+                },
+                {
+                    "count": 1,
+                    "id_type": "number",
+                    "param_type": "number",
+                    "point_type": "array",
+                    "time_type": "number",
+                    "type_type": "string",
+                    "point_length": 2,
+                    "point_item_types": ["number"],
+                },
+            ],
+        },
         "semantic_count": 2,
         "semantic_boundary_point_count": 3,
         "semantic_key_counts": {"data": 1, "label": 1, "type": 2},
@@ -261,6 +294,72 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
     expected_sizes = [min(40, payload_size - start) for start in expected_starts]
     assert [call["d"]["start"] for call in mapd_calls] == expected_starts
     assert [call["d"]["size"] for call in mapd_calls] == expected_sizes
+
+
+def test_app_maps_explain_rejected_point_values_without_exposing_them() -> None:
+    client = _client()
+    cloud = _FakeAppMapCloud(
+        {
+            "point": [
+                {
+                    "id": 401,
+                    "param": {},
+                    "point": {"x": 5910, "y": 12400},
+                    "time": "created",
+                    "type": "maintenance",
+                },
+                {
+                    "id": "402",
+                    "param": 0,
+                    "point": ["7100", "8300"],
+                    "time": 0,
+                    "type": 1,
+                },
+            ]
+        }
+    )
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    result = client._sync_get_app_maps(include_payload=False)
+
+    validation = result["maps"][0]["summary"]["point_record_validation"]
+    assert validation == {
+        "total_count": 2,
+        "exact_shape_count": 2,
+        "parser_accepted_count": 0,
+        "identified_count": 0,
+        "rejection_reason_counts": [
+            {"reason": "id_not_positive_integer", "count": 1},
+            {"reason": "point_coordinates_not_finite_numbers", "count": 1},
+            {"reason": "point_not_coordinate_pair", "count": 1},
+            {"reason": "type_not_integer", "count": 1},
+        ],
+        "value_type_shapes": [
+            {
+                "count": 1,
+                "id_type": "number",
+                "param_type": "object",
+                "point_type": "object",
+                "time_type": "string",
+                "type_type": "string",
+            },
+            {
+                "count": 1,
+                "id_type": "string",
+                "param_type": "number",
+                "point_type": "array",
+                "time_type": "number",
+                "type_type": "number",
+                "point_length": 2,
+                "point_item_types": ["string"],
+            },
+        ],
+    }
+    assert "401" not in repr(validation)
+    assert "402" not in repr(validation)
+    assert "5910" not in repr(validation)
+    assert "12400" not in repr(validation)
+    assert "maintenance" not in repr(validation)
 
 
 def test_app_maps_reject_hash_mismatched_payload() -> None:
@@ -402,12 +501,12 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
         "available_map_count": 1,
         "created_map_count": 1,
         "object_count": 1,
-            "object_error": None,
-            "objects": [
-                {
-                    "extension": "bin",
-                    "url_present": False,
-                }
+        "object_error": None,
+        "objects": [
+            {
+                "extension": "bin",
+                "url_present": False,
+            }
         ],
         "maps": [
             {
@@ -436,6 +535,14 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
                         "item_types": ["number"],
                     }
                 ],
+                "point_record_validation": {
+                    "total_count": 1,
+                    "exact_shape_count": 0,
+                    "parser_accepted_count": 0,
+                    "identified_count": 0,
+                    "rejection_reason_counts": [{"reason": "not_object", "count": 1}],
+                    "value_type_shapes": [],
+                },
                 "trajectory_count": 1,
                 "trajectory_point_count": 3,
                 "trajectory_length_m": 1.41,

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -164,7 +164,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
         device=device,
     )
 
-    assert payload["diagnostic_schema_version"] == 7
+    assert payload["diagnostic_schema_version"] == 8
     assert payload["entry"]["username"] == "**REDACTED**"
     assert payload["entry"]["password"] == "**REDACTED**"
     assert payload["entry"]["token"] == "**REDACTED**"
@@ -272,7 +272,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
     }
     assert payload["state_reconciliation"]["warnings"] == []
     assert payload["triage"] == {
-        "schema_version": 7,
+        "schema_version": 8,
         "known_model": True,
         "model": "dreame.mower.g2408",
         "display_model": "A2",
@@ -512,7 +512,7 @@ def test_build_debug_payload_highlights_state_disagreements() -> None:
         "raw_mower_state_looks_docked_but_raw_docked_false",
         "raw_mower_state_differs_from_state_name",
     ]
-    assert payload["triage"]["schema_version"] == 7
+    assert payload["triage"]["schema_version"] == 8
     assert payload["triage"]["error"] == {
         "active": True,
         "code": 73,

--- a/tests/test_diagnostics_download.py
+++ b/tests/test_diagnostics_download.py
@@ -166,7 +166,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
     )
 
-    assert payload["diagnostic_schema_version"] == 7
+    assert payload["diagnostic_schema_version"] == 8
     assert payload["report_context"]["integration_version"] == "0.3.0"
     assert payload["report_context"]["home_assistant"]["arch"] == "aarch64"
     assert "user" not in payload["report_context"]["home_assistant"]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -195,31 +195,63 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
                                 "BackGarden",
                                 True,
                             ],
-                                "point_entry_shapes": [
+                            "point_record_validation": {
+                                "total_count": 1,
+                                "exact_shape_count": 1,
+                                "parser_accepted_count": 1,
+                                "identified_count": 1,
+                                "rejection_reason_counts": [
                                     {
-                                        "kind": "object",
+                                        "reason": "type_not_integer",
                                         "count": 1,
-                                        "keys": [
-                                            "id",
-                                            "param",
-                                            "point",
-                                            "time",
-                                            "type",
+                                    },
+                                    {
+                                        "reason": "BackGarden",
+                                        "count": 1,
+                                    },
+                                ],
+                                "value_type_shapes": [
+                                    {
+                                        "count": 1,
+                                        "id_type": "number",
+                                        "param_type": "number",
+                                        "point_type": "array",
+                                        "time_type": "number",
+                                        "type_type": "number",
+                                        "point_length": 2,
+                                        "point_item_types": [
+                                            "number",
+                                            "BackGarden",
                                         ],
+                                        "raw_id": 301,
                                     }
                                 ],
                             },
-                            "payload": {
-                                "point": [
-                                    {
-                                        "id": 301,
-                                        "param": 0,
-                                        "point": [5910, 12400],
-                                        "time": 0,
-                                        "type": 1,
-                                    }
-                                ]
-                            },
+                            "point_entry_shapes": [
+                                {
+                                    "kind": "object",
+                                    "count": 1,
+                                    "keys": [
+                                        "id",
+                                        "param",
+                                        "point",
+                                        "time",
+                                        "type",
+                                    ],
+                                }
+                            ],
+                        },
+                        "payload": {
+                            "point": [
+                                {
+                                    "id": 301,
+                                    "param": 0,
+                                    "point": [5910, 12400],
+                                    "time": 0,
+                                    "type": 1,
+                                }
+                            ]
+                        },
                     }
                 ],
             },
@@ -251,13 +283,37 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
                 "point_count": 1,
                 "maintenance_point_ids": [301],
                 "point_type_codes": [1],
-                    "point_entry_shapes": [
+                "point_record_validation": {
+                    "total_count": 1,
+                    "exact_shape_count": 1,
+                    "parser_accepted_count": 1,
+                    "identified_count": 1,
+                    "rejection_reason_counts": [
                         {
-                            "kind": "object",
+                            "reason": "type_not_integer",
                             "count": 1,
-                            "keys": ["id", "param", "point", "time", "type"],
                         }
                     ],
+                    "value_type_shapes": [
+                        {
+                            "count": 1,
+                            "id_type": "number",
+                            "param_type": "number",
+                            "point_type": "array",
+                            "time_type": "number",
+                            "type_type": "number",
+                            "point_length": 2,
+                            "point_item_types": ["number"],
+                        }
+                    ],
+                },
+                "point_entry_shapes": [
+                    {
+                        "kind": "object",
+                        "count": 1,
+                        "keys": ["id", "param", "point", "time", "type"],
+                    }
+                ],
             }
         ],
         "vector_maps": [
@@ -270,6 +326,7 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
     }
     assert "5910" not in repr(diagnostics)
     assert "12400" not in repr(diagnostics)
+    assert "BackGarden" not in repr(diagnostics)
 
 
 def test_map_probe_uses_probed_current_map_over_stale_coordinator_selection() -> None:


### PR DESCRIPTION
## Summary

- add privacy-safe maintenance-point record diagnostics that show why app-map records were rejected and what JSON value shapes were received
- keep maintenance-point parsing and mower movement behavior unchanged
- move record classification into a focused module and bump the diagnostic schema to 8

The new diagnostics expose only fixed reason names, JSON type names, counts, and coordinate-container shape. Raw point IDs, coordinates, map names, payload values, and arbitrary vendor strings remain excluded.

## Validation

- Ruff
- full CI-equivalent pytest suite
- focused diagnostic privacy and classification tests
- independent read-only review with no actionable findings

Relates to #79.