### PR TITLE
Allow maintenance movement from inactive paused state

### DIFF
--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -20,7 +20,7 @@ from .coordinator import DreameLawnMowerCoordinator
 from .debug import build_debug_payload, sanitize_debug_data
 from .dreame_lawn_mower_client.maintenance import MAINTENANCE_ITEMS, MaintenanceItem
 from .entity import DreameLawnMowerEntity
-from .manual_control import remote_control_block_reason
+from .manual_control import maintenance_point_movement_block_reason
 from .reporting import build_maintenance_point_diagnostics
 from .task_status_probe import TASK_STATUS_PROBE_KEYS, task_status_probe_payload
 
@@ -107,17 +107,22 @@ class DreameLawnMowerGoToMaintenancePointButton(
 
     def _movement_block_reason(self) -> str | None:
         """Return why maintenance-point movement is unsafe right now."""
-        snapshot = self.coordinator.data
-        block_reason = remote_control_block_reason(snapshot)
-        if block_reason is not None:
-            return block_reason
-        activity = str(getattr(snapshot, "activity", "") or "").casefold()
-        if activity not in {"idle", "docked"}:
-            return (
-                "The mower must be idle or docked before going to a "
+        return maintenance_point_movement_block_reason(self.coordinator.data)
+
+    async def _async_refresh_movement_state(self) -> None:
+        """Require a successful fresh snapshot before physical movement."""
+        try:
+            await self.coordinator.async_refresh()
+        except Exception as err:
+            raise ValueError(
+                "Fresh mower state is required before moving to a "
+                "maintenance point."
+            ) from err
+        if not self.coordinator.last_update_success:
+            raise ValueError(
+                "Fresh mower state is required before moving to a "
                 "maintenance point."
             )
-        return None
 
     @property
     def available(self) -> bool:
@@ -128,7 +133,7 @@ class DreameLawnMowerGoToMaintenancePointButton(
 
     async def async_press(self) -> None:
         """Drive to the selected mower-configured maintenance point."""
-        await self.coordinator.async_request_refresh()
+        await self._async_refresh_movement_state()
         block_reason = self._movement_block_reason()
         if block_reason is not None:
             raise ValueError(block_reason)
@@ -155,7 +160,7 @@ class DreameLawnMowerGoToMaintenancePointButton(
             raise ValueError(
                 "No maintenance point is configured on the selected mower map."
             )
-        await self.coordinator.async_request_refresh()
+        await self._async_refresh_movement_state()
         block_reason = self._movement_block_reason()
         if block_reason is not None:
             raise ValueError(block_reason)

--- a/custom_components/dreame_lawn_mower/manual_control.py
+++ b/custom_components/dreame_lawn_mower/manual_control.py
@@ -6,5 +6,32 @@ from .dreame_lawn_mower_client.models import (
     remote_control_block_reason,
     remote_control_state_safe,
 )
+from .dreame_lawn_mower_client.runtime_state import snapshot_session_control_state
 
-__all__ = ["remote_control_block_reason", "remote_control_state_safe"]
+__all__ = [
+    "maintenance_point_movement_block_reason",
+    "remote_control_block_reason",
+    "remote_control_state_safe",
+]
+
+
+def maintenance_point_movement_block_reason(snapshot: object) -> str | None:
+    """Return why configured maintenance-point movement is unsafe."""
+    if snapshot is not None and not getattr(snapshot, "available", True):
+        return "Mower is not available."
+
+    block_reason = remote_control_block_reason(snapshot)
+    if block_reason is not None:
+        return block_reason
+
+    session_active = getattr(snapshot, "mowing_session_active", None)
+    control_state = (
+        snapshot_session_control_state(snapshot)
+        if session_active is not None
+        else str(getattr(snapshot, "activity", "") or "").casefold()
+    )
+    if control_state not in {"idle", "docked"}:
+        return (
+            "The mower must be idle or docked before going to a maintenance point."
+        )
+    return None

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -6,6 +6,7 @@ from collections.abc import Callable, Iterable, Mapping, Sequence
 from typing import Any
 
 from .debug import sanitize_debug_data, sanitize_diagnostic_text
+from .manual_control import maintenance_point_movement_block_reason
 
 _SYSTEM_INFO_KEYS = (
     "installation_type",
@@ -165,14 +166,30 @@ def build_maintenance_point_diagnostics(
     )
     mismatch = bool(current_app_point_count) and not current_vector_point_ids
     control_point_ids = current_vector_point_ids or current_app_point_ids
+    selected_point_id = _positive_int(
+        getattr(coordinator, "selected_maintenance_point_id", None)
+    )
+    selected_point_ready = (
+        bool(control_point_ids)
+        and (selected_point_id is None or selected_point_id in control_point_ids)
+    )
+    button_block_reason = (
+        None
+        if selected_point_ready
+        else "No maintenance point is configured on the selected mower map."
+    )
+    if button_block_reason is None:
+        button_block_reason = maintenance_point_movement_block_reason(
+            getattr(coordinator, "data", None)
+        )
 
     result = {
         "source": source,
         "current_map_index": current_map_index,
-        "selected_point_id": _positive_int(
-            getattr(coordinator, "selected_maintenance_point_id", None)
-        ),
+        "selected_point_id": selected_point_id,
         "control_ready": bool(control_point_ids),
+        "button_ready": button_block_reason is None,
+        "button_block_reason": button_block_reason,
         "control_point_source": (
             "vector_map"
             if current_vector_point_ids

--- a/tests/test_maintenance_point_controls.py
+++ b/tests/test_maintenance_point_controls.py
@@ -20,12 +20,15 @@ def _coordinator(*, activity: str = "idle") -> SimpleNamespace:
     return SimpleNamespace(
         data=SimpleNamespace(
             activity=activity,
+            available=True,
             battery_level=80,
             docked=activity == "docked",
+            mowing_session_active=None,
             mowing=activity == "mowing",
             raw_attributes={},
             returning=False,
             state="charging" if activity == "docked" else "idle",
+            task_status=None,
         ),
         app_maps={"current_map_index": 0, "maps": [{"idx": 0, "current": True}]},
         batch_device_data={},
@@ -50,6 +53,8 @@ def _coordinator(*, activity: str = "idle") -> SimpleNamespace:
         selected_maintenance_point_id=None,
         client=SimpleNamespace(async_go_to_maintenance_point=AsyncMock()),
         async_update_listeners=Mock(),
+        last_update_success=True,
+        async_refresh=AsyncMock(),
         async_request_refresh=AsyncMock(),
         app_maps_refreshed_at=None,
         vector_map_details_refreshed_at=None,
@@ -175,7 +180,8 @@ def test_go_to_maintenance_point_uses_selected_configured_id() -> None:
     asyncio.run(entity.async_press())
 
     coordinator.client.async_go_to_maintenance_point.assert_awaited_once_with(302)
-    assert coordinator.async_request_refresh.await_count == 3
+    assert coordinator.async_refresh.await_count == 2
+    coordinator.async_request_refresh.assert_awaited_once()
 
 
 def test_go_to_maintenance_point_uses_fresh_a2_app_map_id() -> None:
@@ -190,7 +196,109 @@ def test_go_to_maintenance_point_uses_fresh_a2_app_map_id() -> None:
     asyncio.run(entity.async_press())
 
     coordinator.client.async_go_to_maintenance_point.assert_awaited_once_with(402)
-    assert coordinator.async_request_refresh.await_count == 3
+    assert coordinator.async_refresh.await_count == 2
+    coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_go_to_maintenance_point_allows_reporter_inactive_paused_state() -> None:
+    coordinator = _a2_app_map_coordinator(activity="paused")
+    coordinator.data.state = "paused"
+    coordinator.data.task_status = "idle"
+    coordinator.data.mowing_session_active = False
+    _complete_fresh_map_refresh(coordinator)
+    coordinator.selected_maintenance_point_id = 402
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    assert entity.available is True
+
+    asyncio.run(entity.async_press())
+
+    coordinator.client.async_go_to_maintenance_point.assert_awaited_once_with(402)
+    assert coordinator.async_refresh.await_count == 2
+
+
+def test_go_to_maintenance_point_blocks_active_paused_session() -> None:
+    coordinator = _a2_app_map_coordinator(activity="paused")
+    coordinator.data.state = "paused"
+    coordinator.data.task_status = "paused"
+    coordinator.data.mowing_session_active = True
+    _complete_fresh_map_refresh(coordinator)
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    assert entity.available is False
+    with pytest.raises(ValueError, match="must be idle or docked"):
+        asyncio.run(entity.async_press())
+
+    coordinator.async_refresh_app_maps.assert_not_awaited()
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
+
+
+def test_go_to_maintenance_point_blocks_paused_state_without_session_evidence() -> None:
+    coordinator = _a2_app_map_coordinator(activity="paused")
+    coordinator.data.state = "paused"
+    coordinator.data.mowing_session_active = None
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    assert entity.available is False
+    with pytest.raises(ValueError, match="must be idle or docked"):
+        asyncio.run(entity.async_press())
+
+    coordinator.async_refresh_app_maps.assert_not_awaited()
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
+
+
+def test_go_to_maintenance_point_blocks_unavailable_snapshot() -> None:
+    coordinator = _a2_app_map_coordinator(activity="idle")
+    coordinator.data.available = False
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    assert entity.available is False
+    with pytest.raises(ValueError, match="not available"):
+        asyncio.run(entity.async_press())
+
+    coordinator.async_refresh_app_maps.assert_not_awaited()
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
+
+
+def test_go_to_maintenance_point_blocks_failed_initial_state_refresh() -> None:
+    coordinator = _a2_app_map_coordinator(activity="idle")
+    coordinator.last_update_success = False
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    with pytest.raises(ValueError, match="Fresh mower state"):
+        asyncio.run(entity.async_press())
+
+    coordinator.async_refresh.assert_awaited_once()
+    coordinator.async_refresh_app_maps.assert_not_awaited()
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
+
+
+def test_go_to_maintenance_point_blocks_failed_final_state_refresh() -> None:
+    coordinator = _a2_app_map_coordinator(activity="idle")
+    _complete_fresh_map_refresh(coordinator)
+    refresh_count = 0
+
+    async def refresh_state() -> None:
+        nonlocal refresh_count
+        refresh_count += 1
+        coordinator.last_update_success = refresh_count == 1
+
+    coordinator.async_refresh.side_effect = refresh_state
+    entity = object.__new__(DreameLawnMowerGoToMaintenancePointButton)
+    entity.coordinator = coordinator
+
+    with pytest.raises(ValueError, match="Fresh mower state"):
+        asyncio.run(entity.async_press())
+
+    assert coordinator.async_refresh.await_count == 2
+    coordinator.async_refresh_app_maps.assert_awaited_once()
+    coordinator.async_refresh_vector_map_details.assert_awaited_once()
+    coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
 
 
 @pytest.mark.parametrize(
@@ -238,7 +346,7 @@ def test_go_to_maintenance_point_revalidates_safety_after_map_refresh() -> None:
     with pytest.raises(ValueError, match="battery is low"):
         asyncio.run(entity.async_press())
 
-    assert coordinator.async_request_refresh.await_count == 2
+    assert coordinator.async_refresh.await_count == 2
     coordinator.client.async_go_to_maintenance_point.assert_not_awaited()
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -113,6 +113,10 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
             "current_map_index": None,
             "selected_point_id": None,
             "control_ready": False,
+            "button_ready": False,
+            "button_block_reason": (
+                "No maintenance point is configured on the selected mower map."
+            ),
             "control_point_source": None,
             "app_points_without_vector_ids": False,
             "app_maps": [],
@@ -179,6 +183,18 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
         SimpleNamespace(
             selected_map_index=0,
             selected_maintenance_point_id=None,
+            data=SimpleNamespace(
+                activity="paused",
+                available=True,
+                battery_level=94,
+                docked=False,
+                mowing=False,
+                mowing_session_active=False,
+                raw_attributes={},
+                returning=False,
+                state="paused",
+                task_status="idle",
+            ),
             app_maps={
                 "current_map_index": 0,
                 "maps": [
@@ -272,6 +288,8 @@ def test_maintenance_point_diagnostics_explain_app_vector_mismatch_privately() -
         "current_map_index": 0,
         "selected_point_id": None,
         "control_ready": True,
+        "button_ready": True,
+        "button_block_reason": None,
         "control_point_source": "app_map",
         "app_points_without_vector_ids": True,
         "app_maps": [


### PR DESCRIPTION
## Summary

- make the maintenance-point button use authoritative realtime session evidence, so an A2 whose raw state remains paused but whose heartbeat confirms no active mowing session can move to a configured point
- keep active or unconfirmed paused sessions blocked, and require successful fresh mower-state reads both before and after map metadata refreshes
- add privacy-safe button readiness and block-reason fields to maintenance-point diagnostics

The point ID remains mower-configured and ID-only. Existing mapping, low-battery, error, mowing, returning, unavailable-state, point-selection, and fresh app/vector map gates remain fail-closed.

## Validation

- complete test suite: 1,089 passed, 1 skipped
- Ruff checks and staged diff checks passed
- independent movement-safety review completed; its stale-refresh P1 was fixed and targeted confirmation found no remaining P0-P2 issues

Physical movement still requires reporter confirmation after release.

Related to #79.