### PR TITLE
Recover schedules and metadata after slow cloud reads

### DIFF
--- a/custom_components/dreame_lawn_mower/calendar.py
+++ b/custom_components/dreame_lawn_mower/calendar.py
@@ -276,11 +276,16 @@ def schedule_calendar_attributes(
 
 def _active_schedule_version(payload: Mapping[str, Any]) -> int | None:
     current_task = payload.get("current_task")
-    if not isinstance(current_task, Mapping):
-        return None
+    if isinstance(current_task, Mapping):
+        try:
+            return int(current_task["version"])
+        except (KeyError, TypeError, ValueError):
+            pass
+
+    active_version = payload.get("active_schedule_version")
     try:
-        return int(current_task["version"])
-    except (KeyError, TypeError, ValueError):
+        return int(active_version) if active_version is not None else None
+    except (TypeError, ValueError):
         return None
 
 

--- a/custom_components/dreame_lawn_mower/calendar.py
+++ b/custom_components/dreame_lawn_mower/calendar.py
@@ -189,12 +189,15 @@ def schedule_calendar_events(
     active_version = (
         None if include_all_schedules else _active_schedule_version(payload)
     )
+    active_index = None if include_all_schedules else _active_schedule_index(payload)
     for day in _candidate_days(local_start.date(), local_end.date()):
         week_day = _schedule_week_day(day)
         for schedule in payload.get("schedules") or []:
             if not isinstance(schedule, Mapping):
                 continue
             if active_version is not None and schedule.get("version") != active_version:
+                continue
+            if active_index is not None and schedule.get("idx") != active_index:
                 continue
             map_index = schedule.get("idx")
             map_label = _schedule_label(schedule)
@@ -236,6 +239,7 @@ def schedule_calendar_selection(
     active_version = (
         None if include_all_schedules else _active_schedule_version(payload)
     )
+    active_index = None if include_all_schedules else _active_schedule_index(payload)
     active_selection_available = (
         include_all_schedules
         or payload.get("active_selection_available") is not False
@@ -247,6 +251,8 @@ def schedule_calendar_selection(
         target = included_schedules
         if not active_selection_available or (
             active_version is not None and schedule.get("version") != active_version
+        ) or (
+            active_index is not None and schedule.get("idx") != active_index
         ):
             target = hidden_schedules
         target.append(_schedule_selection_entry(schedule))
@@ -263,6 +269,8 @@ def schedule_calendar_selection(
         "included_schedules": included_schedules,
         "hidden_schedules": hidden_schedules,
     }
+    if active_index is not None:
+        selection["active_index"] = active_index
     if not active_selection_available:
         selection["active_selection_available"] = False
     current_task = payload.get("current_task")
@@ -301,6 +309,15 @@ def _active_schedule_version(payload: Mapping[str, Any]) -> int | None:
         return int(active_version) if active_version is not None else None
     except (TypeError, ValueError):
         return None
+
+
+def _active_schedule_index(payload: Mapping[str, Any]) -> int | None:
+    active_index = payload.get("active_schedule_index")
+    return (
+        active_index
+        if isinstance(active_index, int) and not isinstance(active_index, bool)
+        else None
+    )
 
 
 def _schedule_selection_entry(schedule: Mapping[str, Any]) -> dict[str, Any]:

--- a/custom_components/dreame_lawn_mower/calendar.py
+++ b/custom_components/dreame_lawn_mower/calendar.py
@@ -190,6 +190,9 @@ def schedule_calendar_events(
         None if include_all_schedules else _active_schedule_version(payload)
     )
     active_index = None if include_all_schedules else _active_schedule_index(payload)
+    filter_active_index = (
+        not include_all_schedules and "active_schedule_index" in payload
+    )
     for day in _candidate_days(local_start.date(), local_end.date()):
         week_day = _schedule_week_day(day)
         for schedule in payload.get("schedules") or []:
@@ -197,7 +200,7 @@ def schedule_calendar_events(
                 continue
             if active_version is not None and schedule.get("version") != active_version:
                 continue
-            if active_index is not None and schedule.get("idx") != active_index:
+            if filter_active_index and schedule.get("idx") != active_index:
                 continue
             map_index = schedule.get("idx")
             map_label = _schedule_label(schedule)
@@ -240,6 +243,9 @@ def schedule_calendar_selection(
         None if include_all_schedules else _active_schedule_version(payload)
     )
     active_index = None if include_all_schedules else _active_schedule_index(payload)
+    filter_active_index = (
+        not include_all_schedules and "active_schedule_index" in payload
+    )
     active_selection_available = (
         include_all_schedules
         or payload.get("active_selection_available") is not False
@@ -252,7 +258,7 @@ def schedule_calendar_selection(
         if not active_selection_available or (
             active_version is not None and schedule.get("version") != active_version
         ) or (
-            active_index is not None and schedule.get("idx") != active_index
+            filter_active_index and schedule.get("idx") != active_index
         ):
             target = hidden_schedules
         target.append(_schedule_selection_entry(schedule))

--- a/custom_components/dreame_lawn_mower/calendar.py
+++ b/custom_components/dreame_lawn_mower/calendar.py
@@ -181,6 +181,11 @@ def schedule_calendar_events(
         return []
 
     events: list[CalendarEvent] = []
+    if (
+        not include_all_schedules
+        and payload.get("active_selection_available") is False
+    ):
+        return events
     active_version = (
         None if include_all_schedules else _active_schedule_version(payload)
     )
@@ -231,12 +236,18 @@ def schedule_calendar_selection(
     active_version = (
         None if include_all_schedules else _active_schedule_version(payload)
     )
+    active_selection_available = (
+        include_all_schedules
+        or payload.get("active_selection_available") is not False
+    )
     included_schedules: list[dict[str, Any]] = []
     hidden_schedules: list[dict[str, Any]] = []
 
     for schedule in schedules:
         target = included_schedules
-        if active_version is not None and schedule.get("version") != active_version:
+        if not active_selection_available or (
+            active_version is not None and schedule.get("version") != active_version
+        ):
             target = hidden_schedules
         target.append(_schedule_selection_entry(schedule))
 
@@ -244,13 +255,16 @@ def schedule_calendar_selection(
         "mode": "all_schedules" if include_all_schedules else "active_schedule",
         "active_version": active_version,
         "active_version_filter_applied": bool(
-            active_version is not None and not include_all_schedules
+            (active_version is not None or not active_selection_available)
+            and not include_all_schedules
         ),
         "included_schedule_count": len(included_schedules),
         "hidden_schedule_count": len(hidden_schedules),
         "included_schedules": included_schedules,
         "hidden_schedules": hidden_schedules,
     }
+    if not active_selection_available:
+        selection["active_selection_available"] = False
     current_task = payload.get("current_task")
     if isinstance(current_task, Mapping):
         selection["current_task"] = dict(current_task)

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -42,6 +42,7 @@ from .dreame_lawn_mower_client.map_visuals import (
     map_render_style,
 )
 from .dreame_lawn_mower_client.models import DreameLawnMowerMapView
+from .ha_tasks import create_background_task
 from .image import (
     app_maps_contact_sheet_jpeg,
     map_diagnostics_jpeg,
@@ -246,7 +247,11 @@ class DreameLawnMowerMapCamera(
         task = self._map_refresh_task
         if task is not None and not task.done():
             return task
-        task = self.hass.async_create_task(self._async_refresh_and_render_map_image())
+        task = create_background_task(
+            self.hass,
+            self._async_refresh_and_render_map_image(),
+            "dreame-lawn-mower-map-render",
+        )
         self._map_refresh_task = task
         task.add_done_callback(self._map_refresh_finished)
         return task

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -574,6 +574,9 @@ class DreameLawnMowerCoordinator(
             payload,
             captured_at=now,
             allow_unknown_slot=allow_incomplete,
+            allowed_hint_indices=(
+                [] if allow_incomplete else [-1, *known_map_indices]
+            ),
             preserve_indices=preserve_indices,
         )
         if normalized is None:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1518,6 +1518,14 @@ class DreameLawnMowerCoordinator(
         previous_map_indices = set(
             _app_map_index_hints(getattr(self, "app_maps", None))
         )
+        previous_map_hints_authoritative = _app_map_hints_are_authoritative(
+            getattr(self, "app_maps", None),
+            refresh_succeeded=getattr(
+                self,
+                "app_maps_refresh_succeeded",
+                False,
+            ),
+        )
         try:
             app_maps = await self.client.async_get_app_maps(
                 include_payload=True,
@@ -1543,7 +1551,10 @@ class DreameLawnMowerCoordinator(
         )
         if (
             map_hints_authoritative
-            and known_map_indices != previous_map_indices
+            and (
+                not previous_map_hints_authoritative
+                or known_map_indices != previous_map_indices
+            )
         ):
             self._invalidate_schedule_map_hint()
         if current_idx is not None:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1528,6 +1528,8 @@ class DreameLawnMowerCoordinator(
         self.app_maps_refresh_succeeded = True
         current_idx = active_map_index(payload)
         if current_idx is not None:
+            if self.selected_map_index != current_idx:
+                self._invalidate_schedule_map_hint()
             if (
                 self.selected_map_index is not None
                 and self.selected_map_index != current_idx
@@ -1638,6 +1640,8 @@ class DreameLawnMowerCoordinator(
     async def async_switch_current_map(self, map_index: int) -> None:
         """Switch the active mower map and refresh all map-scoped state."""
         await self.client.async_switch_current_map(map_index)
+        if self.selected_map_index != map_index:
+            self._invalidate_schedule_map_hint()
         self.selected_map_index = map_index
         self.selected_contour_id = None
         self.selected_zone_id = None
@@ -1653,6 +1657,12 @@ class DreameLawnMowerCoordinator(
             source="vector_map_switch_current_map",
         )
         self.async_update_listeners()
+
+    def _invalidate_schedule_map_hint(self) -> None:
+        """Expire schedule selection tied to the previous active map."""
+        self.schedules_refreshed_at = None
+        if isinstance(getattr(self, "schedules", None), dict):
+            self.schedules["active_selection_available"] = False
 
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -546,7 +546,8 @@ class DreameLawnMowerCoordinator(
             )
             latest_map_index_hint = self._schedule_map_index_hint()
             if latest_map_index_hint != map_index_hint:
-                batch_payload = _batch_schedule_without_map_hint(batch_payload)
+                self._invalidate_schedule_map_hint()
+                batch_payload = _discard_stale_batch_schedule(batch_payload)
             latest_expected_indices = _schedule_expected_indices(
                 self.schedules,
                 payload,
@@ -1315,7 +1316,8 @@ class DreameLawnMowerCoordinator(
                 self.client.async_get_batch_ota_info(include_raw=False),
             )
             if self._schedule_map_index_hint() != map_index_hint:
-                schedule = _batch_schedule_without_map_hint(schedule)
+                self._invalidate_schedule_map_hint()
+                schedule = _discard_stale_batch_schedule(schedule)
             return schedule, preferences, ota, schedule_generation
 
         batch_mowing_preferences, batch_ota_info = await asyncio.gather(
@@ -1511,7 +1513,6 @@ class DreameLawnMowerCoordinator(
             and self.app_maps_refreshed_at is not None
             and now - self.app_maps_refreshed_at < APP_MAP_REFRESH_INTERVAL
         ):
-            self.app_maps_refresh_succeeded = True
             return self.app_maps
 
         try:
@@ -1543,6 +1544,19 @@ class DreameLawnMowerCoordinator(
                 self.selected_zone_id = None
                 self.selected_spot_id = None
             self.selected_map_index = current_idx
+        elif (
+            self.selected_map_index is not None
+            and _app_map_hints_are_authoritative(
+                payload,
+                refresh_succeeded=True,
+            )
+            and not _app_map_index_hints(payload)
+        ):
+            self._invalidate_schedule_map_hint()
+            self.selected_map_index = None
+            self.selected_contour_id = None
+            self.selected_zone_id = None
+            self.selected_spot_id = None
         return payload
 
     async def async_refresh_weather_protection(
@@ -1727,10 +1741,10 @@ def _schedule_expected_indices(
     map_hints_authoritative: bool,
 ) -> list[int]:
     """Return authoritative or conservatively discovered schedule slot ids."""
-    if known_map_indices or map_hints_authoritative:
+    if map_hints_authoritative:
         return [-1, *known_map_indices]
 
-    indices = [-1]
+    indices = [-1, *known_map_indices]
     for payload in (existing, incoming):
         schedules = payload.get("schedules") if isinstance(payload, Mapping) else None
         if not isinstance(schedules, Sequence) or isinstance(
@@ -1780,24 +1794,29 @@ def _schedule_payload_has_active_selection(
     return isinstance(version, int) and not isinstance(version, bool)
 
 
-def _batch_schedule_without_map_hint(
+def _discard_stale_batch_schedule(
     payload: Mapping[str, Any],
 ) -> dict[str, Any]:
-    """Return a batch schedule copy without a stale caller-supplied slot hint."""
+    """Return a non-publishable batch result after its map hint changed."""
     normalized = dict(payload)
-    schedules = payload.get("schedules")
-    if (
-        not isinstance(schedules, Sequence)
-        or isinstance(schedules, str | bytes | bytearray)
-        or len(schedules) != 1
-        or not isinstance(schedules[0], Mapping)
-    ):
-        return normalized
-    schedule = dict(schedules[0])
-    schedule["idx"] = None
-    schedule["label"] = "active_schedule"
-    schedule["writable"] = False
-    normalized["schedules"] = [schedule]
+    normalized["available"] = False
+    normalized["schedules"] = []
+    normalized.pop("active_schedule_version", None)
+    normalized.pop("active_schedule_index", None)
+    normalized.pop("current_task", None)
+    errors = payload.get("errors")
+    normalized["errors"] = [
+        *(
+            errors
+            if isinstance(errors, Sequence)
+            and not isinstance(errors, str | bytes | bytearray)
+            else []
+        ),
+        {
+            "stage": "schedule",
+            "error": "active map changed during batch read",
+        },
+    ]
     return normalized
 
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -139,6 +139,7 @@ class DreameLawnMowerCoordinator(
         ] = {}
         self._pending_schedule_uploads: dict[int, dict[str, Any]] = {}
         self._pending_schedule_upload_contradictions: dict[int, int] = {}
+        self._pending_schedule_upload_active_indices: set[int] = set()
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
@@ -778,6 +779,15 @@ class DreameLawnMowerCoordinator(
         if not pending_states or not isinstance(schedules, Sequence):
             return
         for (map_index, plan_id), (version, enabled) in pending_states.items():
+            matching_numeric_indices = {
+                schedule.get("idx")
+                for schedule in schedules
+                if isinstance(schedule, Mapping)
+                and schedule.get("version") == version
+                and isinstance(schedule.get("idx"), int)
+                and not isinstance(schedule.get("idx"), bool)
+            }
+            unknown_slot_is_unambiguous = matching_numeric_indices == {map_index}
             for schedule in schedules:
                 if not isinstance(schedule, dict) or not (
                     schedule.get("idx") == map_index
@@ -785,6 +795,7 @@ class DreameLawnMowerCoordinator(
                         version is not None
                         and schedule.get("idx") is None
                         and schedule.get("version") == version
+                        and unknown_slot_is_unambiguous
                     )
                 ):
                     continue
@@ -796,6 +807,19 @@ class DreameLawnMowerCoordinator(
                 for plan in plans:
                     if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
                         plan["enabled"] = enabled
+            if (
+                version is not None
+                and not unknown_slot_is_unambiguous
+                and isinstance(self.schedules, dict)
+                and self.schedules.get("active_schedule_index") is None
+                and any(
+                    isinstance(schedule, Mapping)
+                    and schedule.get("idx") is None
+                    and schedule.get("version") == version
+                    for schedule in schedules
+                )
+            ):
+                self.schedules["active_selection_available"] = False
 
     def _remember_pending_schedule_upload(
         self,
@@ -860,6 +884,21 @@ class DreameLawnMowerCoordinator(
             pending_contradictions = {}
             self._pending_schedule_upload_contradictions = pending_contradictions
         pending_contradictions.pop(map_index, None)
+        pending_active_indices = getattr(
+            self,
+            "_pending_schedule_upload_active_indices",
+            None,
+        )
+        if pending_active_indices is None:
+            pending_active_indices = set()
+            self._pending_schedule_upload_active_indices = pending_active_indices
+        if (
+            isinstance(getattr(self, "schedules", None), Mapping)
+            and self.schedules.get("active_schedule_index") == map_index
+        ):
+            pending_active_indices.add(map_index)
+        else:
+            pending_active_indices.discard(map_index)
 
     def _acknowledge_pending_schedule_uploads(
         self,
@@ -878,6 +917,14 @@ class DreameLawnMowerCoordinator(
         if pending_contradictions is None:
             pending_contradictions = {}
             self._pending_schedule_upload_contradictions = pending_contradictions
+        pending_active_indices = getattr(
+            self,
+            "_pending_schedule_upload_active_indices",
+            None,
+        )
+        if pending_active_indices is None:
+            pending_active_indices = set()
+            self._pending_schedule_upload_active_indices = pending_active_indices
 
         for map_index, pending_schedule in tuple(pending_uploads.items()):
             schedule = next(
@@ -899,10 +946,19 @@ class DreameLawnMowerCoordinator(
             ):
                 pending_uploads.pop(map_index, None)
                 pending_contradictions.pop(map_index, None)
+                pending_active_indices.discard(map_index)
                 continue
             if schedule.get("plans") == pending_schedule.get("plans"):
+                if (
+                    map_index in pending_active_indices
+                    and isinstance(self.schedules, dict)
+                ):
+                    self.schedules["active_schedule_version"] = pending_version
+                    self.schedules["active_schedule_index"] = map_index
+                    self.schedules["active_selection_available"] = True
                 pending_uploads.pop(map_index, None)
                 pending_contradictions.pop(map_index, None)
+                pending_active_indices.discard(map_index)
                 continue
             contradictory_reads = pending_contradictions.get(map_index, 0) + 1
             if (
@@ -911,6 +967,7 @@ class DreameLawnMowerCoordinator(
             ):
                 pending_uploads.pop(map_index, None)
                 pending_contradictions.pop(map_index, None)
+                pending_active_indices.discard(map_index)
             else:
                 pending_contradictions[map_index] = contradictory_reads
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -926,9 +926,17 @@ class DreameLawnMowerCoordinator(
                 plans = schedule.get("plans")
                 if not isinstance(plans, Sequence):
                     continue
+                plan_updated = False
                 for plan in plans:
                     if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
                         plan["enabled"] = enabled
+                        plan_updated = True
+                if plan_updated:
+                    schedule["enabled_plan_count"] = sum(
+                        1
+                        for plan in plans
+                        if isinstance(plan, Mapping) and plan.get("enabled")
+                    )
             if (
                 version is not None
                 and not unknown_slot_is_unambiguous

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -47,6 +47,12 @@ from .dreame_lawn_mower_client.models import (
 )
 from .performance import DreameLawnMowerPerformanceTracker
 from .runtime_cache import DreameLawnMowerRuntimeTelemetryCache
+from .schedule_cache import (
+    has_complete_schedule_cache,
+    merge_app_schedule_payload,
+    merge_batch_schedule_payload,
+    schedule_payload_has_usable_data,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -420,15 +426,20 @@ class DreameLawnMowerCoordinator(
             return self.schedules
 
         known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
+        map_index_hint = getattr(self, "selected_map_index", None)
+        if map_index_hint is None:
+            map_index_hint = active_map_index(getattr(self, "app_maps", None))
+        if map_index_hint is None and len(known_map_indices) == 1:
+            map_index_hint = known_map_indices[0]
         if (
             not force
-            and len(known_map_indices) == 1
+            and map_index_hint is not None
             and self._has_complete_schedule_cache(known_map_indices)
         ):
             try:
                 batch_payload = await self.client.async_get_batch_schedules(
                     include_raw=False,
-                    map_index_hint=known_map_indices[0],
+                    map_index_hint=map_index_hint,
                 )
             except Exception as err:  # noqa: BLE001 - optional cloud capability
                 _LOGGER.debug("Failed to refresh batch mower schedules: %s", err)
@@ -437,56 +448,62 @@ class DreameLawnMowerCoordinator(
                     return self.schedules
 
         try:
-            payload = await self.client.async_get_app_schedules()
+            payload = await self.client.async_get_app_schedules(
+                include_current_task=False,
+                map_indices=(
+                    [-1, *known_map_indices] if known_map_indices else None
+                ),
+            )
         except Exception as err:  # noqa: BLE001 - optional cloud capability
             _LOGGER.debug("Failed to refresh mower schedules: %s", err)
             if force:
                 raise
             return self.schedules
-        self.schedules = payload
-        self.schedules_refreshed_at = now
-        return payload
+        action_read_succeeded = schedule_payload_has_usable_data(payload)
+        self.schedules = merge_app_schedule_payload(self.schedules, payload)
+        batch_read_succeeded = False
+        try:
+            batch_payload = await self.client.async_get_batch_schedules(
+                include_raw=False,
+                map_index_hint=map_index_hint,
+            )
+        except Exception as err:  # noqa: BLE001 - optional cloud capability
+            _LOGGER.debug("Failed to recover batch mower schedules: %s", err)
+        else:
+            batch_read_succeeded = self._cache_batch_schedules(
+                batch_payload,
+                now=now,
+                allow_incomplete=True,
+            )
+        if action_read_succeeded or batch_read_succeeded:
+            self.schedules_refreshed_at = now
+        return self.schedules
 
     def _cache_batch_schedules(
         self,
         payload: Mapping[str, Any],
         *,
         now: datetime,
+        allow_incomplete: bool = False,
     ) -> bool:
-        """Merge one fast physical-map read into a complete app schedule cache."""
-        schedules = payload.get("schedules")
-        errors = payload.get("errors")
+        """Merge one fast effective-schedule read into the app schedule cache."""
         known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
         if (
-            len(known_map_indices) != 1
-            or not self._has_complete_schedule_cache(known_map_indices)
-            or not isinstance(schedules, Sequence)
-            or isinstance(schedules, str | bytes | bytearray)
-            or not schedules
-            or errors
-            or any(
-                not isinstance(schedule, Mapping)
-                or schedule.get("idx") != known_map_indices[0]
-                for schedule in schedules
+            not isinstance(self.schedules, Mapping)
+            or (
+                not allow_incomplete
+                and not self._has_complete_schedule_cache(known_map_indices)
             )
         ):
             return False
-        existing_schedules = self.schedules["schedules"]
-        batch_schedule = dict(schedules[0])
-        normalized = dict(self.schedules)
-        normalized["schedules"] = [
-            (
-                batch_schedule
-                if isinstance(schedule, Mapping)
-                and schedule.get("idx") == known_map_indices[0]
-                else schedule
-            )
-            for schedule in existing_schedules
-        ]
-        if "current_task" in payload:
-            normalized["current_task"] = payload["current_task"]
-        normalized["captured_at"] = now.isoformat()
-        normalized["source"] = "app_action_schedule_with_batch_refresh"
+        normalized = merge_batch_schedule_payload(
+            self.schedules,
+            payload,
+            captured_at=now,
+            allow_unknown_slot=allow_incomplete,
+        )
+        if normalized is None:
+            return False
         self.schedules = normalized
         self.schedules_refreshed_at = now
         return True
@@ -496,22 +513,7 @@ class DreameLawnMowerCoordinator(
         known_map_indices: Sequence[int],
     ) -> bool:
         """Return whether default and every known physical map are represented."""
-        schedules = (
-            self.schedules.get("schedules")
-            if isinstance(self.schedules, Mapping)
-            else None
-        )
-        if not isinstance(schedules, Sequence) or isinstance(
-            schedules,
-            str | bytes | bytearray,
-        ):
-            return False
-        cached_indices = {
-            schedule.get("idx")
-            for schedule in schedules
-            if isinstance(schedule, Mapping)
-        }
-        return {-1, *known_map_indices}.issubset(cached_indices)
+        return has_complete_schedule_cache(self.schedules, known_map_indices)
 
     async def async_set_schedule_plan_enabled(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -428,7 +428,16 @@ class DreameLawnMowerCoordinator(
         ):
             return self.schedules
 
-        known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
+        app_maps = getattr(self, "app_maps", None)
+        known_map_indices = _app_map_index_hints(app_maps)
+        map_hints_authoritative = _app_map_hints_are_authoritative(
+            app_maps,
+            refresh_succeeded=getattr(
+                self,
+                "app_maps_refresh_succeeded",
+                False,
+            ),
+        )
         map_index_hint = getattr(self, "selected_map_index", None)
         if map_index_hint is None:
             map_index_hint = active_map_index(getattr(self, "app_maps", None))
@@ -457,7 +466,9 @@ class DreameLawnMowerCoordinator(
             payload = await self.client.async_get_app_schedules(
                 include_current_task=False,
                 map_indices=(
-                    [-1, *known_map_indices] if known_map_indices else None
+                    [-1, *known_map_indices]
+                    if known_map_indices or map_hints_authoritative
+                    else None
                 ),
             )
         except Exception as err:  # noqa: BLE001 - optional cloud capability
@@ -472,6 +483,7 @@ class DreameLawnMowerCoordinator(
             self.schedules,
             payload,
             known_map_indices,
+            map_hints_authoritative=map_hints_authoritative,
         )
         self.schedules = merge_app_schedule_payload(
             self.schedules,
@@ -496,6 +508,16 @@ class DreameLawnMowerCoordinator(
             )
         if not self._schedule_refresh_is_current(refresh_generation):
             return self.schedules
+        if (
+            action_read_succeeded
+            and not batch_read_succeeded
+            and not _schedule_payload_has_active_selection(self.schedules)
+            and isinstance(self.schedules, dict)
+        ):
+            # Without SCHDT or a batch version, the normal calendar cannot
+            # safely choose one slot. Keep the decoded schedules for the
+            # diagnostic all-schedules view without presenting them as active.
+            self.schedules["active_selection_available"] = False
         if action_read_succeeded or batch_read_succeeded:
             self.schedules_refreshed_at = now
         return self.schedules
@@ -568,6 +590,7 @@ class DreameLawnMowerCoordinator(
                 map_index=map_index,
                 plan_id=plan_id,
                 enabled=enabled,
+                schedule_version=_schedule_write_version(result),
             )
             try:
                 await self.async_refresh_schedules(force=True)
@@ -583,6 +606,7 @@ class DreameLawnMowerCoordinator(
         map_index: int,
         plan_id: int,
         enabled: bool,
+        schedule_version: int | None = None,
     ) -> None:
         """Apply a confirmed schedule write to the shared cache."""
         schedules = (
@@ -593,7 +617,14 @@ class DreameLawnMowerCoordinator(
         if not isinstance(schedules, list):
             return
         for schedule in schedules:
-            if not isinstance(schedule, dict) or schedule.get("idx") != map_index:
+            if not isinstance(schedule, dict) or not (
+                schedule.get("idx") == map_index
+                or (
+                    schedule_version is not None
+                    and schedule.get("idx") is None
+                    and schedule.get("version") == schedule_version
+                )
+            ):
                 continue
             plans = schedule.get("plans")
             if not isinstance(plans, list):
@@ -639,6 +670,7 @@ class DreameLawnMowerCoordinator(
             self.schedules = invalidate_schedule_slot(
                 getattr(self, "schedules", None),
                 map_index,
+                schedule_version=_schedule_write_version(result),
             )
             self.schedules_refreshed_at = None
             try:
@@ -1046,13 +1078,30 @@ def _app_map_index_hints(app_maps: Mapping[str, Any] | None) -> list[int]:
     return indices
 
 
+def _app_map_hints_are_authoritative(
+    app_maps: Mapping[str, Any] | None,
+    *,
+    refresh_succeeded: bool,
+) -> bool:
+    """Return whether an empty map list is a confirmed, current result."""
+    if not refresh_succeeded or not isinstance(app_maps, Mapping):
+        return False
+    maps = app_maps.get("maps")
+    return isinstance(maps, Sequence) and not isinstance(
+        maps,
+        str | bytes | bytearray,
+    )
+
+
 def _schedule_expected_indices(
     existing: Mapping[str, Any] | None,
     incoming: Mapping[str, Any],
     known_map_indices: Sequence[int],
+    *,
+    map_hints_authoritative: bool,
 ) -> list[int]:
     """Return authoritative or conservatively discovered schedule slot ids."""
-    if known_map_indices:
+    if known_map_indices or map_hints_authoritative:
         return [-1, *known_map_indices]
 
     indices = [-1]
@@ -1073,3 +1122,28 @@ def _schedule_expected_indices(
             ):
                 indices.append(index)
     return indices
+
+
+def _schedule_payload_has_active_selection(
+    payload: Mapping[str, Any] | None,
+) -> bool:
+    """Return whether the cache identifies the effective schedule version."""
+    if not isinstance(payload, Mapping):
+        return False
+    current_task = payload.get("current_task")
+    if isinstance(current_task, Mapping):
+        version = current_task.get("version")
+        if isinstance(version, int) and not isinstance(version, bool):
+            return True
+    version = payload.get("active_schedule_version")
+    return isinstance(version, int) and not isinstance(version, bool)
+
+
+def _schedule_write_version(result: Mapping[str, Any]) -> int | None:
+    """Return the writable version confirmed by a schedule write."""
+    version = result.get("version")
+    return (
+        version
+        if isinstance(version, int) and not isinstance(version, bool)
+        else None
+    )

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -74,6 +74,7 @@ SCHEDULE_REFRESH_INTERVAL = timedelta(minutes=5)
 FIRMWARE_UPDATE_REFRESH_INTERVAL = timedelta(minutes=15)
 DEVICE_SNAPSHOT_GENERATION_HISTORY = 32
 PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS = 1
+BATCH_SCHEDULE_RESULT_COALESCE_SECONDS = 1.0
 
 
 _runtime_tracking_active = runtime_tracking_active
@@ -140,6 +141,9 @@ class DreameLawnMowerCoordinator(
         self._pending_schedule_uploads: dict[int, dict[str, Any]] = {}
         self._pending_schedule_upload_contradictions: dict[int, int] = {}
         self._pending_schedule_upload_active_indices: set[int] = set()
+        self._batch_schedule_read_task: asyncio.Task[dict[str, Any]] | None = None
+        self._batch_schedule_read_key: tuple[int | None, bool] | None = None
+        self._batch_schedule_read_completed_at: float | None = None
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
@@ -458,11 +462,7 @@ class DreameLawnMowerCoordinator(
                 False,
             ),
         )
-        map_index_hint = getattr(self, "selected_map_index", None)
-        if map_index_hint is None:
-            map_index_hint = active_map_index(getattr(self, "app_maps", None))
-        if map_index_hint is None and len(known_map_indices) == 1:
-            map_index_hint = known_map_indices[0]
+        map_index_hint = self._schedule_map_index_hint()
 
         try:
             action_read_generation = self._begin_schedule_read()
@@ -510,16 +510,9 @@ class DreameLawnMowerCoordinator(
         batch_read_succeeded = False
         try:
             batch_read_generation = self._begin_schedule_read()
-            batch_options: dict[str, Any] = {
-                "include_raw": False,
-                "map_index_hint": map_index_hint,
-            }
-            if map_index_hint is None:
-                # App-map discovery already ran as part of the bounded action
-                # read. Batch decoding can safely retain an unknown slot.
-                batch_options["discover_map_index"] = False
-            batch_payload = await self.client.async_get_batch_schedules(
-                **batch_options
+            batch_payload = await self._async_get_shared_batch_schedules(
+                map_index_hint=map_index_hint,
+                force=force,
             )
         except Exception as err:  # noqa: BLE001 - optional cloud capability
             _LOGGER.debug("Failed to recover batch mower schedules: %s", err)
@@ -692,6 +685,17 @@ class DreameLawnMowerCoordinator(
         )
         if not isinstance(schedules, list):
             return
+        matching_numeric_indices = {
+            schedule.get("idx")
+            for schedule in schedules
+            if isinstance(schedule, Mapping)
+            and schedule.get("version") == schedule_version
+            and isinstance(schedule.get("idx"), int)
+            and not isinstance(schedule.get("idx"), bool)
+        }
+        unknown_slot_is_unambiguous = (
+            not matching_numeric_indices or matching_numeric_indices == {map_index}
+        )
         for schedule in schedules:
             if not isinstance(schedule, dict) or not (
                 schedule.get("idx") == map_index
@@ -699,6 +703,7 @@ class DreameLawnMowerCoordinator(
                     schedule_version is not None
                     and schedule.get("idx") is None
                     and schedule.get("version") == schedule_version
+                    and unknown_slot_is_unambiguous
                 )
             ):
                 continue
@@ -709,6 +714,19 @@ class DreameLawnMowerCoordinator(
                 if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
                     plan["enabled"] = enabled
                     return
+        if (
+            schedule_version is not None
+            and not unknown_slot_is_unambiguous
+            and isinstance(self.schedules, dict)
+            and self.schedules.get("active_schedule_index") is None
+            and any(
+                isinstance(schedule, Mapping)
+                and schedule.get("idx") is None
+                and schedule.get("version") == schedule_version
+                for schedule in schedules
+            )
+        ):
+            self.schedules["active_selection_available"] = False
 
     def _acknowledge_pending_schedule_plan_states(
         self,
@@ -789,7 +807,10 @@ class DreameLawnMowerCoordinator(
                 and isinstance(schedule.get("idx"), int)
                 and not isinstance(schedule.get("idx"), bool)
             }
-            unknown_slot_is_unambiguous = matching_numeric_indices == {map_index}
+            unknown_slot_is_unambiguous = (
+                not matching_numeric_indices
+                or matching_numeric_indices == {map_index}
+            )
             for schedule in schedules:
                 if not isinstance(schedule, dict) or not (
                     schedule.get("idx") == map_index
@@ -1142,7 +1163,7 @@ class DreameLawnMowerCoordinator(
                 batch_mowing_preferences,
                 batch_ota_info,
                 batch_schedule_generation,
-            ) = await self._async_fetch_batch_device_data()
+            ) = await self._async_fetch_batch_device_data(force=force)
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh batch device data: %s", err)
             return self.batch_device_data
@@ -1156,7 +1177,10 @@ class DreameLawnMowerCoordinator(
         }
         self.batch_device_data = payload
         self.batch_device_data_refreshed_at = now
-        if self._schedule_refresh_is_current(schedule_generation):
+        if (
+            batch_schedule is not self.schedules
+            and self._schedule_refresh_is_current(schedule_generation)
+        ):
             self._cache_batch_schedules(
                 batch_schedule,
                 now=now,
@@ -1199,13 +1223,18 @@ class DreameLawnMowerCoordinator(
 
     async def _async_fetch_batch_device_data(
         self,
+        *,
+        force: bool = False,
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], int]:
         """Fetch batch schedule, settings, and OTA payloads in parallel."""
         cached_schedule = self._fresh_batch_schedule()
         if cached_schedule is None:
             schedule_generation = self._begin_schedule_read()
             schedule, preferences, ota = await asyncio.gather(
-                self.client.async_get_batch_schedules(include_raw=False),
+                self._async_get_shared_batch_schedules(
+                    map_index_hint=self._schedule_map_index_hint(),
+                    force=force,
+                ),
                 self.client.async_get_batch_mowing_preferences(
                     include_raw=False,
                     map_index_hints=_app_map_index_hints(self.app_maps),
@@ -1228,12 +1257,72 @@ class DreameLawnMowerCoordinator(
             getattr(self, "_published_schedule_read_generation", 0),
         )
 
+    def _schedule_map_index_hint(self) -> int | None:
+        """Return the safest available writable-slot hint for batch decoding."""
+        map_index_hint = getattr(self, "selected_map_index", None)
+        if map_index_hint is None:
+            map_index_hint = active_map_index(getattr(self, "app_maps", None))
+        known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
+        if map_index_hint is None and len(known_map_indices) == 1:
+            map_index_hint = known_map_indices[0]
+        return map_index_hint
+
+    async def _async_get_shared_batch_schedules(
+        self,
+        *,
+        map_index_hint: int | None,
+        force: bool,
+    ) -> dict[str, Any]:
+        """Coalesce aligned schedule and batch-metadata cloud reads."""
+        discover_map_index = map_index_hint is not None
+        key = (map_index_hint, discover_map_index)
+        loop = asyncio.get_running_loop()
+        task = getattr(self, "_batch_schedule_read_task", None)
+        completed_at = getattr(self, "_batch_schedule_read_completed_at", None)
+        reusable_result = (
+            task is not None
+            and task.done()
+            and not force
+            and completed_at is not None
+            and loop.time() - completed_at <= BATCH_SCHEDULE_RESULT_COALESCE_SECONDS
+        )
+        if (
+            task is None
+            or getattr(self, "_batch_schedule_read_key", None) != key
+            or (task.done() and not reusable_result)
+        ):
+            options: dict[str, Any] = {
+                "include_raw": False,
+                "map_index_hint": map_index_hint,
+            }
+            if not discover_map_index:
+                # App-map discovery already ran in this metadata cycle. Batch
+                # decoding can safely retain an explicit unknown slot.
+                options["discover_map_index"] = False
+            task = asyncio.create_task(
+                self.client.async_get_batch_schedules(**options)
+            )
+            self._batch_schedule_read_task = task
+            self._batch_schedule_read_key = key
+            self._batch_schedule_read_completed_at = None
+
+            def record_completion(completed: asyncio.Task[dict[str, Any]]) -> None:
+                if getattr(self, "_batch_schedule_read_task", None) is completed:
+                    self._batch_schedule_read_completed_at = loop.time()
+
+            task.add_done_callback(record_completion)
+        return await asyncio.shield(task)
+
     def _fresh_batch_schedule(self) -> dict[str, Any] | None:
         """Return the recent shared schedule cache when batch-sourced."""
         refreshed_at = self.schedules_refreshed_at
         if (
             not isinstance(self.schedules, dict)
-            or self.schedules.get("source") != "batch_device_data_schedule"
+            or self.schedules.get("source")
+            not in {
+                "batch_device_data_schedule",
+                "app_action_schedule_with_batch_refresh",
+            }
             or refreshed_at is None
             or datetime.now(UTC) - refreshed_at >= SCHEDULE_REFRESH_INTERVAL
         ):
@@ -1538,9 +1627,10 @@ def _app_map_hints_are_authoritative(
     if not refresh_succeeded or not isinstance(app_maps, Mapping):
         return False
     maps = app_maps.get("maps")
-    return isinstance(maps, Sequence) and not isinstance(
-        maps,
-        str | bytes | bytearray,
+    return (
+        app_maps.get("map_list_valid") is True
+        and isinstance(maps, Sequence)
+        and not isinstance(maps, str | bytes | bytearray)
     )
 
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -543,6 +543,9 @@ class DreameLawnMowerCoordinator(
                     False,
                 ),
             )
+            latest_map_index_hint = self._schedule_map_index_hint()
+            if latest_map_index_hint != map_index_hint:
+                batch_payload = _batch_schedule_without_map_hint(batch_payload)
             latest_expected_indices = _schedule_expected_indices(
                 self.schedules,
                 payload,
@@ -1760,6 +1763,27 @@ def _schedule_payload_has_active_selection(
             return True
     version = payload.get("active_schedule_version")
     return isinstance(version, int) and not isinstance(version, bool)
+
+
+def _batch_schedule_without_map_hint(
+    payload: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Return a batch schedule copy without a stale caller-supplied slot hint."""
+    normalized = dict(payload)
+    schedules = payload.get("schedules")
+    if (
+        not isinstance(schedules, Sequence)
+        or isinstance(schedules, str | bytes | bytearray)
+        or len(schedules) != 1
+        or not isinstance(schedules[0], Mapping)
+    ):
+        return normalized
+    schedule = dict(schedules[0])
+    schedule["idx"] = None
+    schedule["label"] = "active_schedule"
+    schedule["writable"] = False
+    normalized["schedules"] = [schedule]
+    return normalized
 
 
 def _schedule_write_version(result: Mapping[str, Any]) -> int | None:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -68,6 +68,7 @@ VOICE_SETTINGS_REFRESH_INTERVAL = timedelta(minutes=5)
 SCHEDULE_REFRESH_INTERVAL = timedelta(minutes=5)
 FIRMWARE_UPDATE_REFRESH_INTERVAL = timedelta(minutes=15)
 DEVICE_SNAPSHOT_GENERATION_HISTORY = 32
+PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS = 1
 
 
 _runtime_tracking_active = runtime_tracking_active
@@ -126,6 +127,10 @@ class DreameLawnMowerCoordinator(
         self._pending_schedule_plan_states: dict[
             tuple[int, int],
             tuple[int | None, bool],
+        ] = {}
+        self._pending_schedule_plan_state_contradictions: dict[
+            tuple[int, int],
+            int,
         ] = {}
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
@@ -633,6 +638,17 @@ class DreameLawnMowerCoordinator(
                 schedule_version,
                 bool(enabled),
             )
+            pending_contradictions = getattr(
+                self,
+                "_pending_schedule_plan_state_contradictions",
+                None,
+            )
+            if pending_contradictions is None:
+                pending_contradictions = {}
+                self._pending_schedule_plan_state_contradictions = (
+                    pending_contradictions
+                )
+            pending_contradictions.pop((map_index, plan_id), None)
             self._reconcile_cached_schedule_plan_enabled(
                 map_index=map_index,
                 plan_id=plan_id,
@@ -690,6 +706,16 @@ class DreameLawnMowerCoordinator(
         schedules = payload.get("schedules")
         if not pending_states or not isinstance(schedules, Sequence):
             return
+        pending_contradictions = getattr(
+            self,
+            "_pending_schedule_plan_state_contradictions",
+            None,
+        )
+        if pending_contradictions is None:
+            pending_contradictions = {}
+            self._pending_schedule_plan_state_contradictions = (
+                pending_contradictions
+            )
         for key, (version, enabled) in tuple(pending_states.items()):
             map_index, plan_id = key
             schedule = next(
@@ -706,6 +732,7 @@ class DreameLawnMowerCoordinator(
                 continue
             if version is not None and schedule.get("version") != version:
                 pending_states.pop(key, None)
+                pending_contradictions.pop(key, None)
                 continue
             plans = schedule.get("plans")
             plan = next(
@@ -718,6 +745,17 @@ class DreameLawnMowerCoordinator(
             )
             if plan is None or bool(plan.get("enabled")) == enabled:
                 pending_states.pop(key, None)
+                pending_contradictions.pop(key, None)
+                continue
+            contradictory_reads = pending_contradictions.get(key, 0) + 1
+            if (
+                contradictory_reads
+                > PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS
+            ):
+                pending_states.pop(key, None)
+                pending_contradictions.pop(key, None)
+            else:
+                pending_contradictions[key] = contradictory_reads
 
     def _apply_pending_schedule_plan_states(self) -> None:
         """Keep confirmed toggles visible while cloud readbacks lag."""
@@ -783,9 +821,15 @@ class DreameLawnMowerCoordinator(
             self._invalidate_inflight_schedule_refreshes()
             pending_states = getattr(self, "_pending_schedule_plan_states", None)
             if pending_states:
+                pending_contradictions = getattr(
+                    self,
+                    "_pending_schedule_plan_state_contradictions",
+                    {},
+                )
                 for key in tuple(pending_states):
                     if key[0] == map_index:
                         pending_states.pop(key, None)
+                        pending_contradictions.pop(key, None)
             # Never let a recently cached pre-upload payload hide the new plans.
             self.schedules = invalidate_schedule_slot(
                 getattr(self, "schedules", None),

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -49,6 +49,7 @@ from .performance import DreameLawnMowerPerformanceTracker
 from .runtime_cache import DreameLawnMowerRuntimeTelemetryCache
 from .schedule_cache import (
     has_complete_schedule_cache,
+    invalidate_schedule_slot,
     merge_app_schedule_payload,
     merge_batch_schedule_payload,
     schedule_payload_has_usable_data,
@@ -608,6 +609,10 @@ class DreameLawnMowerCoordinator(
             )
             self.last_schedule_write_result = result
             # Never let a recently cached pre-upload payload hide the new plans.
+            self.schedules = invalidate_schedule_slot(
+                getattr(self, "schedules", None),
+                map_index,
+            )
             self.schedules_refreshed_at = None
             try:
                 await self.async_refresh_schedules(force=True)

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -120,6 +120,8 @@ class DreameLawnMowerCoordinator(
         self.schedules: dict[str, Any] | None = None
         self.schedules_refreshed_at: datetime | None = None
         self._schedule_cache_generation = 0
+        self._schedule_read_generation = 0
+        self._published_schedule_read_generation = 0
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
@@ -474,6 +476,7 @@ class DreameLawnMowerCoordinator(
         )
         batch_read_succeeded = False
         try:
+            batch_read_generation = self._begin_schedule_read()
             batch_payload = await self.client.async_get_batch_schedules(
                 include_raw=False,
                 map_index_hint=map_index_hint,
@@ -487,6 +490,7 @@ class DreameLawnMowerCoordinator(
                 batch_payload,
                 now=now,
                 allow_incomplete=True,
+                read_generation=batch_read_generation,
             )
         if not self._schedule_refresh_is_current(refresh_generation):
             return self.schedules
@@ -510,8 +514,15 @@ class DreameLawnMowerCoordinator(
         *,
         now: datetime,
         allow_incomplete: bool = False,
+        read_generation: int | None = None,
     ) -> bool:
         """Merge one fast effective-schedule read into the app schedule cache."""
+        if (
+            read_generation is not None
+            and read_generation
+            < getattr(self, "_published_schedule_read_generation", 0)
+        ):
+            return False
         known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
         if (
             not isinstance(self.schedules, Mapping)
@@ -531,6 +542,8 @@ class DreameLawnMowerCoordinator(
             return False
         self.schedules = normalized
         self.schedules_refreshed_at = now
+        if read_generation is not None:
+            self._published_schedule_read_generation = read_generation
         return True
 
     def _has_complete_schedule_cache(
@@ -543,6 +556,12 @@ class DreameLawnMowerCoordinator(
     def _schedule_refresh_is_current(self, generation: int) -> bool:
         """Return whether a schedule read predates no confirmed write."""
         return generation == getattr(self, "_schedule_cache_generation", 0)
+
+    def _begin_schedule_read(self) -> int:
+        """Return an ordering token for one batch schedule request."""
+        generation = getattr(self, "_schedule_read_generation", 0) + 1
+        self._schedule_read_generation = generation
+        return generation
 
     def _invalidate_inflight_schedule_refreshes(self) -> None:
         """Prevent reads started before a confirmed write from publishing."""
@@ -684,6 +703,7 @@ class DreameLawnMowerCoordinator(
                 batch_schedule,
                 batch_mowing_preferences,
                 batch_ota_info,
+                batch_schedule_generation,
             ) = await self._async_fetch_batch_device_data()
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh batch device data: %s", err)
@@ -699,7 +719,11 @@ class DreameLawnMowerCoordinator(
         self.batch_device_data = payload
         self.batch_device_data_refreshed_at = now
         if self._schedule_refresh_is_current(schedule_generation):
-            self._cache_batch_schedules(batch_schedule, now=now)
+            self._cache_batch_schedules(
+                batch_schedule,
+                now=now,
+                read_generation=batch_schedule_generation,
+            )
         return payload
 
     async def async_plan_mowing_preference_update(
@@ -737,11 +761,12 @@ class DreameLawnMowerCoordinator(
 
     async def _async_fetch_batch_device_data(
         self,
-    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any]]:
+    ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], int]:
         """Fetch batch schedule, settings, and OTA payloads in parallel."""
         cached_schedule = self._fresh_batch_schedule()
         if cached_schedule is None:
-            return await asyncio.gather(
+            schedule_generation = self._begin_schedule_read()
+            schedule, preferences, ota = await asyncio.gather(
                 self.client.async_get_batch_schedules(include_raw=False),
                 self.client.async_get_batch_mowing_preferences(
                     include_raw=False,
@@ -749,6 +774,7 @@ class DreameLawnMowerCoordinator(
                 ),
                 self.client.async_get_batch_ota_info(include_raw=False),
             )
+            return schedule, preferences, ota, schedule_generation
 
         batch_mowing_preferences, batch_ota_info = await asyncio.gather(
             self.client.async_get_batch_mowing_preferences(
@@ -757,7 +783,12 @@ class DreameLawnMowerCoordinator(
             ),
             self.client.async_get_batch_ota_info(include_raw=False),
         )
-        return cached_schedule, batch_mowing_preferences, batch_ota_info
+        return (
+            cached_schedule,
+            batch_mowing_preferences,
+            batch_ota_info,
+            getattr(self, "_published_schedule_read_generation", 0),
+        )
 
     def _fresh_batch_schedule(self) -> dict[str, Any] | None:
         """Return the recent shared schedule cache when batch-sourced."""

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -119,6 +119,7 @@ class DreameLawnMowerCoordinator(
         self.voice_settings_refreshed_at: datetime | None = None
         self.schedules: dict[str, Any] | None = None
         self.schedules_refreshed_at: datetime | None = None
+        self._schedule_cache_generation = 0
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
@@ -418,6 +419,7 @@ class DreameLawnMowerCoordinator(
     ) -> dict[str, Any] | None:
         """Refresh schedules through the fast batch path with app fallback."""
         now = datetime.now(UTC)
+        refresh_generation = getattr(self, "_schedule_cache_generation", 0)
         if (
             not force
             and self.schedules is not None
@@ -446,6 +448,8 @@ class DreameLawnMowerCoordinator(
             except Exception as err:  # noqa: BLE001 - optional cloud capability
                 _LOGGER.debug("Failed to refresh batch mower schedules: %s", err)
             else:
+                if not self._schedule_refresh_is_current(refresh_generation):
+                    return self.schedules
                 if self._cache_batch_schedules(batch_payload, now=now):
                     return self.schedules
 
@@ -461,11 +465,18 @@ class DreameLawnMowerCoordinator(
             if force:
                 raise
             return self.schedules
+        if not self._schedule_refresh_is_current(refresh_generation):
+            return self.schedules
         action_read_succeeded = schedule_payload_has_usable_data(payload)
+        expected_indices = _schedule_expected_indices(
+            self.schedules,
+            payload,
+            known_map_indices,
+        )
         self.schedules = merge_app_schedule_payload(
             self.schedules,
             payload,
-            expected_indices=[-1, *known_map_indices],
+            expected_indices=expected_indices,
         )
         batch_read_succeeded = False
         try:
@@ -476,11 +487,15 @@ class DreameLawnMowerCoordinator(
         except Exception as err:  # noqa: BLE001 - optional cloud capability
             _LOGGER.debug("Failed to recover batch mower schedules: %s", err)
         else:
+            if not self._schedule_refresh_is_current(refresh_generation):
+                return self.schedules
             batch_read_succeeded = self._cache_batch_schedules(
                 batch_payload,
                 now=now,
                 allow_incomplete=True,
             )
+        if not self._schedule_refresh_is_current(refresh_generation):
+            return self.schedules
         if action_read_succeeded or batch_read_succeeded:
             self.schedules_refreshed_at = now
         return self.schedules
@@ -521,6 +536,16 @@ class DreameLawnMowerCoordinator(
         """Return whether default and every known physical map are represented."""
         return has_complete_schedule_cache(self.schedules, known_map_indices)
 
+    def _schedule_refresh_is_current(self, generation: int) -> bool:
+        """Return whether a schedule read predates no confirmed write."""
+        return generation == getattr(self, "_schedule_cache_generation", 0)
+
+    def _invalidate_inflight_schedule_refreshes(self) -> None:
+        """Prevent reads started before a confirmed write from publishing."""
+        self._schedule_cache_generation = (
+            getattr(self, "_schedule_cache_generation", 0) + 1
+        )
+
     async def async_set_schedule_plan_enabled(
         self,
         *,
@@ -538,6 +563,7 @@ class DreameLawnMowerCoordinator(
                 confirm_write=True,
             )
             self.last_schedule_write_result = result
+            self._invalidate_inflight_schedule_refreshes()
             self._reconcile_cached_schedule_plan_enabled(
                 map_index=map_index,
                 plan_id=plan_id,
@@ -608,6 +634,7 @@ class DreameLawnMowerCoordinator(
                 confirm_write=confirm_write,
             )
             self.last_schedule_write_result = result
+            self._invalidate_inflight_schedule_refreshes()
             # Never let a recently cached pre-upload payload hide the new plans.
             self.schedules = invalidate_schedule_slot(
                 getattr(self, "schedules", None),
@@ -637,6 +664,7 @@ class DreameLawnMowerCoordinator(
         ):
             return self.batch_device_data
 
+        schedule_generation = getattr(self, "_schedule_cache_generation", 0)
         try:
             (
                 batch_schedule,
@@ -656,7 +684,8 @@ class DreameLawnMowerCoordinator(
         }
         self.batch_device_data = payload
         self.batch_device_data_refreshed_at = now
-        self._cache_batch_schedules(batch_schedule, now=now)
+        if self._schedule_refresh_is_current(schedule_generation):
+            self._cache_batch_schedules(batch_schedule, now=now)
         return payload
 
     async def async_plan_mowing_preference_update(
@@ -1014,4 +1043,33 @@ def _app_map_index_hints(app_maps: Mapping[str, Any] | None) -> list[int]:
         if not isinstance(index, int) or index < 0 or index in indices:
             continue
         indices.append(index)
+    return indices
+
+
+def _schedule_expected_indices(
+    existing: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any],
+    known_map_indices: Sequence[int],
+) -> list[int]:
+    """Return authoritative or conservatively discovered schedule slot ids."""
+    if known_map_indices:
+        return [-1, *known_map_indices]
+
+    indices = [-1]
+    for payload in (existing, incoming):
+        schedules = payload.get("schedules") if isinstance(payload, Mapping) else None
+        if not isinstance(schedules, Sequence) or isinstance(
+            schedules,
+            str | bytes | bytearray,
+        ):
+            continue
+        for schedule in schedules:
+            index = schedule.get("idx") if isinstance(schedule, Mapping) else None
+            if (
+                isinstance(index, int)
+                and not isinstance(index, bool)
+                and index >= 0
+                and index not in indices
+            ):
+                indices.append(index)
     return indices

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1515,6 +1515,9 @@ class DreameLawnMowerCoordinator(
         ):
             return self.app_maps
 
+        previous_map_indices = set(
+            _app_map_index_hints(getattr(self, "app_maps", None))
+        )
         try:
             app_maps = await self.client.async_get_app_maps(
                 include_payload=True,
@@ -1533,6 +1536,16 @@ class DreameLawnMowerCoordinator(
         self.app_maps_refreshed_at = now
         self.app_maps_refresh_succeeded = True
         current_idx = active_map_index(payload)
+        known_map_indices = set(_app_map_index_hints(payload))
+        map_hints_authoritative = _app_map_hints_are_authoritative(
+            payload,
+            refresh_succeeded=True,
+        )
+        if (
+            map_hints_authoritative
+            and known_map_indices != previous_map_indices
+        ):
+            self._invalidate_schedule_map_hint()
         if current_idx is not None:
             if self.selected_map_index != current_idx:
                 self._invalidate_schedule_map_hint()
@@ -1546,11 +1559,8 @@ class DreameLawnMowerCoordinator(
             self.selected_map_index = current_idx
         elif (
             self.selected_map_index is not None
-            and _app_map_hints_are_authoritative(
-                payload,
-                refresh_succeeded=True,
-            )
-            and not _app_map_index_hints(payload)
+            and map_hints_authoritative
+            and self.selected_map_index not in known_map_indices
         ):
             self._invalidate_schedule_map_hint()
             self.selected_map_index = None

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -443,24 +443,6 @@ class DreameLawnMowerCoordinator(
             map_index_hint = active_map_index(getattr(self, "app_maps", None))
         if map_index_hint is None and len(known_map_indices) == 1:
             map_index_hint = known_map_indices[0]
-        if (
-            not force
-            and len(known_map_indices) == 1
-            and map_index_hint is not None
-            and self._has_complete_schedule_cache(known_map_indices)
-        ):
-            try:
-                batch_payload = await self.client.async_get_batch_schedules(
-                    include_raw=False,
-                    map_index_hint=map_index_hint,
-                )
-            except Exception as err:  # noqa: BLE001 - optional cloud capability
-                _LOGGER.debug("Failed to refresh batch mower schedules: %s", err)
-            else:
-                if not self._schedule_refresh_is_current(refresh_generation):
-                    return self.schedules
-                if self._cache_batch_schedules(batch_payload, now=now):
-                    return self.schedules
 
         try:
             payload = await self.client.async_get_app_schedules(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -576,6 +576,20 @@ class DreameLawnMowerCoordinator(
                 read_generation=batch_read_generation,
                 preserve_indices=action_read_indices,
             )
+            batch_schedules = batch_payload.get("schedules")
+            if (
+                not batch_read_succeeded
+                and not allow_unknown_batch_slot
+                and not batch_payload.get("errors")
+                and isinstance(batch_schedules, Sequence)
+                and not isinstance(batch_schedules, str | bytes | bytearray)
+                and len(batch_schedules) == 1
+                and isinstance(batch_schedules[0], Mapping)
+                and isinstance(batch_schedules[0].get("version"), int)
+                and not isinstance(batch_schedules[0].get("version"), bool)
+                and isinstance(self.schedules, dict)
+            ):
+                self.schedules["active_selection_available"] = False
         if not self._schedule_refresh_is_current(refresh_generation):
             return self.schedules
         if (

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -575,10 +575,20 @@ class DreameLawnMowerCoordinator(
                 allow_unknown_batch_slot = not (
                     map_hints_authoritative and action_read_complete
                 )
+            allowed_batch_hint_indices = (
+                [map_index_hint]
+                if (
+                    allow_unknown_batch_slot
+                    and map_hints_authoritative
+                    and map_index_hint in known_map_indices
+                )
+                else None
+            )
             batch_read_succeeded = self._cache_batch_schedules(
                 batch_payload,
                 now=now,
                 allow_incomplete=allow_unknown_batch_slot,
+                allowed_hint_indices=allowed_batch_hint_indices,
                 read_generation=batch_read_generation,
                 preserve_indices=action_read_indices,
             )
@@ -618,6 +628,7 @@ class DreameLawnMowerCoordinator(
         *,
         now: datetime,
         allow_incomplete: bool = False,
+        allowed_hint_indices: Sequence[int] | None = None,
         read_generation: int | None = None,
         preserve_indices: Sequence[int] = (),
     ) -> bool:
@@ -641,7 +652,9 @@ class DreameLawnMowerCoordinator(
             captured_at=now,
             allow_unknown_slot=allow_incomplete,
             allowed_hint_indices=(
-                [] if allow_incomplete else [-1, *known_map_indices]
+                allowed_hint_indices
+                if allowed_hint_indices is not None
+                else ([] if allow_incomplete else [-1, *known_map_indices])
             ),
             preserve_indices=preserve_indices,
         )

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -433,6 +433,7 @@ class DreameLawnMowerCoordinator(
             map_index_hint = known_map_indices[0]
         if (
             not force
+            and len(known_map_indices) == 1
             and map_index_hint is not None
             and self._has_complete_schedule_cache(known_map_indices)
         ):

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -52,6 +52,7 @@ from .schedule_cache import (
     invalidate_schedule_slot,
     merge_app_schedule_payload,
     merge_batch_schedule_payload,
+    schedule_entry_has_usable_data,
     schedule_payload_has_usable_data,
 )
 
@@ -122,6 +123,10 @@ class DreameLawnMowerCoordinator(
         self._schedule_cache_generation = 0
         self._schedule_read_generation = 0
         self._published_schedule_read_generation = 0
+        self._pending_schedule_plan_states: dict[
+            tuple[int, int],
+            tuple[int | None, bool],
+        ] = {}
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
@@ -447,6 +452,7 @@ class DreameLawnMowerCoordinator(
             map_index_hint = known_map_indices[0]
 
         try:
+            action_read_generation = self._begin_schedule_read()
             payload = await self.client.async_get_app_schedules(
                 include_current_task=False,
                 map_indices=(
@@ -463,6 +469,11 @@ class DreameLawnMowerCoordinator(
         if not self._schedule_refresh_is_current(refresh_generation):
             return self.schedules
         action_read_succeeded = schedule_payload_has_usable_data(payload)
+        if (
+            action_read_succeeded
+            and not self._schedule_read_can_publish(action_read_generation)
+        ):
+            return self.schedules
         expected_indices = _schedule_expected_indices(
             self.schedules,
             payload,
@@ -474,6 +485,11 @@ class DreameLawnMowerCoordinator(
             payload,
             expected_indices=expected_indices,
         )
+        if action_read_succeeded:
+            self._record_schedule_read_publication(action_read_generation)
+        self._acknowledge_pending_schedule_plan_states(payload)
+        self._apply_pending_schedule_plan_states()
+        action_read_indices = _usable_schedule_indices(payload)
         batch_read_succeeded = False
         try:
             batch_read_generation = self._begin_schedule_read()
@@ -491,6 +507,7 @@ class DreameLawnMowerCoordinator(
                 now=now,
                 allow_incomplete=True,
                 read_generation=batch_read_generation,
+                preserve_indices=action_read_indices,
             )
         if not self._schedule_refresh_is_current(refresh_generation):
             return self.schedules
@@ -515,12 +532,11 @@ class DreameLawnMowerCoordinator(
         now: datetime,
         allow_incomplete: bool = False,
         read_generation: int | None = None,
+        preserve_indices: Sequence[int] = (),
     ) -> bool:
         """Merge one fast effective-schedule read into the app schedule cache."""
-        if (
-            read_generation is not None
-            and read_generation
-            < getattr(self, "_published_schedule_read_generation", 0)
+        if read_generation is not None and not self._schedule_read_can_publish(
+            read_generation
         ):
             return False
         known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
@@ -537,13 +553,15 @@ class DreameLawnMowerCoordinator(
             payload,
             captured_at=now,
             allow_unknown_slot=allow_incomplete,
+            preserve_indices=preserve_indices,
         )
         if normalized is None:
             return False
         self.schedules = normalized
         self.schedules_refreshed_at = now
         if read_generation is not None:
-            self._published_schedule_read_generation = read_generation
+            self._record_schedule_read_publication(read_generation)
+        self._apply_pending_schedule_plan_states()
         return True
 
     def _has_complete_schedule_cache(
@@ -558,10 +576,22 @@ class DreameLawnMowerCoordinator(
         return generation == getattr(self, "_schedule_cache_generation", 0)
 
     def _begin_schedule_read(self) -> int:
-        """Return an ordering token for one batch schedule request."""
+        """Return an ordering token for one schedule request."""
         generation = getattr(self, "_schedule_read_generation", 0) + 1
         self._schedule_read_generation = generation
         return generation
+
+    def _schedule_read_can_publish(self, generation: int) -> bool:
+        """Return whether no newer schedule request has published."""
+        return generation >= getattr(
+            self,
+            "_published_schedule_read_generation",
+            0,
+        )
+
+    def _record_schedule_read_publication(self, generation: int) -> None:
+        """Record the newest schedule request allowed to publish."""
+        self._published_schedule_read_generation = generation
 
     def _invalidate_inflight_schedule_refreshes(self) -> None:
         """Prevent reads started before a confirmed write from publishing."""
@@ -587,11 +617,20 @@ class DreameLawnMowerCoordinator(
             )
             self.last_schedule_write_result = result
             self._invalidate_inflight_schedule_refreshes()
+            schedule_version = _schedule_write_version(result)
+            pending_states = getattr(self, "_pending_schedule_plan_states", None)
+            if pending_states is None:
+                pending_states = {}
+                self._pending_schedule_plan_states = pending_states
+            pending_states[(map_index, plan_id)] = (
+                schedule_version,
+                bool(enabled),
+            )
             self._reconcile_cached_schedule_plan_enabled(
                 map_index=map_index,
                 plan_id=plan_id,
                 enabled=enabled,
-                schedule_version=_schedule_write_version(result),
+                schedule_version=schedule_version,
             )
             try:
                 await self.async_refresh_schedules(force=True)
@@ -634,6 +673,74 @@ class DreameLawnMowerCoordinator(
                 if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
                     plan["enabled"] = enabled
                     return
+
+    def _acknowledge_pending_schedule_plan_states(
+        self,
+        payload: Mapping[str, Any],
+    ) -> None:
+        """Clear confirmed writes once an action read observes their result."""
+        pending_states = getattr(self, "_pending_schedule_plan_states", None)
+        schedules = payload.get("schedules")
+        if not pending_states or not isinstance(schedules, Sequence):
+            return
+        for key, (version, enabled) in tuple(pending_states.items()):
+            map_index, plan_id = key
+            schedule = next(
+                (
+                    entry
+                    for entry in schedules
+                    if isinstance(entry, Mapping)
+                    and entry.get("idx") == map_index
+                    and schedule_entry_has_usable_data(entry)
+                ),
+                None,
+            )
+            if schedule is None:
+                continue
+            if version is not None and schedule.get("version") != version:
+                pending_states.pop(key, None)
+                continue
+            plans = schedule.get("plans")
+            plan = next(
+                (
+                    entry
+                    for entry in plans
+                    if isinstance(entry, Mapping) and entry.get("plan_id") == plan_id
+                ),
+                None,
+            )
+            if plan is None or bool(plan.get("enabled")) == enabled:
+                pending_states.pop(key, None)
+
+    def _apply_pending_schedule_plan_states(self) -> None:
+        """Keep confirmed toggles visible while cloud readbacks lag."""
+        pending_states = getattr(self, "_pending_schedule_plan_states", None)
+        schedules = (
+            self.schedules.get("schedules")
+            if isinstance(self.schedules, Mapping)
+            else None
+        )
+        if not pending_states or not isinstance(schedules, Sequence):
+            return
+        for (map_index, plan_id), (version, enabled) in pending_states.items():
+            for schedule in schedules:
+                if not isinstance(schedule, dict) or not (
+                    schedule.get("idx") == map_index
+                    or (
+                        version is not None
+                        and schedule.get("idx") is None
+                        and schedule.get("version") == version
+                    )
+                ):
+                    continue
+                if version is not None and schedule.get("version") != version:
+                    continue
+                plans = schedule.get("plans")
+                if not isinstance(plans, Sequence):
+                    continue
+                for plan in plans:
+                    if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
+                        plan["enabled"] = enabled
 
     async def async_plan_schedule_upload(
         self,
@@ -1135,6 +1242,21 @@ def _schedule_expected_indices(
             ):
                 indices.append(index)
     return indices
+
+
+def _usable_schedule_indices(payload: Mapping[str, Any]) -> list[int]:
+    """Return writable slots read authoritatively in one action payload."""
+    schedules = payload.get("schedules")
+    if not isinstance(schedules, Sequence):
+        return []
+    return [
+        index
+        for schedule in schedules
+        if isinstance(schedule, Mapping)
+        and schedule_entry_has_usable_data(schedule)
+        and isinstance((index := schedule.get("idx")), int)
+        and not isinstance(index, bool)
+    ]
 
 
 def _schedule_payload_has_active_selection(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -142,6 +142,7 @@ class DreameLawnMowerCoordinator(
         self._pending_schedule_upload_contradictions: dict[int, int] = {}
         self._pending_schedule_upload_active_indices: set[int] = set()
         self._batch_schedule_read_task: asyncio.Task[dict[str, Any]] | None = None
+        self._batch_schedule_read_tasks: set[asyncio.Task[dict[str, Any]]] = set()
         self._batch_schedule_read_key: tuple[int | None, bool] | None = None
         self._batch_schedule_read_completed_at: float | None = None
         self._schedule_write_lock = asyncio.Lock()
@@ -1401,12 +1402,21 @@ class DreameLawnMowerCoordinator(
                 self.client.async_get_batch_schedules(**options)
             )
             self._batch_schedule_read_task = task
+            batch_tasks = getattr(self, "_batch_schedule_read_tasks", None)
+            if batch_tasks is None:
+                batch_tasks = set()
+                self._batch_schedule_read_tasks = batch_tasks
+            batch_tasks.add(task)
             self._batch_schedule_read_key = key
             self._batch_schedule_read_completed_at = None
 
             def record_completion(completed: asyncio.Task[dict[str, Any]]) -> None:
                 if getattr(self, "_batch_schedule_read_task", None) is completed:
                     self._batch_schedule_read_completed_at = loop.time()
+                if not completed.cancelled():
+                    with suppress(Exception):
+                        completed.exception()
+                batch_tasks.discard(completed)
 
             task.add_done_callback(record_completion)
         return await asyncio.shield(task)
@@ -1451,6 +1461,7 @@ class DreameLawnMowerCoordinator(
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh firmware update support: %s", err)
+            self.firmware_update_support_refreshed_at = None
             return self.firmware_update_support
 
         self.firmware_update_support = support
@@ -1480,6 +1491,7 @@ class DreameLawnMowerCoordinator(
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh app map objects: %s", err)
+            self.app_map_objects_refreshed_at = None
             return self.app_map_objects
 
         payload = {
@@ -1511,6 +1523,7 @@ class DreameLawnMowerCoordinator(
             vector_map_details = await self.client.async_get_vector_map_details()
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh vector map details: %s", err)
+            self.vector_map_details_refreshed_at = None
             return self.vector_map_details
 
         payload = dict(vector_map_details)
@@ -1626,6 +1639,7 @@ class DreameLawnMowerCoordinator(
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh weather protection: %s", err)
+            self.weather_protection_refreshed_at = None
             return self.weather_protection
 
         payload = dict(weather_protection)
@@ -1658,6 +1672,7 @@ class DreameLawnMowerCoordinator(
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh maintenance status: %s", err)
+            self.maintenance_status_refreshed_at = None
             return self.maintenance_status
 
         payload = dict(maintenance_status)
@@ -1689,6 +1704,7 @@ class DreameLawnMowerCoordinator(
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh voice settings: %s", err)
+            self.voice_settings_refreshed_at = None
             return self.voice_settings
 
         payload = {
@@ -1739,6 +1755,13 @@ class DreameLawnMowerCoordinator(
                     for entry in entries
                     if not isinstance(entry, Mapping) or entry.get("idx") is not None
                 ]
+        pending_active_indices = getattr(
+            self,
+            "_pending_schedule_upload_active_indices",
+            None,
+        )
+        if pending_active_indices is not None:
+            pending_active_indices.clear()
 
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1563,7 +1563,7 @@ class DreameLawnMowerCoordinator(
         payload["source"] = source
         self.app_maps = payload
         self.app_maps_refreshed_at = now
-        self.app_maps_refresh_succeeded = True
+        self.app_maps_refresh_succeeded = payload.get("map_list_valid") is True
         current_idx = active_map_index(payload)
         known_map_indices = set(_app_map_index_hints(payload))
         map_hints_authoritative = _app_map_hints_are_authoritative(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -463,16 +463,20 @@ class DreameLawnMowerCoordinator(
                 False,
             ),
         )
+        request_schedule_indices = [-1, *request_map_indices]
+        if not request_map_hints_authoritative:
+            # A partial or malformed MAPL result cannot exclude the other
+            # likely writable slot. Keep discovery bounded without issuing a
+            # second MAPL request inside the schedule action read.
+            for fallback_index in (0, 1):
+                if fallback_index not in request_schedule_indices:
+                    request_schedule_indices.append(fallback_index)
 
         try:
             action_read_generation = self._begin_schedule_read()
             payload = await self.client.async_get_app_schedules(
                 include_current_task=False,
-                map_indices=(
-                    [-1, *request_map_indices]
-                    if request_map_indices or request_map_hints_authoritative
-                    else None
-                ),
+                map_indices=request_schedule_indices,
             )
         except Exception as err:  # noqa: BLE001 - optional cloud capability
             _LOGGER.debug("Failed to refresh mower schedules: %s", err)

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -452,25 +452,24 @@ class DreameLawnMowerCoordinator(
         ):
             return self.schedules
 
-        app_maps = getattr(self, "app_maps", None)
-        known_map_indices = _app_map_index_hints(app_maps)
-        map_hints_authoritative = _app_map_hints_are_authoritative(
-            app_maps,
+        request_app_maps = getattr(self, "app_maps", None)
+        request_map_indices = _app_map_index_hints(request_app_maps)
+        request_map_hints_authoritative = _app_map_hints_are_authoritative(
+            request_app_maps,
             refresh_succeeded=getattr(
                 self,
                 "app_maps_refresh_succeeded",
                 False,
             ),
         )
-        map_index_hint = self._schedule_map_index_hint()
 
         try:
             action_read_generation = self._begin_schedule_read()
             payload = await self.client.async_get_app_schedules(
                 include_current_task=False,
                 map_indices=(
-                    [-1, *known_map_indices]
-                    if known_map_indices or map_hints_authoritative
+                    [-1, *request_map_indices]
+                    if request_map_indices or request_map_hints_authoritative
                     else None
                 ),
             )
@@ -487,6 +486,17 @@ class DreameLawnMowerCoordinator(
             and not self._schedule_read_can_publish(action_read_generation)
         ):
             return self.schedules
+        app_maps = getattr(self, "app_maps", None)
+        known_map_indices = _app_map_index_hints(app_maps)
+        map_hints_authoritative = _app_map_hints_are_authoritative(
+            app_maps,
+            refresh_succeeded=getattr(
+                self,
+                "app_maps_refresh_succeeded",
+                False,
+            ),
+        )
+        map_index_hint = self._schedule_map_index_hint()
         expected_indices = _schedule_expected_indices(
             self.schedules,
             payload,
@@ -523,6 +533,42 @@ class DreameLawnMowerCoordinator(
         else:
             if not self._schedule_refresh_is_current(refresh_generation):
                 return self.schedules
+            latest_app_maps = getattr(self, "app_maps", None)
+            latest_map_indices = _app_map_index_hints(latest_app_maps)
+            latest_map_hints_authoritative = _app_map_hints_are_authoritative(
+                latest_app_maps,
+                refresh_succeeded=getattr(
+                    self,
+                    "app_maps_refresh_succeeded",
+                    False,
+                ),
+            )
+            latest_expected_indices = _schedule_expected_indices(
+                self.schedules,
+                payload,
+                latest_map_indices,
+                map_hints_authoritative=latest_map_hints_authoritative,
+            )
+            if (
+                latest_expected_indices != expected_indices
+                or latest_map_hints_authoritative != map_hints_authoritative
+            ):
+                known_map_indices = latest_map_indices
+                map_hints_authoritative = latest_map_hints_authoritative
+                expected_indices = latest_expected_indices
+                self.schedules = merge_app_schedule_payload(
+                    self.schedules,
+                    payload,
+                    expected_indices=expected_indices,
+                )
+                if map_hints_authoritative:
+                    self._prune_pending_schedule_writes(known_map_indices)
+                action_read_complete = set(expected_indices).issubset(
+                    action_read_indices
+                )
+                allow_unknown_batch_slot = not (
+                    map_hints_authoritative and action_read_complete
+                )
             batch_read_succeeded = self._cache_batch_schedules(
                 batch_payload,
                 now=now,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -460,7 +460,11 @@ class DreameLawnMowerCoordinator(
                 raise
             return self.schedules
         action_read_succeeded = schedule_payload_has_usable_data(payload)
-        self.schedules = merge_app_schedule_payload(self.schedules, payload)
+        self.schedules = merge_app_schedule_payload(
+            self.schedules,
+            payload,
+            expected_indices=[-1, *known_map_indices],
+        )
         batch_read_succeeded = False
         try:
             batch_payload = await self.client.async_get_batch_schedules(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -507,6 +507,7 @@ class DreameLawnMowerCoordinator(
             self.schedules,
             payload,
             expected_indices=expected_indices,
+            prune_unexpected_indices=map_hints_authoritative,
         )
         if action_read_succeeded:
             self._record_schedule_read_publication(action_read_generation)
@@ -563,6 +564,7 @@ class DreameLawnMowerCoordinator(
                     self.schedules,
                     payload,
                     expected_indices=expected_indices,
+                    prune_unexpected_indices=map_hints_authoritative,
                 )
                 if map_hints_authoritative:
                     self._prune_pending_schedule_writes(known_map_indices)
@@ -1300,9 +1302,10 @@ class DreameLawnMowerCoordinator(
         cached_schedule = self._fresh_batch_schedule()
         if cached_schedule is None:
             schedule_generation = self._begin_schedule_read()
+            map_index_hint = self._schedule_map_index_hint()
             schedule, preferences, ota = await asyncio.gather(
                 self._async_get_shared_batch_schedules(
-                    map_index_hint=self._schedule_map_index_hint(),
+                    map_index_hint=map_index_hint,
                     force=force,
                 ),
                 self.client.async_get_batch_mowing_preferences(
@@ -1311,6 +1314,8 @@ class DreameLawnMowerCoordinator(
                 ),
                 self.client.async_get_batch_ota_info(include_raw=False),
             )
+            if self._schedule_map_index_hint() != map_index_hint:
+                schedule = _batch_schedule_without_map_hint(schedule)
             return schedule, preferences, ota, schedule_generation
 
         batch_mowing_preferences, batch_ota_info = await asyncio.gather(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -493,9 +493,16 @@ class DreameLawnMowerCoordinator(
         batch_read_succeeded = False
         try:
             batch_read_generation = self._begin_schedule_read()
+            batch_options: dict[str, Any] = {
+                "include_raw": False,
+                "map_index_hint": map_index_hint,
+            }
+            if map_index_hint is None:
+                # App-map discovery already ran as part of the bounded action
+                # read. Batch decoding can safely retain an unknown slot.
+                batch_options["discover_map_index"] = False
             batch_payload = await self.client.async_get_batch_schedules(
-                include_raw=False,
-                map_index_hint=map_index_hint,
+                **batch_options
             )
         except Exception as err:  # noqa: BLE001 - optional cloud capability
             _LOGGER.debug("Failed to recover batch mower schedules: %s", err)
@@ -774,6 +781,11 @@ class DreameLawnMowerCoordinator(
             )
             self.last_schedule_write_result = result
             self._invalidate_inflight_schedule_refreshes()
+            pending_states = getattr(self, "_pending_schedule_plan_states", None)
+            if pending_states:
+                for key in tuple(pending_states):
+                    if key[0] == map_index:
+                        pending_states.pop(key, None)
             # Never let a recently cached pre-upload payload hide the new plans.
             self.schedules = invalidate_schedule_slot(
                 getattr(self, "schedules", None),

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -812,6 +812,12 @@ class DreameLawnMowerCoordinator(
             for plan in plans:
                 if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
                     plan["enabled"] = enabled
+                    schedule["enabled_plan_count"] = sum(
+                        1
+                        for cached_plan in plans
+                        if isinstance(cached_plan, Mapping)
+                        and cached_plan.get("enabled")
+                    )
                     return
         if (
             schedule_version is not None

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -618,7 +618,15 @@ class DreameLawnMowerCoordinator(
             # safely choose one slot. Keep the decoded schedules for the
             # diagnostic all-schedules view without presenting them as active.
             self.schedules["active_selection_available"] = False
-        if action_read_succeeded or batch_read_succeeded:
+        action_read_confirms_active_schedule = (
+            action_read_succeeded
+            and isinstance(self.schedules, Mapping)
+            and (
+                self.schedules.get("active_selection_available") is False
+                or self.schedules.get("active_schedule_index") in action_read_indices
+            )
+        )
+        if action_read_confirms_active_schedule or batch_read_succeeded:
             self.schedules_refreshed_at = now
         return self.schedules
 
@@ -1717,7 +1725,20 @@ class DreameLawnMowerCoordinator(
         """Expire schedule selection tied to the previous active map."""
         self.schedules_refreshed_at = None
         if isinstance(getattr(self, "schedules", None), dict):
+            self.schedules.pop("active_schedule_version", None)
+            self.schedules.pop("active_schedule_index", None)
+            self.schedules.pop("current_task", None)
             self.schedules["active_selection_available"] = False
+            entries = self.schedules.get("schedules")
+            if isinstance(entries, Sequence) and not isinstance(
+                entries,
+                str | bytes | bytearray,
+            ):
+                self.schedules["schedules"] = [
+                    entry
+                    for entry in entries
+                    if not isinstance(entry, Mapping) or entry.get("idx") is not None
+                ]
 
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1313,7 +1313,7 @@ class DreameLawnMowerCoordinator(
         force: bool = False,
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], int]:
         """Fetch batch schedule, settings, and OTA payloads in parallel."""
-        cached_schedule = self._fresh_batch_schedule()
+        cached_schedule = None if force else self._fresh_batch_schedule()
         if cached_schedule is None:
             schedule_generation = self._begin_schedule_read()
             map_index_hint = self._schedule_map_index_hint()
@@ -1580,6 +1580,7 @@ class DreameLawnMowerCoordinator(
                 self.selected_contour_id = None
                 self.selected_zone_id = None
                 self.selected_spot_id = None
+                self.selected_maintenance_point_id = None
             self.selected_map_index = current_idx
         elif (
             self.selected_map_index is not None
@@ -1591,6 +1592,7 @@ class DreameLawnMowerCoordinator(
             self.selected_contour_id = None
             self.selected_zone_id = None
             self.selected_spot_id = None
+            self.selected_maintenance_point_id = None
         return payload
 
     async def async_refresh_weather_protection(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import Mapping, Sequence
 from contextlib import suppress
+from copy import deepcopy
 from datetime import UTC, datetime, timedelta
 from typing import Any
 
@@ -44,6 +45,10 @@ from .diagnostic_events import DreameLawnMowerDiagnosticEventStore
 from .dreame_lawn_mower_client.models import (
     DreameLawnMowerStatusBlob,
     display_name_for_model,
+)
+from .dreame_lawn_mower_client.schedule import (
+    decode_schedule_payload_text,
+    encode_schedule_payload_text,
 )
 from .performance import DreameLawnMowerPerformanceTracker
 from .runtime_cache import DreameLawnMowerRuntimeTelemetryCache
@@ -132,6 +137,8 @@ class DreameLawnMowerCoordinator(
             tuple[int, int],
             int,
         ] = {}
+        self._pending_schedule_uploads: dict[int, dict[str, Any]] = {}
+        self._pending_schedule_upload_contradictions: dict[int, int] = {}
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
@@ -493,7 +500,9 @@ class DreameLawnMowerCoordinator(
         if action_read_succeeded:
             self._record_schedule_read_publication(action_read_generation)
         self._acknowledge_pending_schedule_plan_states(payload)
+        self._acknowledge_pending_schedule_uploads(payload)
         self._apply_pending_schedule_plan_states()
+        self._apply_pending_schedule_uploads()
         action_read_indices = _usable_schedule_indices(payload)
         batch_read_succeeded = False
         try:
@@ -574,6 +583,7 @@ class DreameLawnMowerCoordinator(
         if read_generation is not None:
             self._record_schedule_read_publication(read_generation)
         self._apply_pending_schedule_plan_states()
+        self._apply_pending_schedule_uploads()
         return True
 
     def _has_complete_schedule_cache(
@@ -787,6 +797,164 @@ class DreameLawnMowerCoordinator(
                     if isinstance(plan, dict) and plan.get("plan_id") == plan_id:
                         plan["enabled"] = enabled
 
+    def _remember_pending_schedule_upload(
+        self,
+        *,
+        map_index: int,
+        plans: Sequence[Mapping[str, Any]],
+        schedule_version: int | None,
+    ) -> None:
+        """Retain a confirmed full upload until an action read settles it."""
+        normalized_plans = decode_schedule_payload_text(
+            encode_schedule_payload_text(list(plans))
+        )
+        schedules = (
+            self.schedules.get("schedules")
+            if isinstance(getattr(self, "schedules", None), Mapping)
+            else None
+        )
+        cached_schedule = next(
+            (
+                schedule
+                for schedule in schedules or []
+                if isinstance(schedule, Mapping)
+                and schedule.get("idx") == map_index
+            ),
+            None,
+        )
+        if schedule_version is None and isinstance(cached_schedule, Mapping):
+            cached_version = cached_schedule.get("version")
+            if isinstance(cached_version, int) and not isinstance(
+                cached_version,
+                bool,
+            ):
+                schedule_version = cached_version
+
+        pending_schedule: dict[str, Any] = {
+            "idx": map_index,
+            "available": bool(normalized_plans),
+            "writable": True,
+            "version": schedule_version,
+            "plan_count": len(normalized_plans),
+            "enabled_plan_count": sum(
+                1 for plan in normalized_plans if plan.get("enabled")
+            ),
+            "plans": normalized_plans,
+        }
+        if isinstance(cached_schedule, Mapping):
+            for key in ("label", "name"):
+                if key in cached_schedule:
+                    pending_schedule[key] = cached_schedule[key]
+
+        pending_uploads = getattr(self, "_pending_schedule_uploads", None)
+        if pending_uploads is None:
+            pending_uploads = {}
+            self._pending_schedule_uploads = pending_uploads
+        pending_uploads[map_index] = pending_schedule
+        pending_contradictions = getattr(
+            self,
+            "_pending_schedule_upload_contradictions",
+            None,
+        )
+        if pending_contradictions is None:
+            pending_contradictions = {}
+            self._pending_schedule_upload_contradictions = pending_contradictions
+        pending_contradictions.pop(map_index, None)
+
+    def _acknowledge_pending_schedule_uploads(
+        self,
+        payload: Mapping[str, Any],
+    ) -> None:
+        """Settle full uploads only from authoritative action-slot reads."""
+        pending_uploads = getattr(self, "_pending_schedule_uploads", None)
+        schedules = payload.get("schedules")
+        if not pending_uploads or not isinstance(schedules, Sequence):
+            return
+        pending_contradictions = getattr(
+            self,
+            "_pending_schedule_upload_contradictions",
+            None,
+        )
+        if pending_contradictions is None:
+            pending_contradictions = {}
+            self._pending_schedule_upload_contradictions = pending_contradictions
+
+        for map_index, pending_schedule in tuple(pending_uploads.items()):
+            schedule = next(
+                (
+                    entry
+                    for entry in schedules
+                    if isinstance(entry, Mapping)
+                    and entry.get("idx") == map_index
+                    and schedule_entry_has_usable_data(entry)
+                ),
+                None,
+            )
+            if schedule is None:
+                continue
+            pending_version = pending_schedule.get("version")
+            if (
+                pending_version is not None
+                and schedule.get("version") != pending_version
+            ):
+                pending_uploads.pop(map_index, None)
+                pending_contradictions.pop(map_index, None)
+                continue
+            if schedule.get("plans") == pending_schedule.get("plans"):
+                pending_uploads.pop(map_index, None)
+                pending_contradictions.pop(map_index, None)
+                continue
+            contradictory_reads = pending_contradictions.get(map_index, 0) + 1
+            if (
+                contradictory_reads
+                > PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS
+            ):
+                pending_uploads.pop(map_index, None)
+                pending_contradictions.pop(map_index, None)
+            else:
+                pending_contradictions[map_index] = contradictory_reads
+
+    def _apply_pending_schedule_uploads(self) -> None:
+        """Keep confirmed full uploads visible while cloud readbacks lag."""
+        pending_uploads = getattr(self, "_pending_schedule_uploads", None)
+        schedules = (
+            self.schedules.get("schedules")
+            if isinstance(getattr(self, "schedules", None), dict)
+            else None
+        )
+        if not pending_uploads or not isinstance(schedules, list):
+            return
+
+        for map_index, pending_schedule in pending_uploads.items():
+            replaced = False
+            for position, schedule in enumerate(schedules):
+                if isinstance(schedule, Mapping) and schedule.get("idx") == map_index:
+                    schedules[position] = deepcopy(pending_schedule)
+                    replaced = True
+                    break
+            if not replaced:
+                schedules.append(deepcopy(pending_schedule))
+
+            pending_version = pending_schedule.get("version")
+            unknown_fallback = next(
+                (
+                    schedule
+                    for schedule in schedules
+                    if isinstance(schedule, Mapping)
+                    and schedule.get("idx") is None
+                    and schedule.get("version") == pending_version
+                ),
+                None,
+            )
+            if (
+                isinstance(unknown_fallback, Mapping)
+                and unknown_fallback.get("plans") != pending_schedule.get("plans")
+                and self.schedules.get("active_schedule_index") is None
+            ):
+                # The batch version cannot identify which colliding slot is
+                # active, and its content may predate the confirmed upload.
+                self.schedules["active_selection_available"] = False
+
     async def async_plan_schedule_upload(
         self,
         *,
@@ -830,12 +998,19 @@ class DreameLawnMowerCoordinator(
                     if key[0] == map_index:
                         pending_states.pop(key, None)
                         pending_contradictions.pop(key, None)
+            schedule_version = _schedule_write_version(result)
+            self._remember_pending_schedule_upload(
+                map_index=map_index,
+                plans=plans,
+                schedule_version=schedule_version,
+            )
             # Never let a recently cached pre-upload payload hide the new plans.
             self.schedules = invalidate_schedule_slot(
                 getattr(self, "schedules", None),
                 map_index,
-                schedule_version=_schedule_write_version(result),
+                schedule_version=schedule_version,
             )
+            self._apply_pending_schedule_uploads()
             self.schedules_refreshed_at = None
             try:
                 await self.async_refresh_schedules(force=True)

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -507,6 +507,10 @@ class DreameLawnMowerCoordinator(
         self._apply_pending_schedule_plan_states()
         self._apply_pending_schedule_uploads()
         action_read_indices = _usable_schedule_indices(payload)
+        action_read_complete = set(expected_indices).issubset(action_read_indices)
+        allow_unknown_batch_slot = not (
+            map_hints_authoritative and action_read_complete
+        )
         batch_read_succeeded = False
         try:
             batch_read_generation = self._begin_schedule_read()
@@ -522,7 +526,7 @@ class DreameLawnMowerCoordinator(
             batch_read_succeeded = self._cache_batch_schedules(
                 batch_payload,
                 now=now,
-                allow_incomplete=True,
+                allow_incomplete=allow_unknown_batch_slot,
                 read_generation=batch_read_generation,
                 preserve_indices=action_read_indices,
             )

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -500,6 +500,8 @@ class DreameLawnMowerCoordinator(
         )
         if action_read_succeeded:
             self._record_schedule_read_publication(action_read_generation)
+        if map_hints_authoritative:
+            self._prune_pending_schedule_writes(known_map_indices)
         self._acknowledge_pending_schedule_plan_states(payload)
         self._acknowledge_pending_schedule_uploads(payload)
         self._apply_pending_schedule_plan_states()
@@ -820,6 +822,47 @@ class DreameLawnMowerCoordinator(
                 )
             ):
                 self.schedules["active_selection_available"] = False
+
+    def _prune_pending_schedule_writes(
+        self,
+        known_map_indices: Sequence[int],
+    ) -> None:
+        """Drop pending writes for maps absent from authoritative app metadata."""
+        valid_indices = {-1, *known_map_indices}
+        pending_states = getattr(self, "_pending_schedule_plan_states", None)
+        pending_state_contradictions = getattr(
+            self,
+            "_pending_schedule_plan_state_contradictions",
+            None,
+        )
+        if pending_states:
+            for key in tuple(pending_states):
+                if key[0] in valid_indices:
+                    continue
+                pending_states.pop(key, None)
+                if pending_state_contradictions is not None:
+                    pending_state_contradictions.pop(key, None)
+
+        pending_uploads = getattr(self, "_pending_schedule_uploads", None)
+        pending_upload_contradictions = getattr(
+            self,
+            "_pending_schedule_upload_contradictions",
+            None,
+        )
+        pending_active_indices = getattr(
+            self,
+            "_pending_schedule_upload_active_indices",
+            None,
+        )
+        if pending_uploads:
+            for map_index in tuple(pending_uploads):
+                if map_index in valid_indices:
+                    continue
+                pending_uploads.pop(map_index, None)
+                if pending_upload_contradictions is not None:
+                    pending_upload_contradictions.pop(map_index, None)
+                if pending_active_indices is not None:
+                    pending_active_indices.discard(map_index)
 
     def _remember_pending_schedule_upload(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -600,7 +600,7 @@ class DreameLawnMowerRefreshMixin:
         return await self._async_drain_batch_schedule_for_shutdown()
 
     async def _async_drain_batch_schedule_for_shutdown(self) -> bool:
-        """Cancel and retrieve the shared shielded batch-schedule task."""
+        """Wait for shared batch reads without cancelling their worker threads."""
         tasks = set(getattr(self, "_batch_schedule_read_tasks", set()))
         latest = getattr(self, "_batch_schedule_read_task", None)
         if latest is not None:
@@ -609,7 +609,7 @@ class DreameLawnMowerRefreshMixin:
         if not tasks:
             return True
 
-        drain_task = asyncio.create_task(self._async_cancel_batch_schedule_read())
+        drain_task = asyncio.create_task(self._async_wait_batch_schedule_reads())
         try:
             async with asyncio.timeout(METADATA_SHUTDOWN_GRACE_SECONDS):
                 await asyncio.shield(drain_task)
@@ -624,34 +624,34 @@ class DreameLawnMowerRefreshMixin:
             return False
         return True
 
-    async def _async_cancel_batch_schedule_read(self) -> None:
-        """Cancel the shared batch task and consume its terminal result."""
-        tasks = set(getattr(self, "_batch_schedule_read_tasks", set()))
-        latest = getattr(self, "_batch_schedule_read_task", None)
-        if latest is not None:
-            tasks.add(latest)
-        tasks.discard(asyncio.current_task())
-        if not tasks:
-            return
-        for task in tasks:
-            task.cancel()
-        results = await asyncio.gather(*tasks, return_exceptions=True)
-        for result in results:
-            if isinstance(result, Exception) and not isinstance(
-                result,
-                asyncio.CancelledError,
-            ):
-                _LOGGER.debug(
-                    "Batch schedule task failed during shutdown: %s",
+    async def _async_wait_batch_schedule_reads(self) -> None:
+        """Wait until every tracked batch worker reaches a terminal result."""
+        while True:
+            tasks = set(getattr(self, "_batch_schedule_read_tasks", set()))
+            latest = getattr(self, "_batch_schedule_read_task", None)
+            if latest is not None:
+                tasks.add(latest)
+            tasks.discard(asyncio.current_task())
+            if not tasks:
+                return
+
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for result in results:
+                if isinstance(result, Exception) and not isinstance(
                     result,
-                )
-        tracked_tasks = getattr(self, "_batch_schedule_read_tasks", None)
-        if tracked_tasks is not None:
-            tracked_tasks.difference_update(tasks)
-        if getattr(self, "_batch_schedule_read_task", None) in tasks:
-            self._batch_schedule_read_task = None
-            self._batch_schedule_read_key = None
-            self._batch_schedule_read_completed_at = None
+                    asyncio.CancelledError,
+                ):
+                    _LOGGER.debug(
+                        "Batch schedule task failed during shutdown: %s",
+                        result,
+                    )
+            tracked_tasks = getattr(self, "_batch_schedule_read_tasks", None)
+            if tracked_tasks is not None:
+                tracked_tasks.difference_update(tasks)
+            if getattr(self, "_batch_schedule_read_task", None) in tasks:
+                self._batch_schedule_read_task = None
+                self._batch_schedule_read_key = None
+                self._batch_schedule_read_completed_at = None
 
     async def _async_close_after_metadata(
         self,
@@ -662,7 +662,7 @@ class DreameLawnMowerRefreshMixin:
             with suppress(asyncio.CancelledError, Exception):
                 await metadata_task
         finally:
-            await self._async_cancel_batch_schedule_read()
+            await self._async_wait_batch_schedule_reads()
             await self.client.async_close()
 
     @staticmethod

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import suppress
 from typing import Any
 
@@ -40,10 +40,17 @@ SLOW_METADATA_REFRESH_SECONDS = 30.0
 
 def runtime_tracking_active(snapshot: DreameLawnMowerSnapshot) -> bool:
     """Prefer explicit heartbeat session state over legacy activity state."""
+    activity = getattr(snapshot, "activity", None)
+    state = getattr(snapshot, "state", None)
+    if (
+        getattr(snapshot, "docked", False)
+        or state in {"charging", "charging_completed"}
+    ):
+        return False
     session_active = getattr(snapshot, "mowing_session_active", None)
     if session_active is not None:
         return bool(session_active)
-    return getattr(snapshot, "activity", None) in {"mowing", "paused", "returning"}
+    return activity in {"mowing", "paused", "returning"}
 
 
 class DreameLawnMowerRefreshMixin:
@@ -491,8 +498,20 @@ class DreameLawnMowerRefreshMixin:
     def _metadata_phase_needs_retry(self, phase: str, result: Any) -> bool:
         """Return whether one core phase has not populated its cache yet."""
         if phase == "app_maps":
-            return hasattr(self, "app_maps_refresh_succeeded") and not bool(
-                self.app_maps_refresh_succeeded
+            if not hasattr(self, "app_maps_refresh_succeeded"):
+                return False
+            if not self.app_maps_refresh_succeeded:
+                return True
+            app_maps = getattr(self, "app_maps", None)
+            current_index = active_map_index(app_maps)
+            maps = app_maps.get("maps") if isinstance(app_maps, Mapping) else None
+            if current_index is None or not isinstance(maps, Sequence):
+                return False
+            return not any(
+                isinstance(item, Mapping)
+                and item.get("idx") == current_index
+                and bool(item.get("available"))
+                for item in maps
             )
         refreshed_at_by_phase = {
             "firmware": "firmware_update_support_refreshed_at",

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -585,8 +585,12 @@ class DreameLawnMowerRefreshMixin:
 
     async def _async_drain_batch_schedule_for_shutdown(self) -> bool:
         """Cancel and retrieve the shared shielded batch-schedule task."""
-        task = getattr(self, "_batch_schedule_read_task", None)
-        if task is None or task is asyncio.current_task():
+        tasks = set(getattr(self, "_batch_schedule_read_tasks", set()))
+        latest = getattr(self, "_batch_schedule_read_task", None)
+        if latest is not None:
+            tasks.add(latest)
+        tasks.discard(asyncio.current_task())
+        if not tasks:
             return True
 
         drain_task = asyncio.create_task(self._async_cancel_batch_schedule_read())
@@ -606,20 +610,32 @@ class DreameLawnMowerRefreshMixin:
 
     async def _async_cancel_batch_schedule_read(self) -> None:
         """Cancel the shared batch task and consume its terminal result."""
-        task = getattr(self, "_batch_schedule_read_task", None)
-        if task is None or task is asyncio.current_task():
+        tasks = set(getattr(self, "_batch_schedule_read_tasks", set()))
+        latest = getattr(self, "_batch_schedule_read_task", None)
+        if latest is not None:
+            tasks.add(latest)
+        tasks.discard(asyncio.current_task())
+        if not tasks:
             return
-        task.cancel()
-        try:
-            await task
-        except asyncio.CancelledError:
-            pass
-        except Exception as err:  # noqa: BLE001 - shutdown consumes task failure
-            _LOGGER.debug("Batch schedule task failed during shutdown: %s", err)
-        finally:
-            if getattr(self, "_batch_schedule_read_task", None) is task:
-                self._batch_schedule_read_task = None
-                self._batch_schedule_read_completed_at = None
+        for task in tasks:
+            task.cancel()
+        results = await asyncio.gather(*tasks, return_exceptions=True)
+        for result in results:
+            if isinstance(result, Exception) and not isinstance(
+                result,
+                asyncio.CancelledError,
+            ):
+                _LOGGER.debug(
+                    "Batch schedule task failed during shutdown: %s",
+                    result,
+                )
+        tracked_tasks = getattr(self, "_batch_schedule_read_tasks", None)
+        if tracked_tasks is not None:
+            tracked_tasks.difference_update(tasks)
+        if getattr(self, "_batch_schedule_read_task", None) in tasks:
+            self._batch_schedule_read_task = None
+            self._batch_schedule_read_key = None
+            self._batch_schedule_read_completed_at = None
 
     async def _async_close_after_metadata(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -18,6 +18,7 @@ from .const import DOMAIN
 from .control_options import active_map_index
 from .debug import sanitize_diagnostic_text
 from .diagnostic_events import record_diagnostic_event
+from .ha_tasks import create_background_task
 from .performance import (
     DreameLawnMowerPerformanceCycle,
     DreameLawnMowerPerformanceSample,
@@ -69,9 +70,8 @@ class DreameLawnMowerRefreshMixin:
             0,
         )
         for candidate, generation in generations.values():
-            if (
-                generation == published_generation
-                and not self._snapshot_is_stale(candidate)
+            if generation == published_generation and not self._snapshot_is_stale(
+                candidate
             ):
                 return candidate
         raise UpdateFailed(
@@ -278,7 +278,8 @@ class DreameLawnMowerRefreshMixin:
             return
         self._metadata_refresh_pending = False
         self._metadata_refresh_publish = True
-        self._metadata_refresh_task = self.hass.async_create_task(
+        self._metadata_refresh_task = create_background_task(
+            self.hass,
             self._async_refresh_metadata(
                 refresh_map_and_runtime=refresh_map_and_runtime,
             ),
@@ -297,16 +298,15 @@ class DreameLawnMowerRefreshMixin:
         tasks: list[asyncio.Task[Any]] = []
         try:
             if refresh_map_and_runtime:
-                app_maps_task = asyncio.create_task(
-                    self._async_run_metadata_phase(
-                        cycle,
-                        "app_maps",
-                        lambda: self.async_refresh_app_maps(force=False),
+                tasks.append(
+                    asyncio.create_task(
+                        self._async_run_metadata_phase(
+                            cycle,
+                            "app_maps",
+                            lambda: self.async_refresh_app_maps(force=False),
+                        )
                     )
                 )
-                tasks.append(app_maps_task)
-            else:
-                app_maps_task = None
 
             operations: tuple[
                 tuple[str, Callable[[], Awaitable[Any]]],
@@ -346,38 +346,54 @@ class DreameLawnMowerRefreshMixin:
                 for phase, operation in operations
             )
 
-            if app_maps_task is not None:
-                await app_maps_task
-            tasks.extend(
-                (
-                    asyncio.create_task(
-                        self._async_run_metadata_phase(
-                            cycle,
-                            "schedules",
-                            lambda: self.async_refresh_schedules(force=False),
-                        )
-                    ),
-                    asyncio.create_task(
+            core_results = await asyncio.gather(*tasks, return_exceptions=True)
+            core_unexpected = [
+                result
+                for result in core_results
+                if isinstance(result, Exception)
+                and not isinstance(result, asyncio.CancelledError)
+            ]
+            if core_unexpected:
+                outcome = "partial"
+                _LOGGER.debug(
+                    "Optional mower core metadata refresh had unexpected failures: %s",
+                    ", ".join(type(error).__name__ for error in core_unexpected),
+                )
+
+            if not self._shutting_down and getattr(
+                self, "_metadata_refresh_publish", True
+            ):
+                self.async_update_listeners()
+
+            tasks = [
+                asyncio.create_task(
+                    self._async_run_metadata_phase(
+                        cycle,
+                        "schedules",
+                        lambda: self.async_refresh_schedules(force=False),
+                    )
+                ),
+                asyncio.create_task(
                     self._async_run_metadata_phase(
                         cycle,
                         "batch_device_data",
                         lambda: self.async_refresh_batch_device_data(force=False),
                     )
-                    ),
-                )
-            )
-            results = await asyncio.gather(*tasks, return_exceptions=True)
-            unexpected = [
+                ),
+            ]
+            schedule_results = await asyncio.gather(*tasks, return_exceptions=True)
+            schedule_unexpected = [
                 result
-                for result in results
+                for result in schedule_results
                 if isinstance(result, Exception)
                 and not isinstance(result, asyncio.CancelledError)
             ]
-            if unexpected:
+            if schedule_unexpected:
                 outcome = "partial"
                 _LOGGER.debug(
-                    "Optional mower metadata refresh had unexpected failures: %s",
-                    ", ".join(type(error).__name__ for error in unexpected),
+                    "Optional mower schedule metadata refresh had unexpected "
+                    "failures: %s",
+                    ", ".join(type(error).__name__ for error in schedule_unexpected),
                 )
         except asyncio.CancelledError:
             outcome = "cancelled"
@@ -479,8 +495,7 @@ class DreameLawnMowerRefreshMixin:
         """Log deterministic privacy-safe timings at an appropriate level."""
         total, phases = format_performance_sample(sample)
         message = (
-            "Dreame mower performance: operation=%s outcome=%s total=%.3fs "
-            "phases=[%s]"
+            "Dreame mower performance: operation=%s outcome=%s total=%.3fs phases=[%s]"
         )
         args = (sample.operation, sample.outcome, total, phases)
         if total >= slow_after:

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -6,6 +6,7 @@ import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from contextlib import suppress
+from functools import partial
 from typing import Any
 
 from homeassistant.helpers.update_coordinator import UpdateFailed
@@ -374,15 +375,26 @@ class DreameLawnMowerRefreshMixin:
             ):
                 self.async_update_listeners()
 
-            retry_operations = [
-                (phase, operation)
-                for (phase, operation), result in zip(
-                    core_operations,
-                    core_results,
-                    strict=True,
+            retry_operations: list[
+                tuple[str, Callable[[], Awaitable[Any]]]
+            ] = []
+            for (phase, operation), result in zip(
+                core_operations,
+                core_results,
+                strict=True,
+            ):
+                if not self._metadata_phase_needs_retry(phase, result):
+                    continue
+                if phase == "app_maps":
+                    retry_operation = partial(
+                        self.async_refresh_app_maps,
+                        force=True,
+                    )
+                else:
+                    retry_operation = operation
+                retry_operations.append(
+                    (phase, retry_operation)
                 )
-                if self._metadata_phase_needs_retry(phase, result)
-            ]
             if retry_operations:
                 await asyncio.sleep(METADATA_RETRY_DELAY_SECONDS)
                 tasks = [

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -515,8 +515,13 @@ class DreameLawnMowerRefreshMixin:
             if not self.app_maps_refresh_succeeded:
                 return True
             app_maps = getattr(self, "app_maps", None)
+            if (
+                not isinstance(app_maps, Mapping)
+                or app_maps.get("map_list_valid") is not True
+            ):
+                return True
             current_index = active_map_index(app_maps)
-            maps = app_maps.get("maps") if isinstance(app_maps, Mapping) else None
+            maps = app_maps.get("maps")
             if current_index is None or not isinstance(maps, Sequence):
                 return False
             return not any(
@@ -557,7 +562,7 @@ class DreameLawnMowerRefreshMixin:
         """Cancel queued metadata and bound the wait for an in-flight request."""
         metadata_task = self._metadata_refresh_task
         if metadata_task is None or metadata_task is asyncio.current_task():
-            return True
+            return await self._async_drain_batch_schedule_for_shutdown()
 
         close_task = getattr(self, "_metadata_shutdown_close_task", None)
         if close_task is not None and not close_task.done():
@@ -576,17 +581,56 @@ class DreameLawnMowerRefreshMixin:
                 f"{DOMAIN}-metadata-shutdown",
             )
             return False
+        return await self._async_drain_batch_schedule_for_shutdown()
+
+    async def _async_drain_batch_schedule_for_shutdown(self) -> bool:
+        """Cancel and retrieve the shared shielded batch-schedule task."""
+        task = getattr(self, "_batch_schedule_read_task", None)
+        if task is None or task is asyncio.current_task():
+            return True
+
+        drain_task = asyncio.create_task(self._async_cancel_batch_schedule_read())
+        try:
+            async with asyncio.timeout(METADATA_SHUTDOWN_GRACE_SECONDS):
+                await asyncio.shield(drain_task)
+        except asyncio.CancelledError:
+            if not drain_task.done():
+                raise
+        except TimeoutError:
+            self._metadata_shutdown_close_task = self.hass.async_create_task(
+                self._async_close_after_metadata(drain_task),
+                f"{DOMAIN}-batch-schedule-shutdown",
+            )
+            return False
         return True
+
+    async def _async_cancel_batch_schedule_read(self) -> None:
+        """Cancel the shared batch task and consume its terminal result."""
+        task = getattr(self, "_batch_schedule_read_task", None)
+        if task is None or task is asyncio.current_task():
+            return
+        task.cancel()
+        try:
+            await task
+        except asyncio.CancelledError:
+            pass
+        except Exception as err:  # noqa: BLE001 - shutdown consumes task failure
+            _LOGGER.debug("Batch schedule task failed during shutdown: %s", err)
+        finally:
+            if getattr(self, "_batch_schedule_read_task", None) is task:
+                self._batch_schedule_read_task = None
+                self._batch_schedule_read_completed_at = None
 
     async def _async_close_after_metadata(
         self,
-        metadata_task: asyncio.Task[None],
+        metadata_task: asyncio.Task[Any],
     ) -> None:
         """Close the shared client once a cancellation-resistant request drains."""
         try:
-            with suppress(asyncio.CancelledError):
+            with suppress(asyncio.CancelledError, Exception):
                 await metadata_task
         finally:
+            await self._async_cancel_batch_schedule_read()
             await self.client.async_close()
 
     @staticmethod

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -32,6 +32,7 @@ _LOGGER = logging.getLogger(__name__)
 # requests session. Keep its background calls serialized until that owner
 # provides an explicit concurrency contract.
 METADATA_REFRESH_CONCURRENCY = 1
+METADATA_RETRY_DELAY_SECONDS = 2.0
 METADATA_SHUTDOWN_GRACE_SECONDS = 5.0
 SLOW_FOREGROUND_REFRESH_SECONDS = 15.0
 SLOW_METADATA_REFRESH_SECONDS = 30.0
@@ -297,14 +298,14 @@ class DreameLawnMowerRefreshMixin:
         current_task = asyncio.current_task()
         tasks: list[asyncio.Task[Any]] = []
         try:
+            core_operations: list[
+                tuple[str, Callable[[], Awaitable[Any]]]
+            ] = []
             if refresh_map_and_runtime:
-                tasks.append(
-                    asyncio.create_task(
-                        self._async_run_metadata_phase(
-                            cycle,
-                            "app_maps",
-                            lambda: self.async_refresh_app_maps(force=False),
-                        )
+                core_operations.append(
+                    (
+                        "app_maps",
+                        lambda: self.async_refresh_app_maps(force=False),
                     )
                 )
 
@@ -339,12 +340,13 @@ class DreameLawnMowerRefreshMixin:
                 ),
             )
 
-            tasks.extend(
+            core_operations.extend(operations)
+            tasks = [
                 asyncio.create_task(
                     self._async_run_metadata_phase(cycle, phase, operation)
                 )
-                for phase, operation in operations
-            )
+                for phase, operation in core_operations
+            ]
 
             core_results = await asyncio.gather(*tasks, return_exceptions=True)
             core_unexpected = [
@@ -364,6 +366,58 @@ class DreameLawnMowerRefreshMixin:
                 self, "_metadata_refresh_publish", True
             ):
                 self.async_update_listeners()
+
+            retry_operations = [
+                (phase, operation)
+                for (phase, operation), result in zip(
+                    core_operations,
+                    core_results,
+                    strict=True,
+                )
+                if self._metadata_phase_needs_retry(phase, result)
+            ]
+            if retry_operations:
+                await asyncio.sleep(METADATA_RETRY_DELAY_SECONDS)
+                tasks = [
+                    asyncio.create_task(
+                        self._async_run_metadata_phase(
+                            cycle,
+                            f"{phase}_retry",
+                            operation,
+                        )
+                    )
+                    for phase, operation in retry_operations
+                ]
+                retry_results = await asyncio.gather(
+                    *tasks,
+                    return_exceptions=True,
+                )
+                retry_failures = [
+                    result
+                    for (phase, _operation), result in zip(
+                        retry_operations,
+                        retry_results,
+                        strict=True,
+                    )
+                    if self._metadata_phase_needs_retry(phase, result)
+                ]
+                if retry_failures:
+                    outcome = "partial"
+                    _LOGGER.debug(
+                        "Optional mower core metadata remained incomplete "
+                        "after one bounded retry: %s",
+                        ", ".join(
+                            type(error).__name__
+                            if isinstance(error, Exception)
+                            else "empty"
+                            for error in retry_failures
+                        ),
+                    )
+                if (
+                    not self._shutting_down
+                    and getattr(self, "_metadata_refresh_publish", True)
+                ):
+                    self.async_update_listeners()
 
             tasks = [
                 asyncio.create_task(
@@ -433,6 +487,25 @@ class DreameLawnMowerRefreshMixin:
                 self._schedule_metadata_refresh(
                     refresh_map_and_runtime=True,
                 )
+
+    def _metadata_phase_needs_retry(self, phase: str, result: Any) -> bool:
+        """Return whether one core phase has not populated its cache yet."""
+        if phase == "app_maps":
+            return hasattr(self, "app_maps_refresh_succeeded") and not bool(
+                self.app_maps_refresh_succeeded
+            )
+        refreshed_at_by_phase = {
+            "firmware": "firmware_update_support_refreshed_at",
+            "app_map_objects": "app_map_objects_refreshed_at",
+            "vector_map": "vector_map_details_refreshed_at",
+            "weather": "weather_protection_refreshed_at",
+            "maintenance": "maintenance_status_refreshed_at",
+            "voice": "voice_settings_refreshed_at",
+        }
+        marker = refreshed_at_by_phase.get(phase)
+        if marker is None or not hasattr(self, marker):
+            return False
+        return isinstance(result, Exception) or getattr(self, marker) is None
 
     async def _async_run_metadata_phase(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -522,7 +522,23 @@ class DreameLawnMowerRefreshMixin:
                 return True
             current_index = active_map_index(app_maps)
             maps = app_maps.get("maps")
-            if current_index is None or not isinstance(maps, Sequence):
+            if not isinstance(maps, Sequence):
+                return False
+            if current_index is None:
+                selected_index = getattr(self, "selected_map_index", None)
+                if (
+                    isinstance(selected_index, int)
+                    and not isinstance(selected_index, bool)
+                    and selected_index >= 0
+                    and any(
+                        isinstance(item, Mapping)
+                        and item.get("idx") == selected_index
+                        and item.get("created") is not False
+                        for item in maps
+                    )
+                ):
+                    current_index = selected_index
+            if current_index is None:
                 return False
             return not any(
                 isinstance(item, Mapping)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
@@ -60,6 +60,8 @@ def decode_batch_schedule_payload(
         payload = json.loads(payload_text)
         version = _to_int(payload.get("v")) if isinstance(payload, Mapping) else None
         plans = decode_schedule_payload_text(payload_text)
+        if version is not None:
+            result["active_schedule_version"] = version
         schedule.update(
             {
                 "version": version,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
@@ -59,6 +59,12 @@ def decode_batch_schedule_payload(
     try:
         payload = json.loads(payload_text)
         version = _to_int(payload.get("v")) if isinstance(payload, Mapping) else None
+        plan_data = payload.get("d") if isinstance(payload, Mapping) else None
+        if not isinstance(plan_data, Sequence) or isinstance(
+            plan_data,
+            str | bytes | bytearray,
+        ):
+            raise ValueError("missing_or_invalid_batch_schedule_plans")
         plans = decode_schedule_payload_text(payload_text)
         if version is not None:
             result["active_schedule_version"] = version

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -896,6 +896,7 @@ class DreameLawnMowerClient(
         include_raw: bool = False,
         map_indices: Sequence[int] | None = None,
         chunk_size: int = SCHEDULE_CHUNK_SIZE,
+        include_current_task: bool = True,
     ) -> dict[str, Any]:
         """Return read-only mower schedules from the app action protocol."""
         return await asyncio.to_thread(
@@ -903,6 +904,7 @@ class DreameLawnMowerClient(
             include_raw,
             map_indices,
             chunk_size,
+            include_current_task,
         )
 
     async def async_set_app_schedule_plan_enabled(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1130,12 +1130,14 @@ class DreameLawnMowerClient(
         *,
         include_raw: bool = False,
         map_index_hint: int | None = None,
+        discover_map_index: bool = True,
     ) -> dict[str, Any]:
         """Fetch and decode schedule data from batch device data."""
         return await asyncio.to_thread(
             self._sync_get_batch_schedules,
             include_raw,
             map_index_hint,
+            discover_map_index,
         )
 
     async def async_get_batch_mowing_preferences(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -80,6 +80,9 @@ from .client_maps import (
     _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS,
     _DreameLawnMowerClientMapsMixin,
 )
+from .client_settings import (
+    SCHEDULE_READ_TIMEOUT_SECONDS as _SCHEDULE_READ_TIMEOUT_SECONDS,
+)
 from .client_settings import _DreameLawnMowerClientSettingsMixin
 from .deadline import DeadlineExceededError as DeadlineExceededError
 from .deadline import run_with_deadline as run_with_deadline
@@ -1131,13 +1134,16 @@ class DreameLawnMowerClient(
         include_raw: bool = False,
         map_index_hint: int | None = None,
         discover_map_index: bool = True,
+        timeout: float = _SCHEDULE_READ_TIMEOUT_SECONDS,
     ) -> dict[str, Any]:
         """Fetch and decode schedule data from batch device data."""
+        timeout = _validate_positive_number(timeout, "batch schedule timeout")
         return await asyncio.to_thread(
             self._sync_get_batch_schedules,
             include_raw,
             map_index_hint,
             discover_map_index,
+            timeout,
         )
 
     async def async_get_batch_mowing_preferences(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -610,11 +610,28 @@ class _DreameLawnMowerClientCoreMixin:
     def _sync_get_batch_device_data(
         self,
         keys: Sequence[str] | None = None,
+        *,
+        deadline: float | None = None,
     ) -> Mapping[str, Any] | None:
-        cloud = self._sync_get_cloud_protocol()
+        cloud = (
+            self._sync_get_cloud_protocol(deadline=deadline)
+            if deadline is not None
+            else self._sync_get_cloud_protocol()
+        )
         requested = list(keys or [])
         try:
-            response = cloud.get_batch_device_datas(requested)
+            request_options: dict[str, Any] = {}
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    raise DreameLawnMowerConnectionError(
+                        "Batch device-data request timed out."
+                    )
+                request_options = {
+                    "timeout": remaining,
+                    "deadline": deadline,
+                }
+            response = cloud.get_batch_device_datas(requested, **request_options)
         except DeviceException as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
         return response if isinstance(response, Mapping) else None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -401,6 +401,27 @@ def _normalize_app_map_entries(value: Any) -> list[dict[str, Any]]:
     return result
 
 
+def _app_map_entries_are_valid(
+    value: Any,
+    entries: Sequence[Mapping[str, Any]],
+) -> bool:
+    """Return whether MAPL supplied one complete, unambiguous list."""
+    raw_entries = _app_action_data(value)
+    indices = [entry.get("idx") for entry in entries]
+    return (
+        isinstance(raw_entries, Sequence)
+        and not isinstance(raw_entries, str | bytes | bytearray)
+        and len(entries) == len(raw_entries)
+        and all(
+            isinstance(index, int)
+            and not isinstance(index, bool)
+            and index >= 0
+            for index in indices
+        )
+        and len(set(indices)) == len(indices)
+    )
+
+
 def _app_map_payload_summary(value: Any) -> dict[str, Any]:
     if not isinstance(value, Mapping):
         return {"payload_type": _operation_value_type(value)}

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -408,6 +408,11 @@ def _app_map_entries_are_valid(
     """Return whether MAPL supplied one complete, unambiguous list."""
     raw_entries = _app_action_data(value)
     indices = [entry.get("idx") for entry in entries]
+    current_created_count = sum(
+        1
+        for entry in entries
+        if entry.get("created") is not False and entry.get("current") is True
+    )
     return (
         isinstance(raw_entries, Sequence)
         and not isinstance(raw_entries, str | bytes | bytearray)
@@ -419,6 +424,7 @@ def _app_map_entries_are_valid(
             for index in indices
         )
         and len(set(indices)) == len(indices)
+        and current_created_count <= 1
     )
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -417,6 +417,7 @@ def _app_map_entries_are_valid(
         isinstance(raw_entries, Sequence)
         and not isinstance(raw_entries, str | bytes | bytearray)
         and len(entries) == len(raw_entries)
+        and all(_app_map_status_flags_are_valid(item) for item in raw_entries)
         and all(
             isinstance(index, int)
             and not isinstance(index, bool)
@@ -425,6 +426,24 @@ def _app_map_entries_are_valid(
         )
         and len(set(indices)) == len(indices)
         and current_created_count <= 1
+    )
+
+
+def _app_map_status_flags_are_valid(value: Any) -> bool:
+    """Return whether one raw MAPL row uses only boolean or 0/1 flags."""
+    if not isinstance(value, Sequence) or isinstance(value, str | bytes | bytearray):
+        return False
+    values = list(value)
+    if len(values) < 4:
+        return False
+    return all(
+        isinstance(flag, bool)
+        or (
+            isinstance(flag, int)
+            and not isinstance(flag, bool)
+            and flag in {0, 1}
+        )
+        for flag in values[1:5]
     )
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -562,10 +562,25 @@ class _DreameLawnMowerClientMapsMixin:
     ) -> dict[str, Any]:
         chunk_size = _validate_app_map_chunk_size(chunk_size)
         map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
+        map_list_data = _app_action_data(map_list_result)
         map_entries = _normalize_app_map_entries(map_list_result)
+        map_indices = [entry.get("idx") for entry in map_entries]
+        map_list_valid = (
+            isinstance(map_list_data, Sequence)
+            and not isinstance(map_list_data, str | bytes | bytearray)
+            and len(map_entries) == len(map_list_data)
+            and all(
+                isinstance(index, int)
+                and not isinstance(index, bool)
+                and index >= 0
+                for index in map_indices
+            )
+            and len(set(map_indices)) == len(map_indices)
+        )
         result: dict[str, Any] = {
             "source": "app_action_map",
             "available": False,
+            "map_list_valid": map_list_valid,
             "map_count": len(map_entries),
             "created_map_count": sum(
                 1 for entry in map_entries if entry.get("created") is not False

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -24,6 +24,7 @@ from .app_protocol import (
     mower_state_label,
 )
 from .client_map_helpers import (
+    _app_map_entries_are_valid,
     _app_map_payload_summary,
     _app_map_view_details,
     _app_map_view_summary,
@@ -562,20 +563,10 @@ class _DreameLawnMowerClientMapsMixin:
     ) -> dict[str, Any]:
         chunk_size = _validate_app_map_chunk_size(chunk_size)
         map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
-        map_list_data = _app_action_data(map_list_result)
         map_entries = _normalize_app_map_entries(map_list_result)
-        map_indices = [entry.get("idx") for entry in map_entries]
-        map_list_valid = (
-            isinstance(map_list_data, Sequence)
-            and not isinstance(map_list_data, str | bytes | bytearray)
-            and len(map_entries) == len(map_list_data)
-            and all(
-                isinstance(index, int)
-                and not isinstance(index, bool)
-                and index >= 0
-                for index in map_indices
-            )
-            and len(set(map_indices)) == len(map_indices)
+        map_list_valid = _app_map_entries_are_valid(
+            map_list_result,
+            map_entries,
         )
         result: dict[str, Any] = {
             "source": "app_action_map",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -582,7 +582,7 @@ class _DreameLawnMowerClientMapsMixin:
             "errors": [],
         }
         for entry in map_entries:
-            if entry.get("current"):
+            if map_list_valid and entry.get("current"):
                 result["current_map_index"] = entry["idx"]
             if not entry.get("created"):
                 result["maps"].append(entry)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -582,7 +582,11 @@ class _DreameLawnMowerClientMapsMixin:
             "errors": [],
         }
         for entry in map_entries:
-            if map_list_valid and entry.get("current"):
+            if (
+                map_list_valid
+                and entry.get("created") is not False
+                and entry.get("current")
+            ):
                 result["current_map_index"] = entry["idx"]
             if not entry.get("created"):
                 result["maps"].append(entry)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -87,6 +87,8 @@ from .schedule import (
 )
 
 SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS = 5.0
+SCHEDULE_READ_DEADLINE_SECONDS = 10.0
+SCHEDULE_READ_TIMEOUT_SECONDS = 5.0
 
 
 class _DreameLawnMowerClientSettingsMixin:
@@ -95,6 +97,7 @@ class _DreameLawnMowerClientSettingsMixin:
         include_raw: bool = False,
         map_indices: Sequence[int] | None = None,
         chunk_size: int = SCHEDULE_CHUNK_SIZE,
+        include_current_task: bool = True,
     ) -> dict[str, Any]:
         """Fetch and decode mower schedules through read-only app actions."""
         if chunk_size <= 0:
@@ -108,23 +111,30 @@ class _DreameLawnMowerClientSettingsMixin:
             "errors": [],
         }
 
-        try:
-            current_task_deadline = (
-                time.monotonic() + SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS
-            )
-            task_result = self._sync_call_app_action(
-                {"m": "g", "t": "SCHDT", "d": {"t": 0}},
-                retry_count=0,
-                timeout=SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS,
-                deadline=current_task_deadline,
-            )
-            result["raw_current_task"] = _json_safe(task_result, max_depth=4)
-            task_data = _app_action_data(task_result)
-            result["current_task"] = schedule_task_summary(task_data)
-        except Exception as err:  # noqa: BLE001 - schedule task is diagnostic
-            result["errors"].append({"stage": "current_task", "error": str(err)})
+        if include_current_task:
+            try:
+                current_task_deadline = (
+                    time.monotonic() + SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS
+                )
+                task_result = self._sync_call_app_action(
+                    {"m": "g", "t": "SCHDT", "d": {"t": 0}},
+                    retry_count=0,
+                    timeout=SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS,
+                    deadline=current_task_deadline,
+                )
+                result["raw_current_task"] = _json_safe(task_result, max_depth=4)
+                task_data = _app_action_data(task_result)
+                result["current_task"] = schedule_task_summary(task_data)
+            except Exception as err:  # noqa: BLE001 - optional diagnostic
+                result["errors"].append(
+                    {"stage": "current_task", "error": str(err)}
+                )
 
-        for map_index in self._app_schedule_map_indices(map_indices):
+        schedule_deadline = time.monotonic() + SCHEDULE_READ_DEADLINE_SECONDS
+        for map_index in self._app_schedule_map_indices(
+            map_indices,
+            deadline=schedule_deadline,
+        ):
             schedule_result: dict[str, Any] = {
                 "idx": map_index,
                 "label": "default" if map_index == -1 else f"map_{map_index}",
@@ -132,7 +142,10 @@ class _DreameLawnMowerClientSettingsMixin:
             }
             try:
                 info_result = self._sync_call_app_action(
-                    {"m": "g", "t": "SCHDIV2", "d": {"i": map_index}}
+                    {"m": "g", "t": "SCHDIV2", "d": {"i": map_index}},
+                    retry_count=0,
+                    timeout=SCHEDULE_READ_TIMEOUT_SECONDS,
+                    deadline=schedule_deadline,
                 )
                 schedule_result["raw_info"] = _json_safe(info_result, max_depth=4)
                 info = _app_action_data(info_result)
@@ -153,6 +166,7 @@ class _DreameLawnMowerClientSettingsMixin:
                     size=size,
                     version=version,
                     chunk_size=chunk_size,
+                    deadline=schedule_deadline,
                 )
                 plans = decode_schedule_payload_text(payload_text)
                 schedule_result.update(
@@ -1089,6 +1103,7 @@ class _DreameLawnMowerClientSettingsMixin:
         size: int,
         version: int,
         chunk_size: int = SCHEDULE_CHUNK_SIZE,
+        deadline: float | None = None,
     ) -> tuple[str, int, int]:
         chunks = bytearray()
         offset = 0
@@ -1100,7 +1115,10 @@ class _DreameLawnMowerClientSettingsMixin:
                     "m": "g",
                     "t": "SCHDDV2",
                     "d": {"s": offset, "l": request_size, "v": version},
-                }
+                },
+                retry_count=0,
+                timeout=SCHEDULE_READ_TIMEOUT_SECONDS,
+                deadline=deadline,
             )
             data = _app_action_data(chunk_result)
             if not isinstance(data, Mapping) or "d" not in data:
@@ -1126,19 +1144,35 @@ class _DreameLawnMowerClientSettingsMixin:
     def _app_schedule_map_indices(
         self,
         map_indices: Sequence[int] | None,
+        *,
+        deadline: float | None = None,
     ) -> list[int]:
         if map_indices is not None:
             return _dedupe_ints(map_indices)
-        return _dedupe_ints([-1, *self._app_map_indices(None)])
+        return _dedupe_ints(
+            [-1, *self._app_map_indices(None, deadline=deadline)]
+        )
 
     def _app_map_indices(
         self,
         map_indices: Sequence[int] | None,
+        *,
+        deadline: float | None = None,
     ) -> list[int]:
         if map_indices is not None:
             return [idx for idx in _dedupe_ints(map_indices) if idx >= 0]
         try:
-            map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
+            request_options: dict[str, Any] = {}
+            if deadline is not None:
+                request_options = {
+                    "retry_count": 0,
+                    "timeout": SCHEDULE_READ_TIMEOUT_SECONDS,
+                    "deadline": deadline,
+                }
+            map_list_result = self._sync_call_app_action(
+                {"m": "g", "t": "MAPL"},
+                **request_options,
+            )
             detected = [
                 entry["idx"] for entry in _normalize_app_map_entries(map_list_result)
             ]

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -130,10 +130,19 @@ class _DreameLawnMowerClientSettingsMixin:
                     {"stage": "current_task", "error": str(err)}
                 )
 
-        schedule_deadline = time.monotonic() + SCHEDULE_READ_DEADLINE_SECONDS
+        schedule_started_at = time.monotonic()
+        schedule_deadline = schedule_started_at + SCHEDULE_READ_DEADLINE_SECONDS
+        map_discovery_deadline = schedule_deadline
+        if map_indices is None:
+            # Treat MAPL as another fair-budget participant so a nonresponsive
+            # discovery probe cannot consume the schedule slots' whole window.
+            map_discovery_deadline = min(
+                schedule_deadline,
+                schedule_started_at + SCHEDULE_READ_DEADLINE_SECONDS / 4,
+            )
         schedule_indices = self._app_schedule_map_indices(
             map_indices,
-            deadline=schedule_deadline,
+            deadline=map_discovery_deadline,
         )
         for position, map_index in enumerate(schedule_indices):
             now = time.monotonic()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -21,6 +21,7 @@ from .client_constants import (
     VOICE_PROMPT_FIELDS,
 )
 from .client_map_helpers import (
+    _app_map_entries_are_valid,
     _normalize_app_map_entries,
 )
 from .client_settings_helpers import (
@@ -1293,9 +1294,10 @@ class _DreameLawnMowerClientSettingsMixin:
                 {"m": "g", "t": "MAPL"},
                 **request_options,
             )
-            detected = [
-                entry["idx"] for entry in _normalize_app_map_entries(map_list_result)
-            ]
+            map_entries = _normalize_app_map_entries(map_list_result)
+            if not _app_map_entries_are_valid(map_list_result, map_entries):
+                return [0, 1]
+            detected = [entry["idx"] for entry in map_entries]
         except Exception:  # noqa: BLE001 - fall back to the two likely map slots
             detected = [0, 1]
         return _dedupe_ints(detected)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -131,10 +131,18 @@ class _DreameLawnMowerClientSettingsMixin:
                 )
 
         schedule_deadline = time.monotonic() + SCHEDULE_READ_DEADLINE_SECONDS
-        for map_index in self._app_schedule_map_indices(
+        schedule_indices = self._app_schedule_map_indices(
             map_indices,
             deadline=schedule_deadline,
-        ):
+        )
+        for position, map_index in enumerate(schedule_indices):
+            now = time.monotonic()
+            remaining = max(0.0, schedule_deadline - now)
+            remaining_slots = len(schedule_indices) - position
+            slot_deadline = min(
+                schedule_deadline,
+                now + remaining / remaining_slots,
+            )
             schedule_result: dict[str, Any] = {
                 "idx": map_index,
                 "label": "default" if map_index == -1 else f"map_{map_index}",
@@ -145,7 +153,7 @@ class _DreameLawnMowerClientSettingsMixin:
                     {"m": "g", "t": "SCHDIV2", "d": {"i": map_index}},
                     retry_count=0,
                     timeout=SCHEDULE_READ_TIMEOUT_SECONDS,
-                    deadline=schedule_deadline,
+                    deadline=slot_deadline,
                 )
                 schedule_result["raw_info"] = _json_safe(info_result, max_depth=4)
                 info = _app_action_data(info_result)
@@ -166,7 +174,7 @@ class _DreameLawnMowerClientSettingsMixin:
                     size=size,
                     version=version,
                     chunk_size=chunk_size,
-                    deadline=schedule_deadline,
+                    deadline=slot_deadline,
                 )
                 plans = decode_schedule_payload_text(payload_text)
                 schedule_result.update(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -144,6 +144,7 @@ class _DreameLawnMowerClientSettingsMixin:
             map_indices,
             deadline=map_discovery_deadline,
         )
+        failed_schedule_positions: list[int] = []
         for position, map_index in enumerate(schedule_indices):
             now = time.monotonic()
             remaining = max(0.0, schedule_deadline - now)
@@ -152,64 +153,120 @@ class _DreameLawnMowerClientSettingsMixin:
                 schedule_deadline,
                 now + remaining / remaining_slots,
             )
-            schedule_result: dict[str, Any] = {
-                "idx": map_index,
-                "label": "default" if map_index == -1 else f"map_{map_index}",
-                "available": False,
-            }
-            try:
-                info_result = self._sync_call_app_action(
-                    {"m": "g", "t": "SCHDIV2", "d": {"i": map_index}},
-                    retry_count=0,
-                    timeout=SCHEDULE_READ_TIMEOUT_SECONDS,
-                    deadline=slot_deadline,
-                )
-                schedule_result["raw_info"] = _json_safe(info_result, max_depth=4)
-                info = _app_action_data(info_result)
-                if not isinstance(info, Mapping):
-                    raise DreameLawnMowerConnectionError(
-                        "SCHDIV2 returned invalid schedule metadata."
-                    )
-                size = _positive_int(info.get("l"))
-                version = _positive_int(info.get("v"))
-                schedule_result["size"] = size
-                schedule_result["version"] = version
-                if not size or version is None or version == EMPTY_SCHEDULE_VERSION:
-                    schedule_result["plans"] = []
-                    result["schedules"].append(schedule_result)
-                    continue
-
-                payload_text, chunk_count, offset = self._sync_get_app_schedule_text(
-                    size=size,
-                    version=version,
-                    chunk_size=chunk_size,
-                    deadline=slot_deadline,
-                )
-                plans = decode_schedule_payload_text(payload_text)
-                schedule_result.update(
-                    {
-                        "available": bool(plans),
-                        "chunk_count": chunk_count,
-                        "downloaded_size": offset,
-                        "plan_count": len(plans),
-                        "enabled_plan_count": sum(
-                            1 for plan in plans if plan.get("enabled")
-                        ),
-                        "plans": plans,
-                    }
-                )
-                if include_raw:
-                    schedule_result["raw_text"] = payload_text
-                if plans:
-                    result["available"] = True
-            except Exception as err:  # noqa: BLE001 - keep probing other maps
-                schedule_result["error"] = str(err)
+            schedule_result, error = self._sync_get_app_schedule_slot(
+                map_index=map_index,
+                chunk_size=chunk_size,
+                include_raw=include_raw,
+                deadline=slot_deadline,
+            )
+            if error is not None:
+                failed_schedule_positions.append(position)
                 result["errors"].append(
-                    {"idx": map_index, "stage": "schedule", "error": str(err)}
+                    {"idx": map_index, "stage": "schedule", "error": str(error)}
                 )
+            elif schedule_result.get("plans"):
+                result["available"] = True
             result["schedules"].append(schedule_result)
 
+        # A fair first pass prevents one slow slot from starving the rest. If
+        # later slots return quickly, spend the unused shared budget on one
+        # recovery pass so a valid early slot is not permanently limited to
+        # only its initial fraction of the operation deadline.
+        for position in failed_schedule_positions:
+            now = time.monotonic()
+            if now >= schedule_deadline:
+                break
+            map_index = schedule_indices[position]
+            retry_deadline = min(
+                schedule_deadline,
+                now + SCHEDULE_READ_TIMEOUT_SECONDS,
+            )
+            schedule_result, error = self._sync_get_app_schedule_slot(
+                map_index=map_index,
+                chunk_size=chunk_size,
+                include_raw=include_raw,
+                deadline=retry_deadline,
+            )
+            result["schedules"][position] = schedule_result
+            prior_error = next(
+                (
+                    item
+                    for item in result["errors"]
+                    if item.get("idx") == map_index
+                    and item.get("stage") == "schedule"
+                ),
+                None,
+            )
+            if error is None:
+                if prior_error is not None:
+                    result["errors"].remove(prior_error)
+                if schedule_result.get("plans"):
+                    result["available"] = True
+            elif prior_error is not None:
+                prior_error["error"] = str(error)
+
         return result
+
+    def _sync_get_app_schedule_slot(
+        self,
+        *,
+        map_index: int,
+        chunk_size: int,
+        include_raw: bool,
+        deadline: float,
+    ) -> tuple[dict[str, Any], Exception | None]:
+        """Fetch one schedule slot within its assigned deadline."""
+        schedule_result: dict[str, Any] = {
+            "idx": map_index,
+            "label": "default" if map_index == -1 else f"map_{map_index}",
+            "available": False,
+        }
+        try:
+            info_result = self._sync_call_app_action(
+                {"m": "g", "t": "SCHDIV2", "d": {"i": map_index}},
+                retry_count=0,
+                timeout=SCHEDULE_READ_TIMEOUT_SECONDS,
+                deadline=deadline,
+            )
+            schedule_result["raw_info"] = _json_safe(info_result, max_depth=4)
+            info = _app_action_data(info_result)
+            if not isinstance(info, Mapping):
+                raise DreameLawnMowerConnectionError(
+                    "SCHDIV2 returned invalid schedule metadata."
+                )
+            size = _positive_int(info.get("l"))
+            version = _positive_int(info.get("v"))
+            schedule_result["size"] = size
+            schedule_result["version"] = version
+            if not size or version is None or version == EMPTY_SCHEDULE_VERSION:
+                schedule_result["plans"] = []
+                return schedule_result, None
+
+            payload_text, chunk_count, offset = self._sync_get_app_schedule_text(
+                size=size,
+                version=version,
+                chunk_size=chunk_size,
+                deadline=deadline,
+            )
+            plans = decode_schedule_payload_text(payload_text)
+            schedule_result.update(
+                {
+                    "available": bool(plans),
+                    "chunk_count": chunk_count,
+                    "downloaded_size": offset,
+                    "plan_count": len(plans),
+                    "enabled_plan_count": sum(
+                        1 for plan in plans if plan.get("enabled")
+                    ),
+                    "plans": plans,
+                }
+            )
+            if include_raw:
+                schedule_result["raw_text"] = payload_text
+        except Exception as err:  # noqa: BLE001 - caller keeps probing other maps
+            schedule_result["error"] = str(err)
+            return schedule_result, err
+        return schedule_result, None
 
     def _sync_set_app_schedule_plan_enabled(
         self,
@@ -586,9 +643,10 @@ class _DreameLawnMowerClientSettingsMixin:
         self,
         include_raw: bool = False,
         map_index_hint: int | None = None,
+        discover_map_index: bool = True,
     ) -> dict[str, Any]:
         """Fetch and decode schedule data from batch device data."""
-        if map_index_hint is None:
+        if map_index_hint is None and discover_map_index:
             map_index_hint = self._sync_get_current_app_map_index()
         batch_data = self._sync_get_batch_device_data(_batch_schedule_keys())
         if batch_data is None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -665,11 +665,18 @@ class _DreameLawnMowerClientSettingsMixin:
         include_raw: bool = False,
         map_index_hint: int | None = None,
         discover_map_index: bool = True,
+        timeout: float | None = None,
     ) -> dict[str, Any]:
         """Fetch and decode schedule data from batch device data."""
+        if timeout is not None and timeout <= 0:
+            raise ValueError("timeout must be greater than zero.")
+        deadline = time.monotonic() + timeout if timeout is not None else None
         if map_index_hint is None and discover_map_index:
-            map_index_hint = self._sync_get_current_app_map_index()
-        batch_data = self._sync_get_batch_device_data(_batch_schedule_keys())
+            map_index_hint = self._sync_get_current_app_map_index(deadline=deadline)
+        batch_data = self._sync_get_batch_device_data(
+            _batch_schedule_keys(),
+            deadline=deadline,
+        )
         if batch_data is None:
             return {
                 "source": "batch_device_data_schedule",
@@ -689,9 +696,26 @@ class _DreameLawnMowerClientSettingsMixin:
             map_index_hint=map_index_hint,
         )
 
-    def _sync_get_current_app_map_index(self) -> int | None:
+    def _sync_get_current_app_map_index(
+        self,
+        *,
+        deadline: float | None = None,
+    ) -> int | None:
         try:
-            map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
+            request_options: dict[str, Any] = {}
+            if deadline is not None:
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return None
+                request_options = {
+                    "retry_count": 0,
+                    "timeout": remaining,
+                    "deadline": deadline,
+                }
+            map_list_result = self._sync_call_app_action(
+                {"m": "g", "t": "MAPL"},
+                **request_options,
+            )
             for entry in _normalize_app_map_entries(map_list_result):
                 if entry.get("current"):
                     return _positive_int(entry.get("idx"))

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -144,13 +144,24 @@ class _DreameLawnMowerClientSettingsMixin:
             map_indices,
             deadline=map_discovery_deadline,
         )
+        first_pass_deadline = schedule_deadline
+        if len(schedule_indices) > 1:
+            now = time.monotonic()
+            remaining = max(0.0, schedule_deadline - now)
+            # Reserve enough of the shared window for one slower slot to make
+            # meaningful progress after every slot receives a fair first pass.
+            recovery_reserve = min(
+                SCHEDULE_READ_TIMEOUT_SECONDS,
+                remaining / 2,
+            )
+            first_pass_deadline = schedule_deadline - recovery_reserve
         failed_schedule_positions: list[int] = []
         for position, map_index in enumerate(schedule_indices):
             now = time.monotonic()
-            remaining = max(0.0, schedule_deadline - now)
+            remaining = max(0.0, first_pass_deadline - now)
             remaining_slots = len(schedule_indices) - position
             slot_deadline = min(
-                schedule_deadline,
+                first_pass_deadline,
                 now + remaining / remaining_slots,
             )
             schedule_result, error = self._sync_get_app_schedule_slot(
@@ -172,6 +183,16 @@ class _DreameLawnMowerClientSettingsMixin:
         # later slots return quickly, spend the unused shared budget on one
         # recovery pass so a valid early slot is not permanently limited to
         # only its initial fraction of the operation deadline.
+        retry_offset = getattr(self, "_app_schedule_retry_offset", 0)
+        if failed_schedule_positions:
+            retry_offset %= len(failed_schedule_positions)
+            failed_schedule_positions = [
+                *failed_schedule_positions[retry_offset:],
+                *failed_schedule_positions[:retry_offset],
+            ]
+            self._app_schedule_retry_offset = (
+                retry_offset + 1
+            ) % len(failed_schedule_positions)
         for position in failed_schedule_positions:
             now = time.monotonic()
             if now >= schedule_deadline:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -139,10 +139,12 @@ class DreameMowerProtocol:
         return info
 
     def disconnect(self):
-        if self.cloud is not None:
-            self.cloud.disconnect()
-        if self.device_cloud is not None:
-            self.device_cloud.disconnect()
+        disconnected_protocols: set[int] = set()
+        for cloud in (self.cloud, self.device_cloud):
+            if cloud is None or id(cloud) in disconnected_protocols:
+                continue
+            disconnected_protocols.add(id(cloud))
+            cloud.disconnect()
         self._connected = False
 
     def send_async(self, callback, method, parameters: Any = None, retry_count: int = 0):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -9,7 +9,8 @@ import hmac
 import requests
 import zlib
 import queue
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from threading import RLock, Thread, Timer
 from time import sleep
 import time
@@ -182,6 +183,30 @@ class DreameMowerDreameHomeCloudProtocol:
             lock = RLock()
             self._request_lock = lock
         return lock
+
+    @contextmanager
+    def _operation_lock_with_deadline(
+        self,
+        deadline: float | None,
+    ) -> Iterator[None]:
+        """Acquire the shared cloud lock without exceeding an overall deadline."""
+        lock = self._operation_lock()
+        if deadline is None:
+            with lock:
+                yield
+            return
+
+        remaining = deadline - time.monotonic()
+        if remaining <= 0 or not lock.acquire(timeout=remaining):
+            raise requests.exceptions.Timeout(
+                "The cloud operation timed out waiting for the shared request lock."
+            )
+        try:
+            if time.monotonic() >= deadline:
+                raise requests.exceptions.Timeout("The cloud operation timed out.")
+            yield
+        finally:
+            lock.release()
 
     def _api_task(self):
         while True:
@@ -376,7 +401,7 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
     ) -> bool:
-        with self._operation_lock():
+        with self._operation_lock_with_deadline(deadline):
             return self._login_unlocked(timeout, deadline=deadline)
 
     def _login_unlocked(
@@ -845,7 +870,7 @@ class DreameMowerDreameHomeCloudProtocol:
         on_dispatch: Callable[[], None] | None = None,
         raise_on_api_error: bool = False,
     ) -> Any:
-        with self._operation_lock():
+        with self._operation_lock_with_deadline(deadline):
             return self._send_unlocked(
                 method,
                 parameters,
@@ -1125,7 +1150,7 @@ class DreameMowerDreameHomeCloudProtocol:
         redact_response: bool = False,
         on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
-        with self._operation_lock():
+        with self._operation_lock_with_deadline(deadline):
             return self._request_unlocked(
                 url,
                 data,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -155,6 +155,7 @@ class DreameMowerDreameHomeCloudProtocol:
         self._request_lock = RLock()
         self._deadline_operation_state = local()
         self._disconnect_pending = False
+        self._shutdown_requested = False
         self._disconnect_cleanup_thread = None
         self._session = requests.session()
         self._queue = queue.Queue()
@@ -198,6 +199,10 @@ class DreameMowerDreameHomeCloudProtocol:
         """Return whether teardown is waiting for an active transport to exit."""
         return bool(getattr(self, "_disconnect_pending", False))
 
+    def _shutdown_is_requested(self) -> bool:
+        """Return whether this protocol instance has started permanent teardown."""
+        return bool(getattr(self, "_shutdown_requested", False))
+
     def _run_serialized_operation(
         self,
         operation: Callable[[], Any],
@@ -205,9 +210,16 @@ class DreameMowerDreameHomeCloudProtocol:
         deadline: float | None,
     ) -> Any:
         """Keep the shared lock with a deadline worker until transport exits."""
+        def run_if_active() -> Any:
+            if self._shutdown_is_requested():
+                return None
+            return operation()
+
+        if self._shutdown_is_requested():
+            return None
         if deadline is None or self._deadline_operation_runs_in_worker():
             with self._operation_lock_with_deadline(deadline):
-                return operation()
+                return run_if_active()
 
         state = getattr(self, "_deadline_operation_state", None)
         if state is None:
@@ -218,7 +230,7 @@ class DreameMowerDreameHomeCloudProtocol:
             state.active = True
             try:
                 with self._operation_lock_with_deadline(deadline):
-                    return operation()
+                    return run_if_active()
             finally:
                 state.active = False
 
@@ -400,6 +412,8 @@ class DreameMowerDreameHomeCloudProtocol:
 
     def connect(self, message_callback=None, connected_callback=None):
         with self._operation_lock():
+            if self._shutdown_is_requested():
+                return None
             return self._connect_unlocked(message_callback, connected_callback)
 
     def _connect_unlocked(self, message_callback=None, connected_callback=None):
@@ -871,6 +885,8 @@ class DreameMowerDreameHomeCloudProtocol:
 
     def send_async(self, callback, method, parameters, retry_count: int = 2):
         with self._operation_lock():
+            if self._shutdown_is_requested():
+                return None
             return self._send_async_unlocked(
                 callback,
                 method,
@@ -1401,6 +1417,8 @@ class DreameMowerDreameHomeCloudProtocol:
         retry_count=2,
     ) -> Any:
         with self._operation_lock():
+            if self._shutdown_is_requested():
+                return None
             return self._get_unlocked(url, params, retry_count)
 
     def _get_unlocked(
@@ -1481,6 +1499,7 @@ class DreameMowerDreameHomeCloudProtocol:
         return None
 
     def disconnect(self, timeout: float = _CLOUD_DISCONNECT_TIMEOUT_SECONDS):
+        self._shutdown_requested = True
         self._disconnect_pending = True
         deadline = time.monotonic() + max(0.0, timeout)
         try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -11,7 +11,7 @@ import zlib
 import queue
 from collections.abc import Callable, Iterator
 from contextlib import contextmanager
-from threading import RLock, Thread, Timer
+from threading import RLock, Thread, Timer, local
 from time import sleep
 import time
 import locale
@@ -121,6 +121,7 @@ def _post_cloud_response(
     *,
     deadline: float | None,
     on_dispatch: Callable[[], None] | None = None,
+    run_in_worker: bool = True,
 ) -> Any:
     """Post while bounding the response-header phase by an absolute deadline."""
     def post() -> Any:
@@ -128,7 +129,7 @@ def _post_cloud_response(
             on_dispatch()
         return session.post(url, **request_options)
 
-    if deadline is None:
+    if deadline is None or not run_in_worker:
         return post()
     try:
         return run_with_deadline(
@@ -151,6 +152,7 @@ class DreameMowerDreameHomeCloudProtocol:
         self._location = country
         self._did = did
         self._request_lock = RLock()
+        self._deadline_operation_state = local()
         self._session = requests.session()
         self._queue = queue.Queue()
         self._thread = None
@@ -183,6 +185,42 @@ class DreameMowerDreameHomeCloudProtocol:
             lock = RLock()
             self._request_lock = lock
         return lock
+
+    def _deadline_operation_runs_in_worker(self) -> bool:
+        """Return whether this thread owns a deadline-bounded cloud operation."""
+        state = getattr(self, "_deadline_operation_state", None)
+        return bool(state is not None and getattr(state, "active", False))
+
+    def _run_serialized_operation(
+        self,
+        operation: Callable[[], Any],
+        *,
+        deadline: float | None,
+    ) -> Any:
+        """Keep the shared lock with a deadline worker until transport exits."""
+        if deadline is None or self._deadline_operation_runs_in_worker():
+            with self._operation_lock_with_deadline(deadline):
+                return operation()
+
+        state = getattr(self, "_deadline_operation_state", None)
+        if state is None:
+            state = local()
+            self._deadline_operation_state = state
+
+        def run() -> Any:
+            state.active = True
+            try:
+                with self._operation_lock_with_deadline(deadline):
+                    return operation()
+            finally:
+                state.active = False
+
+        try:
+            return run_with_deadline(run, deadline=deadline)
+        except DeadlineExceededError as err:
+            raise requests.exceptions.Timeout(
+                "The cloud operation timed out."
+            ) from err
 
     @contextmanager
     def _operation_lock_with_deadline(
@@ -401,8 +439,10 @@ class DreameMowerDreameHomeCloudProtocol:
         *,
         deadline: float | None = None,
     ) -> bool:
-        with self._operation_lock_with_deadline(deadline):
-            return self._login_unlocked(timeout, deadline=deadline)
+        return self._run_serialized_operation(
+            lambda: self._login_unlocked(timeout, deadline=deadline),
+            deadline=deadline,
+        )
 
     def _login_unlocked(
         self,
@@ -461,6 +501,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 self.get_api_url() + self._strings[17],
                 request_options,
                 deadline=deadline,
+                run_in_worker=not self._deadline_operation_runs_in_worker(),
             )
             if deadline is not None:
                 try:
@@ -870,8 +911,8 @@ class DreameMowerDreameHomeCloudProtocol:
         on_dispatch: Callable[[], None] | None = None,
         raise_on_api_error: bool = False,
     ) -> Any:
-        with self._operation_lock_with_deadline(deadline):
-            return self._send_unlocked(
+        return self._run_serialized_operation(
+            lambda: self._send_unlocked(
                 method,
                 parameters,
                 retry_count,
@@ -880,7 +921,9 @@ class DreameMowerDreameHomeCloudProtocol:
                 redact_response=redact_response,
                 on_dispatch=on_dispatch,
                 raise_on_api_error=raise_on_api_error,
-            )
+            ),
+            deadline=deadline,
+        )
 
     def _send_unlocked(
         self,
@@ -1150,8 +1193,8 @@ class DreameMowerDreameHomeCloudProtocol:
         redact_response: bool = False,
         on_dispatch: Callable[[], None] | None = None,
     ) -> Any:
-        with self._operation_lock_with_deadline(deadline):
-            return self._request_unlocked(
+        return self._run_serialized_operation(
+            lambda: self._request_unlocked(
                 url,
                 data,
                 retry_count,
@@ -1159,7 +1202,9 @@ class DreameMowerDreameHomeCloudProtocol:
                 deadline=deadline,
                 redact_response=redact_response,
                 on_dispatch=on_dispatch,
-            )
+            ),
+            deadline=deadline,
+        )
 
     def _request_unlocked(
         self,
@@ -1237,6 +1282,7 @@ class DreameMowerDreameHomeCloudProtocol:
                     url,
                     request_options,
                     **post_options,
+                    run_in_worker=not self._deadline_operation_runs_in_worker(),
                 )
                 if deadline is not None:
                     try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -154,6 +154,8 @@ class DreameMowerDreameHomeCloudProtocol:
         self._did = did
         self._request_lock = RLock()
         self._deadline_operation_state = local()
+        self._disconnect_pending = False
+        self._disconnect_cleanup_thread = None
         self._session = requests.session()
         self._queue = queue.Queue()
         self._thread = None
@@ -191,6 +193,10 @@ class DreameMowerDreameHomeCloudProtocol:
         """Return whether this thread owns a deadline-bounded cloud operation."""
         state = getattr(self, "_deadline_operation_state", None)
         return bool(state is not None and getattr(state, "active", False))
+
+    def _disconnect_is_pending(self) -> bool:
+        """Return whether teardown is waiting for an active transport to exit."""
+        return bool(getattr(self, "_disconnect_pending", False))
 
     def _run_serialized_operation(
         self,
@@ -397,6 +403,8 @@ class DreameMowerDreameHomeCloudProtocol:
             return self._connect_unlocked(message_callback, connected_callback)
 
     def _connect_unlocked(self, message_callback=None, connected_callback=None):
+        if self._disconnect_is_pending():
+            return None
         if self._logged_in:
             info = self.get_device_info()
             if info:
@@ -430,6 +438,8 @@ class DreameMowerDreameHomeCloudProtocol:
                     elif not self._client_connected:
                         _LOGGER.error("Not connected to the device client")
                         self._set_client_key()
+                if self._disconnect_is_pending():
+                    return None
                 self._connected = True
                 return info
         return None
@@ -516,7 +526,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 response_text = response.text
             if response.status_code == 200:
                 data = json.loads(response_text)
-                if self._strings[18] in data:
+                if self._strings[18] in data and not self._disconnect_is_pending():
                     self._key = data.get(self._strings[18])
                     self._secondary_key = data.get(self._strings[19])
                     self._key_expire = time.time(
@@ -546,7 +556,7 @@ class DreameMowerDreameHomeCloudProtocol:
             response = None
             _LOGGER.error("Login failed: %s", str(ex))
 
-        if self._logged_in:
+        if self._logged_in and not self._disconnect_is_pending():
             self._fail_count = 0
             self._connected = True
         return self._logged_in
@@ -1326,6 +1336,8 @@ class DreameMowerDreameHomeCloudProtocol:
             "DreameMowerDreameHomeCloudProtocol.request response: %s", response)
         if response is not None:
             if response.status_code == 200:
+                if self._disconnect_is_pending():
+                    return None
                 self._fail_count = 0
                 self._connected = True
                 _LOGGER.debug(
@@ -1446,6 +1458,8 @@ class DreameMowerDreameHomeCloudProtocol:
 
         if response is not None:
             if response.status_code == 200:
+                if self._disconnect_is_pending():
+                    return None
                 self._fail_count = 0
                 self._connected = True
                 _LOGGER.debug(
@@ -1467,6 +1481,7 @@ class DreameMowerDreameHomeCloudProtocol:
         return None
 
     def disconnect(self, timeout: float = _CLOUD_DISCONNECT_TIMEOUT_SECONDS):
+        self._disconnect_pending = True
         deadline = time.monotonic() + max(0.0, timeout)
         try:
             with self._operation_lock_with_deadline(deadline):
@@ -1486,18 +1501,41 @@ class DreameMowerDreameHomeCloudProtocol:
             request_queue = getattr(self, "_queue", None)
             if thread and request_queue is not None:
                 request_queue.put([])
+            self._schedule_deferred_disconnect()
             return False
         return True
 
     def _disconnect_unlocked(self):
-        self._session.close()
-        self._connected = False
-        self._logged_in = False
-        self._disconnect_mqtt_client()
-        if self._thread:
-            self._queue.put([])
-        self._message_callback = None
-        self._connected_callback = None
+        try:
+            self._session.close()
+            self._connected = False
+            self._logged_in = False
+            self._disconnect_mqtt_client()
+            if self._thread:
+                self._queue.put([])
+            self._message_callback = None
+            self._connected_callback = None
+        finally:
+            self._disconnect_pending = False
+
+    def _schedule_deferred_disconnect(self):
+        """Finish session teardown after an active serialized request exits."""
+        cleanup_thread = getattr(self, "_disconnect_cleanup_thread", None)
+        if cleanup_thread is not None and cleanup_thread.is_alive():
+            return
+        cleanup_thread = Thread(
+            target=self._complete_deferred_disconnect,
+            name="dreame-cloud-disconnect",
+            daemon=True,
+        )
+        self._disconnect_cleanup_thread = cleanup_thread
+        cleanup_thread.start()
+
+    def _complete_deferred_disconnect(self):
+        """Acquire the transport lock and complete a pending disconnect."""
+        with self._operation_lock():
+            if self._disconnect_is_pending():
+                self._disconnect_unlocked()
 
     def _disconnect_mqtt_client(self):
         client = self._client

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -37,6 +37,7 @@ _REDACTED_APP_ACTION_RESPONSE = "<redacted app action response>"
 _DEADLINE_RESPONSE_CHUNK_BYTES = 8 * 1024
 _MAX_DEADLINE_RESPONSE_BYTES = 1024 * 1024
 _READ_RETRY_DELAYS_SECONDS = (0.25, 1.0)
+_CLOUD_DISCONNECT_TIMEOUT_SECONDS = 2.0
 
 
 
@@ -1465,9 +1466,27 @@ class DreameMowerDreameHomeCloudProtocol:
             self._fail_count = self._fail_count + 1
         return None
 
-    def disconnect(self):
-        with self._operation_lock():
-            self._disconnect_unlocked()
+    def disconnect(self, timeout: float = _CLOUD_DISCONNECT_TIMEOUT_SECONDS):
+        deadline = time.monotonic() + max(0.0, timeout)
+        try:
+            with self._operation_lock_with_deadline(deadline):
+                self._disconnect_unlocked()
+        except requests.exceptions.Timeout:
+            _LOGGER.warning(
+                "Cloud disconnect skipped after waiting %.1f seconds for an "
+                "active request to finish.",
+                timeout,
+            )
+            self._connected = False
+            self._logged_in = False
+            self._message_callback = None
+            self._connected_callback = None
+            thread = getattr(self, "_thread", None)
+            request_queue = getattr(self, "_queue", None)
+            if thread and request_queue is not None:
+                request_queue.put([])
+            return False
+        return True
 
     def _disconnect_unlocked(self):
         self._session.close()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -1087,10 +1087,18 @@ class DreameMowerDreameHomeCloudProtocol:
 
         return api_response["data"][self._strings[33]]
 
-    def get_batch_device_datas(self, props) -> Any:
+    def get_batch_device_datas(
+        self,
+        props,
+        *,
+        timeout: float = 20,
+        deadline: float | None = None,
+    ) -> Any:
         api_response = self._api_call(
             f"{self._strings[23]}/{self._strings[26]}/{self._strings[44]}",
             {"did": self._did, self._strings[35]: props},
+            timeout=timeout,
+            deadline=deadline,
         )
         if api_response is None or "data" not in api_response:
             return None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -1481,6 +1481,7 @@ class DreameMowerDreameHomeCloudProtocol:
             self._logged_in = False
             self._message_callback = None
             self._connected_callback = None
+            self._disconnect_mqtt_client()
             thread = getattr(self, "_thread", None)
             request_queue = getattr(self, "_queue", None)
             if thread and request_queue is not None:
@@ -1492,13 +1493,24 @@ class DreameMowerDreameHomeCloudProtocol:
         self._session.close()
         self._connected = False
         self._logged_in = False
-        if self._client is not None:
-            self._client.loop_stop()
-            self._client.disconnect()
-            self._client = None
-            self._client_connected = False
-            self._client_connecting = False
+        self._disconnect_mqtt_client()
         if self._thread:
             self._queue.put([])
         self._message_callback = None
         self._connected_callback = None
+
+    def _disconnect_mqtt_client(self):
+        client = self._client
+        self._client = None
+        self._client_connected = False
+        self._client_connecting = False
+        if client is None:
+            return
+        try:
+            client.loop_stop()
+        except Exception as ex:
+            _LOGGER.debug("Failed to stop cloud MQTT loop: %s", ex)
+        try:
+            client.disconnect()
+        except Exception as ex:
+            _LOGGER.debug("Failed to disconnect cloud MQTT client: %s", ex)

--- a/custom_components/dreame_lawn_mower/ha_tasks.py
+++ b/custom_components/dreame_lawn_mower/ha_tasks.py
@@ -1,0 +1,27 @@
+"""Home Assistant task ownership helpers."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Coroutine
+from typing import Any
+
+from homeassistant.core import HomeAssistant
+
+
+def create_background_task[T](
+    hass: HomeAssistant,
+    coroutine: Coroutine[Any, Any, T],
+    name: str,
+) -> asyncio.Task[T]:
+    """Create intentionally long-lived work outside config-entry setup tracking."""
+    create = getattr(hass, "async_create_background_task", None)
+    if callable(create):
+        return create(coroutine, name)
+
+    # Keep lightweight test doubles and older Home Assistant builds usable.
+    create = hass.async_create_task
+    try:
+        return create(coroutine, name)
+    except TypeError:
+        return create(coroutine)

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -55,6 +55,8 @@ def has_complete_schedule_cache(
 def merge_app_schedule_payload(
     existing: Mapping[str, Any] | None,
     incoming: Mapping[str, Any],
+    *,
+    expected_indices: Sequence[int],
 ) -> dict[str, Any]:
     """Merge successful action slots while retaining cached failed slots."""
     if not isinstance(existing, Mapping):
@@ -100,6 +102,13 @@ def merge_app_schedule_payload(
         and isinstance(schedule.get("version"), int)
         and not isinstance(schedule.get("version"), bool)
     }
+    usable_incoming_by_index = {
+        schedule.get("idx"): schedule
+        for schedule in incoming_schedules
+        if schedule_entry_has_usable_data(schedule)
+        and isinstance(schedule.get("idx"), int)
+        and not isinstance(schedule.get("idx"), bool)
+    }
     if discovered_versions:
         merged = [
             schedule
@@ -110,6 +119,47 @@ def merge_app_schedule_payload(
                 and schedule.get("version") in discovered_versions
             )
         ]
+
+    cached_active_version = existing.get("active_schedule_version")
+    cached_active_indices = {
+        schedule.get("idx")
+        for schedule in existing_schedules
+        if isinstance(schedule, Mapping)
+        and schedule.get("version") == cached_active_version
+        and isinstance(schedule.get("idx"), int)
+        and not isinstance(schedule.get("idx"), bool)
+    }
+    complete_refresh = set(expected_indices).issubset(usable_incoming_by_index)
+    active_version_invalidated = (
+        isinstance(cached_active_version, int)
+        and not isinstance(cached_active_version, bool)
+        and cached_active_version not in discovered_versions
+        and incoming.get("current_task") is None
+        and (
+            complete_refresh
+            or (
+                bool(cached_active_indices)
+                and cached_active_indices.issubset(usable_incoming_by_index)
+            )
+        )
+    )
+    if active_version_invalidated:
+        merged = [
+            schedule
+            for schedule in merged
+            if not (
+                isinstance(schedule, Mapping)
+                and schedule.get("idx") is None
+                and schedule.get("version") == cached_active_version
+            )
+        ]
+        normalized.pop("active_schedule_version", None)
+        current_task = normalized.get("current_task")
+        if (
+            isinstance(current_task, Mapping)
+            and current_task.get("version") == cached_active_version
+        ):
+            normalized.pop("current_task", None)
 
     normalized.update(
         {

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -182,13 +182,6 @@ def merge_app_schedule_payload(
         and isinstance(schedule.get("idx"), int)
         and not isinstance(schedule.get("idx"), bool)
     }
-    discovered_versions = {
-        schedule.get("version")
-        for schedule in usable_incoming_by_index.values()
-        if isinstance(schedule.get("version"), int)
-        and not isinstance(schedule.get("version"), bool)
-    }
-
     cached_active_version = existing.get("active_schedule_version")
     cached_active_index = existing.get("active_schedule_index")
     cached_active_index_is_valid = isinstance(
@@ -198,14 +191,25 @@ def merge_app_schedule_payload(
     expected_index_set = set(expected_indices)
     complete_refresh = expected_index_set.issubset(usable_incoming_by_index)
     can_prune_unexpected_indices = complete_refresh or prune_unexpected_indices
+    resolution_incoming_by_index = {
+        index: schedule
+        for index, schedule in usable_incoming_by_index.items()
+        if not prune_unexpected_indices or index in expected_index_set
+    }
     incoming_indices_by_version = {
         version: {
             index
-            for index, schedule in usable_incoming_by_index.items()
+            for index, schedule in resolution_incoming_by_index.items()
             if schedule.get("version") == version
         }
-        for version in discovered_versions
+        for version in {
+            schedule.get("version")
+            for schedule in resolution_incoming_by_index.values()
+            if isinstance(schedule.get("version"), int)
+            and not isinstance(schedule.get("version"), bool)
+        }
     }
+    discovered_versions = set(incoming_indices_by_version)
     resolved_fallback_versions = {
         version
         for version, indices in incoming_indices_by_version.items()

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -60,6 +60,8 @@ def has_complete_schedule_cache(
 def invalidate_schedule_slot(
     existing: Mapping[str, Any] | None,
     map_index: int,
+    *,
+    schedule_version: int | None = None,
 ) -> dict[str, Any] | None:
     """Remove one confirmed-stale writable slot and its derived metadata."""
     if not isinstance(existing, Mapping):
@@ -79,6 +81,8 @@ def invalidate_schedule_slot(
         and isinstance(schedule.get("version"), int)
         and not isinstance(schedule.get("version"), bool)
     }
+    if isinstance(schedule_version, int) and not isinstance(schedule_version, bool):
+        invalidated_versions.add(schedule_version)
     retained = [
         schedule
         for schedule in schedules
@@ -248,6 +252,7 @@ def merge_app_schedule_payload(
     normalized["schedules"] = merged
     if incoming.get("current_task") is not None:
         normalized["current_task"] = incoming["current_task"]
+        normalized["active_selection_available"] = True
     normalized["available"] = any(
         isinstance(schedule, Mapping) and bool(schedule.get("available"))
         for schedule in merged
@@ -344,6 +349,7 @@ def merge_batch_schedule_payload(
         for schedule in normalized["schedules"]
     )
     normalized["active_schedule_version"] = batch_version
+    normalized["active_selection_available"] = True
     if incoming.get("current_task") is not None:
         normalized["current_task"] = incoming["current_task"]
     normalized["captured_at"] = captured_at.isoformat()

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -399,8 +399,6 @@ def merge_batch_schedule_payload(
             ),
             None,
         )
-        if matching_schedule is None and len(numeric_matching_schedules) == 1:
-            matching_schedule = numeric_matching_schedules[0]
         if matching_schedule is None and hinted_index_is_allowed:
             matching_schedule = next(
                 (
@@ -411,6 +409,8 @@ def merge_batch_schedule_payload(
                 ),
                 None,
             )
+        if matching_schedule is None and len(numeric_matching_schedules) == 1:
+            matching_schedule = numeric_matching_schedules[0]
     else:
         matching_schedule = (
             numeric_matching_schedules[0]

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -174,15 +174,6 @@ def merge_app_schedule_payload(
         elif schedule_entry_has_usable_data(schedule):
             merged[position] = schedule
 
-    discovered_versions = {
-        schedule.get("version")
-        for schedule in incoming_schedules
-        if schedule_entry_has_usable_data(schedule)
-        and isinstance(schedule.get("idx"), int)
-        and not isinstance(schedule.get("idx"), bool)
-        and isinstance(schedule.get("version"), int)
-        and not isinstance(schedule.get("version"), bool)
-    }
     usable_incoming_by_index = {
         schedule.get("idx"): schedule
         for schedule in incoming_schedules
@@ -190,18 +181,65 @@ def merge_app_schedule_payload(
         and isinstance(schedule.get("idx"), int)
         and not isinstance(schedule.get("idx"), bool)
     }
-    if discovered_versions:
+    discovered_versions = {
+        schedule.get("version")
+        for schedule in usable_incoming_by_index.values()
+        if isinstance(schedule.get("version"), int)
+        and not isinstance(schedule.get("version"), bool)
+    }
+
+    cached_active_version = existing.get("active_schedule_version")
+    cached_active_index = existing.get("active_schedule_index")
+    cached_active_index_is_valid = isinstance(
+        cached_active_index,
+        int,
+    ) and not isinstance(cached_active_index, bool)
+    expected_index_set = set(expected_indices)
+    complete_refresh = expected_index_set.issubset(usable_incoming_by_index)
+    incoming_indices_by_version = {
+        version: {
+            index
+            for index, schedule in usable_incoming_by_index.items()
+            if schedule.get("version") == version
+        }
+        for version in discovered_versions
+    }
+    resolved_fallback_versions = {
+        version
+        for version, indices in incoming_indices_by_version.items()
+        if (
+            cached_active_index_is_valid
+            and cached_active_index in indices
+        )
+        or (complete_refresh and len(indices) == 1)
+    }
+    active_version_indices = incoming_indices_by_version.get(
+        cached_active_version,
+        set(),
+    )
+    if cached_active_index_is_valid:
+        resolved_active_index = (
+            cached_active_index
+            if cached_active_index in active_version_indices
+            else None
+        )
+    else:
+        resolved_active_index = (
+            next(iter(active_version_indices))
+            if complete_refresh and len(active_version_indices) == 1
+            else None
+        )
+    if resolved_fallback_versions:
         merged = [
             schedule
             for schedule in merged
             if not (
                 isinstance(schedule, Mapping)
                 and schedule.get("idx") is None
-                and schedule.get("version") in discovered_versions
+                and schedule.get("version") in resolved_fallback_versions
             )
         ]
 
-    cached_active_version = existing.get("active_schedule_version")
     cached_active_indices = {
         schedule.get("idx")
         for schedule in existing_schedules
@@ -210,13 +248,17 @@ def merge_app_schedule_payload(
         and isinstance(schedule.get("idx"), int)
         and not isinstance(schedule.get("idx"), bool)
     }
-    cached_active_index = existing.get("active_schedule_index")
-    cached_active_index_is_valid = isinstance(
-        cached_active_index,
-        int,
-    ) and not isinstance(cached_active_index, bool)
-    expected_index_set = set(expected_indices)
-    complete_refresh = expected_index_set.issubset(usable_incoming_by_index)
+    ambiguous_active_fallback = (
+        not cached_active_index_is_valid
+        and cached_active_version in discovered_versions
+        and cached_active_version not in resolved_fallback_versions
+        and any(
+            isinstance(schedule, Mapping)
+            and schedule.get("idx") is None
+            and schedule.get("version") == cached_active_version
+            for schedule in existing_schedules
+        )
+    )
     if complete_refresh:
         merged = [
             schedule
@@ -284,6 +326,11 @@ def merge_app_schedule_payload(
     if incoming.get("current_task") is not None:
         normalized["current_task"] = incoming["current_task"]
         normalized["active_selection_available"] = True
+    elif resolved_active_index is not None:
+        normalized["active_schedule_index"] = resolved_active_index
+        normalized["active_selection_available"] = True
+    elif ambiguous_active_fallback:
+        normalized["active_selection_available"] = False
     normalized["available"] = any(
         isinstance(schedule, Mapping) and bool(schedule.get("available"))
         for schedule in merged

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -466,7 +466,6 @@ def merge_batch_schedule_payload(
             and isinstance(schedule, Mapping)
             and schedule is not matching_schedule
             and schedule.get("idx") is None
-            and schedule.get("version") == batch_version
         )
     ]
     if matching_schedule is None:

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -344,6 +344,7 @@ def merge_batch_schedule_payload(
     *,
     captured_at: datetime,
     allow_unknown_slot: bool,
+    allowed_hint_indices: Sequence[int] = (),
     preserve_indices: Sequence[int] = (),
 ) -> dict[str, Any] | None:
     """Merge one effective batch schedule without guessing its writable slot."""
@@ -380,6 +381,9 @@ def merge_batch_schedule_payload(
         hinted_index,
         bool,
     )
+    hinted_index_is_allowed = (
+        hinted_index_is_valid and hinted_index in set(allowed_hint_indices)
+    )
     numeric_matching_schedules = [
         schedule
         for schedule in matching_schedules
@@ -397,6 +401,16 @@ def merge_batch_schedule_payload(
         )
         if matching_schedule is None and len(numeric_matching_schedules) == 1:
             matching_schedule = numeric_matching_schedules[0]
+        if matching_schedule is None and hinted_index_is_allowed:
+            matching_schedule = next(
+                (
+                    schedule
+                    for schedule in existing_schedules
+                    if isinstance(schedule, Mapping)
+                    and schedule.get("idx") == hinted_index
+                ),
+                None,
+            )
     else:
         matching_schedule = (
             numeric_matching_schedules[0]
@@ -410,13 +424,17 @@ def merge_batch_schedule_payload(
                 None,
             )
         )
-    if matching_schedule is None and not allow_unknown_slot:
+    if (
+        matching_schedule is None
+        and not allow_unknown_slot
+        and not hinted_index_is_allowed
+    ):
         return None
     if matching_schedule is not None:
         for key in ("idx", "label", "name"):
             if key in matching_schedule:
                 batch_schedule[key] = matching_schedule[key]
-    else:
+    elif not hinted_index_is_allowed:
         batch_schedule["idx"] = None
         batch_schedule["label"] = "active_schedule"
         batch_schedule["writable"] = False
@@ -426,6 +444,7 @@ def merge_batch_schedule_payload(
     if (
         matching_schedule is not None
         and matching_schedule.get("idx") in preserved_indices
+        and matching_schedule.get("version") == batch_version
         and schedule_entry_has_usable_data(matching_schedule)
     ):
         # A successful action read from this refresh is the authoritative plan

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -267,6 +267,7 @@ def merge_batch_schedule_payload(
     *,
     captured_at: datetime,
     allow_unknown_slot: bool,
+    preserve_indices: Sequence[int] = (),
 ) -> dict[str, Any] | None:
     """Merge one effective batch schedule without guessing its writable slot."""
     schedules = incoming.get("schedules")
@@ -317,10 +318,21 @@ def merge_batch_schedule_payload(
         batch_schedule["label"] = "active_schedule"
         batch_schedule["writable"] = False
 
+    preserved_indices = set(preserve_indices)
+    replacement_schedule = batch_schedule
+    if (
+        matching_schedule is not None
+        and matching_schedule.get("idx") in preserved_indices
+        and schedule_entry_has_usable_data(matching_schedule)
+    ):
+        # A successful action read from this refresh is the authoritative plan
+        # content; use batch data only to select the active version.
+        replacement_schedule = matching_schedule
+
     normalized = dict(existing)
     normalized["schedules"] = [
         (
-            batch_schedule
+            replacement_schedule
             if isinstance(schedule, Mapping) and schedule is matching_schedule
             else schedule
         )

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -352,6 +352,13 @@ def merge_batch_schedule_payload(
     normalized["active_selection_available"] = True
     if incoming.get("current_task") is not None:
         normalized["current_task"] = incoming["current_task"]
+    else:
+        cached_current_task = normalized.get("current_task")
+        if (
+            isinstance(cached_current_task, Mapping)
+            and cached_current_task.get("version") != batch_version
+        ):
+            normalized.pop("current_task", None)
     normalized["captured_at"] = captured_at.isoformat()
     normalized["source"] = "app_action_schedule_with_batch_refresh"
     return normalized

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -298,15 +298,33 @@ def merge_batch_schedule_payload(
         if isinstance(schedule, Mapping)
         and schedule.get("version") == batch_version
     ]
-    matching_schedule = next(
-        (
-            schedule
-            for schedule in matching_schedules
-            if isinstance(schedule.get("idx"), int)
-            and not isinstance(schedule.get("idx"), bool)
-        ),
-        matching_schedules[0] if matching_schedules else None,
+    hinted_index = batch_schedule.get("idx")
+    hinted_index_is_valid = isinstance(hinted_index, int) and not isinstance(
+        hinted_index,
+        bool,
     )
+    numeric_matching_schedules = [
+        schedule
+        for schedule in matching_schedules
+        if isinstance(schedule.get("idx"), int)
+        and not isinstance(schedule.get("idx"), bool)
+    ]
+    if hinted_index_is_valid:
+        matching_schedule = next(
+            (
+                schedule
+                for schedule in numeric_matching_schedules
+                if schedule.get("idx") == hinted_index
+            ),
+            None,
+        )
+        if matching_schedule is None and len(numeric_matching_schedules) == 1:
+            matching_schedule = numeric_matching_schedules[0]
+    else:
+        matching_schedule = next(
+            iter(numeric_matching_schedules),
+            matching_schedules[0] if matching_schedules else None,
+        )
     if matching_schedule is None and not allow_unknown_slot:
         return None
     if matching_schedule is not None:

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -52,6 +52,66 @@ def has_complete_schedule_cache(
     )
 
 
+def invalidate_schedule_slot(
+    existing: Mapping[str, Any] | None,
+    map_index: int,
+) -> dict[str, Any] | None:
+    """Remove one confirmed-stale writable slot and its derived metadata."""
+    if not isinstance(existing, Mapping):
+        return None
+    schedules = existing.get("schedules")
+    if not isinstance(schedules, Sequence) or isinstance(
+        schedules,
+        str | bytes | bytearray,
+    ):
+        return dict(existing)
+
+    invalidated_versions = {
+        schedule.get("version")
+        for schedule in schedules
+        if isinstance(schedule, Mapping)
+        and schedule.get("idx") == map_index
+        and isinstance(schedule.get("version"), int)
+        and not isinstance(schedule.get("version"), bool)
+    }
+    retained = [
+        schedule
+        for schedule in schedules
+        if not (
+            isinstance(schedule, Mapping)
+            and (
+                schedule.get("idx") == map_index
+                or (
+                    schedule.get("idx") is None
+                    and isinstance(schedule.get("version"), int)
+                    and not isinstance(schedule.get("version"), bool)
+                    and schedule.get("version") in invalidated_versions
+                )
+            )
+        )
+    ]
+    normalized = dict(existing)
+    normalized["schedules"] = retained
+    cached_active_version = normalized.get("active_schedule_version")
+    if (
+        isinstance(cached_active_version, int)
+        and not isinstance(cached_active_version, bool)
+        and cached_active_version in invalidated_versions
+    ):
+        normalized.pop("active_schedule_version", None)
+        current_task = normalized.get("current_task")
+        if (
+            isinstance(current_task, Mapping)
+            and current_task.get("version") == cached_active_version
+        ):
+            normalized.pop("current_task", None)
+    normalized["available"] = any(
+        isinstance(schedule, Mapping) and bool(schedule.get("available"))
+        for schedule in retained
+    )
+    return normalized
+
+
 def merge_app_schedule_payload(
     existing: Mapping[str, Any] | None,
     incoming: Mapping[str, Any],
@@ -130,6 +190,18 @@ def merge_app_schedule_payload(
         and not isinstance(schedule.get("idx"), bool)
     }
     complete_refresh = set(expected_indices).issubset(usable_incoming_by_index)
+    if complete_refresh:
+        expected_index_set = set(expected_indices)
+        merged = [
+            schedule
+            for schedule in merged
+            if not (
+                isinstance(schedule, Mapping)
+                and isinstance(schedule.get("idx"), int)
+                and not isinstance(schedule.get("idx"), bool)
+                and schedule.get("idx") not in expected_index_set
+            )
+        ]
     active_version_invalidated = (
         isinstance(cached_active_version, int)
         and not isinstance(cached_active_version, bool)

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -142,7 +142,11 @@ def merge_app_schedule_payload(
 ) -> dict[str, Any]:
     """Merge successful action slots while retaining cached failed slots."""
     if not isinstance(existing, Mapping):
-        return dict(incoming)
+        return _initial_app_schedule_payload(
+            incoming,
+            expected_indices=expected_indices,
+            prune_unexpected_indices=prune_unexpected_indices,
+        )
 
     normalized = dict(existing)
     incoming_schedules = incoming.get("schedules")
@@ -156,7 +160,11 @@ def merge_app_schedule_payload(
         existing_schedules,
         str | bytes | bytearray,
     ):
-        return dict(incoming)
+        return _initial_app_schedule_payload(
+            incoming,
+            expected_indices=expected_indices,
+            prune_unexpected_indices=prune_unexpected_indices,
+        )
 
     merged = list(existing_schedules)
     positions = {
@@ -345,6 +353,41 @@ def merge_app_schedule_payload(
     normalized["available"] = any(
         isinstance(schedule, Mapping) and bool(schedule.get("available"))
         for schedule in merged
+    )
+    return normalized
+
+
+def _initial_app_schedule_payload(
+    incoming: Mapping[str, Any],
+    *,
+    expected_indices: Sequence[int],
+    prune_unexpected_indices: bool,
+) -> dict[str, Any]:
+    """Normalize a first action payload against authoritative map indices."""
+    normalized = dict(incoming)
+    schedules = incoming.get("schedules")
+    if (
+        not prune_unexpected_indices
+        or not isinstance(schedules, Sequence)
+        or isinstance(schedules, str | bytes | bytearray)
+    ):
+        return normalized
+
+    expected_index_set = set(expected_indices)
+    normalized_schedules = [
+        schedule
+        for schedule in schedules
+        if not (
+            isinstance(schedule, Mapping)
+            and isinstance(schedule.get("idx"), int)
+            and not isinstance(schedule.get("idx"), bool)
+            and schedule.get("idx") not in expected_index_set
+        )
+    ]
+    normalized["schedules"] = normalized_schedules
+    normalized["available"] = any(
+        isinstance(schedule, Mapping) and bool(schedule.get("available"))
+        for schedule in normalized_schedules
     )
     return normalized
 

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -46,6 +46,11 @@ def has_complete_schedule_cache(
         for schedule in schedules
         if isinstance(schedule, Mapping)
     }
+    if any(
+        isinstance(schedule, Mapping) and schedule.get("idx") is None
+        for schedule in schedules
+    ):
+        return False
     return all(
         schedule_entry_has_usable_data(schedule_by_index.get(index))
         for index in {-1, *known_map_indices}

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -138,6 +138,7 @@ def merge_app_schedule_payload(
     incoming: Mapping[str, Any],
     *,
     expected_indices: Sequence[int],
+    prune_unexpected_indices: bool = False,
 ) -> dict[str, Any]:
     """Merge successful action slots while retaining cached failed slots."""
     if not isinstance(existing, Mapping):
@@ -196,6 +197,7 @@ def merge_app_schedule_payload(
     ) and not isinstance(cached_active_index, bool)
     expected_index_set = set(expected_indices)
     complete_refresh = expected_index_set.issubset(usable_incoming_by_index)
+    can_prune_unexpected_indices = complete_refresh or prune_unexpected_indices
     incoming_indices_by_version = {
         version: {
             index
@@ -259,7 +261,7 @@ def merge_app_schedule_payload(
             for schedule in existing_schedules
         )
     )
-    if complete_refresh:
+    if can_prune_unexpected_indices:
         merged = [
             schedule
             for schedule in merged
@@ -278,7 +280,7 @@ def merge_app_schedule_payload(
                 and refreshed_active_slot.get("version") != cached_active_version
             )
             or (
-                complete_refresh
+                can_prune_unexpected_indices
                 and cached_active_index not in expected_index_set
             )
         )
@@ -290,6 +292,11 @@ def merge_app_schedule_payload(
             and incoming.get("current_task") is None
             and (
                 complete_refresh
+                or (
+                    prune_unexpected_indices
+                    and bool(cached_active_indices)
+                    and cached_active_indices.isdisjoint(expected_index_set)
+                )
                 or (
                     bool(cached_active_indices)
                     and cached_active_indices.issubset(usable_incoming_by_index)

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -102,12 +102,23 @@ def invalidate_schedule_slot(
     normalized = dict(existing)
     normalized["schedules"] = retained
     cached_active_version = normalized.get("active_schedule_version")
-    if (
-        isinstance(cached_active_version, int)
-        and not isinstance(cached_active_version, bool)
-        and cached_active_version in invalidated_versions
-    ):
+    cached_active_index = normalized.get("active_schedule_index")
+    active_index_is_valid = isinstance(cached_active_index, int) and not isinstance(
+        cached_active_index,
+        bool,
+    )
+    active_slot_invalidated = (
+        cached_active_index == map_index
+        if active_index_is_valid
+        else (
+            isinstance(cached_active_version, int)
+            and not isinstance(cached_active_version, bool)
+            and cached_active_version in invalidated_versions
+        )
+    )
+    if active_slot_invalidated:
         normalized.pop("active_schedule_version", None)
+        normalized.pop("active_schedule_index", None)
         normalized["active_selection_available"] = False
         current_task = normalized.get("current_task")
         if (
@@ -199,9 +210,14 @@ def merge_app_schedule_payload(
         and isinstance(schedule.get("idx"), int)
         and not isinstance(schedule.get("idx"), bool)
     }
-    complete_refresh = set(expected_indices).issubset(usable_incoming_by_index)
+    cached_active_index = existing.get("active_schedule_index")
+    cached_active_index_is_valid = isinstance(
+        cached_active_index,
+        int,
+    ) and not isinstance(cached_active_index, bool)
+    expected_index_set = set(expected_indices)
+    complete_refresh = expected_index_set.issubset(usable_incoming_by_index)
     if complete_refresh:
-        expected_index_set = set(expected_indices)
         merged = [
             schedule
             for schedule in merged
@@ -212,19 +228,32 @@ def merge_app_schedule_payload(
                 and schedule.get("idx") not in expected_index_set
             )
         ]
-    active_version_invalidated = (
-        isinstance(cached_active_version, int)
-        and not isinstance(cached_active_version, bool)
-        and cached_active_version not in discovered_versions
-        and incoming.get("current_task") is None
-        and (
-            complete_refresh
+    if cached_active_index_is_valid:
+        refreshed_active_slot = usable_incoming_by_index.get(cached_active_index)
+        active_version_invalidated = incoming.get("current_task") is None and (
+            (
+                refreshed_active_slot is not None
+                and refreshed_active_slot.get("version") != cached_active_version
+            )
             or (
-                bool(cached_active_indices)
-                and cached_active_indices.issubset(usable_incoming_by_index)
+                complete_refresh
+                and cached_active_index not in expected_index_set
             )
         )
-    )
+    else:
+        active_version_invalidated = (
+            isinstance(cached_active_version, int)
+            and not isinstance(cached_active_version, bool)
+            and cached_active_version not in discovered_versions
+            and incoming.get("current_task") is None
+            and (
+                complete_refresh
+                or (
+                    bool(cached_active_indices)
+                    and cached_active_indices.issubset(usable_incoming_by_index)
+                )
+            )
+        )
     if active_version_invalidated:
         merged = [
             schedule
@@ -236,6 +265,7 @@ def merge_app_schedule_payload(
             )
         ]
         normalized.pop("active_schedule_version", None)
+        normalized.pop("active_schedule_index", None)
         current_task = normalized.get("current_task")
         if (
             isinstance(current_task, Mapping)
@@ -380,6 +410,11 @@ def merge_batch_schedule_payload(
         for schedule in normalized["schedules"]
     )
     normalized["active_schedule_version"] = batch_version
+    active_index = batch_schedule.get("idx")
+    if isinstance(active_index, int) and not isinstance(active_index, bool):
+        normalized["active_schedule_index"] = active_index
+    else:
+        normalized.pop("active_schedule_index", None)
     normalized["active_selection_available"] = True
     if incoming.get("current_task") is not None:
         normalized["current_task"] = incoming["current_task"]

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -398,9 +398,17 @@ def merge_batch_schedule_payload(
         if matching_schedule is None and len(numeric_matching_schedules) == 1:
             matching_schedule = numeric_matching_schedules[0]
     else:
-        matching_schedule = next(
-            iter(numeric_matching_schedules),
-            matching_schedules[0] if matching_schedules else None,
+        matching_schedule = (
+            numeric_matching_schedules[0]
+            if len(numeric_matching_schedules) == 1
+            else next(
+                (
+                    schedule
+                    for schedule in matching_schedules
+                    if schedule.get("idx") is None
+                ),
+                None,
+            )
         )
     if matching_schedule is None and not allow_unknown_slot:
         return None

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -1,0 +1,224 @@
+"""Schedule cache validation and merge policy."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from datetime import datetime
+from typing import Any
+
+
+def schedule_entry_has_usable_data(value: Any) -> bool:
+    """Return whether one slot was read authoritatively, including empty plans."""
+    if not isinstance(value, Mapping) or value.get("error"):
+        return False
+    plans = value.get("plans")
+    return isinstance(plans, Sequence) and not isinstance(
+        plans,
+        str | bytes | bytearray,
+    )
+
+
+def schedule_payload_has_usable_data(
+    payload: Mapping[str, Any] | None,
+) -> bool:
+    """Return whether at least one authoritative schedule slot is cached."""
+    schedules = payload.get("schedules") if isinstance(payload, Mapping) else None
+    return bool(
+        isinstance(schedules, Sequence)
+        and not isinstance(schedules, str | bytes | bytearray)
+        and any(schedule_entry_has_usable_data(schedule) for schedule in schedules)
+    )
+
+
+def has_complete_schedule_cache(
+    payload: Mapping[str, Any] | None,
+    known_map_indices: Sequence[int],
+) -> bool:
+    """Return whether default and every known physical map are usable."""
+    schedules = payload.get("schedules") if isinstance(payload, Mapping) else None
+    if not isinstance(schedules, Sequence) or isinstance(
+        schedules,
+        str | bytes | bytearray,
+    ):
+        return False
+    schedule_by_index = {
+        schedule.get("idx"): schedule
+        for schedule in schedules
+        if isinstance(schedule, Mapping)
+    }
+    return all(
+        schedule_entry_has_usable_data(schedule_by_index.get(index))
+        for index in {-1, *known_map_indices}
+    )
+
+
+def merge_app_schedule_payload(
+    existing: Mapping[str, Any] | None,
+    incoming: Mapping[str, Any],
+) -> dict[str, Any]:
+    """Merge successful action slots while retaining cached failed slots."""
+    if not isinstance(existing, Mapping):
+        return dict(incoming)
+
+    normalized = dict(existing)
+    incoming_schedules = incoming.get("schedules")
+    existing_schedules = existing.get("schedules")
+    if not isinstance(incoming_schedules, Sequence) or isinstance(
+        incoming_schedules,
+        str | bytes | bytearray,
+    ):
+        return normalized
+    if not isinstance(existing_schedules, Sequence) or isinstance(
+        existing_schedules,
+        str | bytes | bytearray,
+    ):
+        return dict(incoming)
+
+    merged = list(existing_schedules)
+    positions = {
+        schedule.get("idx"): index
+        for index, schedule in enumerate(merged)
+        if isinstance(schedule, Mapping)
+    }
+    for schedule in incoming_schedules:
+        if not isinstance(schedule, Mapping):
+            continue
+        index = schedule.get("idx")
+        position = positions.get(index)
+        if position is None:
+            positions[index] = len(merged)
+            merged.append(schedule)
+        elif schedule_entry_has_usable_data(schedule):
+            merged[position] = schedule
+
+    discovered_versions = {
+        schedule.get("version")
+        for schedule in incoming_schedules
+        if schedule_entry_has_usable_data(schedule)
+        and isinstance(schedule.get("idx"), int)
+        and not isinstance(schedule.get("idx"), bool)
+        and isinstance(schedule.get("version"), int)
+        and not isinstance(schedule.get("version"), bool)
+    }
+    if discovered_versions:
+        merged = [
+            schedule
+            for schedule in merged
+            if not (
+                isinstance(schedule, Mapping)
+                and schedule.get("idx") is None
+                and schedule.get("version") in discovered_versions
+            )
+        ]
+
+    normalized.update(
+        {
+            key: value
+            for key, value in incoming.items()
+            if key not in {"schedules", "current_task", "active_schedule_version"}
+        }
+    )
+    normalized["schedules"] = merged
+    if incoming.get("current_task") is not None:
+        normalized["current_task"] = incoming["current_task"]
+    normalized["available"] = any(
+        isinstance(schedule, Mapping) and bool(schedule.get("available"))
+        for schedule in merged
+    )
+    return normalized
+
+
+def merge_batch_schedule_payload(
+    existing: Mapping[str, Any],
+    incoming: Mapping[str, Any],
+    *,
+    captured_at: datetime,
+    allow_unknown_slot: bool,
+) -> dict[str, Any] | None:
+    """Merge one effective batch schedule without guessing its writable slot."""
+    schedules = incoming.get("schedules")
+    errors = incoming.get("errors")
+    if (
+        not isinstance(schedules, Sequence)
+        or isinstance(schedules, str | bytes | bytearray)
+        or len(schedules) != 1
+        or errors
+        or not isinstance(schedules[0], Mapping)
+    ):
+        return None
+
+    batch_schedule = dict(schedules[0])
+    batch_version = batch_schedule.get("version")
+    if not isinstance(batch_version, int) or isinstance(batch_version, bool):
+        return None
+    existing_schedules = existing.get("schedules")
+    if not isinstance(existing_schedules, Sequence) or isinstance(
+        existing_schedules,
+        str | bytes | bytearray,
+    ):
+        return None
+
+    matching_schedules = [
+        schedule
+        for schedule in existing_schedules
+        if isinstance(schedule, Mapping)
+        and schedule.get("version") == batch_version
+    ]
+    matching_schedule = next(
+        (
+            schedule
+            for schedule in matching_schedules
+            if isinstance(schedule.get("idx"), int)
+            and not isinstance(schedule.get("idx"), bool)
+        ),
+        matching_schedules[0] if matching_schedules else None,
+    )
+    if matching_schedule is None and not allow_unknown_slot:
+        return None
+    if matching_schedule is not None:
+        for key in ("idx", "label", "name"):
+            if key in matching_schedule:
+                batch_schedule[key] = matching_schedule[key]
+    else:
+        batch_schedule["idx"] = None
+        batch_schedule["label"] = "active_schedule"
+        batch_schedule["writable"] = False
+
+    normalized = dict(existing)
+    normalized["schedules"] = [
+        (
+            batch_schedule
+            if isinstance(schedule, Mapping) and schedule is matching_schedule
+            else schedule
+        )
+        for schedule in existing_schedules
+        if not (
+            matching_schedule is not None
+            and isinstance(matching_schedule.get("idx"), int)
+            and not isinstance(matching_schedule.get("idx"), bool)
+            and isinstance(schedule, Mapping)
+            and schedule is not matching_schedule
+            and schedule.get("idx") is None
+            and schedule.get("version") == batch_version
+        )
+    ]
+    if matching_schedule is None:
+        normalized["schedules"] = [
+            schedule
+            for schedule in normalized["schedules"]
+            if not (
+                isinstance(schedule, Mapping)
+                and schedule.get("idx") is None
+            )
+        ]
+        normalized["schedules"].append(batch_schedule)
+    normalized["available"] = any(
+        isinstance(schedule, Mapping) and bool(schedule.get("available"))
+        for schedule in normalized["schedules"]
+    )
+    normalized["active_schedule_version"] = batch_version
+    if incoming.get("current_task") is not None:
+        normalized["current_task"] = incoming["current_task"]
+    normalized["captured_at"] = captured_at.isoformat()
+    normalized["source"] = "app_action_schedule_with_batch_refresh"
+    return normalized

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -469,7 +469,10 @@ def merge_batch_schedule_payload(
     if isinstance(active_index, int) and not isinstance(active_index, bool):
         normalized["active_schedule_index"] = active_index
     else:
-        normalized.pop("active_schedule_index", None)
+        # Keep an explicit unknown-slot selection so calendar consumers can
+        # filter to the authoritative idx=None fallback instead of treating a
+        # missing numeric index as "include every slot with this version".
+        normalized["active_schedule_index"] = None
     normalized["active_selection_available"] = True
     if incoming.get("current_task") is not None:
         normalized["current_task"] = incoming["current_task"]

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -108,6 +108,7 @@ def invalidate_schedule_slot(
         and cached_active_version in invalidated_versions
     ):
         normalized.pop("active_schedule_version", None)
+        normalized["active_selection_available"] = False
         current_task = normalized.get("current_task")
         if (
             isinstance(current_task, Mapping)

--- a/custom_components/dreame_lawn_mower/video_flv_relay.py
+++ b/custom_components/dreame_lawn_mower/video_flv_relay.py
@@ -19,6 +19,8 @@ from aiohttp import ClientResponseError, ClientSession, ClientTimeout, web
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.aiohttp_client import async_get_clientsession
 
+from .ha_tasks import create_background_task
+
 _LOGGER = logging.getLogger(__name__)
 
 _QUEUE_DEPTH: Final = 96
@@ -619,8 +621,10 @@ class DreameLawnMowerFlvRelay:
                 if self._pump_task is None or self._pump_task.done():
                     self._last_failure = None
                     self._started_at = asyncio.get_running_loop().time()
-                    self._pump_task = self._hass.async_create_task(
-                        self._async_pump()
+                    self._pump_task = create_background_task(
+                        self._hass,
+                        self._async_pump(),
+                        "dreame-lawn-mower-video-relay",
                     )
                 break
 

--- a/custom_components/dreame_lawn_mower/video_session_lifecycle.py
+++ b/custom_components/dreame_lawn_mower/video_session_lifecycle.py
@@ -9,6 +9,8 @@ from typing import Any, Protocol
 
 from homeassistant.core import HomeAssistant
 
+from .ha_tasks import create_background_task
+
 _DEFAULT_PROVIDER_GRACE = 30.0
 _DEFAULT_IDLE_GRACE = 15.0
 _DEFAULT_IDLE_POLL_INTERVAL = 1.0
@@ -51,7 +53,11 @@ class DreameLawnMowerHaStreamIdleMonitor:
         task = self._task
         if task is not None and not task.done():
             task.cancel()
-        self._task = self._hass.async_create_task(self._async_watch(ha_stream, session))
+        self._task = create_background_task(
+            self._hass,
+            self._async_watch(ha_stream, session),
+            "dreame-lawn-mower-video-idle-monitor",
+        )
 
     async def async_cancel(self) -> None:
         """Cancel the current watcher without cancelling itself during cleanup."""

--- a/custom_components/dreame_lawn_mower/video_stream_helpers.py
+++ b/custom_components/dreame_lawn_mower/video_stream_helpers.py
@@ -29,6 +29,8 @@ _STREAM_HEALTH_ATTEMPTS = 3
 _STREAM_HEALTH_RETRY_INTERVAL = 0.5
 _STREAM_HEALTH_TIMEOUT = 3.0
 _STREAM_HEALTH_BYTES = 16
+
+
 def option_text(entry: ConfigEntry, key: str) -> str | None:
     """Return a trimmed non-empty string option."""
     value = entry.options.get(key)
@@ -118,7 +120,14 @@ def managed_runtime_environment() -> dict[str, str | bool | int]:
         if supported
         else "unsupported"
     )
-    libc_name, libc_version = platform.libc_ver()
+    libc_name = "unknown"
+    libc_version = "unknown"
+    try:
+        libc_description = os.confstr("CS_GNU_LIBC_VERSION")
+    except (AttributeError, OSError, ValueError):
+        libc_description = None
+    if libc_description:
+        libc_name, _, libc_version = libc_description.partition(" ")
     return {
         "system": system,
         "machine": normalized_machine,

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -344,6 +344,27 @@ def test_app_maps_ignore_current_flag_on_uncreated_map() -> None:
     assert result["created_map_count"] == 1
 
 
+def test_app_maps_reject_malformed_status_flags() -> None:
+    client = _client()
+    malformed_rows = (
+        [[0, "0", "0", 0]],
+        [[0, 2, 1, 1]],
+        [[0, 1, 1, 1, "0"]],
+    )
+
+    for rows in malformed_rows:
+        client._sync_call_app_action = (
+            lambda payload, rows=rows: {"r": 0, "d": rows}
+            if payload["t"] == "MAPL"
+            else None
+        )
+
+        result = client._sync_get_app_maps(include_objects=False)
+
+        assert result["map_list_valid"] is False
+        assert result["current_map_index"] is None
+
+
 def test_app_maps_explain_rejected_point_values_without_exposing_them() -> None:
     client = _client()
     cloud = _FakeAppMapCloud(

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -203,6 +203,7 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
     result = client._sync_get_app_maps(chunk_size=40, include_payload=True)
 
     assert result["available"] is True
+    assert result["map_list_valid"] is True
     assert result["map_count"] == 2
     assert result["created_map_count"] == 1
     assert result["current_map_index"] == 0
@@ -294,6 +295,18 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
     expected_sizes = [min(40, payload_size - start) for start in expected_starts]
     assert [call["d"]["start"] for call in mapd_calls] == expected_starts
     assert [call["d"]["size"] for call in mapd_calls] == expected_sizes
+
+
+def test_app_maps_mark_missing_map_list_response_invalid() -> None:
+    client = _client()
+    client._sync_call_app_action = lambda *_args, **_kwargs: None
+
+    result = client._sync_get_app_maps(include_objects=False)
+
+    assert result["available"] is False
+    assert result["map_list_valid"] is False
+    assert result["map_count"] == 0
+    assert result["maps"] == []
 
 
 def test_app_maps_explain_rejected_point_values_without_exposing_them() -> None:

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -309,6 +309,23 @@ def test_app_maps_mark_missing_map_list_response_invalid() -> None:
     assert result["maps"] == []
 
 
+def test_app_maps_reject_multiple_current_created_maps() -> None:
+    client = _client()
+
+    def app_action(payload):
+        if payload["t"] == "MAPL":
+            return {"r": 0, "d": [[0, 1, 1, 1], [1, 1, 1, 1]]}
+        return None
+
+    client._sync_call_app_action = app_action
+
+    result = client._sync_get_app_maps(include_objects=False)
+
+    assert result["map_list_valid"] is False
+    assert result["current_map_index"] is None
+    assert result["map_count"] == 2
+
+
 def test_app_maps_explain_rejected_point_values_without_exposing_them() -> None:
     client = _client()
     cloud = _FakeAppMapCloud(

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -326,6 +326,24 @@ def test_app_maps_reject_multiple_current_created_maps() -> None:
     assert result["map_count"] == 2
 
 
+def test_app_maps_ignore_current_flag_on_uncreated_map() -> None:
+    client = _client()
+
+    def app_action(payload):
+        if payload["t"] == "MAPL":
+            return {"r": 0, "d": [[0, 0, 1, 1], [1, 1, 0, 0]]}
+        return None
+
+    client._sync_call_app_action = app_action
+
+    result = client._sync_get_app_maps(include_objects=False)
+
+    assert result["map_list_valid"] is True
+    assert result["current_map_index"] is None
+    assert result["map_count"] == 2
+    assert result["created_map_count"] == 1
+
+
 def test_app_maps_explain_rejected_point_values_without_exposing_them() -> None:
     client = _client()
     cloud = _FakeAppMapCloud(

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -204,10 +204,6 @@ def test_app_schedules_decode_plans_and_current_task() -> None:
     }
     assert 0 < cloud.request_options[1]["timeout"] <= 2.5
     assert isinstance(cloud.request_options[1]["deadline"], float)
-    assert (
-        cloud.request_options[1]["deadline"]
-        < cloud.request_options[2]["deadline"]
-    )
     assert cloud.request_options[2]["retry_count"] == 0
     assert 0 < cloud.request_options[2]["timeout"] <= 5.0
 
@@ -307,7 +303,7 @@ def test_app_schedules_reserve_slot_time_when_map_discovery_times_out(
     map_deadline = cloud.request_options[0]["deadline"]
     first_schedule_deadline = cloud.request_options[1]["deadline"]
     assert map_deadline == pytest.approx(102.5)
-    assert first_schedule_deadline == pytest.approx(105.0)
+    assert first_schedule_deadline == pytest.approx(103.75)
 
 
 def test_app_schedules_retry_early_slot_with_unused_shared_budget(
@@ -357,12 +353,69 @@ def test_app_schedules_retry_early_slot_with_unused_shared_budget(
         for call, option in zip(cloud.calls, cloud.request_options, strict=True)
         if call["t"] == "SCHDIV2" and call["d"]["i"] == -1
     ]
-    assert default_deadlines == pytest.approx([103.3333333333, 108.3333333333])
+    assert default_deadlines == pytest.approx([101.6666666667, 106.6666666667])
     assert max(
         option["deadline"]
         for option in cloud.request_options
         if option["deadline"] is not None
     ) <= 110.0
+
+
+def test_app_schedules_rotate_reserved_recovery_across_slow_slots(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+
+    class _MultipleSlowSlotsCloud(_FakeAppScheduleCloud):
+        def call_app_action(
+            self,
+            payload: dict[str, object],
+            **kwargs: object,
+        ) -> dict[str, object]:
+            command = payload.get("t")
+            if command == "MAPL":
+                self.calls.append(payload)
+                self.request_options.append(
+                    {
+                        "command": "MAPL",
+                        "retry_count": kwargs.get("retry_count"),
+                        "timeout": kwargs.get("timeout"),
+                        "deadline": kwargs.get("deadline"),
+                    }
+                )
+                clock[0] = float(kwargs["deadline"])
+                raise TimeoutError("MAPL timed out")
+            if command == "SCHDIV2" and payload["d"]["i"] in {-1, 0}:
+                deadline = float(kwargs["deadline"])
+                if deadline - clock[0] < 3.0:
+                    self.calls.append(payload)
+                    self.request_options.append(
+                        {
+                            "command": "SCHDIV2",
+                            "retry_count": kwargs.get("retry_count"),
+                            "timeout": kwargs.get("timeout"),
+                            "deadline": kwargs.get("deadline"),
+                        }
+                    )
+                    clock[0] = deadline
+                    raise TimeoutError("slot needs three seconds")
+                clock[0] += 3.0
+            return super().call_app_action(payload, **kwargs)
+
+    cloud = _MultipleSlowSlotsCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+    settings_time = client._sync_get_app_schedules.__func__.__globals__["time"]
+    monkeypatch.setattr(settings_time, "monotonic", lambda: clock[0])
+
+    first = client._sync_get_app_schedules(include_current_task=False)
+    second = client._sync_get_app_schedules(include_current_task=False)
+
+    assert first["schedules"][0]["version"] == 31345
+    assert first["schedules"][1]["available"] is False
+    assert second["schedules"][0]["available"] is False
+    assert second["schedules"][1]["version"] == 19383
+    assert client._app_schedule_retry_offset == 0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -194,16 +194,22 @@ def test_app_schedules_decode_plans_and_current_task() -> None:
     assert 0 < cloud.request_options[0]["timeout"] <= 5.0
     assert isinstance(cloud.request_options[0]["deadline"], float)
     assert cloud.request_options[0]["deadline"] > 0
-    assert cloud.request_options[1] == {
+    assert {
+        key: value
+        for key, value in cloud.request_options[1].items()
+        if key != "deadline"
+    } == {
         "command": "MAPL",
         "retry_count": 0,
         "timeout": 5.0,
-        "deadline": cloud.request_options[2]["deadline"],
     }
     assert isinstance(cloud.request_options[1]["deadline"], float)
-    assert cloud.request_options[1]["deadline"] > 0
+    assert (
+        cloud.request_options[1]["deadline"]
+        > cloud.request_options[2]["deadline"]
+    )
     assert cloud.request_options[2]["retry_count"] == 0
-    assert cloud.request_options[2]["timeout"] == 5.0
+    assert 0 < cloud.request_options[2]["timeout"] <= 5.0
 
 
 def test_app_schedules_can_include_raw_payload_text() -> None:
@@ -238,6 +244,30 @@ def test_app_schedules_can_skip_optional_current_task_and_bound_plan_reads() -> 
     assert all(option["retry_count"] == 0 for option in cloud.request_options)
     assert all(option["timeout"] == 5.0 for option in cloud.request_options)
     assert cloud.request_options[0]["deadline"] == cloud.request_options[1]["deadline"]
+
+
+def test_app_schedules_allocate_shared_deadline_fairly_across_slots() -> None:
+    client = _client()
+    cloud = _FakeAppScheduleCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+
+    result = client._sync_get_app_schedules(
+        map_indices=[-1, 0, 1],
+        include_current_task=False,
+    )
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0, 1]
+    metadata_deadlines = [
+        options["deadline"]
+        for call, options in zip(
+            cloud.calls,
+            cloud.request_options,
+            strict=True,
+        )
+        if call["t"] == "SCHDIV2"
+    ]
+    assert len(metadata_deadlines) == 3
+    assert metadata_deadlines[0] < metadata_deadlines[1] < metadata_deadlines[2]
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -196,10 +196,14 @@ def test_app_schedules_decode_plans_and_current_task() -> None:
     assert cloud.request_options[0]["deadline"] > 0
     assert cloud.request_options[1] == {
         "command": "MAPL",
-        "retry_count": None,
-        "timeout": None,
-        "deadline": None,
+        "retry_count": 0,
+        "timeout": 5.0,
+        "deadline": cloud.request_options[2]["deadline"],
     }
+    assert isinstance(cloud.request_options[1]["deadline"], float)
+    assert cloud.request_options[1]["deadline"] > 0
+    assert cloud.request_options[2]["retry_count"] == 0
+    assert cloud.request_options[2]["timeout"] == 5.0
 
 
 def test_app_schedules_can_include_raw_payload_text() -> None:
@@ -216,6 +220,24 @@ def test_app_schedules_can_include_raw_payload_text() -> None:
     assert [schedule["idx"] for schedule in result["schedules"]] == [0]
     assert result["schedules"][0]["raw_text"].startswith('{"d":')
     assert [call["t"] for call in cloud.calls] == ["SCHDT", "SCHDIV2", "SCHDDV2"]
+
+
+def test_app_schedules_can_skip_optional_current_task_and_bound_plan_reads() -> None:
+    client = _client()
+    cloud = _FakeAppScheduleCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+
+    result = client._sync_get_app_schedules(
+        map_indices=[0],
+        include_current_task=False,
+    )
+
+    assert result["available"] is True
+    assert result["current_task"] is None
+    assert [call["t"] for call in cloud.calls] == ["SCHDIV2", "SCHDDV2"]
+    assert all(option["retry_count"] == 0 for option in cloud.request_options)
+    assert all(option["timeout"] == 5.0 for option in cloud.request_options)
+    assert cloud.request_options[0]["deadline"] == cloud.request_options[1]["deadline"]
 
 
 @pytest.mark.parametrize(
@@ -352,7 +374,10 @@ def test_set_app_schedule_plan_enabled_rejects_failed_write_response() -> None:
     cloud = _FakeAppScheduleCloud()
     client._sync_get_cloud_protocol = lambda **_kwargs: cloud
 
-    def failing_call(payload: dict[str, object]) -> dict[str, object]:
+    def failing_call(
+        payload: dict[str, object],
+        **_kwargs: object,
+    ) -> dict[str, object]:
         if payload["t"] == "SCHDSV2":
             return {"m": "r", "r": 0, "d": {"r": 1, "v": 19383}}
         return cloud.call_app_action(payload)["out"][0]
@@ -375,7 +400,7 @@ def test_set_app_schedule_plan_enabled_rejects_lost_acknowledgement() -> None:
     client._sync_get_cloud_protocol = lambda **_kwargs: cloud
     normal_call = client._sync_call_app_action
 
-    def lost_ack(payload: dict[str, object]) -> object:
+    def lost_ack(payload: dict[str, object], **_kwargs: object) -> object:
         if payload["t"] == "SCHDSV2":
             return None
         return normal_call(payload)

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -306,6 +306,36 @@ def test_app_schedules_reserve_slot_time_when_map_discovery_times_out(
     assert first_schedule_deadline == pytest.approx(103.75)
 
 
+def test_app_schedules_fall_back_to_likely_slots_when_map_list_is_missing() -> None:
+    client = _client()
+
+    class _MissingMapListCloud(_FakeAppScheduleCloud):
+        def call_app_action(
+            self,
+            payload: dict[str, object],
+            **kwargs: object,
+        ) -> dict[str, object] | None:
+            if payload.get("t") == "MAPL":
+                self.calls.append(payload)
+                self.request_options.append(
+                    {
+                        "command": "MAPL",
+                        "retry_count": kwargs.get("retry_count"),
+                        "timeout": kwargs.get("timeout"),
+                        "deadline": kwargs.get("deadline"),
+                    }
+                )
+                return None
+            return super().call_app_action(payload, **kwargs)
+
+    cloud = _MissingMapListCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+
+    result = client._sync_get_app_schedules(include_current_task=False)
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0, 1]
+
+
 def test_app_schedules_retry_early_slot_with_unused_shared_budget(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -197,16 +197,16 @@ def test_app_schedules_decode_plans_and_current_task() -> None:
     assert {
         key: value
         for key, value in cloud.request_options[1].items()
-        if key != "deadline"
+        if key not in {"deadline", "timeout"}
     } == {
         "command": "MAPL",
         "retry_count": 0,
-        "timeout": 5.0,
     }
+    assert 0 < cloud.request_options[1]["timeout"] <= 2.5
     assert isinstance(cloud.request_options[1]["deadline"], float)
     assert (
         cloud.request_options[1]["deadline"]
-        > cloud.request_options[2]["deadline"]
+        < cloud.request_options[2]["deadline"]
     )
     assert cloud.request_options[2]["retry_count"] == 0
     assert 0 < cloud.request_options[2]["timeout"] <= 5.0
@@ -268,6 +268,46 @@ def test_app_schedules_allocate_shared_deadline_fairly_across_slots() -> None:
     ]
     assert len(metadata_deadlines) == 3
     assert metadata_deadlines[0] < metadata_deadlines[1] < metadata_deadlines[2]
+
+
+def test_app_schedules_reserve_slot_time_when_map_discovery_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+
+    class _SlowMapCloud(_FakeAppScheduleCloud):
+        def call_app_action(
+            self,
+            payload: dict[str, object],
+            **kwargs: object,
+        ) -> dict[str, object]:
+            if payload.get("t") == "MAPL":
+                self.calls.append(payload)
+                self.request_options.append(
+                    {
+                        "command": "MAPL",
+                        "retry_count": kwargs.get("retry_count"),
+                        "timeout": kwargs.get("timeout"),
+                        "deadline": kwargs.get("deadline"),
+                    }
+                )
+                clock[0] = float(kwargs["deadline"])
+                raise TimeoutError("MAPL timed out")
+            return super().call_app_action(payload, **kwargs)
+
+    cloud = _SlowMapCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+    settings_time = client._sync_get_app_schedules.__func__.__globals__["time"]
+    monkeypatch.setattr(settings_time, "monotonic", lambda: clock[0])
+
+    result = client._sync_get_app_schedules(include_current_task=False)
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0, 1]
+    map_deadline = cloud.request_options[0]["deadline"]
+    first_schedule_deadline = cloud.request_options[1]["deadline"]
+    assert map_deadline == pytest.approx(102.5)
+    assert first_schedule_deadline == pytest.approx(105.0)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_app_schedules.py
+++ b/tests/test_app_schedules.py
@@ -310,6 +310,61 @@ def test_app_schedules_reserve_slot_time_when_map_discovery_times_out(
     assert first_schedule_deadline == pytest.approx(105.0)
 
 
+def test_app_schedules_retry_early_slot_with_unused_shared_budget(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    default_attempts = 0
+
+    class _RecoveringSlotCloud(_FakeAppScheduleCloud):
+        def call_app_action(
+            self,
+            payload: dict[str, object],
+            **kwargs: object,
+        ) -> dict[str, object]:
+            nonlocal default_attempts
+            if payload.get("t") == "SCHDIV2" and payload["d"]["i"] == -1:
+                default_attempts += 1
+                if default_attempts == 1:
+                    self.calls.append(payload)
+                    self.request_options.append(
+                        {
+                            "command": "SCHDIV2",
+                            "retry_count": kwargs.get("retry_count"),
+                            "timeout": kwargs.get("timeout"),
+                            "deadline": kwargs.get("deadline"),
+                        }
+                    )
+                    clock[0] = float(kwargs["deadline"])
+                    raise TimeoutError("initial fair share expired")
+            return super().call_app_action(payload, **kwargs)
+
+    cloud = _RecoveringSlotCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+    settings_time = client._sync_get_app_schedules.__func__.__globals__["time"]
+    monkeypatch.setattr(settings_time, "monotonic", lambda: clock[0])
+
+    result = client._sync_get_app_schedules(
+        map_indices=[-1, 0, 1],
+        include_current_task=False,
+    )
+
+    assert result["errors"] == []
+    assert result["schedules"][0]["version"] == 31345
+    default_deadlines = [
+        option["deadline"]
+        for call, option in zip(cloud.calls, cloud.request_options, strict=True)
+        if call["t"] == "SCHDIV2" and call["d"]["i"] == -1
+    ]
+    assert default_deadlines == pytest.approx([103.3333333333, 108.3333333333])
+    assert max(
+        option["deadline"]
+        for option in cloud.request_options
+        if option["deadline"] is not None
+    ) <= 110.0
+
+
 @pytest.mark.parametrize(
     "payload_text",
     [

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -183,6 +183,31 @@ def test_decode_batch_schedule_payload_decodes_live_shaped_schedule() -> None:
     )
 
 
+@pytest.mark.parametrize("plan_data", [None, {}, "invalid"])
+def test_decode_batch_schedule_payload_rejects_invalid_plan_list(
+    plan_data: object,
+) -> None:
+    payload: dict[str, object] = {"v": 22}
+    if plan_data is not None:
+        payload["d"] = plan_data
+    payload_text = json.dumps(payload, separators=(",", ":"))
+
+    result = decode_batch_schedule_payload({"SCHEDULE.0": payload_text})
+
+    assert result["available"] is False
+    assert "active_schedule_version" not in result
+    assert result["schedules"][0]["available"] is False
+    assert result["schedules"][0]["error"] == (
+        "missing_or_invalid_batch_schedule_plans"
+    )
+    assert result["errors"] == [
+        {
+            "stage": "schedule",
+            "error": "missing_or_invalid_batch_schedule_plans",
+        }
+    ]
+
+
 def test_decode_batch_mowing_preferences_decodes_map_settings() -> None:
     result = decode_batch_mowing_preferences(
         {

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
+import time
 
 import pytest
 
@@ -103,6 +105,7 @@ class _FakeBatchCloud:
         schedule_text = _schedule_text()
         settings_text = _settings_text()
         self.calls: list[list[str]] = []
+        self.request_options: list[dict[str, float | None]] = []
         self.payload = {
             "SCHEDULE.0": schedule_text,
             "SCHEDULE.info": str(len(schedule_text)),
@@ -115,8 +118,20 @@ class _FakeBatchCloud:
             "prop.s_auto_upgrade": "0",
         }
 
-    def get_batch_device_datas(self, keys: list[str]) -> dict[str, object]:
+    def get_batch_device_datas(
+        self,
+        keys: list[str],
+        *,
+        timeout: float | None = None,
+        deadline: float | None = None,
+    ) -> dict[str, object]:
         self.calls.append(list(keys))
+        self.request_options.append(
+            {
+                "timeout": timeout,
+                "deadline": deadline,
+            }
+        )
         return dict(self.payload)
 
 
@@ -297,6 +312,24 @@ def test_batch_schedule_recovery_can_skip_map_discovery() -> None:
     assert result["schedules"][0]["idx"] is None
     assert len(cloud.calls) == 1
     assert "SCHEDULE.info" in cloud.calls[0]
+
+
+def test_async_batch_schedule_recovery_has_an_overall_deadline() -> None:
+    client = _client()
+    cloud = _FakeBatchCloud()
+    client._sync_get_cloud_protocol = lambda **_kwargs: cloud
+    started = time.monotonic()
+
+    result = asyncio.run(
+        client.async_get_batch_schedules(map_index_hint=0)
+    )
+
+    assert result["schedules"][0]["version"] == 19383
+    request_options = cloud.request_options[0]
+    assert request_options["timeout"] is not None
+    assert 0 < request_options["timeout"] <= 5.0
+    assert request_options["deadline"] is not None
+    assert started < request_options["deadline"] <= started + 5.1
 
 
 def test_vector_map_batch_fetch_requests_all_device_sized_path_chunks() -> None:

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -156,6 +156,7 @@ def test_decode_batch_schedule_payload_decodes_live_shaped_schedule() -> None:
 
     assert result["source"] == "batch_device_data_schedule"
     assert result["available"] is True
+    assert result["active_schedule_version"] == 19383
     assert result["schedules"][0]["idx"] == 0
     assert result["schedules"][0]["version"] == 19383
     assert result["schedules"][0]["plan_count"] == 2

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import json
 
+import pytest
+
 from dreame_lawn_mower_client import (
     DreameLawnMowerClient,
     batch_data_text,
@@ -280,6 +282,21 @@ def test_client_batch_helpers_use_batch_device_data_api() -> None:
     assert ota_result["ota_progress"] == 0
     assert ota_result["auto_upgrade_enabled"] is False
     assert len(cloud.calls) == 3
+
+
+def test_batch_schedule_recovery_can_skip_map_discovery() -> None:
+    client = _client()
+    cloud = _FakeBatchCloud()
+    client._sync_get_cloud_protocol = lambda: cloud
+    client._sync_get_current_app_map_index = lambda: pytest.fail(
+        "batch recovery must not probe MAPL"
+    )
+
+    result = client._sync_get_batch_schedules(discover_map_index=False)
+
+    assert result["schedules"][0]["idx"] is None
+    assert len(cloud.calls) == 1
+    assert "SCHEDULE.info" in cloud.calls[0]
 
 
 def test_vector_map_batch_fetch_requests_all_device_sized_path_chunks() -> None:

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -506,3 +506,17 @@ def test_app_map_refresh_synchronizes_selected_map_identity() -> None:
     assert coordinator.selected_contour_id is None
     assert coordinator.selected_zone_id is None
     assert coordinator.selected_spot_id is None
+
+
+def test_app_map_cache_hit_preserves_failed_refresh_status() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(async_get_app_maps=AsyncMock())
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.app_maps_refreshed_at = datetime.now(UTC)
+    coordinator.app_maps_refresh_succeeded = False
+
+    result = asyncio.run(coordinator.async_refresh_app_maps())
+
+    assert result is coordinator.app_maps
+    assert coordinator.app_maps_refresh_succeeded is False
+    coordinator.client.async_get_app_maps.assert_not_awaited()

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -568,3 +568,26 @@ def test_app_map_cache_hit_preserves_failed_refresh_status() -> None:
     assert result is coordinator.app_maps
     assert coordinator.app_maps_refresh_succeeded is False
     coordinator.client.async_get_app_maps.assert_not_awaited()
+
+
+def test_app_map_refresh_marks_invalid_inventory_for_retry() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "map_list_valid": False,
+                "current_map_index": None,
+                "maps": [{"idx": 0, "created": True}],
+            }
+        )
+    )
+    coordinator.app_maps = None
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = False
+    coordinator.selected_map_index = None
+
+    result = asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert result["map_list_valid"] is False
+    assert coordinator.app_maps_refresh_succeeded is False
+    assert coordinator._metadata_phase_needs_retry("app_maps", result)

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -520,6 +520,42 @@ def test_app_map_refresh_synchronizes_selected_map_identity() -> None:
     assert coordinator.selected_spot_id is None
 
 
+def test_app_map_refresh_clears_map_scoped_selection_for_deleted_map() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "current_map_index": None,
+                "map_list_valid": True,
+                "maps": [{"idx": 0, "created": True}],
+            }
+        )
+    )
+    coordinator.app_maps = {
+        "current_map_index": 1,
+        "map_list_valid": True,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+    }
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 1
+    coordinator.selected_contour_id = (3, 0)
+    coordinator.selected_zone_id = 3
+    coordinator.selected_spot_id = 2
+    coordinator.selected_maintenance_point_id = 302
+
+    asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert coordinator.selected_map_index is None
+    assert coordinator.selected_contour_id is None
+    assert coordinator.selected_zone_id is None
+    assert coordinator.selected_spot_id is None
+    assert coordinator.selected_maintenance_point_id is None
+
+
 def test_app_map_cache_hit_preserves_failed_refresh_status() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.client = SimpleNamespace(async_get_app_maps=AsyncMock())

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -105,6 +105,18 @@ def test_runtime_tracking_falls_back_when_heartbeat_state_is_unknown() -> None:
     assert _runtime_tracking_active(snapshot) is True
 
 
+def test_runtime_tracking_rejects_stale_paused_heartbeat_while_docked() -> None:
+    snapshot = SimpleNamespace(
+        mowing_session_active=True,
+        task_status="paused",
+        activity="docked",
+        state="charging_completed",
+        docked=True,
+    )
+
+    assert _runtime_tracking_active(snapshot) is False
+
+
 def test_active_runtime_tracking_uses_fresh_app_map_identity() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     snapshot = SimpleNamespace(

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -471,6 +472,62 @@ def test_schedule_refresh_reads_inactive_default_slot_on_single_map_device() -> 
         include_raw=False,
         map_index_hint=2,
     )
+
+
+@pytest.mark.parametrize(
+    ("task_version", "expected_present"),
+    [(5, False), (6, True)],
+)
+def test_schedule_refresh_reconciles_current_task_with_batch_version(
+    task_version: int,
+    expected_present: bool,
+) -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    current_task = {"version": task_version}
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "active_schedule_version": task_version,
+        "current_task": current_task,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 5, "plans": []},
+            {"idx": 2, "available": True, "version": 6, "plans": []},
+        ],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.app_maps = {
+        "current_map_index": 2,
+        "maps": [{"idx": 2, "created": True}],
+    }
+    coordinator.selected_map_index = 2
+    app_payload = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 5, "plans": []},
+            {"idx": 2, "available": True, "version": 6, "plans": []},
+        ],
+        "errors": [],
+    }
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "current_task": None,
+        "schedules": [
+            {"idx": 2, "available": True, "version": 6, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
+        async_get_app_schedules=AsyncMock(return_value=app_payload),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules())
+
+    assert result["active_schedule_version"] == 6
+    if expected_present:
+        assert result["current_task"] is current_task
+    else:
+        assert "current_task" not in result
 
 
 def test_schedule_refresh_reads_inactive_maps_instead_of_batch_fast_path() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -88,6 +88,12 @@ def test_batch_schedule_merge_prefers_explicit_hint_on_version_collision() -> No
                 "version": 8,
                 "plans": [{"plan_id": 2, "name": "Garden"}],
             },
+            {
+                "idx": None,
+                "available": True,
+                "version": 7,
+                "plans": [{"plan_id": 4, "name": "Old fallback"}],
+            },
         ]
     }
     incoming = {
@@ -114,6 +120,7 @@ def test_batch_schedule_merge_prefers_explicit_hint_on_version_collision() -> No
     assert result["schedules"][0]["plans"][0]["name"] == "Default"
     assert result["schedules"][1]["idx"] == 2
     assert result["schedules"][1]["plans"][0]["name"] == "Batch"
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 2]
 
 
 def test_batch_schedule_merge_keeps_unknown_slot_on_unhinted_collision() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -450,6 +450,60 @@ def test_metadata_hydration_serializes_shared_vendor_protocol_calls() -> None:
     asyncio.run(scenario())
 
 
+def test_metadata_hydration_retries_only_missing_core_phase() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        app_map_object_calls = 0
+
+        async def refresh_app_map_objects(*, force: bool) -> dict[str, object] | None:
+            nonlocal app_map_object_calls
+            assert force is False
+            app_map_object_calls += 1
+            if app_map_object_calls == 1:
+                return None
+            coordinator.app_map_objects_refreshed_at = object()
+            return {"app_map_objects": []}
+
+        async def complete(*_args, **_kwargs) -> None:
+            return None
+
+        coordinator.performance = DreameLawnMowerPerformanceTracker()
+        coordinator._metadata_refresh_count = 0
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_refresh_semaphore = asyncio.Semaphore(
+            METADATA_REFRESH_CONCURRENCY
+        )
+        coordinator._shutting_down = False
+        coordinator.app_map_objects_refreshed_at = None
+        coordinator.async_update_listeners = Mock()
+        coordinator.async_refresh_app_map_objects = refresh_app_map_objects
+        coordinator.async_refresh_schedules = complete
+        coordinator.async_refresh_batch_device_data = complete
+        coordinator._async_refresh_bluetooth_state = complete
+        coordinator.async_refresh_firmware_update_support = complete
+        coordinator.async_refresh_vector_map_details = complete
+        coordinator.async_refresh_weather_protection = complete
+        coordinator.async_refresh_maintenance_status = complete
+        coordinator.async_refresh_voice_settings = complete
+
+        with patch(
+            "custom_components.dreame_lawn_mower.coordinator_refresh."
+            "METADATA_RETRY_DELAY_SECONDS",
+            0,
+        ):
+            await coordinator._async_refresh_metadata(
+                refresh_map_and_runtime=False,
+            )
+
+        assert app_map_object_calls == 2
+        assert coordinator.async_update_listeners.call_count == 3
+        sample = coordinator.performance.as_dict()["samples"][-1]
+        assert sample["outcome"] == "completed"
+        assert "app_map_objects_retry" in sample["phases_ms"]
+
+    asyncio.run(scenario())
+
+
 def test_active_session_reuses_verified_map_identity_between_polls() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1253,6 +1253,11 @@ def test_schedule_refresh_does_not_mark_retained_cache_fresh_after_failures() ->
 
     assert result["schedules"][0]["version"] == 1
     assert coordinator.schedules_refreshed_at is None
+    coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hint=None,
+        discover_map_index=False,
+    )
 
 
 def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -331,8 +331,23 @@ def test_first_refresh_does_not_wait_for_optional_metadata() -> None:
         coordinator._metadata_refresh_task = None
         coordinator._runtime_map_identity_verified = False
         coordinator._shutting_down = False
+        background_tasks: list[asyncio.Task[None]] = []
+
+        def create_background_task(
+            coroutine,
+            _name: str,
+        ) -> asyncio.Task[None]:
+            task = asyncio.create_task(coroutine)
+            background_tasks.append(task)
+            return task
+
         coordinator.hass = SimpleNamespace(
-            async_create_task=lambda coroutine, _name: asyncio.create_task(coroutine)
+            async_create_task=Mock(
+                side_effect=AssertionError(
+                    "metadata hydration must not be tracked as config-entry setup work"
+                )
+            ),
+            async_create_background_task=create_background_task,
         )
         coordinator.client = SimpleNamespace(
             async_refresh=AsyncMock(return_value=snapshot),
@@ -346,6 +361,7 @@ def test_first_refresh_does_not_wait_for_optional_metadata() -> None:
         await asyncio.wait_for(metadata_started.wait(), timeout=1)
         assert coordinator._metadata_refresh_task is not None
         assert not coordinator._metadata_refresh_task.done()
+        assert background_tasks == [coordinator._metadata_refresh_task]
         sample = coordinator.performance.as_dict()["samples"][-1]
         assert sample["operation"] == "foreground_refresh"
         assert set(sample["phases_ms"]) == {"snapshot"}
@@ -417,12 +433,13 @@ def test_metadata_hydration_serializes_shared_vendor_protocol_calls() -> None:
         release_app_maps.set()
         await asyncio.wait_for(schedules_started.wait(), timeout=1)
         assert not batch_started.is_set()
+        coordinator.async_update_listeners.assert_called_once_with()
 
         release_schedules.set()
         await asyncio.wait_for(batch_started.wait(), timeout=1)
         await task
 
-        coordinator.async_update_listeners.assert_called_once_with()
+        assert coordinator.async_update_listeners.call_count == 2
         sample = coordinator.performance.as_dict()["samples"][-1]
         assert sample["operation"] == "metadata_refresh"
         assert sample["outcome"] == "completed"

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -641,6 +641,79 @@ def test_schedule_refresh_recovers_active_map_from_batch_after_action_failure() 
     )
 
 
+def test_schedule_refresh_retries_app_when_batch_slot_is_unknown() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "active_schedule_version": 12,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+            },
+            {
+                "idx": None,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 2}],
+                "writable": False,
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    failed_app_payload = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+            {"idx": 0, "available": False, "error": "timed out"},
+        ],
+        "errors": [
+            {"idx": -1, "stage": "schedule", "error": "timed out"},
+            {"idx": 0, "stage": "schedule", "error": "timed out"},
+        ],
+    }
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "active_schedule_version": 12,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 0,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 2}],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=failed_app_payload),
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules())
+
+    assert result["active_schedule_version"] == 12
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 0],
+    )
+    coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hint=0,
+    )
+
+
 def test_schedule_refresh_keeps_complete_app_payload_for_multiple_maps() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None
@@ -928,6 +1001,43 @@ def test_schedule_refresh_prunes_deleted_map_after_complete_read() -> None:
 
     assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
     assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
+
+
+def test_schedule_refresh_keeps_auto_discovered_maps_without_app_hints() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {"maps": []}
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+            {"idx": 1, "available": True, "version": 22, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0, 1]
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 21, 22]
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=None,
+    )
 
 
 def test_schedule_refresh_does_not_mark_all_failed_reads_fresh() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1204,7 +1204,9 @@ def test_schedule_refresh_prunes_deleted_map_after_complete_read() -> None:
     coordinator.app_maps = {
         "current_map_index": 0,
         "maps": [{"idx": 0, "created": True}],
+        "map_list_valid": True,
     }
+    coordinator.app_maps_refresh_succeeded = True
     incoming = {
         "source": "app_action_schedule",
         "schedules": [
@@ -1266,6 +1268,48 @@ def test_schedule_refresh_prunes_deleted_map_after_partial_read() -> None:
     assert result["active_selection_available"] is False
     assert "active_schedule_version" not in result
     assert "active_schedule_index" not in result
+
+
+def test_non_authoritative_map_subset_preserves_cached_schedule_slots() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+            {"idx": 1, "available": True, "version": 12, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+        "map_list_valid": False,
+    }
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0, 1]
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 21, 12]
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 0],
+    )
 
 
 def test_schedule_refresh_keeps_auto_discovered_maps_without_app_hints() -> None:
@@ -1690,7 +1734,7 @@ def test_schedule_refresh_rejects_batch_hint_after_selected_map_changes() -> Non
                     {
                         "idx": 0,
                         "available": True,
-                        "version": 22,
+                        "version": 21,
                         "plans": [{"plan_id": 1}],
                     }
                 ],
@@ -1729,8 +1773,9 @@ def test_schedule_refresh_rejects_batch_hint_after_selected_map_changes() -> Non
         release_batch.set()
         result = await refresh_task
 
-        assert result["active_schedule_index"] == 1
-        assert result["active_schedule_version"] == 22
+        assert result["active_selection_available"] is False
+        assert "active_schedule_index" not in result
+        assert "active_schedule_version" not in result
         assert result["schedules"][1]["version"] == 21
         assert result["schedules"][2]["version"] == 22
 
@@ -1948,7 +1993,12 @@ def test_batch_metadata_rejects_hint_after_selected_map_changes() -> None:
 
         assert result is not None
         batch_schedule = result["batch_schedule"]
-        assert batch_schedule["schedules"][0]["idx"] is None
+        assert batch_schedule["schedules"] == []
+        assert batch_schedule["available"] is False
+        assert batch_schedule["errors"][-1] == {
+            "stage": "schedule",
+            "error": "active map changed during batch read",
+        }
         assert coordinator.schedules["active_schedule_index"] == 0
         assert coordinator.schedules["active_selection_available"] is False
         assert coordinator.schedules["schedules"][1]["version"] == 11

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1274,6 +1274,19 @@ def test_schedule_refresh_prunes_last_map_after_authoritative_empty_map_list() -
     coordinator.selected_map_index = 0
     coordinator.app_maps = {"maps": []}
     coordinator.app_maps_refresh_succeeded = True
+    coordinator._pending_schedule_plan_states = {(0, 1): (11, False)}
+    coordinator._pending_schedule_plan_state_contradictions = {(0, 1): 1}
+    coordinator._pending_schedule_uploads = {
+        0: {
+            "idx": 0,
+            "available": True,
+            "writable": True,
+            "version": 11,
+            "plans": [{"plan_id": 1}],
+        }
+    }
+    coordinator._pending_schedule_upload_contradictions = {0: 1}
+    coordinator._pending_schedule_upload_active_indices = {0}
     incoming = {
         "source": "app_action_schedule",
         "schedules": [
@@ -1291,6 +1304,11 @@ def test_schedule_refresh_prunes_last_map_after_authoritative_empty_map_list() -
     assert [schedule["idx"] for schedule in result["schedules"]] == [-1]
     assert [schedule["version"] for schedule in result["schedules"]] == [20]
     assert result["active_selection_available"] is False
+    assert coordinator._pending_schedule_plan_states == {}
+    assert coordinator._pending_schedule_plan_state_contradictions == {}
+    assert coordinator._pending_schedule_uploads == {}
+    assert coordinator._pending_schedule_upload_contradictions == {}
+    assert coordinator._pending_schedule_upload_active_indices == set()
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
         map_indices=[-1],

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -795,7 +795,7 @@ def test_schedule_refresh_reads_inactive_default_slot_on_single_map_device() -> 
     assert result["active_schedule_version"] == 6
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=[-1, 2],
+        map_indices=[-1, 2, 0, 1],
     )
     coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
         include_raw=False,
@@ -911,7 +911,7 @@ def test_schedule_refresh_reads_inactive_maps_instead_of_batch_fast_path() -> No
     assert [schedule["version"] for schedule in result["schedules"]] == [3, 5, 6]
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=[-1, 1, 2],
+        map_indices=[-1, 1, 2, 0],
     )
     coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
         include_raw=False,
@@ -964,7 +964,7 @@ def test_initial_single_map_schedule_refresh_keeps_default_app_schedule() -> Non
     )
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=[-1, 2],
+        map_indices=[-1, 2, 0, 1],
     )
 
 
@@ -1102,7 +1102,7 @@ def test_schedule_refresh_retries_app_when_batch_slot_is_unknown() -> None:
     assert result["active_schedule_version"] == 12
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=[-1, 0],
+        map_indices=[-1, 0, 1],
     )
     coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
         include_raw=False,
@@ -1159,7 +1159,7 @@ def test_schedule_refresh_keeps_complete_app_payload_for_multiple_maps() -> None
     )
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=[-1, 1, 2],
+        map_indices=[-1, 1, 2, 0],
     )
 
 
@@ -1609,7 +1609,7 @@ def test_non_authoritative_map_subset_preserves_cached_schedule_slots() -> None:
     assert [schedule["version"] for schedule in result["schedules"]] == [20, 21, 12]
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=[-1, 0],
+        map_indices=[-1, 0, 1],
     )
 
 
@@ -1647,7 +1647,7 @@ def test_schedule_refresh_keeps_auto_discovered_maps_without_app_hints() -> None
     assert [schedule["version"] for schedule in result["schedules"]] == [20, 21, 22]
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
-        map_indices=None,
+        map_indices=[-1, 0, 1],
     )
 
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -421,13 +421,17 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
         "source": "app_action_schedule",
         "schedules": [
             default_schedule,
+            {"idx": 1, "available": True, "version": 4, "plans": []},
             {"idx": 2, "available": True, "version": 6, "plans": []},
         ],
     }
     coordinator.schedules_refreshed_at = None
     coordinator.app_maps = {
         "current_map_index": 2,
-        "maps": [{"idx": 2, "created": True}],
+        "maps": [
+            {"idx": 1, "created": True},
+            {"idx": 2, "created": True},
+        ],
     }
     coordinator.selected_map_index = 2
     batch_payload = {
@@ -438,7 +442,7 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
             {
                 "idx": 2,
                 "available": True,
-                "version": 7,
+                "version": 6,
                 "plans": [],
             }
         ],
@@ -454,7 +458,9 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
     assert result is coordinator.schedules
     assert result["source"] == "app_action_schedule_with_batch_refresh"
     assert result["schedules"][0] is default_schedule
-    assert result["schedules"][1]["version"] == 7
+    assert result["schedules"][1]["version"] == 4
+    assert result["schedules"][2]["version"] == 6
+    assert result["active_schedule_version"] == 6
     coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
         include_raw=False,
         map_index_hint=2,
@@ -473,20 +479,111 @@ def test_initial_single_map_schedule_refresh_keeps_default_app_schedule() -> Non
     app_payload = {
         "source": "app_action_schedule",
         "schedules": [
-            {"idx": -1, "plans": []},
-            {"idx": 2, "plans": []},
+            {"idx": -1, "version": 10, "plans": []},
+            {"idx": 2, "version": 11, "plans": []},
         ],
     }
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": False,
+        "active_schedule_version": 10,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 2,
+                "available": False,
+                "version": 10,
+                "plans": [],
+            }
+        ],
+        "errors": [],
+    }
     coordinator.client = SimpleNamespace(
-        async_get_batch_schedules=AsyncMock(),
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
         async_get_app_schedules=AsyncMock(return_value=app_payload),
     )
 
     result = asyncio.run(coordinator.async_refresh_schedules())
 
-    assert result is app_payload
-    coordinator.client.async_get_batch_schedules.assert_not_awaited()
-    coordinator.client.async_get_app_schedules.assert_awaited_once_with()
+    assert result["active_schedule_version"] == 10
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 2]
+    coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hint=2,
+    )
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 2],
+    )
+
+
+def test_schedule_refresh_recovers_active_map_from_batch_after_action_failure() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = None
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 1
+    coordinator.app_maps = {
+        "current_map_index": 1,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+    }
+    failed_app_payload = {
+        "source": "app_action_schedule",
+        "available": False,
+        "current_task": None,
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+            {"idx": 0, "available": False, "error": "timed out"},
+            {"idx": 1, "available": False, "error": "timed out"},
+        ],
+        "errors": [
+            {"idx": -1, "stage": "schedule", "error": "timed out"},
+            {"idx": 0, "stage": "schedule", "error": "timed out"},
+            {"idx": 1, "stage": "schedule", "error": "timed out"},
+        ],
+    }
+    active_plan = {"plan_id": 7, "enabled": True, "weeks": []}
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 1,
+                "available": True,
+                "version": 12,
+                "plan_count": 1,
+                "enabled_plan_count": 1,
+                "plans": [active_plan],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
+        async_get_app_schedules=AsyncMock(return_value=failed_app_payload),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules())
+
+    assert result is coordinator.schedules
+    assert result["source"] == "app_action_schedule_with_batch_refresh"
+    assert result["available"] is True
+    assert result["active_schedule_version"] == 12
+    assert result["schedules"][3]["idx"] is None
+    assert result["schedules"][3]["writable"] is False
+    assert result["schedules"][3]["plans"] == [active_plan]
+    assert coordinator.schedules_refreshed_at is not None
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 0, 1],
+    )
+    coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hint=1,
+    )
 
 
 def test_schedule_refresh_keeps_complete_app_payload_for_multiple_maps() -> None:
@@ -503,20 +600,232 @@ def test_schedule_refresh_keeps_complete_app_payload_for_multiple_maps() -> None
     app_payload = {
         "source": "app_action_schedule",
         "schedules": [
-            {"idx": 1, "plans": []},
-            {"idx": 2, "plans": []},
+            {"idx": -1, "version": 10, "plans": []},
+            {"idx": 1, "version": 11, "plans": []},
+            {"idx": 2, "version": 12, "plans": []},
         ],
     }
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": False,
+        "active_schedule_version": 11,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 1,
+                "available": False,
+                "version": 11,
+                "plans": [],
+            }
+        ],
+        "errors": [],
+    }
     coordinator.client = SimpleNamespace(
-        async_get_batch_schedules=AsyncMock(),
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
         async_get_app_schedules=AsyncMock(return_value=app_payload),
     )
 
     result = asyncio.run(coordinator.async_refresh_schedules())
 
-    assert result is app_payload
-    coordinator.client.async_get_batch_schedules.assert_not_awaited()
-    coordinator.client.async_get_app_schedules.assert_awaited_once_with()
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 1, 2]
+    assert result["active_schedule_version"] == 11
+    coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hint=1,
+    )
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 1, 2],
+    )
+
+
+def test_schedule_refresh_merges_successful_slots_when_another_slot_fails() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "version": 1, "plans": [{"plan_id": 1}]},
+            {"idx": 0, "version": 2, "plans": [{"plan_id": 2}]},
+            {"idx": 1, "version": 3, "plans": [{"plan_id": 3}]},
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "version": 4, "plans": [{"plan_id": 4}]},
+            {"idx": 0, "available": False, "error": "timed out"},
+            {"idx": 1, "version": 5, "plans": [{"plan_id": 5}]},
+        ],
+        "errors": [{"idx": 0, "stage": "schedule", "error": "timed out"}],
+    }
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "active_schedule_version": 5,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 0,
+                "available": True,
+                "version": 5,
+                "plans": [{"plan_id": 5}],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["schedules"][0]["version"] == 4
+    assert result["schedules"][1]["version"] == 2
+    assert result["schedules"][2]["version"] == 5
+    assert result["active_schedule_version"] == 5
+    assert coordinator.schedules_refreshed_at is not None
+
+
+def test_schedule_refresh_promotes_batch_fallback_when_slot_becomes_known() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+            {
+                "idx": None,
+                "label": "active_schedule",
+                "writable": False,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "active_schedule_version": 12,
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "errors": [{"idx": -1, "stage": "schedule", "error": "timed out"}],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    matching = [
+        schedule
+        for schedule in result["schedules"]
+        if schedule.get("version") == 12
+    ]
+    assert len(matching) == 1
+    assert matching[0]["idx"] == 0
+    assert "writable" not in matching[0]
+
+
+def test_schedule_refresh_does_not_mark_all_failed_reads_fresh() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = None
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    failed_app_payload = {
+        "source": "app_action_schedule",
+        "available": False,
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+            {"idx": 0, "available": False, "error": "timed out"},
+        ],
+        "errors": [
+            {"idx": -1, "stage": "schedule", "error": "timed out"},
+            {"idx": 0, "stage": "schedule", "error": "timed out"},
+        ],
+    }
+    failed_batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": False,
+        "schedules": [],
+        "errors": [{"stage": "schedule", "error": "missing schedule"}],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=failed_app_payload),
+        async_get_batch_schedules=AsyncMock(return_value=failed_batch_payload),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules())
+
+    assert result is not None
+    assert coordinator.schedules_refreshed_at is None
+
+
+def test_schedule_refresh_does_not_mark_retained_cache_fresh_after_failures() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "available": True,
+        "schedules": [
+            {
+                "idx": -1,
+                "available": True,
+                "version": 1,
+                "plans": [{"plan_id": 1}],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = None
+    coordinator.app_maps = {"maps": []}
+    failed_app_payload = {
+        "source": "app_action_schedule",
+        "available": False,
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+        ],
+        "errors": [
+            {"idx": -1, "stage": "schedule", "error": "timed out"},
+        ],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=failed_app_payload),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["schedules"][0]["version"] == 1
+    assert coordinator.schedules_refreshed_at is None
 
 
 def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -116,6 +116,48 @@ def test_batch_schedule_merge_prefers_explicit_hint_on_version_collision() -> No
     assert result["schedules"][1]["plans"][0]["name"] == "Batch"
 
 
+def test_batch_schedule_merge_keeps_unknown_slot_on_unhinted_collision() -> None:
+    existing = {
+        "schedules": [
+            {
+                "idx": -1,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 1, "name": "Default"}],
+            },
+            {
+                "idx": 2,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 2, "name": "Garden"}],
+            },
+        ]
+    }
+    incoming = {
+        "schedules": [
+            {
+                "idx": None,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 3, "name": "Batch"}],
+            }
+        ],
+        "errors": [],
+    }
+
+    result = merge_batch_schedule_payload(
+        existing,
+        incoming,
+        captured_at=datetime(2026, 7, 30, tzinfo=UTC),
+        allow_unknown_slot=True,
+    )
+
+    assert result is not None
+    assert "active_schedule_index" not in result
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 2, None]
+    assert result["schedules"][-1]["plans"][0]["name"] == "Batch"
+
+
 def test_newer_video_safety_snapshot_wins_over_slow_foreground_publication() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._device_snapshot_generation = 0

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1274,12 +1274,109 @@ def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:
             async_get_batch_ota_info=AsyncMock(return_value={"available": True}),
         )
 
-        schedule, preferences, ota = await coordinator._async_fetch_batch_device_data()
+        schedule, preferences, ota, generation = (
+            await coordinator._async_fetch_batch_device_data()
+        )
 
         assert schedule is coordinator.schedules
         assert preferences == {"maps": []}
         assert ota == {"available": True}
+        assert generation == 0
         coordinator.client.async_get_batch_schedules.assert_not_awaited()
+
+    asyncio.run(scenario())
+
+
+def test_parallel_batch_metadata_cannot_replace_newer_schedule_read() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = {
+            "source": "app_action_schedule",
+            "available": True,
+            "schedules": [
+                {"idx": -1, "available": True, "version": 10, "plans": []},
+                {"idx": 0, "available": True, "version": 11, "plans": []},
+            ],
+            "errors": [],
+        }
+        coordinator.schedules_refreshed_at = None
+        coordinator.batch_device_data = None
+        coordinator.batch_device_data_refreshed_at = None
+        coordinator.selected_map_index = 0
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [{"idx": 0, "created": True}],
+        }
+        old_batch_returned = asyncio.Event()
+        release_preferences = asyncio.Event()
+        batch_calls = 0
+
+        async def get_batch_schedules(**_kwargs) -> dict[str, object]:
+            nonlocal batch_calls
+            batch_calls += 1
+            version = 11 if batch_calls == 1 else 12
+            if batch_calls == 1:
+                old_batch_returned.set()
+            return {
+                "source": "batch_device_data_schedule",
+                "available": True,
+                "active_schedule_version": version,
+                "current_task": None,
+                "schedules": [
+                    {
+                        "idx": 0,
+                        "available": True,
+                        "version": version,
+                        "plans": [],
+                    }
+                ],
+                "errors": [],
+            }
+
+        async def get_preferences(**_kwargs) -> dict[str, object]:
+            await release_preferences.wait()
+            return {"maps": []}
+
+        coordinator.client = SimpleNamespace(
+            async_get_app_schedules=AsyncMock(
+                return_value={
+                    "source": "app_action_schedule",
+                    "available": True,
+                    "schedules": [
+                        {
+                            "idx": -1,
+                            "available": True,
+                            "version": 10,
+                            "plans": [],
+                        },
+                        {
+                            "idx": 0,
+                            "available": True,
+                            "version": 12,
+                            "plans": [],
+                        },
+                    ],
+                    "errors": [],
+                }
+            ),
+            async_get_batch_schedules=get_batch_schedules,
+            async_get_batch_mowing_preferences=get_preferences,
+            async_get_batch_ota_info=AsyncMock(return_value={"available": True}),
+        )
+
+        metadata_task = asyncio.create_task(
+            coordinator.async_refresh_batch_device_data(force=True)
+        )
+        await old_batch_returned.wait()
+        await coordinator.async_refresh_schedules(force=True)
+        release_preferences.set()
+        await metadata_task
+
+        assert coordinator.schedules["active_schedule_version"] == 12
+        assert coordinator.schedules["schedules"][1]["version"] == 12
+        assert coordinator.batch_device_data["batch_schedule"][
+            "active_schedule_version"
+        ] == 11
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -153,7 +153,7 @@ def test_batch_schedule_merge_keeps_unknown_slot_on_unhinted_collision() -> None
     )
 
     assert result is not None
-    assert "active_schedule_index" not in result
+    assert result["active_schedule_index"] is None
     assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 2, None]
     assert result["schedules"][-1]["plans"][0]["name"] == "Batch"
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1316,6 +1316,65 @@ def test_schedule_refresh_prunes_last_map_after_authoritative_empty_map_list() -
     )
 
 
+def test_schedule_refresh_rejects_lagging_batch_for_deleted_map(
+) -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "active_schedule_version": 11,
+        "active_schedule_index": 0,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = None
+    coordinator.app_maps = {"maps": [], "map_list_valid": True}
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+        ],
+        "errors": [],
+    }
+    lagging_batch = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "active_schedule_version": 11,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": None,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(return_value=lagging_batch),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1]
+    assert [schedule["version"] for schedule in result["schedules"]] == [20]
+    assert result["active_selection_available"] is False
+    assert "active_schedule_version" not in result
+    assert "active_schedule_index" not in result
+
+
 def test_schedule_refresh_marks_active_selection_unavailable_without_batch() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -33,6 +33,7 @@ from custom_components.dreame_lawn_mower.performance import (
     DreameLawnMowerPerformanceTracker,
 )
 from custom_components.dreame_lawn_mower.schedule_cache import (
+    merge_app_schedule_payload,
     merge_batch_schedule_payload,
 )
 
@@ -1265,6 +1266,51 @@ def test_schedule_refresh_prunes_deleted_map_after_partial_read() -> None:
 
     assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
     assert [schedule["version"] for schedule in result["schedules"]] == [20, 11]
+    assert result["active_selection_available"] is False
+    assert "active_schedule_version" not in result
+    assert "active_schedule_index" not in result
+
+
+def test_authoritative_pruning_does_not_resolve_fallback_to_removed_slot() -> None:
+    existing = {
+        "source": "batch_device_data_schedule",
+        "active_schedule_version": 12,
+        "active_selection_available": False,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+            {
+                "idx": None,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "errors": [],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+            {
+                "idx": 1,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "errors": [],
+    }
+
+    result = merge_app_schedule_payload(
+        existing,
+        incoming,
+        expected_indices=[-1, 0],
+        prune_unexpected_indices=True,
+    )
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
     assert result["active_selection_available"] is False
     assert "active_schedule_version" not in result
     assert "active_schedule_index" not in result

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -889,6 +889,47 @@ def test_schedule_refresh_preserves_active_version_when_its_slot_fails() -> None
     assert [schedule["version"] for schedule in result["schedules"]] == [20, 11]
 
 
+def test_schedule_refresh_prunes_deleted_map_after_complete_read() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+            {
+                "idx": 1,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
+
+
 def test_schedule_refresh_does_not_mark_all_failed_reads_fresh() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1381,6 +1381,72 @@ def test_parallel_batch_metadata_cannot_replace_newer_schedule_read() -> None:
     asyncio.run(scenario())
 
 
+def test_older_app_action_refresh_cannot_replace_newer_schedule_read() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = {
+            "source": "app_action_schedule",
+            "available": True,
+            "schedules": [
+                {"idx": -1, "available": True, "version": 10, "plans": []},
+                {"idx": 0, "available": True, "version": 11, "plans": []},
+            ],
+            "errors": [],
+        }
+        coordinator.schedules_refreshed_at = None
+        coordinator.selected_map_index = 0
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [{"idx": 0, "created": True}],
+        }
+        old_action_started = asyncio.Event()
+        release_old_action = asyncio.Event()
+        action_calls = 0
+
+        async def get_app_schedules(**_kwargs) -> dict[str, object]:
+            nonlocal action_calls
+            action_calls += 1
+            if action_calls == 1:
+                old_action_started.set()
+                await release_old_action.wait()
+                version = 11
+            else:
+                version = 12
+            return {
+                "source": "app_action_schedule",
+                "available": True,
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 10, "plans": []},
+                    {
+                        "idx": 0,
+                        "available": True,
+                        "version": version,
+                        "plans": [{"plan_id": 1, "enabled": version == 12}],
+                    },
+                ],
+                "errors": [],
+            }
+
+        coordinator.client = SimpleNamespace(
+            async_get_app_schedules=get_app_schedules,
+            async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+        )
+
+        old_refresh = asyncio.create_task(
+            coordinator.async_refresh_schedules(force=True)
+        )
+        await old_action_started.wait()
+        await coordinator.async_refresh_schedules(force=True)
+        release_old_action.set()
+        await old_refresh
+
+        current = coordinator.schedules["schedules"][1]
+        assert current["version"] == 12
+        assert current["plans"][0]["enabled"] is True
+
+    asyncio.run(scenario())
+
+
 def test_performance_tracker_keeps_phase_and_aggregate_timings() -> None:
     values = iter((0.0, 1.0, 3.0, 5.0))
     tracker = DreameLawnMowerPerformanceTracker(

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -2214,6 +2214,46 @@ def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:
     asyncio.run(scenario())
 
 
+def test_forced_batch_metadata_bypasses_fresh_merged_schedule_cache() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = {
+            "source": "app_action_schedule_with_batch_refresh",
+            "available": True,
+            "schedules": [{"idx": 0, "version": 11, "plans": []}],
+            "errors": [],
+        }
+        coordinator.schedules_refreshed_at = datetime.now(UTC)
+        coordinator.app_maps = {"current_map_index": 0}
+        fresh_batch_schedule = {
+            "source": "batch_device_data_schedule",
+            "available": True,
+            "schedules": [{"idx": 0, "version": 12, "plans": []}],
+            "errors": [],
+        }
+        coordinator.client = SimpleNamespace(
+            async_get_batch_schedules=AsyncMock(return_value=fresh_batch_schedule),
+            async_get_batch_mowing_preferences=AsyncMock(
+                return_value={"maps": []}
+            ),
+            async_get_batch_ota_info=AsyncMock(return_value={"available": True}),
+        )
+
+        schedule, preferences, ota, _generation = (
+            await coordinator._async_fetch_batch_device_data(force=True)
+        )
+
+        assert schedule is fresh_batch_schedule
+        assert preferences == {"maps": []}
+        assert ota == {"available": True}
+        coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+            include_raw=False,
+            map_index_hint=0,
+        )
+
+    asyncio.run(scenario())
+
+
 def test_batch_metadata_rejects_hint_after_selected_map_changes() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -954,6 +954,64 @@ def test_schedule_refresh_promotes_batch_fallback_when_slot_becomes_known() -> N
             },
         ],
         "active_schedule_version": 12,
+        "active_selection_available": False,
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    matching = [
+        schedule
+        for schedule in result["schedules"]
+        if schedule.get("version") == 12
+    ]
+    assert len(matching) == 1
+    assert matching[0]["idx"] == 0
+    assert "writable" not in matching[0]
+    assert result["active_schedule_index"] == 0
+    assert result["active_selection_available"] is True
+
+
+def test_partial_collision_preserves_ambiguous_schedule_fallback() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "schedules": [
+            {"idx": -1, "available": False, "error": "timed out"},
+            {
+                "idx": None,
+                "label": "active_schedule",
+                "writable": False,
+                "available": True,
+                "version": 12,
+                "plans": [{"plan_id": 7}],
+            },
+        ],
+        "active_schedule_version": 12,
+        "active_selection_available": True,
         "errors": [],
     }
     coordinator.schedules_refreshed_at = None
@@ -987,9 +1045,8 @@ def test_schedule_refresh_promotes_batch_fallback_when_slot_becomes_known() -> N
         for schedule in result["schedules"]
         if schedule.get("version") == 12
     ]
-    assert len(matching) == 1
-    assert matching[0]["idx"] == 0
-    assert "writable" not in matching[0]
+    assert {schedule["idx"] for schedule in matching} == {None, 0}
+    assert result["active_selection_available"] is False
 
 
 def test_schedule_refresh_clears_stale_active_version_after_complete_read() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1224,6 +1224,50 @@ def test_schedule_refresh_prunes_deleted_map_after_complete_read() -> None:
     assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
 
 
+def test_schedule_refresh_prunes_deleted_map_after_partial_read() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "active_schedule_version": 12,
+        "active_schedule_index": 1,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+            {"idx": 1, "available": True, "version": 12, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+        "map_list_valid": True,
+    }
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": False, "error": "timed out"},
+        ],
+        "errors": [{"idx": 0, "stage": "schedule", "error": "timed out"}],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 11]
+    assert result["active_selection_available"] is False
+    assert "active_schedule_version" not in result
+    assert "active_schedule_index" not in result
+
+
 def test_schedule_refresh_keeps_auto_discovered_maps_without_app_hints() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = {
@@ -1831,6 +1875,85 @@ def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:
         assert ota == {"available": True}
         assert generation == 0
         coordinator.client.async_get_batch_schedules.assert_not_awaited()
+
+    asyncio.run(scenario())
+
+
+def test_batch_metadata_rejects_hint_after_selected_map_changes() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = {
+            "source": "app_action_schedule",
+            "available": True,
+            "active_schedule_version": 11,
+            "active_schedule_index": 0,
+            "active_selection_available": True,
+            "schedules": [
+                {"idx": -1, "available": True, "version": 10, "plans": []},
+                {"idx": 0, "available": True, "version": 11, "plans": []},
+                {"idx": 1, "available": True, "version": 12, "plans": []},
+            ],
+            "errors": [],
+        }
+        coordinator.schedules_refreshed_at = None
+        coordinator.batch_device_data = None
+        coordinator.batch_device_data_refreshed_at = None
+        coordinator.selected_map_index = 0
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [
+                {"idx": 0, "created": True},
+                {"idx": 1, "created": True},
+            ],
+        }
+        batch_started = asyncio.Event()
+        release_batch = asyncio.Event()
+
+        async def get_batch_schedules(**_kwargs) -> dict[str, object]:
+            batch_started.set()
+            await release_batch.wait()
+            return {
+                "source": "batch_device_data_schedule",
+                "available": True,
+                "active_schedule_version": 22,
+                "current_task": None,
+                "schedules": [
+                    {
+                        "idx": 0,
+                        "available": True,
+                        "version": 22,
+                        "plans": [],
+                    }
+                ],
+                "errors": [],
+            }
+
+        coordinator.client = SimpleNamespace(
+            async_get_batch_schedules=get_batch_schedules,
+            async_get_batch_mowing_preferences=AsyncMock(
+                return_value={"maps": []}
+            ),
+            async_get_batch_ota_info=AsyncMock(return_value={"available": True}),
+        )
+
+        refresh_task = asyncio.create_task(
+            coordinator.async_refresh_batch_device_data(force=True)
+        )
+        await batch_started.wait()
+        coordinator._invalidate_schedule_map_hint()
+        coordinator.selected_map_index = 1
+        coordinator.app_maps["current_map_index"] = 1
+        release_batch.set()
+        result = await refresh_task
+
+        assert result is not None
+        batch_schedule = result["batch_schedule"]
+        assert batch_schedule["schedules"][0]["idx"] is None
+        assert coordinator.schedules["active_schedule_index"] == 0
+        assert coordinator.schedules["active_selection_available"] is False
+        assert coordinator.schedules["schedules"][1]["version"] == 11
+        assert coordinator.schedules["schedules"][2]["version"] == 12
+        assert coordinator.schedules_refreshed_at is None
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -421,17 +421,13 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
         "source": "app_action_schedule",
         "schedules": [
             default_schedule,
-            {"idx": 1, "available": True, "version": 4, "plans": []},
             {"idx": 2, "available": True, "version": 6, "plans": []},
         ],
     }
     coordinator.schedules_refreshed_at = None
     coordinator.app_maps = {
         "current_map_index": 2,
-        "maps": [
-            {"idx": 1, "created": True},
-            {"idx": 2, "created": True},
-        ],
+        "maps": [{"idx": 2, "created": True}],
     }
     coordinator.selected_map_index = 2
     batch_payload = {
@@ -458,14 +454,73 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
     assert result is coordinator.schedules
     assert result["source"] == "app_action_schedule_with_batch_refresh"
     assert result["schedules"][0] is default_schedule
-    assert result["schedules"][1]["version"] == 4
-    assert result["schedules"][2]["version"] == 6
+    assert result["schedules"][1]["version"] == 6
     assert result["active_schedule_version"] == 6
     coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
         include_raw=False,
         map_index_hint=2,
     )
     coordinator.client.async_get_app_schedules.assert_not_awaited()
+
+
+def test_schedule_refresh_reads_inactive_maps_instead_of_batch_fast_path() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 3, "plans": []},
+            {"idx": 1, "available": True, "version": 4, "plans": []},
+            {"idx": 2, "available": True, "version": 6, "plans": []},
+        ],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.app_maps = {
+        "current_map_index": 2,
+        "maps": [
+            {"idx": 1, "created": True},
+            {"idx": 2, "created": True},
+        ],
+    }
+    coordinator.selected_map_index = 2
+    app_payload = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 3, "plans": []},
+            {"idx": 1, "available": True, "version": 5, "plans": []},
+            {"idx": 2, "available": True, "version": 6, "plans": []},
+        ],
+    }
+    batch_payload = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "active_schedule_version": 6,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 2,
+                "available": True,
+                "version": 6,
+                "plans": [],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_batch_schedules=AsyncMock(return_value=batch_payload),
+        async_get_app_schedules=AsyncMock(return_value=app_payload),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules())
+
+    assert [schedule["version"] for schedule in result["schedules"]] == [3, 5, 6]
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 1, 2],
+    )
+    coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hint=2,
+    )
 
 
 def test_initial_single_map_schedule_refresh_keeps_default_app_schedule() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1571,6 +1571,38 @@ def test_initial_schedule_payload_prunes_authoritatively_removed_map() -> None:
     assert result["available"] is True
 
 
+def test_pending_plan_overlay_recomputes_enabled_counts() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._pending_schedule_plan_states = {
+        (0, 1): (11, False),
+        (1, 2): (12, True),
+    }
+    coordinator.schedules = {
+        "schedules": [
+            {
+                "idx": 0,
+                "version": 11,
+                "enabled_plan_count": 1,
+                "plans": [{"plan_id": 1, "enabled": True}],
+            },
+            {
+                "idx": 1,
+                "version": 12,
+                "enabled_plan_count": 0,
+                "plans": [{"plan_id": 2, "enabled": False}],
+            },
+        ]
+    }
+
+    coordinator._apply_pending_schedule_plan_states()
+
+    schedules = coordinator.schedules["schedules"]
+    assert schedules[0]["plans"][0]["enabled"] is False
+    assert schedules[0]["enabled_plan_count"] == 0
+    assert schedules[1]["plans"][0]["enabled"] is True
+    assert schedules[1]["enabled_plan_count"] == 1
+
+
 def test_non_authoritative_map_subset_preserves_cached_schedule_slots() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = {

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -528,6 +528,56 @@ def test_metadata_hydration_retries_incomplete_current_app_map() -> None:
     )
 
 
+def test_metadata_hydration_forces_incomplete_app_map_retry() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        app_map_forces: list[bool] = []
+
+        async def refresh_app_maps(*, force: bool) -> dict[str, object]:
+            app_map_forces.append(force)
+            coordinator.app_maps_refresh_succeeded = len(app_map_forces) > 1
+            return {"maps": []}
+
+        async def complete(*_args, **_kwargs) -> None:
+            return None
+
+        coordinator.performance = DreameLawnMowerPerformanceTracker()
+        coordinator._metadata_refresh_count = 0
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_refresh_semaphore = asyncio.Semaphore(
+            METADATA_REFRESH_CONCURRENCY
+        )
+        coordinator._shutting_down = False
+        coordinator.app_maps_refresh_succeeded = False
+        coordinator.app_maps = {"maps": []}
+        coordinator.async_update_listeners = Mock()
+        coordinator.async_refresh_app_maps = refresh_app_maps
+        coordinator.async_refresh_schedules = complete
+        coordinator.async_refresh_batch_device_data = complete
+        coordinator._async_refresh_bluetooth_state = complete
+        coordinator.async_refresh_firmware_update_support = complete
+        coordinator.async_refresh_app_map_objects = complete
+        coordinator.async_refresh_vector_map_details = complete
+        coordinator.async_refresh_weather_protection = complete
+        coordinator.async_refresh_maintenance_status = complete
+        coordinator.async_refresh_voice_settings = complete
+
+        with patch(
+            "custom_components.dreame_lawn_mower.coordinator_refresh."
+            "METADATA_RETRY_DELAY_SECONDS",
+            0,
+        ):
+            await coordinator._async_refresh_metadata(
+                refresh_map_and_runtime=True,
+            )
+
+        assert app_map_forces == [False, True]
+        sample = coordinator.performance.as_dict()["samples"][-1]
+        assert "app_maps_retry" in sample["phases_ms"]
+
+    asyncio.run(scenario())
+
+
 def test_active_session_reuses_verified_map_identity_between_polls() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -751,6 +751,89 @@ def test_schedule_refresh_promotes_batch_fallback_when_slot_becomes_known() -> N
     assert "writable" not in matching[0]
 
 
+def test_schedule_refresh_clears_stale_active_version_after_complete_read() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+            {
+                "idx": None,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+                "writable": False,
+            },
+        ],
+        "active_schedule_version": 11,
+        "current_task": {"version": 11},
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert "active_schedule_version" not in result
+    assert "current_task" not in result
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
+
+
+def test_schedule_refresh_preserves_active_version_when_its_slot_fails() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+        ],
+        "active_schedule_version": 11,
+        "current_task": {"version": 11},
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": False, "error": "timed out"},
+        ],
+        "errors": [{"idx": 0, "stage": "schedule", "error": "timed out"}],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["active_schedule_version"] == 11
+    assert result["current_task"]["version"] == 11
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 11]
+
+
 def test_schedule_refresh_does_not_mark_all_failed_reads_fresh() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1229,7 +1229,8 @@ def test_schedule_refresh_keeps_auto_discovered_maps_without_app_hints() -> None
     }
     coordinator.schedules_refreshed_at = None
     coordinator.selected_map_index = 0
-    coordinator.app_maps = {"maps": []}
+    coordinator.app_maps = {"maps": [], "map_list_valid": False}
+    coordinator.app_maps_refresh_succeeded = True
     incoming = {
         "source": "app_action_schedule",
         "schedules": [
@@ -1272,7 +1273,7 @@ def test_schedule_refresh_prunes_last_map_after_authoritative_empty_map_list() -
     }
     coordinator.schedules_refreshed_at = None
     coordinator.selected_map_index = 0
-    coordinator.app_maps = {"maps": []}
+    coordinator.app_maps = {"maps": [], "map_list_valid": True}
     coordinator.app_maps_refresh_succeeded = True
     coordinator._pending_schedule_plan_states = {(0, 1): (11, False)}
     coordinator._pending_schedule_plan_state_contradictions = {(0, 1): 1}
@@ -1457,7 +1458,7 @@ def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:
     asyncio.run(scenario())
 
 
-def test_parallel_batch_metadata_cannot_replace_newer_schedule_read() -> None:
+def test_parallel_schedule_and_batch_metadata_share_one_batch_read() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         coordinator.schedules = {
@@ -1477,35 +1478,32 @@ def test_parallel_batch_metadata_cannot_replace_newer_schedule_read() -> None:
             "current_map_index": 0,
             "maps": [{"idx": 0, "created": True}],
         }
-        old_batch_returned = asyncio.Event()
-        release_preferences = asyncio.Event()
+        batch_started = asyncio.Event()
+        release_batch = asyncio.Event()
         batch_calls = 0
+        batch_options: list[dict[str, object]] = []
 
-        async def get_batch_schedules(**_kwargs) -> dict[str, object]:
+        async def get_batch_schedules(**kwargs) -> dict[str, object]:
             nonlocal batch_calls
             batch_calls += 1
-            version = 11 if batch_calls == 1 else 12
-            if batch_calls == 1:
-                old_batch_returned.set()
+            batch_options.append(kwargs)
+            batch_started.set()
+            await release_batch.wait()
             return {
                 "source": "batch_device_data_schedule",
                 "available": True,
-                "active_schedule_version": version,
+                "active_schedule_version": 12,
                 "current_task": None,
                 "schedules": [
                     {
                         "idx": 0,
                         "available": True,
-                        "version": version,
+                        "version": 12,
                         "plans": [],
                     }
                 ],
                 "errors": [],
             }
-
-        async def get_preferences(**_kwargs) -> dict[str, object]:
-            await release_preferences.wait()
-            return {"maps": []}
 
         coordinator.client = SimpleNamespace(
             async_get_app_schedules=AsyncMock(
@@ -1530,23 +1528,30 @@ def test_parallel_batch_metadata_cannot_replace_newer_schedule_read() -> None:
                 }
             ),
             async_get_batch_schedules=get_batch_schedules,
-            async_get_batch_mowing_preferences=get_preferences,
+            async_get_batch_mowing_preferences=AsyncMock(
+                return_value={"maps": []}
+            ),
             async_get_batch_ota_info=AsyncMock(return_value={"available": True}),
         )
 
         metadata_task = asyncio.create_task(
             coordinator.async_refresh_batch_device_data(force=True)
         )
-        await old_batch_returned.wait()
-        await coordinator.async_refresh_schedules(force=True)
-        release_preferences.set()
-        await metadata_task
+        await batch_started.wait()
+        schedule_task = asyncio.create_task(
+            coordinator.async_refresh_schedules(force=True)
+        )
+        await asyncio.sleep(0)
+        release_batch.set()
+        await asyncio.gather(metadata_task, schedule_task)
 
+        assert batch_calls == 1
+        assert batch_options == [{"include_raw": False, "map_index_hint": 0}]
         assert coordinator.schedules["active_schedule_version"] == 12
         assert coordinator.schedules["schedules"][1]["version"] == 12
         assert coordinator.batch_device_data["batch_schedule"][
             "active_schedule_version"
-        ] == 11
+        ] == 12
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1375,6 +1375,73 @@ def test_schedule_refresh_rejects_lagging_batch_for_deleted_map(
     assert "active_schedule_index" not in result
 
 
+def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "active_schedule_version": 11,
+        "active_schedule_index": 0,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+        "map_list_valid": True,
+    }
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 21,
+                "plans": [{"plan_id": 1}],
+            },
+        ],
+        "errors": [],
+    }
+    newer_batch = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "active_schedule_version": 22,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 0,
+                "available": True,
+                "version": 22,
+                "plans": [{"plan_id": 1}],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(return_value=newer_batch),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["active_schedule_version"] == 22
+    assert result["active_schedule_index"] == 0
+    assert result["active_selection_available"] is True
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 22]
+
+
 def test_schedule_refresh_marks_active_selection_unavailable_without_batch() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -577,6 +578,67 @@ def test_metadata_hydration_forces_incomplete_app_map_retry() -> None:
         assert "app_maps_retry" in sample["phases_ms"]
 
     asyncio.run(scenario())
+
+
+@pytest.mark.parametrize(
+    ("refresh_method", "cache_attr", "refreshed_at_attr", "client_method"),
+    [
+        (
+            "async_refresh_firmware_update_support",
+            "firmware_update_support",
+            "firmware_update_support_refreshed_at",
+            "async_get_firmware_update_support",
+        ),
+        (
+            "async_refresh_app_map_objects",
+            "app_map_objects",
+            "app_map_objects_refreshed_at",
+            "async_get_app_map_objects",
+        ),
+        (
+            "async_refresh_vector_map_details",
+            "vector_map_details",
+            "vector_map_details_refreshed_at",
+            "async_get_vector_map_details",
+        ),
+        (
+            "async_refresh_weather_protection",
+            "weather_protection",
+            "weather_protection_refreshed_at",
+            "async_get_weather_protection",
+        ),
+        (
+            "async_refresh_maintenance_status",
+            "maintenance_status",
+            "maintenance_status_refreshed_at",
+            "async_get_maintenance_status",
+        ),
+        (
+            "async_refresh_voice_settings",
+            "voice_settings",
+            "voice_settings_refreshed_at",
+            "async_get_voice_settings",
+        ),
+    ],
+)
+def test_failed_metadata_refresh_expires_old_cache_marker(
+    refresh_method: str,
+    cache_attr: str,
+    refreshed_at_attr: str,
+    client_method: str,
+) -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    cached = {"cached": True}
+    setattr(coordinator, cache_attr, cached)
+    setattr(coordinator, refreshed_at_attr, datetime.now(UTC))
+    coordinator.client = SimpleNamespace(
+        **{client_method: AsyncMock(side_effect=TimeoutError)}
+    )
+
+    result = asyncio.run(getattr(coordinator, refresh_method)(force=True))
+
+    assert result is cached
+    assert getattr(coordinator, refreshed_at_attr) is None
 
 
 def test_active_session_reuses_verified_map_identity_between_polls() -> None:
@@ -2002,6 +2064,7 @@ def test_schedule_refresh_rejects_batch_hint_after_selected_map_changes() -> Non
         }
         coordinator.schedules_refreshed_at = None
         coordinator.selected_map_index = 0
+        coordinator._pending_schedule_upload_active_indices = {0}
         coordinator.app_maps = {
             "current_map_index": 0,
             "maps": [
@@ -2067,6 +2130,7 @@ def test_schedule_refresh_rejects_batch_hint_after_selected_map_changes() -> Non
         assert result["active_selection_available"] is False
         assert "active_schedule_index" not in result
         assert "active_schedule_version" not in result
+        assert coordinator._pending_schedule_upload_active_indices == set()
         assert result["schedules"][1]["version"] == 21
         assert result["schedules"][2]["version"] == 22
 
@@ -2324,6 +2388,7 @@ def test_batch_metadata_rejects_hint_after_selected_map_changes() -> None:
         coordinator.batch_device_data = None
         coordinator.batch_device_data_refreshed_at = None
         coordinator.selected_map_index = 0
+        coordinator._pending_schedule_upload_active_indices = {0}
         coordinator.app_maps = {
             "current_map_index": 0,
             "maps": [
@@ -2383,6 +2448,7 @@ def test_batch_metadata_rejects_hint_after_selected_map_changes() -> None:
         assert "active_schedule_version" not in coordinator.schedules
         assert "current_task" not in coordinator.schedules
         assert coordinator.schedules["active_selection_available"] is False
+        assert coordinator._pending_schedule_upload_active_indices == set()
         assert coordinator.schedules["schedules"][1]["version"] == 11
         assert coordinator.schedules["schedules"][2]["version"] == 12
         assert coordinator.schedules_refreshed_at is None
@@ -2703,6 +2769,9 @@ def test_shutdown_cancels_shielded_batch_schedule_read() -> None:
         coordinator._client_update_pending = False
         coordinator._client_update_task = None
         coordinator._batch_schedule_read_task = asyncio.create_task(batch_schedule())
+        coordinator._batch_schedule_read_tasks = {
+            coordinator._batch_schedule_read_task
+        }
         coordinator._batch_schedule_read_completed_at = None
         coordinator._metadata_refresh_task = asyncio.create_task(metadata())
         coordinator._metadata_shutdown_close_task = None
@@ -2720,6 +2789,62 @@ def test_shutdown_cancels_shielded_batch_schedule_read() -> None:
         assert batch_cancelled.is_set()
         assert coordinator._batch_schedule_read_task is None
         assert close_calls == ["close"]
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_drains_displaced_keyed_batch_schedule_reads() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        started = {0: asyncio.Event(), 1: asyncio.Event()}
+        cancelled: set[int] = set()
+
+        async def get_batch_schedules(
+            *,
+            map_index_hint: int,
+            **_kwargs,
+        ) -> dict[str, object]:
+            started[map_index_hint].set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                cancelled.add(map_index_hint)
+                raise
+
+        coordinator.client = SimpleNamespace(
+            async_get_batch_schedules=get_batch_schedules
+        )
+        coordinator._batch_schedule_read_task = None
+        coordinator._batch_schedule_read_tasks = set()
+        coordinator._batch_schedule_read_key = None
+        coordinator._batch_schedule_read_completed_at = None
+
+        first = asyncio.create_task(
+            coordinator._async_get_shared_batch_schedules(
+                map_index_hint=0,
+                force=True,
+            )
+        )
+        await started[0].wait()
+        second = asyncio.create_task(
+            coordinator._async_get_shared_batch_schedules(
+                map_index_hint=1,
+                force=True,
+            )
+        )
+        await started[1].wait()
+
+        first.cancel()
+        with suppress(asyncio.CancelledError):
+            await first
+
+        assert await coordinator._async_drain_batch_schedule_for_shutdown()
+
+        with suppress(asyncio.CancelledError):
+            await second
+        assert cancelled == {0, 1}
+        assert coordinator._batch_schedule_read_tasks == set()
+        assert coordinator._batch_schedule_read_task is None
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -414,13 +414,12 @@ def test_failed_due_map_refresh_does_not_stamp_runtime_with_stale_identity() -> 
     asyncio.run(scenario())
 
 
-def test_schedule_refresh_prefers_fast_batch_payload() -> None:
+def test_schedule_refresh_reads_inactive_default_slot_on_single_map_device() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
-    default_schedule = {"idx": -1, "available": True, "plans": []}
     coordinator.schedules = {
         "source": "app_action_schedule",
         "schedules": [
-            default_schedule,
+            {"idx": -1, "available": True, "version": 5, "plans": []},
             {"idx": 2, "available": True, "version": 6, "plans": []},
         ],
     }
@@ -430,6 +429,14 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
         "maps": [{"idx": 2, "created": True}],
     }
     coordinator.selected_map_index = 2
+    app_payload = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {"idx": 2, "available": True, "version": 6, "plans": []},
+        ],
+        "errors": [],
+    }
     batch_payload = {
         "source": "batch_device_data_schedule",
         "available": True,
@@ -446,21 +453,24 @@ def test_schedule_refresh_prefers_fast_batch_payload() -> None:
     }
     coordinator.client = SimpleNamespace(
         async_get_batch_schedules=AsyncMock(return_value=batch_payload),
-        async_get_app_schedules=AsyncMock(),
+        async_get_app_schedules=AsyncMock(return_value=app_payload),
     )
 
     result = asyncio.run(coordinator.async_refresh_schedules())
 
     assert result is coordinator.schedules
     assert result["source"] == "app_action_schedule_with_batch_refresh"
-    assert result["schedules"][0] is default_schedule
+    assert result["schedules"][0]["version"] == 7
     assert result["schedules"][1]["version"] == 6
     assert result["active_schedule_version"] == 6
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 2],
+    )
     coordinator.client.async_get_batch_schedules.assert_awaited_once_with(
         include_raw=False,
         map_index_hint=2,
     )
-    coordinator.client.async_get_app_schedules.assert_not_awaited()
 
 
 def test_schedule_refresh_reads_inactive_maps_instead_of_batch_fast_path() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1387,6 +1387,12 @@ def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> 
             {
                 "idx": 0,
                 "available": True,
+                "version": 22,
+                "plans": [{"plan_id": 7}],
+            },
+            {
+                "idx": 1,
+                "available": True,
                 "version": 11,
                 "plans": [{"plan_id": 1}],
             },
@@ -1394,10 +1400,13 @@ def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> 
         "errors": [],
     }
     coordinator.schedules_refreshed_at = None
-    coordinator.selected_map_index = 0
+    coordinator.selected_map_index = 1
     coordinator.app_maps = {
-        "current_map_index": 0,
-        "maps": [{"idx": 0, "created": True}],
+        "current_map_index": 1,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
         "map_list_valid": True,
     }
     coordinator.app_maps_refresh_succeeded = True
@@ -1407,6 +1416,12 @@ def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> 
             {"idx": -1, "available": True, "version": 20, "plans": []},
             {
                 "idx": 0,
+                "available": True,
+                "version": 22,
+                "plans": [{"plan_id": 7}],
+            },
+            {
+                "idx": 1,
                 "available": True,
                 "version": 21,
                 "plans": [{"plan_id": 1}],
@@ -1421,10 +1436,10 @@ def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> 
         "current_task": None,
         "schedules": [
             {
-                "idx": 0,
+                "idx": 1,
                 "available": True,
                 "version": 22,
-                "plans": [{"plan_id": 1}],
+                "plans": [{"plan_id": 9}],
             }
         ],
         "errors": [],
@@ -1437,9 +1452,99 @@ def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> 
     result = asyncio.run(coordinator.async_refresh_schedules(force=True))
 
     assert result["active_schedule_version"] == 22
-    assert result["active_schedule_index"] == 0
+    assert result["active_schedule_index"] == 1
     assert result["active_selection_available"] is True
-    assert [schedule["version"] for schedule in result["schedules"]] == [20, 22]
+    assert [schedule["version"] for schedule in result["schedules"]] == [
+        20,
+        22,
+        22,
+    ]
+    assert result["schedules"][1]["plans"] == [{"plan_id": 7}]
+    assert result["schedules"][2]["plans"] == [{"plan_id": 9}]
+
+
+def test_schedule_refresh_revalidates_maps_after_action_request() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = {
+            "source": "app_action_schedule_with_batch_refresh",
+            "active_schedule_version": 12,
+            "active_schedule_index": 1,
+            "active_selection_available": True,
+            "schedules": [
+                {"idx": -1, "available": True, "version": 10, "plans": []},
+                {"idx": 0, "available": True, "version": 11, "plans": []},
+                {"idx": 1, "available": True, "version": 12, "plans": []},
+            ],
+            "errors": [],
+        }
+        coordinator.schedules_refreshed_at = None
+        coordinator.selected_map_index = 1
+        coordinator.app_maps = {
+            "current_map_index": 1,
+            "maps": [
+                {"idx": 0, "created": True},
+                {"idx": 1, "created": True},
+            ],
+            "map_list_valid": True,
+        }
+        coordinator.app_maps_refresh_succeeded = True
+        action_started = asyncio.Event()
+        release_action = asyncio.Event()
+
+        async def get_app_schedules(**_kwargs) -> dict[str, object]:
+            action_started.set()
+            await release_action.wait()
+            return {
+                "source": "app_action_schedule",
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 20, "plans": []},
+                    {"idx": 0, "available": True, "version": 21, "plans": []},
+                    {"idx": 1, "available": True, "version": 22, "plans": []},
+                ],
+                "errors": [],
+            }
+
+        coordinator.client = SimpleNamespace(
+            async_get_app_schedules=get_app_schedules,
+            async_get_batch_schedules=AsyncMock(
+                return_value={
+                    "source": "batch_device_data_schedule",
+                    "available": True,
+                    "current_task": None,
+                    "schedules": [
+                        {
+                            "idx": None,
+                            "available": True,
+                            "version": 22,
+                            "plans": [],
+                        }
+                    ],
+                    "errors": [],
+                }
+            ),
+        )
+
+        refresh_task = asyncio.create_task(
+            coordinator.async_refresh_schedules(force=True)
+        )
+        await action_started.wait()
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [{"idx": 0, "created": True}],
+            "map_list_valid": True,
+        }
+        coordinator.selected_map_index = 0
+        release_action.set()
+        result = await refresh_task
+
+        assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
+        assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
+        assert result["active_selection_available"] is False
+        assert "active_schedule_version" not in result
+        assert "active_schedule_index" not in result
+
+    asyncio.run(scenario())
 
 
 def test_schedule_refresh_marks_active_selection_unavailable_without_batch() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 from contextlib import suppress
 from datetime import UTC, datetime
+from threading import Event
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -2801,20 +2802,23 @@ def test_shutdown_drains_metadata_before_closing_shared_client() -> None:
     asyncio.run(scenario())
 
 
-def test_shutdown_cancels_shielded_batch_schedule_read() -> None:
+def test_shutdown_waits_for_shielded_batch_worker_before_close() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         batch_started = asyncio.Event()
-        batch_cancelled = asyncio.Event()
+        batch_release = Event()
+        batch_finished = Event()
         close_calls: list[str] = []
+        loop = asyncio.get_running_loop()
+
+        def blocking_batch_schedule() -> dict[str, object]:
+            loop.call_soon_threadsafe(batch_started.set)
+            batch_release.wait()
+            batch_finished.set()
+            return {}
 
         async def batch_schedule() -> dict[str, object]:
-            batch_started.set()
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                batch_cancelled.set()
-                raise
+            return await asyncio.to_thread(blocking_batch_schedule)
 
         async def metadata() -> None:
             await asyncio.shield(coordinator._batch_schedule_read_task)
@@ -2841,9 +2845,76 @@ def test_shutdown_cancels_shielded_batch_schedule_read() -> None:
         )
         await batch_started.wait()
 
-        await asyncio.wait_for(coordinator.async_shutdown(), timeout=1)
+        shutdown = asyncio.create_task(coordinator.async_shutdown())
+        await asyncio.sleep(0)
+        closed_before_worker_finished = bool(close_calls)
+        batch_release.set()
+        await asyncio.wait_for(shutdown, timeout=1)
 
-        assert batch_cancelled.is_set()
+        assert not closed_before_worker_finished
+        assert batch_finished.is_set()
+        assert coordinator._batch_schedule_read_task is None
+        assert close_calls == ["close"]
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_defers_close_until_batch_thread_finishes_after_grace() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        batch_started = asyncio.Event()
+        batch_release = Event()
+        batch_finished = Event()
+        close_calls: list[str] = []
+        loop = asyncio.get_running_loop()
+
+        def blocking_batch_schedule() -> dict[str, object]:
+            loop.call_soon_threadsafe(batch_started.set)
+            batch_release.wait()
+            batch_finished.set()
+            return {}
+
+        async def batch_schedule() -> dict[str, object]:
+            return await asyncio.to_thread(blocking_batch_schedule)
+
+        async def close() -> None:
+            close_calls.append("close")
+
+        coordinator._shutting_down = False
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._batch_schedule_read_task = asyncio.create_task(batch_schedule())
+        coordinator._batch_schedule_read_tasks = {
+            coordinator._batch_schedule_read_task
+        }
+        coordinator._batch_schedule_read_completed_at = None
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_shutdown_close_task = None
+        coordinator.hass = SimpleNamespace(
+            async_create_task=lambda coroutine, _name: asyncio.create_task(coroutine)
+        )
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=close,
+        )
+        await batch_started.wait()
+
+        with patch(
+            "custom_components.dreame_lawn_mower.coordinator_refresh."
+            "METADATA_SHUTDOWN_GRACE_SECONDS",
+            0.01,
+        ):
+            await asyncio.wait_for(coordinator.async_shutdown(), timeout=1)
+
+        assert close_calls == []
+        cleanup = coordinator._metadata_shutdown_close_task
+        assert cleanup is not None
+        assert not cleanup.done()
+
+        batch_release.set()
+        await asyncio.wait_for(cleanup, timeout=1)
+
+        assert batch_finished.is_set()
         assert coordinator._batch_schedule_read_task is None
         assert close_calls == ["close"]
 
@@ -2854,7 +2925,8 @@ def test_shutdown_drains_displaced_keyed_batch_schedule_reads() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         started = {0: asyncio.Event(), 1: asyncio.Event()}
-        cancelled: set[int] = set()
+        release = {0: asyncio.Event(), 1: asyncio.Event()}
+        completed: set[int] = set()
 
         async def get_batch_schedules(
             *,
@@ -2862,11 +2934,9 @@ def test_shutdown_drains_displaced_keyed_batch_schedule_reads() -> None:
             **_kwargs,
         ) -> dict[str, object]:
             started[map_index_hint].set()
-            try:
-                await asyncio.Event().wait()
-            except asyncio.CancelledError:
-                cancelled.add(map_index_hint)
-                raise
+            await release[map_index_hint].wait()
+            completed.add(map_index_hint)
+            return {}
 
         coordinator.client = SimpleNamespace(
             async_get_batch_schedules=get_batch_schedules
@@ -2895,11 +2965,17 @@ def test_shutdown_drains_displaced_keyed_batch_schedule_reads() -> None:
         with suppress(asyncio.CancelledError):
             await first
 
-        assert await coordinator._async_drain_batch_schedule_for_shutdown()
+        drain = asyncio.create_task(
+            coordinator._async_drain_batch_schedule_for_shutdown()
+        )
+        await asyncio.sleep(0)
+        assert not drain.done()
+        release[0].set()
+        release[1].set()
+        assert await drain
 
-        with suppress(asyncio.CancelledError):
-            await second
-        assert cancelled == {0, 1}
+        await second
+        assert completed == {0, 1}
         assert coordinator._batch_schedule_read_tasks == set()
         assert coordinator._batch_schedule_read_task is None
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -508,6 +508,7 @@ def test_metadata_hydration_retries_incomplete_current_app_map() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.app_maps_refresh_succeeded = True
     coordinator.app_maps = {
+        "map_list_valid": True,
         "current_map_index": 0,
         "maps": [
             {"idx": 0, "available": False},
@@ -536,7 +537,7 @@ def test_metadata_hydration_forces_incomplete_app_map_retry() -> None:
         async def refresh_app_maps(*, force: bool) -> dict[str, object]:
             app_map_forces.append(force)
             coordinator.app_maps_refresh_succeeded = len(app_map_forces) > 1
-            return {"maps": []}
+            return {"map_list_valid": True, "maps": []}
 
         async def complete(*_args, **_kwargs) -> None:
             return None
@@ -2672,6 +2673,52 @@ def test_shutdown_drains_metadata_before_closing_shared_client() -> None:
         metadata_finished.set()
         await shutdown
 
+        assert close_calls == ["close"]
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_cancels_shielded_batch_schedule_read() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        batch_started = asyncio.Event()
+        batch_cancelled = asyncio.Event()
+        close_calls: list[str] = []
+
+        async def batch_schedule() -> dict[str, object]:
+            batch_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                batch_cancelled.set()
+                raise
+
+        async def metadata() -> None:
+            await asyncio.shield(coordinator._batch_schedule_read_task)
+
+        async def close() -> None:
+            close_calls.append("close")
+
+        coordinator._shutting_down = False
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._batch_schedule_read_task = asyncio.create_task(batch_schedule())
+        coordinator._batch_schedule_read_completed_at = None
+        coordinator._metadata_refresh_task = asyncio.create_task(metadata())
+        coordinator._metadata_shutdown_close_task = None
+        coordinator.hass = SimpleNamespace(
+            async_create_task=lambda coroutine, _name: asyncio.create_task(coroutine)
+        )
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=close,
+        )
+        await batch_started.wait()
+
+        await asyncio.wait_for(coordinator.async_shutdown(), timeout=1)
+
+        assert batch_cancelled.is_set()
+        assert coordinator._batch_schedule_read_task is None
         assert close_calls == ["close"]
 
     asyncio.run(scenario())

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -110,6 +110,7 @@ def test_batch_schedule_merge_prefers_explicit_hint_on_version_collision() -> No
     )
 
     assert result is not None
+    assert result["active_schedule_index"] == 2
     assert result["schedules"][0]["plans"][0]["name"] == "Default"
     assert result["schedules"][1]["idx"] == 2
     assert result["schedules"][1]["plans"][0]["name"] == "Batch"
@@ -996,7 +997,7 @@ def test_schedule_refresh_clears_stale_active_version_after_complete_read() -> N
     coordinator.schedules = {
         "source": "app_action_schedule_with_batch_refresh",
         "schedules": [
-            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": -1, "available": True, "version": 11, "plans": []},
             {"idx": 0, "available": True, "version": 11, "plans": []},
             {
                 "idx": None,
@@ -1007,6 +1008,7 @@ def test_schedule_refresh_clears_stale_active_version_after_complete_read() -> N
             },
         ],
         "active_schedule_version": 11,
+        "active_schedule_index": 0,
         "current_task": {"version": 11},
         "errors": [],
     }
@@ -1019,7 +1021,7 @@ def test_schedule_refresh_clears_stale_active_version_after_complete_read() -> N
     incoming = {
         "source": "app_action_schedule",
         "schedules": [
-            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": -1, "available": True, "version": 11, "plans": []},
             {"idx": 0, "available": True, "version": 21, "plans": []},
         ],
         "errors": [],
@@ -1032,8 +1034,9 @@ def test_schedule_refresh_clears_stale_active_version_after_complete_read() -> N
     result = asyncio.run(coordinator.async_refresh_schedules(force=True))
 
     assert "active_schedule_version" not in result
+    assert "active_schedule_index" not in result
     assert "current_task" not in result
-    assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
+    assert [schedule["version"] for schedule in result["schedules"]] == [11, 21]
 
 
 def test_schedule_refresh_preserves_active_version_when_its_slot_fails() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -504,6 +504,30 @@ def test_metadata_hydration_retries_only_missing_core_phase() -> None:
     asyncio.run(scenario())
 
 
+def test_metadata_hydration_retries_incomplete_current_app_map() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [
+            {"idx": 0, "available": False},
+            {"idx": 1, "available": True},
+        ],
+    }
+
+    assert coordinator._metadata_phase_needs_retry(
+        "app_maps",
+        coordinator.app_maps,
+    )
+
+    coordinator.app_maps["maps"][0]["available"] = True
+
+    assert not coordinator._metadata_phase_needs_retry(
+        "app_maps",
+        coordinator.app_maps,
+    )
+
+
 def test_active_session_reuses_verified_map_identity_between_polls() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1826,6 +1826,83 @@ def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> 
     assert result["schedules"][2]["plans"] == [{"plan_id": 9}]
 
 
+def test_partial_schedule_read_honors_validated_selected_map_hint() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 22,
+                "plans": [{"plan_id": 7}],
+            },
+            {
+                "idx": 1,
+                "available": True,
+                "version": 21,
+                "plans": [{"plan_id": 1}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 1
+    coordinator.app_maps = {
+        "current_map_index": 1,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+        "map_list_valid": True,
+    }
+    coordinator.app_maps_refresh_succeeded = True
+    partial_action = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 22,
+                "plans": [{"plan_id": 7}],
+            },
+            {"idx": 1, "available": False, "error": "timed out"},
+        ],
+        "errors": [{"idx": 1, "stage": "schedule", "error": "timed out"}],
+    }
+    batch = {
+        "source": "batch_device_data_schedule",
+        "available": True,
+        "active_schedule_version": 22,
+        "current_task": None,
+        "schedules": [
+            {
+                "idx": 1,
+                "available": True,
+                "version": 22,
+                "plans": [{"plan_id": 9}],
+            }
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=partial_action),
+        async_get_batch_schedules=AsyncMock(return_value=batch),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["active_schedule_version"] == 22
+    assert result["active_schedule_index"] == 1
+    assert result["active_selection_available"] is True
+    assert result["schedules"][1]["idx"] == 0
+    assert result["schedules"][1]["plans"] == [{"plan_id": 7}]
+    assert result["schedules"][2]["idx"] == 1
+    assert result["schedules"][2]["plans"] == [{"plan_id": 9}]
+
+
 def test_schedule_refresh_revalidates_maps_after_action_request() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -32,6 +32,9 @@ from custom_components.dreame_lawn_mower.coordinator import (
 from custom_components.dreame_lawn_mower.performance import (
     DreameLawnMowerPerformanceTracker,
 )
+from custom_components.dreame_lawn_mower.schedule_cache import (
+    merge_batch_schedule_payload,
+)
 
 
 def test_coordinator_registers_its_config_entry_with_home_assistant() -> None:
@@ -68,6 +71,48 @@ def test_coordinator_registers_its_config_entry_with_home_assistant() -> None:
     client.set_update_callback.assert_called_once_with(
         coordinator._handle_client_update
     )
+
+
+def test_batch_schedule_merge_prefers_explicit_hint_on_version_collision() -> None:
+    existing = {
+        "schedules": [
+            {
+                "idx": -1,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 1, "name": "Default"}],
+            },
+            {
+                "idx": 2,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 2, "name": "Garden"}],
+            },
+        ]
+    }
+    incoming = {
+        "schedules": [
+            {
+                "idx": 2,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 3, "name": "Batch"}],
+            }
+        ],
+        "errors": [],
+    }
+
+    result = merge_batch_schedule_payload(
+        existing,
+        incoming,
+        captured_at=datetime(2026, 7, 30, tzinfo=UTC),
+        allow_unknown_slot=True,
+    )
+
+    assert result is not None
+    assert result["schedules"][0]["plans"][0]["name"] == "Default"
+    assert result["schedules"][1]["idx"] == 2
+    assert result["schedules"][1]["plans"][0]["name"] == "Batch"
 
 
 def test_newer_video_safety_snapshot_wins_over_slow_foreground_publication() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1040,6 +1040,77 @@ def test_schedule_refresh_keeps_auto_discovered_maps_without_app_hints() -> None
     )
 
 
+def test_schedule_refresh_prunes_last_map_after_authoritative_empty_map_list() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule",
+        "active_schedule_version": 11,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {"maps": []}
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1]
+    assert [schedule["version"] for schedule in result["schedules"]] == [20]
+    assert result["active_selection_available"] is False
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1],
+    )
+
+
+def test_schedule_refresh_marks_active_selection_unavailable_without_batch() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = None
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["active_selection_available"] is False
+    assert coordinator.schedules_refreshed_at is not None
+
+
 def test_schedule_refresh_does_not_mark_all_failed_reads_fresh() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1602,6 +1602,90 @@ def test_schedule_refresh_revalidates_maps_after_action_request() -> None:
     asyncio.run(scenario())
 
 
+def test_schedule_refresh_rejects_batch_hint_after_selected_map_changes() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = {
+            "source": "app_action_schedule",
+            "schedules": [
+                {"idx": -1, "available": True, "version": 10, "plans": []},
+                {"idx": 0, "available": True, "version": 11, "plans": []},
+                {"idx": 1, "available": True, "version": 12, "plans": []},
+            ],
+            "errors": [],
+        }
+        coordinator.schedules_refreshed_at = None
+        coordinator.selected_map_index = 0
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [
+                {"idx": 0, "created": True},
+                {"idx": 1, "created": True},
+            ],
+            "map_list_valid": True,
+        }
+        coordinator.app_maps_refresh_succeeded = True
+        batch_started = asyncio.Event()
+        release_batch = asyncio.Event()
+
+        async def get_batch_schedules(**_kwargs) -> dict[str, object]:
+            batch_started.set()
+            await release_batch.wait()
+            return {
+                "source": "batch_device_data_schedule",
+                "available": True,
+                "current_task": None,
+                "schedules": [
+                    {
+                        "idx": 0,
+                        "available": True,
+                        "version": 22,
+                        "plans": [{"plan_id": 1}],
+                    }
+                ],
+                "errors": [],
+            }
+
+        coordinator.client = SimpleNamespace(
+            async_get_app_schedules=AsyncMock(
+                return_value={
+                    "source": "app_action_schedule",
+                    "schedules": [
+                        {
+                            "idx": -1,
+                            "available": True,
+                            "version": 20,
+                            "plans": [],
+                        },
+                        {"idx": 0, "available": True, "version": 21, "plans": []},
+                        {"idx": 1, "available": True, "version": 22, "plans": []},
+                    ],
+                    "errors": [],
+                }
+            ),
+            async_get_batch_schedules=get_batch_schedules,
+        )
+
+        refresh_task = asyncio.create_task(
+            coordinator.async_refresh_schedules(force=True)
+        )
+        await batch_started.wait()
+        coordinator.selected_map_index = 1
+        coordinator.app_maps = {
+            **coordinator.app_maps,
+            "current_map_index": 1,
+        }
+        release_batch.set()
+        result = await refresh_task
+
+        assert result["active_schedule_index"] == 1
+        assert result["active_schedule_version"] == 22
+        assert result["schedules"][1]["version"] == 21
+        assert result["schedules"][2]["version"] == 22
+
+    asyncio.run(scenario())
+
+
 def test_schedule_refresh_marks_active_selection_unavailable_without_batch() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = None

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1375,6 +1375,61 @@ def test_schedule_refresh_rejects_lagging_batch_for_deleted_map(
     assert "active_schedule_index" not in result
 
 
+def test_schedule_refresh_hides_stale_selection_for_unhinted_batch_version() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "active_schedule_version": 11,
+        "active_schedule_index": 0,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {"idx": 0, "available": True, "version": 11, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = None
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+        "map_list_valid": True,
+    }
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+        ],
+        "errors": [],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(
+            return_value={
+                "source": "batch_device_data_schedule",
+                "available": True,
+                "current_task": None,
+                "schedules": [
+                    {
+                        "idx": None,
+                        "available": True,
+                        "version": 22,
+                        "plans": [],
+                    }
+                ],
+                "errors": [],
+            }
+        ),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["active_selection_available"] is False
+    assert [schedule["version"] for schedule in result["schedules"]] == [20, 21]
+
+
 def test_schedule_refresh_accepts_newer_batch_version_for_known_hinted_map() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = {

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -1461,6 +1461,28 @@ def test_authoritative_pruning_does_not_resolve_fallback_to_removed_slot() -> No
     assert "active_schedule_index" not in result
 
 
+def test_initial_schedule_payload_prunes_authoritatively_removed_map() -> None:
+    incoming = {
+        "source": "app_action_schedule",
+        "schedules": [
+            {"idx": -1, "available": True, "version": 20, "plans": []},
+            {"idx": 0, "available": True, "version": 21, "plans": []},
+            {"idx": 1, "available": True, "version": 22, "plans": []},
+        ],
+        "errors": [],
+    }
+
+    result = merge_app_schedule_payload(
+        None,
+        incoming,
+        expected_indices=[-1, 0],
+        prune_unexpected_indices=True,
+    )
+
+    assert [schedule["idx"] for schedule in result["schedules"]] == [-1, 0]
+    assert result["available"] is True
+
+
 def test_non_authoritative_map_subset_preserves_cached_schedule_slots() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.schedules = {

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -2182,6 +2182,55 @@ def test_schedule_refresh_does_not_mark_retained_cache_fresh_after_failures() ->
     )
 
 
+def test_schedule_refresh_does_not_mark_unread_active_slot_fresh() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "source": "app_action_schedule_with_batch_refresh",
+        "available": True,
+        "active_schedule_version": 11,
+        "active_schedule_index": 0,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 10, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 11,
+                "plans": [{"plan_id": 1}],
+            },
+        ],
+        "errors": [],
+    }
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "map_list_valid": True,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    coordinator.app_maps_refresh_succeeded = True
+    incoming = {
+        "source": "app_action_schedule",
+        "available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 12, "plans": []},
+            {"idx": 0, "available": False, "error": "timed out"},
+        ],
+        "errors": [{"idx": 0, "stage": "schedule", "error": "timed out"}],
+    }
+    coordinator.client = SimpleNamespace(
+        async_get_app_schedules=AsyncMock(return_value=incoming),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+
+    result = asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    assert result["active_schedule_index"] == 0
+    assert result["active_schedule_version"] == 11
+    assert result["schedules"][1]["plans"] == [{"plan_id": 1}]
+    assert coordinator.schedules_refreshed_at is None
+
+
 def test_batch_metadata_reuses_fresh_schedule_fetch() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
@@ -2329,7 +2378,9 @@ def test_batch_metadata_rejects_hint_after_selected_map_changes() -> None:
             "stage": "schedule",
             "error": "active map changed during batch read",
         }
-        assert coordinator.schedules["active_schedule_index"] == 0
+        assert "active_schedule_index" not in coordinator.schedules
+        assert "active_schedule_version" not in coordinator.schedules
+        assert "current_task" not in coordinator.schedules
         assert coordinator.schedules["active_selection_available"] is False
         assert coordinator.schedules["schedules"][1]["version"] == 11
         assert coordinator.schedules["schedules"][2]["version"] == 12

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -530,6 +530,31 @@ def test_metadata_hydration_retries_incomplete_current_app_map() -> None:
     )
 
 
+def test_metadata_hydration_retries_selected_map_without_current_flag() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 1
+    coordinator.app_maps = {
+        "map_list_valid": True,
+        "maps": [
+            {"idx": 0, "created": True, "available": True},
+            {"idx": 1, "created": True, "available": False},
+        ],
+    }
+
+    assert coordinator._metadata_phase_needs_retry(
+        "app_maps",
+        coordinator.app_maps,
+    )
+
+    coordinator.app_maps["maps"][1]["available"] = True
+
+    assert not coordinator._metadata_phase_needs_retry(
+        "app_maps",
+        coordinator.app_maps,
+    )
+
+
 def test_metadata_hydration_forces_incomplete_app_map_retry() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -487,6 +487,8 @@ def test_coordinator_switch_current_map_updates_device_and_scoped_caches() -> No
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.client = SimpleNamespace(async_switch_current_map=AsyncMock())
     coordinator.selected_map_index = 0
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {"active_selection_available": True}
     coordinator.selected_contour_id = (3, 0)
     coordinator.selected_zone_id = 3
     coordinator.selected_spot_id = 2
@@ -511,6 +513,39 @@ def test_coordinator_switch_current_map_updates_device_and_scoped_caches() -> No
     assert coordinator.selected_contour_id is None
     assert coordinator.selected_zone_id is None
     assert coordinator.selected_spot_id is None
+    assert coordinator.schedules_refreshed_at is None
+    assert coordinator.schedules["active_selection_available"] is False
+
+
+def test_app_map_refresh_invalidates_schedule_selection_after_external_switch() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "current_map_index": 1,
+                "maps": [
+                    {"idx": 0, "created": True},
+                    {"idx": 1, "created": True},
+                ],
+                "map_list_valid": True,
+            }
+        )
+    )
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 0
+    coordinator.selected_contour_id = None
+    coordinator.selected_zone_id = None
+    coordinator.selected_spot_id = None
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {"active_selection_available": True}
+
+    asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert coordinator.selected_map_index == 1
+    assert coordinator.schedules_refreshed_at is None
+    assert coordinator.schedules["active_selection_available"] is False
 
 
 def test_zone_select_sets_zone_and_switches_action() -> None:

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -652,6 +652,38 @@ def test_app_map_refresh_invalidates_schedules_when_inventory_changes() -> None:
     assert coordinator.schedules["active_selection_available"] is False
 
 
+def test_app_map_refresh_invalidates_when_hints_become_authoritative() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "current_map_index": 0,
+                "maps": [{"idx": 0, "created": True}],
+                "map_list_valid": True,
+            }
+        )
+    )
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+        "map_list_valid": False,
+    }
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 0
+    coordinator.selected_contour_id = None
+    coordinator.selected_zone_id = None
+    coordinator.selected_spot_id = None
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {"active_selection_available": True}
+
+    asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert coordinator.selected_map_index == 0
+    assert coordinator.schedules_refreshed_at is None
+    assert coordinator.schedules["active_selection_available"] is False
+
+
 def test_zone_select_sets_zone_and_switches_action() -> None:
     entity = object.__new__(DreameLawnMowerZoneSelect)
     entity.coordinator = SimpleNamespace(

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -548,6 +548,37 @@ def test_app_map_refresh_invalidates_schedule_selection_after_external_switch() 
     assert coordinator.schedules["active_selection_available"] is False
 
 
+def test_app_map_refresh_invalidates_schedule_after_final_map_deletion() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "current_map_index": None,
+                "maps": [],
+                "map_list_valid": True,
+            }
+        )
+    )
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 0
+    coordinator.selected_contour_id = (3, 0)
+    coordinator.selected_zone_id = 3
+    coordinator.selected_spot_id = 2
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {"active_selection_available": True}
+
+    asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert coordinator.selected_map_index is None
+    assert coordinator.selected_contour_id is None
+    assert coordinator.selected_zone_id is None
+    assert coordinator.selected_spot_id is None
+    assert coordinator.schedules_refreshed_at is None
+    assert coordinator.schedules["active_selection_available"] is False
+
+
 def test_zone_select_sets_zone_and_switches_action() -> None:
     entity = object.__new__(DreameLawnMowerZoneSelect)
     entity.coordinator = SimpleNamespace(

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -579,6 +579,79 @@ def test_app_map_refresh_invalidates_schedule_after_final_map_deletion() -> None
     assert coordinator.schedules["active_selection_available"] is False
 
 
+def test_app_map_refresh_clears_selected_map_absent_from_inventory() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "current_map_index": None,
+                "maps": [{"idx": 0, "created": True}],
+                "map_list_valid": True,
+            }
+        )
+    )
+    coordinator.app_maps = {
+        "current_map_index": 1,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+        "map_list_valid": True,
+    }
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 1
+    coordinator.selected_contour_id = (3, 0)
+    coordinator.selected_zone_id = 3
+    coordinator.selected_spot_id = 2
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {"active_selection_available": True}
+
+    asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert coordinator.selected_map_index is None
+    assert coordinator.selected_contour_id is None
+    assert coordinator.selected_zone_id is None
+    assert coordinator.selected_spot_id is None
+    assert coordinator.schedules_refreshed_at is None
+    assert coordinator.schedules["active_selection_available"] is False
+
+
+def test_app_map_refresh_invalidates_schedules_when_inventory_changes() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.client = SimpleNamespace(
+        async_get_app_maps=AsyncMock(
+            return_value={
+                "current_map_index": 0,
+                "maps": [{"idx": 0, "created": True}],
+                "map_list_valid": True,
+            }
+        )
+    )
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+        "map_list_valid": True,
+    }
+    coordinator.app_maps_refreshed_at = None
+    coordinator.app_maps_refresh_succeeded = True
+    coordinator.selected_map_index = 0
+    coordinator.selected_contour_id = None
+    coordinator.selected_zone_id = None
+    coordinator.selected_spot_id = None
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {"active_selection_available": True}
+
+    asyncio.run(coordinator.async_refresh_app_maps(force=True))
+
+    assert coordinator.selected_map_index == 0
+    assert coordinator.schedules_refreshed_at is None
+    assert coordinator.schedules["active_selection_available"] is False
+
+
 def test_zone_select_sets_zone_and_switches_action() -> None:
     entity = object.__new__(DreameLawnMowerZoneSelect)
     entity.coordinator = SimpleNamespace(

--- a/tests/test_ha_tasks.py
+++ b/tests/test_ha_tasks.py
@@ -1,0 +1,40 @@
+"""Home Assistant task ownership contracts."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+from custom_components.dreame_lawn_mower.ha_tasks import create_background_task
+
+
+def test_long_lived_work_uses_home_assistant_background_owner() -> None:
+    async def scenario() -> None:
+        created: list[tuple[str, asyncio.Task[str]]] = []
+
+        def create_background(coroutine, name: str) -> asyncio.Task[str]:
+            task = asyncio.create_task(coroutine)
+            created.append((name, task))
+            return task
+
+        hass = SimpleNamespace(
+            async_create_background_task=create_background,
+            async_create_task=Mock(
+                side_effect=AssertionError(
+                    "background work must not extend config-entry setup"
+                )
+            ),
+        )
+
+        task = create_background_task(
+            hass,
+            asyncio.sleep(0, result="ready"),
+            "dreame-background",
+        )
+
+        assert await task == "ready"
+        assert created == [("dreame-background", task)]
+        hass.async_create_task.assert_not_called()
+
+    asyncio.run(scenario())

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -2270,7 +2270,7 @@ def test_point_cloud_401_reauthentication_uses_remaining_deadline(
     monkeypatch.setattr(
         _internal_protocol_module,
         "_post_cloud_response",
-        lambda session, url, request_options, *, deadline: response,
+        lambda session, url, request_options, *, deadline, run_in_worker=True: response,
     )
     monkeypatch.setattr(
         _internal_protocol_module,

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -133,6 +133,8 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     cloud._logged_in = True
     cloud._message_callback = object()
     cloud._connected_callback = object()
+    cloud._session = Mock()
+    cloud._thread = None
     mqtt_client = Mock()
     cloud._client = mqtt_client
     cloud._client_connected = True
@@ -154,9 +156,12 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     elapsed = time.monotonic() - started
     release_lock.set()
     worker.join(timeout=1)
+    cloud._disconnect_cleanup_thread.join(timeout=1)
 
     assert disconnected is False
     assert elapsed < 0.5
+    assert not cloud._disconnect_cleanup_thread.is_alive()
+    cloud._session.close.assert_called_once_with()
     assert cloud._connected is False
     assert cloud._logged_in is False
     assert cloud._message_callback is None
@@ -166,6 +171,54 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     assert cloud._client_connecting is False
     mqtt_client.loop_stop.assert_called_once_with()
     mqtt_client.disconnect.assert_called_once_with()
+
+
+def test_late_deadline_worker_cannot_restore_state_after_disconnect() -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._request_lock = RLock()
+    cloud._session = Mock()
+    cloud._connected = True
+    cloud._logged_in = True
+    cloud._message_callback = object()
+    cloud._connected_callback = object()
+    cloud._client = None
+    cloud._client_connected = False
+    cloud._client_connecting = False
+    cloud._thread = None
+    operation_started = Event()
+    release_operation = Event()
+    errors: list[Exception] = []
+
+    def late_operation() -> None:
+        operation_started.set()
+        assert release_operation.wait(timeout=1)
+        if not cloud._disconnect_is_pending():
+            cloud._connected = True
+            cloud._logged_in = True
+
+    caller = Thread(
+        target=lambda: _capture_serialized_operation_error(
+            cloud,
+            late_operation,
+            deadline=time.monotonic() + 0.05,
+            errors=errors,
+        )
+    )
+    caller.start()
+    assert operation_started.wait(timeout=1)
+    caller.join(timeout=0.5)
+
+    disconnected = cloud.disconnect(timeout=0.05)
+    release_operation.set()
+    cloud._disconnect_cleanup_thread.join(timeout=1)
+
+    assert disconnected is False
+    assert len(errors) == 1
+    assert isinstance(errors[0], requests.exceptions.Timeout)
+    assert cloud._connected is False
+    assert cloud._logged_in is False
+    assert cloud._session.close.call_count == 1
+    assert cloud._disconnect_pending is False
 
 
 def _capture_request_error(

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import time
+from collections.abc import Callable
 from threading import Event, RLock, Thread
 
 import requests
@@ -79,6 +80,51 @@ def test_cloud_request_deadline_includes_waiting_for_shared_lock() -> None:
     assert isinstance(errors[0], requests.exceptions.Timeout)
 
 
+def test_deadline_worker_keeps_serialization_until_transport_exits() -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._request_lock = RLock()
+    transport_started = Event()
+    release_transport = Event()
+    follower_started = Event()
+    errors: list[Exception] = []
+
+    def slow_transport() -> str:
+        transport_started.set()
+        assert release_transport.wait(timeout=1)
+        return "late"
+
+    caller = Thread(
+        target=lambda: _capture_serialized_operation_error(
+            cloud,
+            slow_transport,
+            deadline=time.monotonic() + 0.05,
+            errors=errors,
+        )
+    )
+    caller.start()
+    assert transport_started.wait(timeout=1)
+    caller.join(timeout=0.5)
+
+    assert not caller.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], requests.exceptions.Timeout)
+
+    follower = Thread(
+        target=lambda: cloud._run_serialized_operation(
+            lambda: follower_started.set(),
+            deadline=None,
+        )
+    )
+    follower.start()
+    assert not follower_started.wait(timeout=0.05)
+
+    release_transport.set()
+    follower.join(timeout=1)
+
+    assert not follower.is_alive()
+    assert follower_started.is_set()
+
+
 def _capture_request_error(
     cloud: protocol_cloud.DreameMowerDreameHomeCloudProtocol,
     *,
@@ -87,6 +133,19 @@ def _capture_request_error(
 ) -> None:
     try:
         cloud.request("https://example.invalid", None, deadline=deadline)
+    except Exception as err:  # noqa: BLE001 - thread forwards the observed failure
+        errors.append(err)
+
+
+def _capture_serialized_operation_error(
+    cloud: protocol_cloud.DreameMowerDreameHomeCloudProtocol,
+    operation: Callable[[], object],
+    *,
+    deadline: float,
+    errors: list[Exception],
+) -> None:
+    try:
+        cloud._run_serialized_operation(operation, deadline=deadline)
     except Exception as err:  # noqa: BLE001 - thread forwards the observed failure
         errors.append(err)
 

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -125,6 +125,39 @@ def test_deadline_worker_keeps_serialization_until_transport_exits() -> None:
     assert follower_started.is_set()
 
 
+def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._request_lock = RLock()
+    cloud._connected = True
+    cloud._logged_in = True
+    cloud._message_callback = object()
+    cloud._connected_callback = object()
+    lock_held = Event()
+    release_lock = Event()
+
+    def hold_lock() -> None:
+        with cloud._request_lock:
+            lock_held.set()
+            assert release_lock.wait(timeout=1)
+
+    worker = Thread(target=hold_lock)
+    worker.start()
+    assert lock_held.wait(timeout=1)
+
+    started = time.monotonic()
+    disconnected = cloud.disconnect(timeout=0.05)
+    elapsed = time.monotonic() - started
+    release_lock.set()
+    worker.join(timeout=1)
+
+    assert disconnected is False
+    assert elapsed < 0.5
+    assert cloud._connected is False
+    assert cloud._logged_in is False
+    assert cloud._message_callback is None
+    assert cloud._connected_callback is None
+
+
 def _capture_request_error(
     cloud: protocol_cloud.DreameMowerDreameHomeCloudProtocol,
     *,

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import time
 from collections.abc import Callable
 from threading import Event, RLock, Thread
+from unittest.mock import Mock
 
 import requests
 
@@ -132,6 +133,10 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     cloud._logged_in = True
     cloud._message_callback = object()
     cloud._connected_callback = object()
+    mqtt_client = Mock()
+    cloud._client = mqtt_client
+    cloud._client_connected = True
+    cloud._client_connecting = True
     lock_held = Event()
     release_lock = Event()
 
@@ -156,6 +161,11 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     assert cloud._logged_in is False
     assert cloud._message_callback is None
     assert cloud._connected_callback is None
+    assert cloud._client is None
+    assert cloud._client_connected is False
+    assert cloud._client_connecting is False
+    mqtt_client.loop_stop.assert_called_once_with()
+    mqtt_client.disconnect.assert_called_once_with()
 
 
 def _capture_request_error(

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -2,7 +2,10 @@
 
 from __future__ import annotations
 
+import time
 from threading import Event, RLock, Thread
+
+import requests
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     protocol_cloud,
@@ -49,6 +52,43 @@ def test_cloud_request_lock_serializes_app_and_device_operations() -> None:
     assert not send_thread.is_alive()
     assert send_started.is_set()
     assert sorted(results) == ["request", "send"]
+
+
+def test_cloud_request_deadline_includes_waiting_for_shared_lock() -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._request_lock = RLock()
+    cloud._request_unlocked = lambda *_args, **_kwargs: "unexpected"
+    errors: list[Exception] = []
+
+    cloud._request_lock.acquire()
+    try:
+        request_thread = Thread(
+            target=lambda: _capture_request_error(
+                cloud,
+                deadline=time.monotonic() + 0.05,
+                errors=errors,
+            )
+        )
+        request_thread.start()
+        request_thread.join(timeout=0.5)
+    finally:
+        cloud._request_lock.release()
+
+    assert not request_thread.is_alive()
+    assert len(errors) == 1
+    assert isinstance(errors[0], requests.exceptions.Timeout)
+
+
+def _capture_request_error(
+    cloud: protocol_cloud.DreameMowerDreameHomeCloudProtocol,
+    *,
+    deadline: float,
+    errors: list[Exception],
+) -> None:
+    try:
+        cloud.request("https://example.invalid", None, deadline=deadline)
+    except Exception as err:  # noqa: BLE001 - thread forwards the observed failure
+        errors.append(err)
 
 
 def test_app_action_retries_reads_but_dispatches_mutations_once() -> None:

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -10,6 +10,7 @@ from unittest.mock import Mock
 import requests
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    protocol,
     protocol_cloud,
 )
 
@@ -219,6 +220,55 @@ def test_late_deadline_worker_cannot_restore_state_after_disconnect() -> None:
     assert cloud._logged_in is False
     assert cloud._session.close.call_count == 1
     assert cloud._disconnect_pending is False
+
+
+def test_queued_operation_cannot_restart_cloud_after_disconnect() -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._request_lock = RLock()
+    cloud._session = Mock()
+    cloud._connected = True
+    cloud._logged_in = True
+    cloud._message_callback = object()
+    cloud._connected_callback = object()
+    cloud._client = None
+    cloud._client_connected = False
+    cloud._client_connecting = False
+    cloud._thread = None
+    operation_started = Event()
+
+    cloud._request_lock.acquire()
+    queued = Thread(
+        target=lambda: cloud._run_serialized_operation(
+            lambda: operation_started.set(),
+            deadline=None,
+        )
+    )
+    queued.start()
+    try:
+        assert cloud.disconnect(timeout=0.05) is True
+    finally:
+        cloud._request_lock.release()
+    queued.join(timeout=1)
+
+    assert not queued.is_alive()
+    assert not operation_started.is_set()
+    assert cloud._shutdown_requested is True
+    assert cloud._disconnect_pending is False
+    assert cloud._connected is False
+    assert cloud._logged_in is False
+
+
+def test_protocol_disconnects_aliased_cloud_only_once() -> None:
+    mower_protocol = object.__new__(protocol.DreameMowerProtocol)
+    cloud = Mock()
+    mower_protocol.cloud = cloud
+    mower_protocol.device_cloud = cloud
+    mower_protocol._connected = True
+
+    mower_protocol.disconnect()
+
+    cloud.disconnect.assert_called_once_with()
+    assert mower_protocol._connected is False
 
 
 def _capture_request_error(

--- a/tests/test_schedule_calendar.py
+++ b/tests/test_schedule_calendar.py
@@ -151,6 +151,58 @@ def test_schedule_calendar_events_prefer_current_task_version() -> None:
     assert [event.start.hour for event in all_events] == [8, 10, 10]
 
 
+def test_schedule_calendar_events_filter_same_version_by_active_index() -> None:
+    payload = {
+        "active_schedule_version": 8,
+        "active_schedule_index": 2,
+        "schedules": [
+            {
+                "idx": -1,
+                "version": 8,
+                "plans": [
+                    {
+                        "plan_id": 1,
+                        "enabled": True,
+                        "weeks": [
+                            {
+                                "week_day": 0,
+                                "tasks": [{"start": 8 * 60, "end": 9 * 60}],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "idx": 2,
+                "version": 8,
+                "plans": [
+                    {
+                        "plan_id": 2,
+                        "enabled": True,
+                        "weeks": [
+                            {
+                                "week_day": 0,
+                                "tasks": [{"start": 10 * 60, "end": 11 * 60}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+    start = datetime(2026, 4, 19, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 4, 20, 0, 0, tzinfo=UTC)
+
+    events = schedule_calendar_events(payload, start, end)
+    selection = schedule_calendar_selection(payload)
+
+    assert len(events) == 1
+    assert events[0].start == datetime(2026, 4, 19, 10, 0, tzinfo=UTC)
+    assert selection["active_index"] == 2
+    assert [schedule["idx"] for schedule in selection["included_schedules"]] == [2]
+    assert [schedule["idx"] for schedule in selection["hidden_schedules"]] == [-1]
+
+
 def test_active_calendar_hides_slots_when_active_selection_is_unavailable() -> None:
     payload = {
         "active_selection_available": False,

--- a/tests/test_schedule_calendar.py
+++ b/tests/test_schedule_calendar.py
@@ -151,6 +151,46 @@ def test_schedule_calendar_events_prefer_current_task_version() -> None:
     assert [event.start.hour for event in all_events] == [8, 10, 10]
 
 
+def test_active_calendar_hides_slots_when_active_selection_is_unavailable() -> None:
+    payload = {
+        "active_selection_available": False,
+        "schedules": [
+            {
+                "idx": 0,
+                "version": 1,
+                "plans": [
+                    {
+                        "plan_id": 0,
+                        "enabled": True,
+                        "weeks": [
+                            {
+                                "week_day": 0,
+                                "tasks": [{"start": 8 * 60, "end": 9 * 60}],
+                            }
+                        ],
+                    }
+                ],
+            }
+        ],
+    }
+    start = datetime(2026, 4, 19, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 4, 20, 0, 0, tzinfo=UTC)
+
+    assert schedule_calendar_events(payload, start, end) == []
+    assert len(
+        schedule_calendar_events(
+            payload,
+            start,
+            end,
+            include_all_schedules=True,
+        )
+    ) == 1
+    selection = schedule_calendar_selection(payload)
+    assert selection["active_selection_available"] is False
+    assert selection["included_schedule_count"] == 0
+    assert selection["hidden_schedule_count"] == 1
+
+
 def test_all_schedules_calendar_is_diagnostic_disabled_by_default() -> None:
     assert DreameLawnMowerAllSchedulesCalendar._include_all_schedules is True
     assert (

--- a/tests/test_schedule_calendar.py
+++ b/tests/test_schedule_calendar.py
@@ -240,6 +240,53 @@ def test_schedule_calendar_selection_can_include_all_schedules() -> None:
     ]
 
 
+def test_schedule_selection_uses_batch_version_when_task_probe_is_skipped() -> None:
+    payload = {
+        "active_schedule_version": 12,
+        "current_task": None,
+        "schedules": [
+            {"idx": 0, "version": 8, "enabled_plan_count": 1},
+            {"idx": 1, "version": 12, "enabled_plan_count": 1},
+        ],
+    }
+
+    selection = schedule_calendar_selection(payload)
+
+    assert selection["active_version"] == 12
+    assert selection["active_version_filter_applied"] is True
+    assert selection["included_schedules"] == [
+        {
+            "idx": 1,
+            "label": "map 1",
+            "version": 12,
+            "enabled_plan_count": 1,
+        }
+    ]
+
+
+def test_schedule_selection_can_keep_default_schedule_active_without_schdt() -> None:
+    payload = {
+        "active_schedule_version": 20,
+        "current_task": None,
+        "schedules": [
+            {"idx": -1, "version": 20, "enabled_plan_count": 1},
+            {"idx": 0, "version": 21, "enabled_plan_count": 1},
+        ],
+    }
+
+    selection = schedule_calendar_selection(payload)
+
+    assert selection["active_version"] == 20
+    assert selection["included_schedules"] == [
+        {
+            "idx": -1,
+            "label": "default schedule",
+            "version": 20,
+            "enabled_plan_count": 1,
+        }
+    ]
+
+
 def test_schedule_calendar_attributes_expose_cached_selection() -> None:
     selection = {
         "mode": "active_schedule",

--- a/tests/test_schedule_calendar.py
+++ b/tests/test_schedule_calendar.py
@@ -203,6 +203,58 @@ def test_schedule_calendar_events_filter_same_version_by_active_index() -> None:
     assert [schedule["idx"] for schedule in selection["hidden_schedules"]] == [-1]
 
 
+def test_schedule_calendar_filters_to_explicit_unknown_active_slot() -> None:
+    payload = {
+        "active_schedule_version": 8,
+        "active_schedule_index": None,
+        "active_selection_available": True,
+        "schedules": [
+            {
+                "idx": 0,
+                "version": 8,
+                "plans": [
+                    {
+                        "plan_id": 1,
+                        "enabled": True,
+                        "weeks": [
+                            {
+                                "week_day": 0,
+                                "tasks": [{"start": 8 * 60, "end": 9 * 60}],
+                            }
+                        ],
+                    }
+                ],
+            },
+            {
+                "idx": None,
+                "version": 8,
+                "plans": [
+                    {
+                        "plan_id": 2,
+                        "enabled": True,
+                        "weeks": [
+                            {
+                                "week_day": 0,
+                                "tasks": [{"start": 10 * 60, "end": 11 * 60}],
+                            }
+                        ],
+                    }
+                ],
+            },
+        ],
+    }
+    start = datetime(2026, 4, 19, 0, 0, tzinfo=UTC)
+    end = datetime(2026, 4, 20, 0, 0, tzinfo=UTC)
+
+    events = schedule_calendar_events(payload, start, end)
+    selection = schedule_calendar_selection(payload)
+
+    assert len(events) == 1
+    assert events[0].start == datetime(2026, 4, 19, 10, 0, tzinfo=UTC)
+    assert [schedule["idx"] for schedule in selection["included_schedules"]] == [None]
+    assert [schedule["idx"] for schedule in selection["hidden_schedules"]] == [0]
+
+
 def test_active_calendar_hides_slots_when_active_selection_is_unavailable() -> None:
     payload = {
         "active_selection_available": False,

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -176,12 +176,54 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
     coordinator.client = SimpleNamespace(
         async_plan_app_schedule_upload=AsyncMock(
             return_value={"executed": True, "request_count": 2}
-        )
+        ),
+        async_get_app_schedules=AsyncMock(
+            return_value={
+                "source": "app_action_schedule",
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 7, "plans": []},
+                    {"idx": 0, "available": False, "error": "timed out"},
+                    {"idx": 1, "available": True, "version": 10, "plans": []},
+                ],
+                "errors": [
+                    {"idx": 0, "stage": "schedule", "error": "timed out"}
+                ],
+            }
+        ),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
     )
-    coordinator.async_refresh_schedules = AsyncMock(return_value={"schedules": []})
     coordinator.async_update_listeners = Mock()
     coordinator.last_schedule_write_result = None
     coordinator.schedules_refreshed_at = object()
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [
+            {"idx": 0, "created": True},
+            {"idx": 1, "created": True},
+        ],
+    }
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "current_task": {"version": 8},
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 9, "enabled": True}],
+            },
+            {
+                "idx": None,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 9, "enabled": True}],
+                "writable": False,
+            },
+            {"idx": 1, "available": True, "version": 10, "plans": []},
+        ],
+    }
     plans = [{"plan_id": 1, "enabled": True, "weeks": []}]
 
     result = asyncio.run(
@@ -202,8 +244,25 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
         execute=True,
         confirm_write=True,
     )
-    assert coordinator.schedules_refreshed_at is None
-    coordinator.async_refresh_schedules.assert_awaited_once_with(force=True)
+    assert coordinator.schedules_refreshed_at is not None
+    assert [schedule["idx"] for schedule in coordinator.schedules["schedules"]] == [
+        -1,
+        1,
+        0,
+    ]
+    uploaded_slot = next(
+        schedule
+        for schedule in coordinator.schedules["schedules"]
+        if schedule["idx"] == 0
+    )
+    assert uploaded_slot["error"] == "timed out"
+    assert "plans" not in uploaded_slot
+    assert "active_schedule_version" not in coordinator.schedules
+    assert "current_task" not in coordinator.schedules
+    coordinator.client.async_get_app_schedules.assert_awaited_once_with(
+        include_current_task=False,
+        map_indices=[-1, 0, 1],
+    )
     coordinator.async_update_listeners.assert_called_once()
 
 

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -335,6 +335,40 @@ def test_pending_schedule_toggle_expires_after_repeated_contradictory_reads() ->
     assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is True
 
 
+def test_pending_toggle_does_not_mutate_ambiguous_active_fallback() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._pending_schedule_plan_states = {(0, 1): (8, True)}
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "active_schedule_index": None,
+        "active_selection_available": True,
+        "schedules": [
+            {
+                "idx": 0,
+                "version": 8,
+                "plans": [{"plan_id": 1, "enabled": False}],
+            },
+            {
+                "idx": 1,
+                "version": 8,
+                "plans": [{"plan_id": 1, "enabled": False}],
+            },
+            {
+                "idx": None,
+                "version": 8,
+                "plans": [{"plan_id": 1, "enabled": False}],
+            },
+        ],
+    }
+
+    coordinator._apply_pending_schedule_plan_states()
+
+    assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is True
+    assert coordinator.schedules["schedules"][1]["plans"][0]["enabled"] is False
+    assert coordinator.schedules["schedules"][2]["plans"][0]["enabled"] is False
+    assert coordinator.schedules["active_selection_available"] is False
+
+
 def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._schedule_write_lock = asyncio.Lock()
@@ -617,6 +651,88 @@ def test_schedule_upload_overrides_lagging_batch_readback() -> None:
     assert uploaded_slot["plans"] == uploaded_plans
     assert coordinator.schedules["active_schedule_index"] == 0
     assert coordinator._pending_schedule_uploads[0]["plans"] == uploaded_plans
+
+
+def test_schedule_upload_confirmation_restores_known_active_slot() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._schedule_write_lock = asyncio.Lock()
+    uploaded_plans = [
+        {
+            "plan_id": 1,
+            "enabled": True,
+            "name": "New",
+            "weeks": [],
+        }
+    ]
+    coordinator.client = SimpleNamespace(
+        async_plan_app_schedule_upload=AsyncMock(
+            return_value={
+                "executed": True,
+                "request_count": 2,
+                "version": 8,
+            }
+        ),
+        async_get_app_schedules=AsyncMock(
+            return_value={
+                "source": "app_action_schedule",
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 7, "plans": []},
+                    {
+                        "idx": 0,
+                        "available": True,
+                        "version": 8,
+                        "plans": uploaded_plans,
+                    },
+                ],
+                "errors": [],
+            }
+        ),
+        async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+    )
+    coordinator.async_update_listeners = Mock()
+    coordinator.last_schedule_write_result = None
+    coordinator.schedules_refreshed_at = object()
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "active_schedule_index": 0,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 8,
+                "plans": [
+                    {
+                        "plan_id": 1,
+                        "enabled": False,
+                        "name": "Old",
+                        "weeks": [],
+                    }
+                ],
+            },
+        ],
+    }
+
+    asyncio.run(
+        coordinator.async_plan_schedule_upload(
+            map_index=0,
+            plans=uploaded_plans,
+            chunk_size=100,
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    assert coordinator._pending_schedule_uploads == {}
+    assert coordinator.schedules["active_schedule_version"] == 8
+    assert coordinator.schedules["active_schedule_index"] == 0
+    assert coordinator.schedules["active_selection_available"] is True
 
 
 def test_schedule_upload_discards_refresh_started_before_confirmed_write() -> None:

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -355,6 +355,7 @@ def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> Non
     coordinator.schedules_refreshed_at = object()
     coordinator.schedules = {
         "active_schedule_version": 8,
+        "active_schedule_index": 1,
         "active_selection_available": True,
         "current_task": {"version": 8},
         "schedules": [
@@ -384,6 +385,7 @@ def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> Non
         -1
     ]
     assert "active_schedule_version" not in coordinator.schedules
+    assert "active_schedule_index" not in coordinator.schedules
     assert coordinator.schedules["active_selection_available"] is False
     assert "current_task" not in coordinator.schedules
     assert coordinator.schedules_refreshed_at is None

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -382,7 +382,13 @@ def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> Non
         )
 
     assert [schedule["idx"] for schedule in coordinator.schedules["schedules"]] == [
-        -1
+        -1,
+        1,
+    ]
+    uploaded_slot = coordinator.schedules["schedules"][1]
+    assert uploaded_slot["version"] == 8
+    assert uploaded_slot["plans"] == [
+        {"plan_id": 2, "enabled": False, "name": "", "weeks": []}
     ]
     assert "active_schedule_version" not in coordinator.schedules
     assert "active_schedule_index" not in coordinator.schedules
@@ -497,8 +503,9 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
         for schedule in coordinator.schedules["schedules"]
         if schedule["idx"] == 0
     )
-    assert uploaded_slot["error"] == "timed out"
-    assert "plans" not in uploaded_slot
+    assert uploaded_slot["plans"] == [
+        {"plan_id": 1, "enabled": True, "name": "", "weeks": []}
+    ]
     assert "active_schedule_version" not in coordinator.schedules
     assert "current_task" not in coordinator.schedules
     assert (0, 9) not in coordinator._pending_schedule_plan_states
@@ -507,6 +514,109 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
         map_indices=[-1, 0, 1],
     )
     coordinator.async_update_listeners.assert_called_once()
+
+
+def test_schedule_upload_overrides_lagging_batch_readback() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._schedule_write_lock = asyncio.Lock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_schedule_upload=AsyncMock(
+            return_value={
+                "executed": True,
+                "request_count": 2,
+                "version": 8,
+            }
+        ),
+        async_get_app_schedules=AsyncMock(
+            return_value={
+                "source": "app_action_schedule",
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 7, "plans": []},
+                    {"idx": 0, "available": False, "error": "timed out"},
+                ],
+                "errors": [
+                    {"idx": 0, "stage": "schedule", "error": "timed out"}
+                ],
+            }
+        ),
+        async_get_batch_schedules=AsyncMock(
+            return_value={
+                "source": "batch_device_data_schedule",
+                "schedules": [
+                    {
+                        "idx": 0,
+                        "available": True,
+                        "version": 8,
+                        "plans": [
+                            {
+                                "plan_id": 1,
+                                "enabled": False,
+                                "name": "Old",
+                                "weeks": [],
+                            }
+                        ],
+                    }
+                ],
+                "errors": [],
+            }
+        ),
+    )
+    coordinator.async_update_listeners = Mock()
+    coordinator.last_schedule_write_result = None
+    coordinator.schedules_refreshed_at = object()
+    coordinator.selected_map_index = 0
+    coordinator.app_maps = {
+        "current_map_index": 0,
+        "maps": [{"idx": 0, "created": True}],
+    }
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "active_schedule_index": 0,
+        "active_selection_available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {
+                "idx": 0,
+                "available": True,
+                "version": 8,
+                "plans": [
+                    {
+                        "plan_id": 1,
+                        "enabled": False,
+                        "name": "Old",
+                        "weeks": [],
+                    }
+                ],
+            },
+        ],
+    }
+    uploaded_plans = [
+        {
+            "plan_id": 1,
+            "enabled": True,
+            "name": "New",
+            "weeks": [],
+        }
+    ]
+
+    asyncio.run(
+        coordinator.async_plan_schedule_upload(
+            map_index=0,
+            plans=uploaded_plans,
+            chunk_size=100,
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    uploaded_slot = next(
+        schedule
+        for schedule in coordinator.schedules["schedules"]
+        if schedule["idx"] == 0
+    )
+    assert uploaded_slot["plans"] == uploaded_plans
+    assert coordinator.schedules["active_schedule_index"] == 0
+    assert coordinator._pending_schedule_uploads[0]["plans"] == uploaded_plans
 
 
 def test_schedule_upload_discards_refresh_started_before_confirmed_write() -> None:
@@ -602,8 +712,9 @@ def test_schedule_upload_discards_refresh_started_before_confirmed_write() -> No
             for schedule in coordinator.schedules["schedules"]
             if schedule["idx"] == 0
         )
-        assert uploaded_slot["error"] == "timed out"
-        assert "plans" not in uploaded_slot
+        assert uploaded_slot["plans"] == [
+            {"plan_id": 1, "enabled": True, "name": "", "weeks": []}
+        ]
         assert coordinator._schedule_cache_generation == 1
 
     asyncio.run(exercise())

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -136,6 +136,7 @@ def test_schedule_write_keeps_confirmed_state_when_readback_fails() -> None:
         "schedules": [
             {
                 "idx": 1,
+                "enabled_plan_count": 1,
                 "plans": [{"plan_id": 2, "enabled": True}],
             }
         ]
@@ -151,6 +152,7 @@ def test_schedule_write_keeps_confirmed_state_when_readback_fails() -> None:
         )
 
     assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is False
+    assert coordinator.schedules["schedules"][0]["enabled_plan_count"] == 0
     coordinator.async_update_listeners.assert_called_once()
 
 

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -293,6 +293,48 @@ def test_schedule_write_keeps_confirmed_toggle_when_batch_readback_lags() -> Non
     coordinator.async_update_listeners.assert_called_once()
 
 
+def test_pending_schedule_toggle_expires_after_repeated_contradictory_reads() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._pending_schedule_plan_states = {(1, 2): (8, False)}
+    coordinator.schedules = {
+        "schedules": [
+            {
+                "idx": 1,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 2, "enabled": True}],
+            }
+        ]
+    }
+    contradictory_payload = {
+        "schedules": [
+            {
+                "idx": 1,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 2, "enabled": True}],
+            }
+        ]
+    }
+
+    coordinator._acknowledge_pending_schedule_plan_states(
+        contradictory_payload
+    )
+    coordinator._apply_pending_schedule_plan_states()
+
+    assert coordinator._pending_schedule_plan_states == {(1, 2): (8, False)}
+    assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is False
+
+    coordinator.schedules = contradictory_payload
+    coordinator._acknowledge_pending_schedule_plan_states(
+        contradictory_payload
+    )
+    coordinator._apply_pending_schedule_plan_states()
+
+    assert coordinator._pending_schedule_plan_states == {}
+    assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is True
+
+
 def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._schedule_write_lock = asyncio.Lock()

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -389,6 +389,10 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
     coordinator.async_update_listeners = Mock()
     coordinator.last_schedule_write_result = None
     coordinator.schedules_refreshed_at = object()
+    coordinator._pending_schedule_plan_states = {
+        (0, 9): (8, False),
+        (1, 7): (10, False),
+    }
     coordinator.selected_map_index = 0
     coordinator.app_maps = {
         "current_map_index": 0,
@@ -453,6 +457,7 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
     assert "plans" not in uploaded_slot
     assert "active_schedule_version" not in coordinator.schedules
     assert "current_task" not in coordinator.schedules
+    assert (0, 9) not in coordinator._pending_schedule_plan_states
     coordinator.client.async_get_app_schedules.assert_awaited_once_with(
         include_current_task=False,
         map_indices=[-1, 0, 1],

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -196,6 +196,103 @@ def test_schedule_write_reconciles_unknown_active_fallback_by_version() -> None:
     coordinator.async_update_listeners.assert_called_once()
 
 
+def test_schedule_write_keeps_confirmed_toggle_when_batch_readback_lags() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._schedule_write_lock = asyncio.Lock()
+    coordinator.client = SimpleNamespace(
+        async_set_app_schedule_plan_enabled=AsyncMock(
+            return_value={
+                "executed": True,
+                "enabled": False,
+                "version": 8,
+            }
+        ),
+        async_get_app_schedules=AsyncMock(
+            return_value={
+                "source": "app_action_schedule",
+                "available": True,
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 7, "plans": []},
+                    {"idx": 1, "available": False, "error": "timed out"},
+                ],
+                "errors": [
+                    {"idx": 1, "stage": "schedule", "error": "timed out"}
+                ],
+            }
+        ),
+        async_get_batch_schedules=AsyncMock(
+            return_value={
+                "source": "batch_device_data_schedule",
+                "available": True,
+                "active_schedule_version": 8,
+                "current_task": None,
+                "schedules": [
+                    {
+                        "idx": 1,
+                        "available": True,
+                        "version": 8,
+                        "plans": [{"plan_id": 2, "enabled": True}],
+                    }
+                ],
+                "errors": [],
+            }
+        ),
+    )
+    coordinator.async_update_listeners = Mock()
+    coordinator.last_schedule_write_result = None
+    coordinator.schedules_refreshed_at = None
+    coordinator.selected_map_index = 1
+    coordinator.app_maps = {
+        "current_map_index": 1,
+        "maps": [{"idx": 1, "created": True}],
+    }
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {
+                "idx": 1,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 2, "enabled": True}],
+            },
+        ],
+    }
+
+    asyncio.run(
+        coordinator.async_set_schedule_plan_enabled(
+            map_index=1,
+            plan_id=2,
+            enabled=False,
+        )
+    )
+
+    plan = coordinator.schedules["schedules"][1]["plans"][0]
+    assert plan["enabled"] is False
+    assert coordinator._pending_schedule_plan_states == {(1, 2): (8, False)}
+
+    coordinator.client.async_get_app_schedules.return_value = {
+        "source": "app_action_schedule",
+        "available": True,
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {
+                "idx": 1,
+                "available": True,
+                "version": 8,
+                "plans": [{"plan_id": 2, "enabled": False}],
+            },
+        ],
+        "errors": [],
+    }
+    asyncio.run(coordinator.async_refresh_schedules(force=True))
+
+    plan = coordinator.schedules["schedules"][1]["plans"][0]
+    assert plan["enabled"] is False
+    assert coordinator._pending_schedule_plan_states == {}
+    coordinator.async_update_listeners.assert_called_once()
+
+
 def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._schedule_write_lock = asyncio.Lock()

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -154,6 +154,101 @@ def test_schedule_write_keeps_confirmed_state_when_readback_fails() -> None:
     coordinator.async_update_listeners.assert_called_once()
 
 
+def test_schedule_write_reconciles_unknown_active_fallback_by_version() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._schedule_write_lock = asyncio.Lock()
+    coordinator.client = SimpleNamespace(
+        async_set_app_schedule_plan_enabled=AsyncMock(
+            return_value={
+                "executed": True,
+                "enabled": False,
+                "version": 8,
+            }
+        )
+    )
+    coordinator.async_refresh_schedules = AsyncMock(
+        side_effect=RuntimeError("readback unavailable")
+    )
+    coordinator.async_update_listeners = Mock()
+    coordinator.last_schedule_write_result = None
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "schedules": [
+            {
+                "idx": None,
+                "version": 8,
+                "writable": False,
+                "plans": [{"plan_id": 2, "enabled": True}],
+            }
+        ],
+    }
+
+    with pytest.raises(RuntimeError, match="readback unavailable"):
+        asyncio.run(
+            coordinator.async_set_schedule_plan_enabled(
+                map_index=1,
+                plan_id=2,
+                enabled=False,
+            )
+        )
+
+    assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is False
+    coordinator.async_update_listeners.assert_called_once()
+
+
+def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._schedule_write_lock = asyncio.Lock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_schedule_upload=AsyncMock(
+            return_value={
+                "executed": True,
+                "request_count": 2,
+                "version": 8,
+            }
+        )
+    )
+    coordinator.async_refresh_schedules = AsyncMock(
+        side_effect=RuntimeError("readback unavailable")
+    )
+    coordinator.async_update_listeners = Mock()
+    coordinator.last_schedule_write_result = None
+    coordinator.schedules_refreshed_at = object()
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "current_task": {"version": 8},
+        "schedules": [
+            {"idx": -1, "available": True, "version": 7, "plans": []},
+            {
+                "idx": None,
+                "available": True,
+                "version": 8,
+                "writable": False,
+                "plans": [{"plan_id": 2, "enabled": True}],
+            },
+        ],
+    }
+
+    with pytest.raises(RuntimeError, match="readback unavailable"):
+        asyncio.run(
+            coordinator.async_plan_schedule_upload(
+                map_index=1,
+                plans=[{"plan_id": 2, "enabled": False, "weeks": []}],
+                chunk_size=100,
+                execute=True,
+                confirm_write=True,
+            )
+        )
+
+    assert [schedule["idx"] for schedule in coordinator.schedules["schedules"]] == [
+        -1
+    ]
+    assert "active_schedule_version" not in coordinator.schedules
+    assert "current_task" not in coordinator.schedules
+    assert coordinator.schedules_refreshed_at is None
+    coordinator.async_update_listeners.assert_called_once()
+
+
 def test_forced_schedule_readback_propagates_cloud_failure() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.client = SimpleNamespace(

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -216,6 +216,7 @@ def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> Non
     coordinator.schedules_refreshed_at = object()
     coordinator.schedules = {
         "active_schedule_version": 8,
+        "active_selection_available": True,
         "current_task": {"version": 8},
         "schedules": [
             {"idx": -1, "available": True, "version": 7, "plans": []},
@@ -244,6 +245,7 @@ def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> Non
         -1
     ]
     assert "active_schedule_version" not in coordinator.schedules
+    assert coordinator.schedules["active_selection_available"] is False
     assert "current_task" not in coordinator.schedules
     assert coordinator.schedules_refreshed_at is None
     coordinator.async_update_listeners.assert_called_once()

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -369,6 +369,38 @@ def test_pending_toggle_does_not_mutate_ambiguous_active_fallback() -> None:
     assert coordinator.schedules["active_selection_available"] is False
 
 
+def test_immediate_toggle_does_not_mutate_ambiguous_active_fallback() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.schedules = {
+        "active_schedule_version": 8,
+        "active_schedule_index": None,
+        "active_selection_available": True,
+        "schedules": [
+            {
+                "idx": 1,
+                "version": 8,
+                "plans": [{"plan_id": 1, "enabled": False}],
+            },
+            {
+                "idx": None,
+                "version": 8,
+                "plans": [{"plan_id": 1, "enabled": False}],
+            },
+        ],
+    }
+
+    coordinator._reconcile_cached_schedule_plan_enabled(
+        map_index=0,
+        plan_id=1,
+        enabled=True,
+        schedule_version=8,
+    )
+
+    assert coordinator.schedules["schedules"][0]["plans"][0]["enabled"] is False
+    assert coordinator.schedules["schedules"][1]["plans"][0]["enabled"] is False
+    assert coordinator.schedules["active_selection_available"] is False
+
+
 def test_schedule_upload_invalidates_unknown_active_fallback_by_version() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._schedule_write_lock = asyncio.Lock()

--- a/tests/test_schedule_switches.py
+++ b/tests/test_schedule_switches.py
@@ -266,6 +266,106 @@ def test_schedule_upload_force_refreshes_shared_cache_after_execution() -> None:
     coordinator.async_update_listeners.assert_called_once()
 
 
+def test_schedule_upload_discards_refresh_started_before_confirmed_write() -> None:
+    async def exercise() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator._schedule_write_lock = asyncio.Lock()
+        coordinator._schedule_cache_generation = 0
+        coordinator.async_update_listeners = Mock()
+        coordinator.last_schedule_write_result = None
+        coordinator.schedules_refreshed_at = None
+        coordinator.selected_map_index = 0
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [
+                {"idx": 0, "created": True},
+                {"idx": 1, "created": True},
+            ],
+        }
+        coordinator.schedules = {
+            "source": "app_action_schedule",
+            "schedules": [
+                {"idx": -1, "available": True, "version": 7, "plans": []},
+                {
+                    "idx": 0,
+                    "available": True,
+                    "version": 8,
+                    "plans": [{"plan_id": 9}],
+                },
+                {"idx": 1, "available": True, "version": 10, "plans": []},
+            ],
+            "errors": [],
+        }
+        stale_read_started = asyncio.Event()
+        release_stale_read = asyncio.Event()
+        read_count = 0
+
+        async def read_schedules(**_kwargs: object) -> dict[str, object]:
+            nonlocal read_count
+            read_count += 1
+            if read_count == 1:
+                stale_read_started.set()
+                await release_stale_read.wait()
+                return {
+                    "source": "app_action_schedule",
+                    "schedules": [
+                        {"idx": -1, "available": True, "version": 7, "plans": []},
+                        {
+                            "idx": 0,
+                            "available": True,
+                            "version": 8,
+                            "plans": [{"plan_id": 9}],
+                        },
+                        {"idx": 1, "available": True, "version": 10, "plans": []},
+                    ],
+                    "errors": [],
+                }
+            return {
+                "source": "app_action_schedule",
+                "schedules": [
+                    {"idx": -1, "available": True, "version": 7, "plans": []},
+                    {"idx": 0, "available": False, "error": "timed out"},
+                    {"idx": 1, "available": True, "version": 10, "plans": []},
+                ],
+                "errors": [
+                    {"idx": 0, "stage": "schedule", "error": "timed out"}
+                ],
+            }
+
+        coordinator.client = SimpleNamespace(
+            async_plan_app_schedule_upload=AsyncMock(
+                return_value={"executed": True, "request_count": 2}
+            ),
+            async_get_app_schedules=read_schedules,
+            async_get_batch_schedules=AsyncMock(side_effect=TimeoutError),
+        )
+
+        stale_refresh = asyncio.create_task(
+            coordinator.async_refresh_schedules(force=True)
+        )
+        await stale_read_started.wait()
+        await coordinator.async_plan_schedule_upload(
+            map_index=0,
+            plans=[{"plan_id": 1, "enabled": True, "weeks": []}],
+            chunk_size=100,
+            execute=True,
+            confirm_write=True,
+        )
+        release_stale_read.set()
+        await stale_refresh
+
+        uploaded_slot = next(
+            schedule
+            for schedule in coordinator.schedules["schedules"]
+            if schedule["idx"] == 0
+        )
+        assert uploaded_slot["error"] == "timed out"
+        assert "plans" not in uploaded_slot
+        assert coordinator._schedule_cache_generation == 1
+
+    asyncio.run(exercise())
+
+
 def test_executed_schedule_upload_waits_for_shared_write_lock() -> None:
     async def exercise() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -234,12 +234,20 @@ def test_managed_runtime_environment_is_privacy_safe(
     monkeypatch.setattr(
         video_helpers_module.platform,
         "libc_ver",
-        lambda: ("glibc", "2.39"),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("platform.libc_ver must not run on the event loop")
+        ),
     )
     monkeypatch.setattr(
         video_helpers_module.os,
         "sysconf",
         lambda _name: 4096,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_helpers_module.os,
+        "confstr",
+        lambda _name: "glibc 2.39",
         raising=False,
     )
 
@@ -272,12 +280,20 @@ def test_managed_runtime_environment_reports_large_page_compatibility(
     monkeypatch.setattr(
         video_helpers_module.platform,
         "libc_ver",
-        lambda: ("musl", "1"),
+        lambda: (_ for _ in ()).throw(
+            AssertionError("platform.libc_ver must not run on the event loop")
+        ),
     )
     monkeypatch.setattr(
         video_helpers_module.os,
         "sysconf",
         lambda _name: 16384,
+        raising=False,
+    )
+    monkeypatch.setattr(
+        video_helpers_module.os,
+        "confstr",
+        lambda _name: None,
         raising=False,
     )
 
@@ -2485,7 +2501,7 @@ def test_video_camera_unload_is_bounded_when_every_cleanup_stage_hangs() -> None
                 video_camera_module.STREAM_DOMAIN: {
                     video_camera_module.ATTR_STREAMS: [stream],
                 }
-            },
+            }
         )
         entity.async_write_ha_state = lambda: None
 
@@ -2677,7 +2693,7 @@ def test_video_camera_exposes_managed_runtime_failure_context() -> None:
                 "returncode": -11,
                 "exit": "signal=11",
                 "native_trace": "xp2p-worker: runtime loaded",
-            }
+            },
         )
 
         with pytest.raises(


### PR DESCRIPTION
## What changes

- keep automatic refreshes moving when optional `SCHDT`/`SCHDIV2` action reads do not respond by capping MAPL discovery, sharing a 10-second action-read deadline fairly across writable slots, and rotating one bounded recovery pass
- use the faster batch payload as the authoritative active schedule version and calendar fallback while preserving safe slot resolution, partial-cache merging, write reconciliation, and deleted-map pruning
- publish core metadata before slow schedule work, retry one incomplete app-map hydration with a forced read, and treat a docked or charging mower as inactive even when a stale heartbeat still says the mowing session is active
- register metadata hydration, map rendering, the video relay pump, and the video idle monitor as Home Assistant background work so setup and shutdown do not wait on long-lived tasks
- avoid the blocking `platform.libc_ver()` probe in the event loop
- bound cloud transport teardown, prevent queued work from reviving a disconnected session, and disconnect an aliased cloud transport only once

## Live A2 and Home Assistant evidence

The project A2 reproduces the schedule boundary from #119: `SCHDT` and `SCHDIV2` return no response, while the batch schedule returns in 0.36 seconds with two plans and one enabled plan. A historical A2 capture returned the expected four-value `SCHDT` payload, so the evidence points to a nonresponsive action path, not a different JSON shape or proven model incompatibility.

The exact PR head was installed on Home Assistant 2026.7.4 and tested with a full restart, without reloading the config entry:

- all 17 metadata-backed acceptance entities populated, including voice, rain protection, maintenance, firmware, vector-map, zone, spot, and edge data
- all five map/video camera entities loaded and remained idle/available
- setup completed in 6.83 seconds; the first refresh completed in 2.76 seconds while slow schedule and app-map work continued in the background
- the A2 still reported the stale combination `docked=true`, `state=charging_completed`, and `mowing_session_active=true`; metadata nevertheless hydrated normally
- Home Assistant's system log contained no Dreame blocking-call warning after restart. The expected bounded `SCHDIV2` timeout warnings remained, and metadata refresh completed through the fallback path.

## Validation

- 105 focused map and coordinator tests passed
- 1,253 broader tests passed, 1 skipped
- Ruff, Python compilation, and diff checks passed

## Limit

When every action read fails, the batch payload does not identify a safe writable schedule slot. Calendar events can be restored, but the integration does not guess a map index for per-plan switches. Existing switches remain available when an earlier successful action read established the slot.

The affected A1 Pro 2000 has not been tested directly; live device validation above is from the project A2.

Addresses #119
Addresses #121
Addresses the residual setup and blocking-call findings in [#117's follow-up](https://github.com/EvotecIT/homeassistant-dreamelawnmower/issues/117#issuecomment-5127903916).




