### PR TITLE
Fix mower dock state when charging is paused

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ brand name:
 | Brand and model | Raw model identifier | Support | Confirmed coverage |
 | --- | --- | --- | --- |
 | Dreame A2 | `dreame.mower.g2408` | **Validated** | Primary development mower; core control, schedules, maps, remote control, guarded preferences, diagnostics, video, and 3D maps |
+| Dreame A2 3000 | `dreame.mower.g2568d` | **Field-reported** | Home Assistant discovery, core state entities, and heartbeat docking state on firmware `4.3.6_0625`; broader controls and media still need live validation |
 | Dreame A3 AWD 1000 | `dreame.mower.q2501a` | **Validated** | Core entities, mower state, maps, and cloud live video on firmware `4.3.6_0418` with an EU account |
 | MOVA LiDAX Ultra 1000 | `mova.mower.g2529c` | **Field-reported** | MOVAhome EU login, commands, battery, and model-specific cloud property handling |
 | Dreame A3 AWD Pro 3500 | `dreame.mower.g2541e` | **Recognized** | Model mapping and diagnostics report; broader live confirmation is still needed |

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -236,7 +236,7 @@ def decode_mower_status_blob(
     heartbeat_docking_state = None
     heartbeat_docking_state_name = None
     heartbeat_docked = None
-    if frame_valid and len(raw) > 14:
+    if frame_valid and len(raw) == 20:
         heartbeat_docking_state = (raw[14] & 0x1C) >> 2
         heartbeat_docking_state_name = _HEARTBEAT_DOCKING_STATES.get(
             heartbeat_docking_state

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -207,7 +207,8 @@ def decode_mower_status_blob(
 
     The Dreamehome app exposes this as a framed byte array. We preserve indexed
     bytes for cross-device comparison and decode only the battery, charging,
-    and task-state fields confirmed by fixtures and supervised transitions.
+    docking, and task-state fields confirmed by app logic, fixtures, and
+    supervised transitions.
     """
     raw = _normalize_byte_array(value)
     if raw is None:
@@ -232,6 +233,17 @@ def decode_mower_status_blob(
         if normalized_battery <= 100:
             candidate_battery_level = normalized_battery
 
+    heartbeat_docking_state = None
+    heartbeat_docking_state_name = None
+    heartbeat_docked = None
+    if frame_valid and len(raw) > 14:
+        heartbeat_docking_state = (raw[14] & 0x1C) >> 2
+        heartbeat_docking_state_name = _HEARTBEAT_DOCKING_STATES.get(
+            heartbeat_docking_state
+        )
+        if heartbeat_docking_state_name is not None:
+            heartbeat_docked = heartbeat_docking_state == 0
+
     task_state = _decode_heartbeat_task_state(raw, frame_valid=frame_valid)
     notes.extend(task_state.pop("notes", ()))
 
@@ -251,6 +263,9 @@ def decode_mower_status_blob(
         bytes_by_index={str(index): item for index, item in enumerate(raw)},
         candidate_battery_level=candidate_battery_level,
         heartbeat_charging=heartbeat_charging,
+        heartbeat_docking_state=heartbeat_docking_state,
+        heartbeat_docking_state_name=heartbeat_docking_state_name,
+        heartbeat_docked=heartbeat_docked,
         main_state=task_state.get("main_state"),
         sub_state=task_state.get("sub_state"),
         task_status=task_state.get("task_status"),
@@ -275,6 +290,14 @@ def decode_mower_status_blob(
 
 
 _HEARTBEAT_MOWING_MAIN_STATE = 4
+_HEARTBEAT_DOCKING_STATES = {
+    0: "in_station",
+    1: "out_of_station",
+    2: "docking_paused",
+    3: "docking_finished",
+    4: "docking_failed",
+    5: "docking_in_base",
+}
 _HEARTBEAT_TASK_SUBSTATE_BASE = 33
 _HEARTBEAT_TASK_STATUSES = {
     0: "idle",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -533,7 +533,7 @@ class DreameLawnMowerClient(
             )
         except DreameLawnMowerConnectionError:
             status_blob = None
-        if status_blob is not None and status_blob.task_status is not None:
+        if status_blob is not None:
             snapshot = snapshot_with_heartbeat_task_state(snapshot, status_blob)
 
         try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
@@ -6,10 +6,10 @@ lifecycle notifications, and operating conditions, so numeric overlap with a
 vacuum code is not evidence of a mower fault.
 
 The base registry is the mower community's cross-model table. The A2 overrides
-come from the g2408 Dreame app plugin fault catalog, whose FAULT/ALERT/INFO
-metadata distinguishes hard faults from notifications. Unknown codes remain
-visible but are never promoted to hard faults solely because a vacuum enum
-happens to contain the same number.
+come from the equivalent g2408 and g2568 Dreame app plugin fault catalogs,
+whose FAULT/ALERT/INFO metadata distinguishes hard faults from notifications.
+Unknown codes remain visible but are never promoted to hard faults solely
+because a vacuum enum happens to contain the same number.
 """
 
 from __future__ import annotations
@@ -145,9 +145,9 @@ _BASE_DEVICE_CODES: Final[dict[int, MowerDeviceCodeDefinition]] = {
 }
 
 
-# Dreame A2 / g2408 app-plugin differences. In particular, 16 and 59 do not
-# mean what the cross-model registry says, and human detection is an attention
-# notice rather than a hard fault.
+# Dreame A2 g2408/g2568 app-plugin differences. In particular, 16 and 59 do
+# not mean what the cross-model registry says, and human detection is an
+# attention notice rather than a hard fault.
 _A2_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
     **_definitions(
         MowerDeviceCodeTier.ERROR,
@@ -202,7 +202,14 @@ _MOVA_DEVICE_CODE_OVERRIDES: Final[dict[int, MowerDeviceCodeDefinition]] = {
     ),
 }
 
-_A2_MODELS: Final[frozenset[str]] = frozenset({"dreame.mower.g2408", "g2408"})
+_A2_MODELS: Final[frozenset[str]] = frozenset(
+    {
+        "dreame.mower.g2408",
+        "dreame.mower.g2568d",
+        "g2408",
+        "g2568d",
+    }
+)
 _A1_MODELS: Final[frozenset[str]] = frozenset(
     {
         "dreame.mower.p2255",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -29,6 +29,7 @@ MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
     "dreame.mower.g2408": "A2",
+    "dreame.mower.g2568d": "A2 3000",
     "dreame.mower.g2541e": "A3 AWD Pro 3500",
     "dreame.mower.q2501a": "A3 AWD 1000",
     "mova.mower.g2529c": "LiDAX Ultra 1000",
@@ -537,6 +538,9 @@ class DreameLawnMowerStatusBlob:
     bytes_by_index: Mapping[str, int] = field(default_factory=dict)
     candidate_battery_level: int | None = None
     heartbeat_charging: bool | None = None
+    heartbeat_docking_state: int | None = None
+    heartbeat_docking_state_name: str | None = None
+    heartbeat_docked: bool | None = None
     main_state: int | None = None
     sub_state: int | None = None
     task_status: str | None = None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -22,18 +22,41 @@ def snapshot_with_heartbeat_task_state(
     snapshot: DreameLawnMowerSnapshot,
     status_blob: DreameLawnMowerStatusBlob,
 ) -> DreameLawnMowerSnapshot:
-    """Apply heartbeat-confirmed mowing-session state to a snapshot."""
+    """Apply heartbeat-confirmed task and physical docking state."""
     task_status = status_blob.task_status
-    if task_status is None:
+    changes: dict[str, Any] = {}
+    if task_status is not None:
+        changes.update(
+            task_status=task_status,
+            task_status_name=task_status.replace("_", " ").title(),
+            task_status_source=f"heartbeat_{status_blob.source or 'unknown'}",
+            mowing_session_active=status_blob.mowing_session_active,
+            task_resumable=status_blob.task_resumable,
+        )
+
+    if status_blob.heartbeat_docked is True:
+        changes.update(raw_docked=True, docked=True)
+        stale_paused_state = snapshot.state in {"paused", "monitoring_paused"}
+        if (
+            status_blob.mowing_session_active is False
+            and snapshot.activity == "paused"
+            and stale_paused_state
+        ):
+            # Some firmware leaves property 2.1 at a paused/event state while
+            # the heartbeat and app both report an idle mower in the station.
+            changes.update(
+                state="idle",
+                state_name="idle",
+                activity="docked",
+                started=False,
+                paused=False,
+                mowing=False,
+                returning=False,
+            )
+
+    if not changes:
         return snapshot
-    return replace(
-        snapshot,
-        task_status=task_status,
-        task_status_name=task_status.replace("_", " ").title(),
-        task_status_source=f"heartbeat_{status_blob.source or 'unknown'}",
-        mowing_session_active=status_blob.mowing_session_active,
-        task_resumable=status_blob.task_resumable,
-    )
+    return replace(snapshot, **changes)
 
 
 def snapshot_with_cloud_presence(

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -414,8 +414,8 @@ SENSORS = [
     DreameSensorDescription(
         key="mower_state",
         name="Mower State",
-        value_fn=lambda snapshot: _raw_attribute(snapshot, "mower_state"),
-        exists_fn=lambda snapshot: bool(_raw_attribute(snapshot, "mower_state")),
+        value_fn=lambda snapshot: snapshot.mower_state,
+        exists_fn=lambda snapshot: bool(snapshot.mower_state),
         icon="mdi:robot-mower-outline",
         entity_category=EntityCategory.DIAGNOSTIC,
     ),

--- a/tests/test_a2_paused_fixture.py
+++ b/tests/test_a2_paused_fixture.py
@@ -15,6 +15,7 @@ def _snapshot() -> SimpleNamespace:
     values = payload["data"]["snapshot"]
     return SimpleNamespace(
         **values,
+        mower_state=values["state"],
         mower_state_name=values["state_name"],
         mowing_task_status_name=values["task_status_name"],
         mowing_mode_name=values["cleaning_mode_name"],

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -264,6 +264,9 @@ def test_status_blob_decoder_accepts_a3_awd_pro_22_byte_frame() -> None:
     assert decoded.candidate_battery_level == 100
     assert decoded.candidate_runtime_pose_x == 0
     assert decoded.candidate_runtime_pose_y == 0
+    assert decoded.heartbeat_docking_state is None
+    assert decoded.heartbeat_docking_state_name is None
+    assert decoded.heartbeat_docked is None
 
 
 def test_status_blob_decoder_does_not_treat_heartbeat_bytes_as_pose() -> None:

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -316,6 +316,41 @@ def test_status_blob_decoder_exposes_paused_resumable_session_at_dock() -> None:
     assert decoded.task_status == "paused"
     assert decoded.mowing_session_active is True
     assert decoded.task_resumable is True
+    assert decoded.heartbeat_docking_state == 0
+    assert decoded.heartbeat_docking_state_name == "in_station"
+    assert decoded.heartbeat_docked is True
+
+
+def test_status_blob_decoder_exposes_out_of_station_state() -> None:
+    decoded = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            128,
+            0,
+            128,
+            87,
+            113,
+            255,
+            4,
+            0,
+            128,
+            206,
+            186,
+            206,
+        ]
+    )
+
+    assert decoded is not None
+    assert decoded.heartbeat_docking_state == 1
+    assert decoded.heartbeat_docking_state_name == "out_of_station"
+    assert decoded.heartbeat_docked is False
 
 
 def test_status_blob_decoder_removes_charging_flag_from_battery_byte() -> None:

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -118,6 +118,22 @@ def test_descriptor_maps_known_model_names() -> None:
     assert descriptor.title == "Garage Mower (A2)"
 
 
+def test_descriptor_maps_a2_3000_model_name() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-127",
+            "model": "dreame.mower.g2568d",
+            "customName": "Garden Mower",
+        },
+        account_type="dreame",
+        country="eu",
+    )
+
+    assert descriptor is not None
+    assert descriptor.display_model == "A2 3000"
+    assert descriptor.title == "Garden Mower (A2 3000)"
+
+
 def test_descriptor_uses_cloud_display_name_for_unknown_rebadge_model() -> None:
     descriptor = descriptor_from_cloud_record(
         {

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -133,6 +133,20 @@ def test_mower_fault_codes_override_vacuum_labels(
     assert snapshot.error_display == expected
 
 
+def test_a2_3000_uses_a2_maintenance_point_notice_catalog() -> None:
+    snapshot = _snapshot(
+        75,
+        "unknown",
+        realtime_error_code=75,
+        model="dreame.mower.g2568d",
+    )
+
+    assert snapshot.error_code is None
+    assert snapshot.status_notice_code == 75
+    assert snapshot.status_notice_name == "maintenance_point_reached"
+    assert snapshot.status_notice_display == "Maintenance point reached"
+
+
 @pytest.mark.parametrize(
     ("code", "inherited_name", "state", "expected_activity", "expected_notice"),
     [

--- a/tests/test_mower_terminology.py
+++ b/tests/test_mower_terminology.py
@@ -119,6 +119,7 @@ def test_home_assistant_labels_change_without_changing_entity_keys() -> None:
         18,
     )
     assert _sensor("state_name").value_fn(snapshot) == "spot_mowing"
+    assert _sensor("mower_state").value_fn(snapshot) == "spot_mowing"
     assert _sensor("task_status").value_fn(snapshot) == "zone_mowing_paused"
     assert _binary_sensor("scheduled_task").value_fn(snapshot) is True
 

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from dataclasses import replace
 
+import pytest
+
 from dreame_lawn_mower_client import (
     DreameLawnMowerDescriptor,
     DreameLawnMowerSnapshot,
@@ -16,13 +18,17 @@ snapshot_with_heartbeat_task_state = load_internal_module(
 ).snapshot_with_heartbeat_task_state
 
 
-def _snapshot() -> DreameLawnMowerSnapshot:
+def _snapshot(
+    *,
+    model: str = "dreame.mower.g2568d",
+    display_model: str = "A2 3000",
+) -> DreameLawnMowerSnapshot:
     return DreameLawnMowerSnapshot(
         descriptor=DreameLawnMowerDescriptor(
             did="device-127",
             name="Garden Mower",
-            model="dreame.mower.g2568d",
-            display_model="A2 3000",
+            model=model,
+            display_model=display_model,
             account_type="dreame",
             country="eu",
         ),
@@ -41,7 +47,17 @@ def _snapshot() -> DreameLawnMowerSnapshot:
     )
 
 
-def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot() -> None:
+@pytest.mark.parametrize(
+    ("model", "display_model"),
+    [
+        ("dreame.mower.g2408", "A2"),
+        ("dreame.mower.g2568d", "A2 3000"),
+    ],
+)
+def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
+    model: str,
+    display_model: str,
+) -> None:
     status_blob = decode_mower_status_blob(
         [
             206,
@@ -69,7 +85,10 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot() -> None:
     )
 
     assert status_blob is not None
-    reconciled = snapshot_with_heartbeat_task_state(_snapshot(), status_blob)
+    reconciled = snapshot_with_heartbeat_task_state(
+        _snapshot(model=model, display_model=display_model),
+        status_blob,
+    )
 
     assert reconciled.state == "idle"
     assert reconciled.state_name == "idle"

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -1,0 +1,138 @@
+"""Regression checks for heartbeat/live snapshot reconciliation."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from dreame_lawn_mower_client import (
+    DreameLawnMowerDescriptor,
+    DreameLawnMowerSnapshot,
+    decode_mower_status_blob,
+)
+from dreame_lawn_mower_client._loader import load_internal_module
+
+snapshot_with_heartbeat_task_state = load_internal_module(
+    "runtime_state"
+).snapshot_with_heartbeat_task_state
+
+
+def _snapshot() -> DreameLawnMowerSnapshot:
+    return DreameLawnMowerSnapshot(
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-127",
+            name="Garden Mower",
+            model="dreame.mower.g2568d",
+            display_model="A2 3000",
+            account_type="dreame",
+            country="eu",
+        ),
+        available=True,
+        state="paused",
+        state_name="paused",
+        activity="paused",
+        battery_level=87,
+        charging=False,
+        raw_charging=False,
+        started=False,
+        raw_started=True,
+        docked=False,
+        raw_docked=False,
+        paused=True,
+    )
+
+
+def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot() -> None:
+    status_blob = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            128,
+            87,
+            113,
+            255,
+            0,
+            0,
+            128,
+            206,
+            186,
+            206,
+        ],
+        source="realtime",
+    )
+
+    assert status_blob is not None
+    reconciled = snapshot_with_heartbeat_task_state(_snapshot(), status_blob)
+
+    assert reconciled.state == "idle"
+    assert reconciled.state_name == "idle"
+    assert reconciled.activity == "docked"
+    assert reconciled.docked is True
+    assert reconciled.raw_docked is True
+    assert reconciled.charging is False
+    assert reconciled.raw_charging is False
+    assert reconciled.paused is False
+    assert reconciled.task_status == "idle"
+    assert reconciled.task_status_source == "heartbeat_realtime"
+    assert reconciled.mowing_session_active is False
+
+
+def test_active_paused_session_keeps_task_activity_while_recording_dock() -> None:
+    status_blob = decode_mower_status_blob(
+        [206, 0, 0, 0, 0, 0, 0, 0, 128, 0, 128, 100, 21, 36, 0, 0, 128, 211, 196, 206]
+    )
+
+    assert status_blob is not None
+    reconciled = snapshot_with_heartbeat_task_state(_snapshot(), status_blob)
+
+    assert reconciled.state == "paused"
+    assert reconciled.activity == "paused"
+    assert reconciled.docked is True
+    assert reconciled.raw_docked is True
+    assert reconciled.task_status == "paused"
+    assert reconciled.mowing_session_active is True
+
+
+def test_idle_in_station_heartbeat_preserves_bare_active_error() -> None:
+    status_blob = decode_mower_status_blob(
+        [206, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 87, 113, 255, 0, 0, 128, 206, 186, 206]
+    )
+
+    assert status_blob is not None
+    error_snapshot = replace(_snapshot(), activity="error", error_code=None)
+    reconciled = snapshot_with_heartbeat_task_state(error_snapshot, status_blob)
+
+    assert reconciled.state == "paused"
+    assert reconciled.activity == "error"
+    assert reconciled.docked is True
+    assert reconciled.raw_docked is True
+
+
+def test_idle_in_station_heartbeat_preserves_dock_lifecycle_state() -> None:
+    status_blob = decode_mower_status_blob(
+        [206, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 87, 113, 255, 0, 0, 128, 206, 186, 206]
+    )
+
+    assert status_blob is not None
+    charging_snapshot = replace(
+        _snapshot(),
+        state="charging",
+        state_name="charging",
+        activity="docked",
+        charging=True,
+        raw_charging=True,
+        paused=False,
+    )
+    reconciled = snapshot_with_heartbeat_task_state(charging_snapshot, status_blob)
+
+    assert reconciled.state == "charging"
+    assert reconciled.state_name == "charging"
+    assert reconciled.activity == "docked"
+    assert reconciled.charging is True


### PR DESCRIPTION
Fixes #127

## What changed

- Decode physical dock presence from the confirmed 20-byte mower heartbeat independently from charging.
- Reconcile a stale paused state only when that heartbeat says the mower is idle and in the station.
- Preserve active errors, active paused tasks, and valid dock lifecycle states.
- Make the `Mower State` sensor use the reconciled state while retaining the raw vendor value in diagnostics.
- Recognize `dreame.mower.g2568d` as the Dreame A2 3000 and apply its matching A2 device-code catalog.

## Scope

The heartbeat behavior is not treated as A2 3000-only. The same 20-byte dock field was confirmed on the A2 (`g2408`) and A2 3000 (`g2568d`) path, and reconciliation is owned by the shared mower client. The different 22-byte A3 frame remains excluded until its dock layout is independently confirmed.

The A2 3000 is the model that exposed the bug: it can remain physically docked while scheduled charging is inactive. Its diagnostic heartbeat reported `in_station` and `charging=false`, but the integration ignored the station field and exposed the mower as paused and undocked. Device code `75` remains the A2 maintenance-point notification; it is not the charging-window message.

## Validation

- Replayed the issue diagnostic heartbeat and covered both A2 model identifiers.
- Confirmed the shared heartbeat dock bit against a live A2 and its Home Assistant entities.
- Added negative coverage preventing the A3 22-byte frame from being decoded by assumption.
- Ran the full test suite and repository-wide Ruff checks.