### PR TITLE
Recover mower video after stale cached startup

### DIFF
--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -218,7 +218,7 @@ class DreameLawnMowerVideoCamera(
             is_current=lambda stream, owner: (
                 self.stream is stream and owner is self._flv_relay
             ),
-            stop_active=self._async_stop_active_session,
+            stop_active=self._async_stop_idle_session,
             has_external_consumers=lambda: (
                 self._flv_relay.direct_subscriber_count > 0
                 or self._snapshot_requests > 0
@@ -375,6 +375,12 @@ class DreameLawnMowerVideoCamera(
         """Apply the configured retention policy to an active mower session."""
         self._reset_video_live_view_if_inactive()
         if not self._video_retention_state_is_fresh():
+            return False
+        # Retention is only for a stream that has already proved it can deliver
+        # decoder-ready media.  Keeping an unverified cold start alive lets a
+        # dashboard's reconnecting consumers pin a zero-frame XP2P attempt
+        # instead of allowing the normal cleanup/retry path to re-arm video.
+        if self._video_first_media_at is None:
             return False
         return mower_video_session_should_stay_warm(
             self.coordinator.data,
@@ -580,6 +586,12 @@ class DreameLawnMowerVideoCamera(
                     reason="relay_failure",
                     failed_pump_task=asyncio.current_task(),
                 )
+            if cached_playback_failed:
+                # Cached XP2P deliberately avoids the cloud camera toggle.  If
+                # that warm/cached route reaches no media, explicitly clear the
+                # mower's stale video mode before the reconnect bypasses cache
+                # and performs a fresh cloud enable.
+                await self._async_disable_camera_stream()
             await self._async_clear_failed_playback_caches(
                 cached_xp2p=cached_playback_failed,
                 lan=lan_playback_failed,
@@ -659,8 +671,32 @@ class DreameLawnMowerVideoCamera(
     async def _async_relay_idle(self) -> None:
         """Release mower video after the last local WebRTC/HLS viewer leaves."""
         async with self._stream_lock:
-            if self._session is not None or getattr(self, "stream", None) is not None:
-                await self._async_stop_active_session(reason="relay_idle")
+            await self._async_stop_idle_session()
+
+    async def _async_stop_idle_session(self) -> None:
+        """Retire one idle session and invalidate an unverified cached route."""
+        cached_start_unverified = (
+            self._video_first_media_at is None
+            and (
+                self._last_video_transport_attempted == "cached_xp2p"
+                or (
+                    self._last_video_transport == "cached_xp2p"
+                    and self._unverified_playback_session is not None
+                )
+            )
+        )
+        if self._session is not None or getattr(self, "stream", None) is not None:
+            await self._async_stop_active_session(reason="stream_idle")
+        if cached_start_unverified:
+            # Both relay and HA Stream idle monitors can cancel the pump without
+            # invoking the relay-failure callback. Invalidate the same zero-frame
+            # cached route before either monitor allows a replacement start.
+            self._bypass_cached_xp2p = True
+            await self._async_disable_camera_stream()
+            await self._async_clear_failed_playback_caches(
+                cached_xp2p=True,
+                lan=False,
+            )
 
     async def _async_start_raw_source(
         self,

--- a/examples/home_assistant_video_playback_probe.py
+++ b/examples/home_assistant_video_playback_probe.py
@@ -106,7 +106,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--frame-out",
         type=Path,
-        help="Optional JPEG path for the deployed HA camera's still image.",
+        help="Optional JPEG path for a frame decoded from the deployed HA HLS stream.",
     )
     parser.add_argument(
         "--video-out",
@@ -325,6 +325,23 @@ async def _wait_for_hls_media(output: Any, *, timeout: float) -> Any:
             await output.part_recv(timeout=min(remaining, 5.0))
 
 
+async def _capture_hls_and_camera_image(
+    camera: Any,
+    hls_output: Any,
+    *,
+    timeout: float,
+) -> tuple[Any, bytes | None]:
+    """Capture HA HLS and snapshot consumers from the same initial keyframes."""
+    camera_image_task = asyncio.create_task(camera.async_camera_image())
+    try:
+        segment = await _wait_for_hls_media(hls_output, timeout=timeout)
+        return segment, await camera_image_task
+    finally:
+        if not camera_image_task.done():
+            camera_image_task.cancel()
+            await asyncio.gather(camera_image_task, return_exceptions=True)
+
+
 def _decode_best_video_frame(
     segment: Any,
     frame_out: Path | None,
@@ -413,7 +430,7 @@ async def _verify_cached_xp2p_after_reload(
     port: int,
     timeout: float,
 ) -> tuple[Any, Any, Any, dict[str, Any]]:
-    """Prove persisted XP2P restart while the whole Dreame client is offline."""
+    """Prove persisted XP2P restart after blocking subsequent Dreame access."""
     blocked_calls: list[str] = []
 
     async def _blocked_refresh(_self: Any) -> Any:
@@ -434,19 +451,23 @@ async def _verify_cached_xp2p_after_reload(
             "Dreame camera toggle was blocked by the cache proof."
         )
 
-    client_type = type(hass.data[DOMAIN][entry.entry_id].client)
-    original_refresh = client_type.async_refresh
-    original_inputs = client_type.async_get_camera_stream_runtime_inputs
-    original_toggle = client_type.async_set_camera_stream_enabled
+    client_type = None
+    original_refresh = None
+    original_inputs = None
+    original_toggle = None
     try:
-        client_type.async_refresh = _blocked_refresh
-        client_type.async_get_camera_stream_runtime_inputs = _blocked_inputs
-        client_type.async_set_camera_stream_enabled = _blocked_toggle
         if not await hass.config_entries.async_reload(entry.entry_id):
             raise RuntimeError("Dreame config entry did not reload for cache proof.")
         await hass.async_block_till_done()
         coordinator = hass.data[DOMAIN][entry.entry_id]
         client = coordinator.client
+        client_type = type(client)
+        original_refresh = client_type.async_refresh
+        original_inputs = client_type.async_get_camera_stream_runtime_inputs
+        original_toggle = client_type.async_set_camera_stream_enabled
+        client_type.async_refresh = _blocked_refresh
+        client_type.async_get_camera_stream_runtime_inputs = _blocked_inputs
+        client_type.async_set_camera_stream_enabled = _blocked_toggle
         camera = _find_video_camera(hass)
         ha_stream = await camera.async_create_stream()
         if ha_stream is None:
@@ -467,9 +488,10 @@ async def _verify_cached_xp2p_after_reload(
         status, playlist = await _fetch_hls_playlist(port, endpoint)
         attributes = camera.extra_state_attributes
     finally:
-        client_type.async_refresh = original_refresh
-        client_type.async_get_camera_stream_runtime_inputs = original_inputs
-        client_type.async_set_camera_stream_enabled = original_toggle
+        if client_type is not None:
+            client_type.async_refresh = original_refresh
+            client_type.async_get_camera_stream_runtime_inputs = original_inputs
+            client_type.async_set_camera_stream_enabled = original_toggle
 
     result = {
         "blocked_dreame_client_calls": blocked_calls,
@@ -481,7 +503,7 @@ async def _verify_cached_xp2p_after_reload(
         "width": frame["width"],
         "height": frame["height"],
         "verified": bool(
-            blocked_calls == ["refresh"]
+            blocked_calls == []
             and attributes["last_video_transport"] == "cached_xp2p"
             and status == 200
             and "#EXTM3U" in playlist
@@ -504,6 +526,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
         "home_assistant_hls_verified": False,
         "playable_video_verified": False,
         "visual_frame_verified": False,
+        "camera_image_verified": False,
     }
     hass: HomeAssistant | None = None
     entry = None
@@ -604,25 +627,25 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             hls_output = ha_stream.add_provider("hls")
             endpoint = ha_stream.endpoint_url("hls")
             await ha_stream.start()
-            segment = await _wait_for_hls_media(
+            segment, camera_jpeg = await _capture_hls_and_camera_image(
+                camera,
                 hls_output,
                 timeout=args.stream_timeout,
-            )
-            camera_jpeg = await camera.async_camera_image()
-            if not camera_jpeg:
-                raise RuntimeError(
-                    "The deployed HA camera returned no still-image bytes."
-                )
-            camera_image = await hass.async_add_executor_job(
-                _inspect_camera_jpeg,
-                camera_jpeg,
-                args.frame_out,
             )
             frame = await hass.async_add_executor_job(
                 _decode_best_video_frame,
                 segment,
-                None,
+                args.frame_out,
                 args.video_out,
+            )
+            camera_image = (
+                await hass.async_add_executor_job(
+                    _inspect_camera_jpeg,
+                    camera_jpeg,
+                    None,
+                )
+                if camera_jpeg
+                else None
             )
             status, playlist = await _fetch_hls_playlist(port, endpoint)
             output["playback"] = {
@@ -647,6 +670,9 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                 and frame["width"] > 0
                 and frame["height"] > 0
                 and frame["jpeg_bytes"] > 0
+            )
+            output["camera_image_verified"] = bool(
+                camera_image is not None
                 and camera_image["width"] > 0
                 and camera_image["height"] > 0
                 and camera_image["jpeg_bytes"] > 0

--- a/examples/home_assistant_video_playback_probe.py
+++ b/examples/home_assistant_video_playback_probe.py
@@ -430,14 +430,8 @@ async def _verify_cached_xp2p_after_reload(
     port: int,
     timeout: float,
 ) -> tuple[Any, Any, Any, dict[str, Any]]:
-    """Prove persisted XP2P restart after blocking subsequent Dreame access."""
+    """Prove cached XP2P restart without new video inputs or camera toggles."""
     blocked_calls: list[str] = []
-
-    async def _blocked_refresh(_self: Any) -> Any:
-        blocked_calls.append("refresh")
-        raise DreameLawnMowerConnectionError(
-            "Dreame client access was blocked by the cache proof."
-        )
 
     async def _blocked_inputs(_self: Any) -> Any:
         blocked_calls.append("runtime_inputs")
@@ -452,7 +446,6 @@ async def _verify_cached_xp2p_after_reload(
         )
 
     client_type = None
-    original_refresh = None
     original_inputs = None
     original_toggle = None
     try:
@@ -462,10 +455,8 @@ async def _verify_cached_xp2p_after_reload(
         coordinator = hass.data[DOMAIN][entry.entry_id]
         client = coordinator.client
         client_type = type(client)
-        original_refresh = client_type.async_refresh
         original_inputs = client_type.async_get_camera_stream_runtime_inputs
         original_toggle = client_type.async_set_camera_stream_enabled
-        client_type.async_refresh = _blocked_refresh
         client_type.async_get_camera_stream_runtime_inputs = _blocked_inputs
         client_type.async_set_camera_stream_enabled = _blocked_toggle
         camera = _find_video_camera(hass)
@@ -489,12 +480,11 @@ async def _verify_cached_xp2p_after_reload(
         attributes = camera.extra_state_attributes
     finally:
         if client_type is not None:
-            client_type.async_refresh = original_refresh
             client_type.async_get_camera_stream_runtime_inputs = original_inputs
             client_type.async_set_camera_stream_enabled = original_toggle
 
     result = {
-        "blocked_dreame_client_calls": blocked_calls,
+        "blocked_dreame_video_calls": blocked_calls,
         "stream_session": attributes["last_stream_session"],
         "last_video_transport": attributes["last_video_transport"],
         "hls_endpoint_status": status,

--- a/examples/home_assistant_video_playback_probe.py
+++ b/examples/home_assistant_video_playback_probe.py
@@ -146,6 +146,25 @@ def _at_station(snapshot: Any) -> bool:
     )
 
 
+class _ProbeMovement:
+    """Track mower movement that this probe must clean up."""
+
+    __slots__ = ("start_attempted",)
+
+    def __init__(self) -> None:
+        self.start_attempted = False
+
+    async def async_start(self, mower: Any) -> None:
+        """Claim cleanup ownership before issuing an ambiguous device mutation."""
+        self.start_attempted = True
+        await mower.async_start_mowing()
+
+
+def _should_dock_after_probe(*, start_attempted: bool) -> bool:
+    """Return whether cleanup must undo mower movement issued by this probe."""
+    return start_attempted
+
+
 async def _wait_for_camera_available(camera: Any, *, timeout: float) -> bool:
     """Wait for HA's debounced coordinator refresh to expose active video."""
     deadline = asyncio.get_running_loop().time() + max(timeout, 0.1)
@@ -492,7 +511,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
     mower = None
     ha_stream = None
     client = None
-    start_sent = False
+    movement = _ProbeMovement()
 
     with tempfile.TemporaryDirectory(prefix="dreame-ha-video-proof-") as temp_dir:
         try:
@@ -540,8 +559,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                         "Mower is docked; rerun under supervision with "
                         "--start-before-active."
                     )
-                await mower.async_start_mowing()
-                start_sent = True
+                await movement.async_start(mower)
                 snapshot = await _wait_for_state(
                     client,
                     lambda value: not _at_station(value),
@@ -673,7 +691,12 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                     output["camera_turn_off_error"] = str(err)
             if ha_stream is not None:
                 await ha_stream.stop()
-            if client is not None and (args.execute or start_sent):
+            # Only undo mower movement that this probe initiated.  A camera-only
+            # proof against an already-active mower must never dock the owner's
+            # in-progress mission during cleanup.
+            if client is not None and _should_dock_after_probe(
+                start_attempted=movement.start_attempted
+            ):
                 dock_request_error = None
                 try:
                     if mower is not None:

--- a/tests/test_camera_stream_probe_example.py
+++ b/tests/test_camera_stream_probe_example.py
@@ -69,6 +69,41 @@ def test_ha_playback_probe_owns_cleanup_before_ambiguous_start_failure() -> None
     assert module._should_dock_after_probe(start_attempted=True) is True
 
 
+def test_ha_playback_probe_starts_snapshot_consumer_with_hls() -> None:
+    module = _load_ha_playback_probe_module()
+
+    async def _run() -> tuple[object, bytes]:
+        snapshot_started = asyncio.Event()
+        segment = SimpleNamespace(
+            complete=True,
+            init=b"ftyp",
+            data_size=1,
+        )
+
+        class _Camera:
+            async def async_camera_image(self) -> bytes:
+                snapshot_started.set()
+                return b"jpeg"
+
+        class _HlsOutput:
+            last_segment = None
+
+            async def recv(self) -> None:
+                await asyncio.wait_for(snapshot_started.wait(), timeout=1)
+                self.last_segment = segment
+
+        return await module._capture_hls_and_camera_image(
+            _Camera(),
+            _HlsOutput(),
+            timeout=1,
+        )
+
+    actual_segment, image = asyncio.run(_run())
+
+    assert actual_segment.complete is True
+    assert image == b"jpeg"
+
+
 def test_probe_help_uses_standalone_client_package(tmp_path) -> None:
     (tmp_path / "sitecustomize.py").write_text(
         "\n".join(

--- a/tests/test_camera_stream_probe_example.py
+++ b/tests/test_camera_stream_probe_example.py
@@ -13,6 +13,7 @@ from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
+import pytest
 import pytest_socket
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
@@ -32,6 +33,40 @@ def _load_probe_module() -> ModuleType:
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
     return module
+
+
+def _load_ha_playback_probe_module() -> ModuleType:
+    path = Path("examples/home_assistant_video_playback_probe.py")
+    spec = importlib.util.spec_from_file_location(
+        "home_assistant_video_playback_probe", path
+    )
+    if spec is None or spec.loader is None:
+        raise AssertionError("Could not load Home Assistant playback probe module")
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_ha_playback_probe_docks_only_mower_movement_it_started() -> None:
+    module = _load_ha_playback_probe_module()
+
+    assert module._should_dock_after_probe(start_attempted=False) is False
+    assert module._should_dock_after_probe(start_attempted=True) is True
+
+
+def test_ha_playback_probe_owns_cleanup_before_ambiguous_start_failure() -> None:
+    module = _load_ha_playback_probe_module()
+    movement = module._ProbeMovement()
+
+    class _Mower:
+        async def async_start_mowing(self) -> None:
+            raise RuntimeError("response lost after command")
+
+    with pytest.raises(RuntimeError, match="response lost"):
+        asyncio.run(movement.async_start(_Mower()))
+
+    assert movement.start_attempted is True
+    assert module._should_dock_after_probe(start_attempted=True) is True
 
 
 def test_probe_help_uses_standalone_client_package(tmp_path) -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -1786,7 +1786,7 @@ def test_video_camera_stays_available_during_active_stream_connectivity_loss() -
 
 
 def test_video_camera_relay_failure_bypasses_stale_cached_xp2p() -> None:
-    async def _run() -> tuple[int, list[bool], bool]:
+    async def _run() -> tuple[int, int, list[bool], bool]:
         entity = _uninitialized_entity()
         entity.async_write_ha_state = lambda: None
         entity._last_video_transport = "cached_xp2p"
@@ -1794,6 +1794,7 @@ def test_video_camera_relay_failure_bypasses_stale_cached_xp2p() -> None:
         entity._session = entity._unverified_playback_session
         entity.stream = None
         clears = 0
+        disables = 0
         skip_values: list[bool] = []
 
         class _ProvisioningCache:
@@ -1810,15 +1811,20 @@ def test_video_camera_relay_failure_bypasses_stale_cached_xp2p() -> None:
             skip_values.append(skip_cached_xp2p)
             return "http://127.0.0.1/fresh.flv"
 
+        async def _disable() -> None:
+            nonlocal disables
+            disables += 1
+
         entity._provisioning_cache = _ProvisioningCache()
         entity._async_stop_active_session = _stop
         entity._async_start_raw_source = _start
+        entity._async_disable_camera_stream = _disable
 
         await entity._async_relay_failed("cached media was invalid")
         await entity._async_start_relay_upstream()
-        return clears, skip_values, entity._bypass_cached_xp2p
+        return clears, disables, skip_values, entity._bypass_cached_xp2p
 
-    assert asyncio.run(_run()) == (1, [True], True)
+    assert asyncio.run(_run()) == (1, 1, [True], True)
 
 
 def test_video_camera_relay_failure_clears_cache_before_reconnect_start() -> None:
@@ -1850,9 +1856,13 @@ def test_video_camera_relay_failure_clears_cache_before_reconnect_start() -> Non
             order.append("replacement_started")
             return "http://127.0.0.1/fresh.flv"
 
+        async def _disable() -> None:
+            order.append("camera_disabled")
+
         entity._provisioning_cache = _ProvisioningCache()
         entity._async_stop_active_session = _stop
         entity._async_start_stream = _start
+        entity._async_disable_camera_stream = _disable
 
         failure = asyncio.create_task(
             entity._async_relay_failed("cached media was invalid")
@@ -1870,10 +1880,64 @@ def test_video_camera_relay_failure_clears_cache_before_reconnect_start() -> Non
         return order, replacement_was_blocked, source
 
     assert asyncio.run(_run()) == (
-        ["clear_started", "clear_finished", "replacement_started"],
+        [
+            "camera_disabled",
+            "clear_started",
+            "clear_finished",
+            "replacement_started",
+        ],
         True,
         "http://127.0.0.1/fresh.flv",
     )
+
+
+@pytest.mark.parametrize("first_media_at", [None, 1.0])
+def test_video_camera_idle_invalidates_only_unverified_cached_start(
+    first_media_at: float | None,
+) -> None:
+    async def _run() -> tuple[list[str], bool]:
+        entity = _uninitialized_entity()
+        entity._last_video_transport = "cached_xp2p"
+        entity._last_video_transport_attempted = "cached_xp2p"
+        entity._bypass_cached_xp2p = False
+        entity._video_first_media_at = first_media_at
+        entity._unverified_playback_session = (
+            object() if first_media_at is None else None
+        )
+        entity._session = object()
+        entity.stream = object()
+        order: list[str] = []
+
+        async def _stop(*, reason: str = "session_stop", **_kwargs: object) -> None:
+            assert reason == "stream_idle"
+            order.append("stopped")
+            entity._session = None
+            entity._unverified_playback_session = None
+            entity.stream = None
+
+        async def _disable() -> None:
+            order.append("camera_disabled")
+
+        async def _clear(*, cached_xp2p: bool, lan: bool) -> None:
+            assert cached_xp2p is True
+            assert lan is False
+            order.append("cache_cleared")
+
+        entity._async_stop_active_session = _stop
+        entity._async_disable_camera_stream = _disable
+        entity._async_clear_failed_playback_caches = _clear
+
+        await entity._async_relay_idle()
+        return order, entity._bypass_cached_xp2p
+
+    order, bypassed = asyncio.run(_run())
+
+    if first_media_at is None:
+        assert order == ["stopped", "camera_disabled", "cache_cleared"]
+        assert bypassed is True
+    else:
+        assert order == ["stopped"]
+        assert bypassed is False
 
 
 def test_video_camera_relay_failure_bypasses_stale_lan_for_auto() -> None:
@@ -2841,12 +2905,14 @@ def test_video_camera_stream_reuses_inflight_runtime_preparation() -> None:
     assert asyncio.run(_run()) == (True, True)
 
 
-def test_video_camera_idle_monitor_ignores_ha_owned_relay_subscriber() -> None:
-    async def _run() -> int:
+def test_video_camera_ha_idle_monitor_invalidates_unverified_cached_start() -> None:
+    async def _run() -> tuple[int, int, int, bool]:
         entity = _uninitialized_entity()
         session = SimpleNamespace(service_id="product-1/device-1")
         outputs_calls = 0
         stops = 0
+        disables = 0
+        clears = 0
 
         class _Stream:
             def outputs(self) -> dict[str, object]:
@@ -2861,21 +2927,39 @@ def test_video_camera_idle_monitor_ignores_ha_owned_relay_subscriber() -> None:
         )
         entity.stream = stream
         entity._session = session
+        entity._unverified_playback_session = session
+        entity._last_video_transport = "cached_xp2p"
+        entity._last_video_transport_attempted = "cached_xp2p"
+        entity._bypass_cached_xp2p = False
 
-        async def _stop() -> None:
+        async def _stop(*, reason: str = "session_stop") -> None:
             nonlocal stops
+            assert reason == "stream_idle"
             stops += 1
             entity.stream = None
             entity._session = None
+            entity._unverified_playback_session = None
+
+        async def _disable() -> None:
+            nonlocal disables
+            disables += 1
+
+        async def _clear(*, cached_xp2p: bool, lan: bool) -> None:
+            nonlocal clears
+            assert cached_xp2p is True
+            assert lan is False
+            clears += 1
 
         entity._async_stop_active_session = _stop
+        entity._async_disable_camera_stream = _disable
+        entity._async_clear_failed_playback_caches = _clear
         monitor = DreameLawnMowerHaStreamIdleMonitor(
             SimpleNamespace(async_create_task=asyncio.create_task),
             stream_lock=entity._stream_lock,
             is_current=lambda actual_stream, actual_session: (
                 entity.stream is actual_stream and entity._session is actual_session
             ),
-            stop_active=entity._async_stop_active_session,
+            stop_active=entity._async_stop_idle_session,
             has_external_consumers=lambda: relay.direct_subscriber_count > 0,
             idle_grace=0,
             poll_interval=0,
@@ -2884,9 +2968,10 @@ def test_video_camera_idle_monitor_ignores_ha_owned_relay_subscriber() -> None:
         monitor.schedule(stream, session)
         while stops == 0:
             await asyncio.sleep(0)
-        return stops
+        await monitor.async_cancel()
+        return stops, disables, clears, entity._bypass_cached_xp2p
 
-    assert asyncio.run(_run()) == 1
+    assert asyncio.run(_run()) == (1, 1, 1, True)
 
 
 def test_video_camera_idle_monitor_keeps_direct_relay_viewer_alive() -> None:
@@ -3122,6 +3207,7 @@ def test_balanced_retention_arms_only_for_live_viewing() -> None:
     entity = _uninitialized_entity(
         snapshot=SimpleNamespace(state="mowing", activity="mowing")
     )
+    entity._video_first_media_at = 1.0
 
     entity._snapshot_requests = 1
     entity._video_relay_subscriber_started(ha_stream_owned=True)
@@ -3148,6 +3234,7 @@ def test_balanced_retention_preserves_intent_across_same_run_pause() -> None:
             mowing_session_active=True,
         )
     )
+    entity._video_first_media_at = 1.0
     entity._mark_video_live_view()
 
     entity.coordinator.data = SimpleNamespace(
@@ -3189,6 +3276,7 @@ def test_video_retention_fails_closed_without_fresh_coordinator_state(
     entity = _uninitialized_entity(
         snapshot=SimpleNamespace(state="mowing", activity="mowing")
     )
+    entity._video_first_media_at = 1.0
     entity._mark_video_live_view()
     entity.coordinator.last_update_success = last_update_success
     entity.coordinator.connection_degraded = connection_degraded
@@ -3204,6 +3292,7 @@ def test_video_retention_preserves_connected_viewer_intent_during_degraded_state
     entity = _uninitialized_entity(
         snapshot=SimpleNamespace(state="mowing", activity="mowing")
     )
+    entity._video_first_media_at = 1.0
     if viewer_kind == "direct":
         entity._flv_relay = SimpleNamespace(direct_subscriber_count=1)
     else:
@@ -3222,6 +3311,7 @@ def test_video_retention_does_not_treat_snapshot_output_as_live_viewer() -> None
     entity = _uninitialized_entity(
         snapshot=SimpleNamespace(state="mowing", activity="mowing")
     )
+    entity._video_first_media_at = 1.0
     stream = SimpleNamespace(outputs=lambda: {"snapshot": object()})
     entity.stream = stream
     entity._snapshot_owned_stream = stream
@@ -3262,8 +3352,8 @@ def test_video_live_view_intent_tracks_the_current_mowing_run(
     assert mower_video_mowing_session_is_current(snapshot) is expected
 
 
-def test_ha_live_stream_arms_balanced_retention_during_snapshot_overlap() -> None:
-    async def _run() -> tuple[bool, bool]:
+def test_ha_live_stream_arms_balanced_retention_after_verified_media() -> None:
+    async def _run() -> tuple[bool, bool, bool, bool]:
         entity = _uninitialized_entity(
             snapshot=SimpleNamespace(state="mowing", activity="mowing")
         )
@@ -3276,9 +3366,16 @@ def test_ha_live_stream_arms_balanced_retention_during_snapshot_overlap() -> Non
 
         entity._async_create_stream_locked = _create_stream
         result = await entity.async_create_stream()
-        return result is stream, entity._video_session_should_stay_warm()
+        warm_before_media = entity._video_session_should_stay_warm()
+        entity._video_first_media_at = 1.0
+        return (
+            result is stream,
+            entity._video_live_view_seen,
+            warm_before_media,
+            entity._video_session_should_stay_warm(),
+        )
 
-    assert asyncio.run(_run()) == (True, True)
+    assert asyncio.run(_run()) == (True, True, False, True)
 
 
 def test_video_camera_idle_monitor_keeps_snapshot_request_alive() -> None:


### PR DESCRIPTION
Fixes #123

## Summary

- retain cached mower video only after decoder-ready media has arrived
- when cached XP2P produces no media, reset the mower video mode, clear stale provisioning, and force the next request through a fresh cloud start
- apply the same recovery to relay-idle and Home Assistant Stream-idle cleanup
- make the supervised playback probe capture HLS consumers together, preserve playback evidence independently from snapshots, and dock only movement it initiated

## Behavior

Working cached streams still use the configured retention mode. A zero-frame cached start is retired instead of being kept alive by reconnecting dashboard consumers, so the following request can re-arm video from a fresh source.

## Live A2 validation

The exact branch candidate was loaded into a clean temporary Home Assistant runtime against the EU A2 account while the mower was active:

- fresh cloud route: HLS returned HTTP 200 with a valid initialized MP4 segment; 100 frames decoded at 640x360 from 456,671 playable bytes
- persisted cache route after integration reload: 100 frames decoded at 640x360 with `last_video_transport=cached_xp2p`
- after the required authoritative mower-state refresh, runtime-input and camera-toggle methods were blocked; the cached stream made zero blocked video-provisioning calls and used `video_provisioning_cache`
- the decoded candidate frame was visually inspected and contained a current mower view
- the candidate camera was turned off and its HA stream was cleared after proof

The mower was already mowing when validation began, so the probe did not claim or interrupt that mission. The installed Home Assistant camera was reset to idle after a separate camera-proxy check.

## Validation

- full test suite under WSL, with one expected skip
- focused camera, FLV relay, and supervised-probe tests
- Ruff, compilation, and diff checks
- installed Home Assistant 2026.7.4 camera proxy returned a valid 43,343-byte JPEG

The temporary HA runtime did not return a separate `async_camera_image` JPEG even though HLS playback decoded successfully. The probe now reports that snapshot result independently; the installed HA camera-proxy path produced and displayed a valid image.