### PR TITLE
Support three-value A2 maintenance points

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance_point_records.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance_point_records.py
@@ -9,6 +9,7 @@ from typing import Any
 from .client_shared_helpers import _operation_value_type
 
 _REQUIRED_KEYS = frozenset({"id", "param", "point", "time", "type"})
+_SUPPORTED_POINT_VECTOR_LENGTHS = frozenset({2, 3})
 
 
 def app_map_maintenance_point_ids(entries: Sequence[Any]) -> list[int]:
@@ -113,18 +114,14 @@ def app_map_point_record_diagnostics(
 
 
 def is_app_map_maintenance_point_record(value: object) -> bool:
-    """Recognize only the exact point-record structure observed on an A2 3000."""
+    """Recognize exact A2-family point records without interpreting geometry."""
     if not isinstance(value, Mapping) or set(value) != _REQUIRED_KEYS:
         return False
     point_type = value.get("type")
     if not isinstance(point_type, int) or isinstance(point_type, bool):
         return False
     coordinates = value.get("point")
-    if (
-        not isinstance(coordinates, Sequence)
-        or isinstance(coordinates, str | bytes | bytearray)
-        or len(coordinates) != 2
-    ):
+    if not _is_supported_point_vector(coordinates):
         return False
     return all(
         isinstance(coordinate, int | float)
@@ -150,11 +147,7 @@ def _maintenance_point_rejection_reasons(value: object) -> list[str]:
         reasons.append("type_not_integer")
 
     coordinates = value.get("point")
-    if (
-        not isinstance(coordinates, Sequence)
-        or isinstance(coordinates, str | bytes | bytearray)
-        or len(coordinates) != 2
-    ):
+    if not _is_supported_point_vector(coordinates):
         reasons.append("point_not_coordinate_pair")
     elif not all(
         isinstance(coordinate, int | float)
@@ -164,6 +157,15 @@ def _maintenance_point_rejection_reasons(value: object) -> list[str]:
     ):
         reasons.append("point_coordinates_not_finite_numbers")
     return reasons
+
+
+def _is_supported_point_vector(value: object) -> bool:
+    """Accept observed XY and opaque three-value mower point vectors."""
+    return (
+        isinstance(value, Sequence)
+        and not isinstance(value, str | bytes | bytearray)
+        and len(value) in _SUPPORTED_POINT_VECTOR_LENGTHS
+    )
 
 
 def _maintenance_point_value_shape(value: Mapping[str, Any]) -> tuple[Any, ...]:

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -362,6 +362,80 @@ def test_app_maps_explain_rejected_point_values_without_exposing_them() -> None:
     assert "maintenance" not in repr(validation)
 
 
+def test_app_maps_accept_three_value_maintenance_point_vectors() -> None:
+    client = _client()
+    cloud = _FakeAppMapCloud(
+        {
+            "point": [
+                {
+                    "id": 501,
+                    "param": {},
+                    "point": [5910, 12400, 270],
+                    "time": 1,
+                    "type": 9,
+                },
+                {
+                    "id": 502,
+                    "param": {},
+                    "point": [7100, 8300, 90],
+                    "time": 2,
+                    "type": 9,
+                },
+                {
+                    "id": 503,
+                    "param": {},
+                    "point": [1, 2, 3, 4],
+                    "time": 3,
+                    "type": 9,
+                },
+            ]
+        }
+    )
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    result = client._sync_get_app_maps(include_payload=False)
+
+    summary = result["maps"][0]["summary"]
+    assert summary["maintenance_point_ids"] == [501, 502]
+    assert summary["point_type_codes"] == [9]
+    assert summary["point_record_validation"] == {
+        "total_count": 3,
+        "exact_shape_count": 3,
+        "parser_accepted_count": 2,
+        "identified_count": 2,
+        "rejection_reason_counts": [
+            {"reason": "point_not_coordinate_pair", "count": 1},
+        ],
+        "value_type_shapes": [
+            {
+                "count": 2,
+                "id_type": "number",
+                "param_type": "object",
+                "point_type": "array",
+                "time_type": "number",
+                "type_type": "number",
+                "point_length": 3,
+                "point_item_types": ["number"],
+            },
+            {
+                "count": 1,
+                "id_type": "number",
+                "param_type": "object",
+                "point_type": "array",
+                "time_type": "number",
+                "type_type": "number",
+                "point_length": 4,
+                "point_item_types": ["number"],
+            },
+        ],
+    }
+    validation = repr(summary["point_record_validation"])
+    assert "5910" not in validation
+    assert "12400" not in validation
+    assert "7100" not in validation
+    assert "8300" not in validation
+
+
 def test_app_maps_reject_hash_mismatched_payload() -> None:
     client = _client()
     payload = {"map": [{"area": 1, "data": [[1, 2], [3, 4], [5, 6]]}]}


### PR DESCRIPTION
## Summary

- recognize the two-number and three-number maintenance-point vectors now evidenced across A2-family app maps
- keep strict record keys, positive numeric IDs, integer vendor types, and finite numeric vector values
- continue exposing and dispatching only the configured point ID; map coordinates and the third opaque value are neither interpreted nor sent
- retain vector-map precedence and the existing fresh-map/state safety gates before physical movement

This should make the maintenance-point select and button available for the two records captured in the latest issue #79 schema-8 diagnostics. Unsupported vector lengths remain rejected.

## Validation

Ruff and the CI-equivalent test suite pass (`1083` passed, `1` skipped). A focused independent safety review found no actionable issues.

Physical movement on the reporter's A2 still requires confirmation after release.

Relates to #79.