### PR TITLE
Enable the primary map camera by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -349,7 +349,7 @@ Common user-facing helpers include:
 Many reverse-engineering and validation helpers are disabled by default. Enable
 them from the entity registry only when troubleshooting:
 
-- map and all-map cameras
+- live-path and all-map cameras
 - map diagnostics camera
 - runtime pose / heading / segment-count sensors
 - all-schedules calendar
@@ -425,6 +425,11 @@ inspect the complete candidate preference payload before sending it.
 The map camera uses the confirmed app-map JSON path first and falls back to the
 vector source when it carries the active session. Both renderers use the same
 palette, bundled Unicode font, path widths, and marker settings.
+
+The primary `Map` camera is enabled by default and follows the current mowing
+session, including the mower position and live path when the device reports
+them. `Live Path Map`, `All Maps`, and `Map Diagnostics` remain optional,
+disabled-by-default cameras for troubleshooting or specialized dashboards.
 
 Enabled map cameras warm their first image in the background during entity
 startup. While a mowing session is active, coordinator updates also refresh the

--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -6,9 +6,14 @@ import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import Platform
 from homeassistant.core import HomeAssistant
+from homeassistant.helpers import entity_registry as er
 
 from .const import (
+    CONF_DID,
+    CONFIG_ENTRY_MINOR_VERSION,
+    CONFIG_ENTRY_VERSION,
     DOMAIN,
     PLATFORMS,
 )
@@ -25,6 +30,41 @@ from .video_provisioning_cache import DreameLawnMowerVideoProvisioningCache
 
 _LOGGER = logging.getLogger(__name__)
 SLOW_SETUP_SECONDS = 15.0
+
+
+async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
+    """Enable the primary map camera without overriding user choices."""
+    if entry.version > CONFIG_ENTRY_VERSION:
+        return False
+
+    if (
+        entry.version == CONFIG_ENTRY_VERSION
+        and entry.minor_version < CONFIG_ENTRY_MINOR_VERSION
+    ):
+        unique_id = entry.data.get(CONF_DID) or entry.unique_id
+        if unique_id and not entry.pref_disable_new_entities:
+            registry = er.async_get(hass)
+            entity_id = registry.async_get_entity_id(
+                Platform.CAMERA,
+                DOMAIN,
+                f"{unique_id}_map",
+            )
+            if entity_id is not None:
+                registry_entry = registry.async_get(entity_id)
+                if (
+                    registry_entry is not None
+                    and registry_entry.disabled_by
+                    is er.RegistryEntryDisabler.INTEGRATION
+                ):
+                    registry.async_update_entity(entity_id, disabled_by=None)
+
+        hass.config_entries.async_update_entry(
+            entry,
+            version=CONFIG_ENTRY_VERSION,
+            minor_version=CONFIG_ENTRY_MINOR_VERSION,
+        )
+
+    return True
 
 
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -95,7 +95,7 @@ class DreameLawnMowerMapCamera(
     _attr_name = "Map"
     _attr_icon = "mdi:map-search-outline"
     _attr_entity_category = EntityCategory.DIAGNOSTIC
-    _attr_entity_registry_enabled_default = False
+    _attr_entity_registry_enabled_default = True
     _requires_map_capability = True
     _prewarm_map_image = True
     _refresh_cached_view_on_coordinator_update = True
@@ -418,6 +418,7 @@ class DreameLawnMowerLivePathMapCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "Live Path Map"
     _attr_icon = "mdi:map-marker-path"
+    _attr_entity_registry_enabled_default = False
 
     def __init__(
         self,
@@ -460,6 +461,7 @@ class DreameLawnMowerMapDataCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "Map Diagnostics"
     _attr_icon = "mdi:code-json"
+    _attr_entity_registry_enabled_default = False
     _requires_map_capability = False
     _prewarm_map_image = False
 
@@ -543,6 +545,7 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "All Maps"
     _attr_icon = "mdi:map-multiple-outline"
+    _attr_entity_registry_enabled_default = False
     _requires_map_capability = False
     _prewarm_map_image = False
     _refresh_cached_view_on_coordinator_update = False

--- a/custom_components/dreame_lawn_mower/config_flow.py
+++ b/custom_components/dreame_lawn_mower/config_flow.py
@@ -42,6 +42,8 @@ from .const import (
     CONF_XP2P_LIBRARY_PATH,
     CONF_XP2P_RUNNER_COMMAND,
     CONF_XP2P_RUNNER_MODE,
+    CONFIG_ENTRY_MINOR_VERSION,
+    CONFIG_ENTRY_VERSION,
     COUNTRY_OPTIONS,
     DEFAULT_COUNTRY,
     DEFAULT_MAP_LABEL_SCALE,
@@ -113,7 +115,8 @@ def auth_error_key(err: Exception) -> str:
 class DreameLawnMowerConfigFlow(ConfigFlow, domain=DOMAIN):
     """Handle the Dreame lawn mower config flow."""
 
-    VERSION = 1
+    VERSION = CONFIG_ENTRY_VERSION
+    MINOR_VERSION = CONFIG_ENTRY_MINOR_VERSION
 
     def __init__(self) -> None:
         self._devices: dict[str, DreameLawnMowerDescriptor] = {}

--- a/custom_components/dreame_lawn_mower/const.py
+++ b/custom_components/dreame_lawn_mower/const.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from homeassistant.const import Platform
 
 DOMAIN = "dreame_lawn_mower"
+CONFIG_ENTRY_VERSION = 1
+CONFIG_ENTRY_MINOR_VERSION = 2
 
 CONF_ACCOUNT_TYPE = "account_type"
 CONF_COUNTRY = "country"

--- a/tests/components/dreame_lawn_mower/test_config_flow.py
+++ b/tests/components/dreame_lawn_mower/test_config_flow.py
@@ -10,8 +10,10 @@ import voluptuous_serialize
 from homeassistant import config_entries
 from homeassistant.data_entry_flow import FlowResultType
 from homeassistant.helpers import config_validation as cv
+from homeassistant.helpers import entity_registry as er
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 
+from custom_components.dreame_lawn_mower import async_migrate_entry
 from custom_components.dreame_lawn_mower.config_flow import DreameLawnMowerOptionsFlow
 from custom_components.dreame_lawn_mower.const import (
     ACCOUNT_TYPE_DREAME,
@@ -82,6 +84,117 @@ async def _start_user_flow(hass):
             CONF_USERNAME: "user@example.com",
         },
     )
+
+
+@pytest.mark.asyncio
+async def test_migration_enables_only_integration_disabled_primary_map(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="device-1",
+        data={CONF_DID: "device-1"},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    primary_map = registry.async_get_or_create(
+        "camera",
+        DOMAIN,
+        "device-1_map",
+        config_entry=entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+    live_path_map = registry.async_get_or_create(
+        "camera",
+        DOMAIN,
+        "device-1_live_path_map",
+        config_entry=entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert registry.async_get(primary_map.entity_id).disabled_by is None
+    assert (
+        registry.async_get(live_path_map.entity_id).disabled_by
+        is er.RegistryEntryDisabler.INTEGRATION
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_user_disabled_primary_map(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="device-1",
+        data={CONF_DID: "device-1"},
+        version=1,
+    )
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    primary_map = registry.async_get_or_create(
+        "camera",
+        DOMAIN,
+        "device-1_map",
+        config_entry=entry,
+        disabled_by=er.RegistryEntryDisabler.USER,
+    )
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert (
+        registry.async_get(primary_map.entity_id).disabled_by
+        is er.RegistryEntryDisabler.USER
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_preserves_disable_new_entities_preference(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="device-1",
+        data={CONF_DID: "device-1"},
+        version=1,
+        minor_version=1,
+        pref_disable_new_entities=True,
+    )
+    entry.add_to_hass(hass)
+    registry = er.async_get(hass)
+    primary_map = registry.async_get_or_create(
+        "camera",
+        DOMAIN,
+        "device-1_map",
+        config_entry=entry,
+        disabled_by=er.RegistryEntryDisabler.INTEGRATION,
+    )
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 1
+    assert entry.minor_version == 2
+    assert (
+        registry.async_get(primary_map.entity_id).disabled_by
+        is er.RegistryEntryDisabler.INTEGRATION
+    )
+
+
+@pytest.mark.asyncio
+async def test_migration_accepts_future_minor_version_without_changes(hass) -> None:
+    entry = MockConfigEntry(
+        domain=DOMAIN,
+        unique_id="device-1",
+        data={CONF_DID: "device-1"},
+        version=1,
+        minor_version=3,
+    )
+    entry.add_to_hass(hass)
+
+    assert await async_migrate_entry(hass, entry) is True
+
+    assert entry.version == 1
+    assert entry.minor_version == 3
 
 
 @pytest.mark.asyncio

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,18 @@
+"""Shared bootstrap for the lightweight unit-test environment."""
+
+from __future__ import annotations
+
+import sys
+from types import ModuleType
+
+try:
+    import turbojpeg  # noqa: F401
+except ModuleNotFoundError:
+    turbojpeg_stub = ModuleType("turbojpeg")
+
+    class _UnavailableTurboJPEG:
+        def __init__(self) -> None:
+            raise RuntimeError("TurboJPEG is unavailable in the lightweight test job")
+
+    turbojpeg_stub.TurboJPEG = _UnavailableTurboJPEG
+    sys.modules["turbojpeg"] = turbojpeg_stub

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -6,6 +6,12 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+from custom_components.dreame_lawn_mower.camera import (
+    DreameLawnMowerAllMapsCamera,
+    DreameLawnMowerLivePathMapCamera,
+    DreameLawnMowerMapCamera,
+    DreameLawnMowerMapDataCamera,
+)
 from custom_components.dreame_lawn_mower.map_attributes import map_camera_attributes
 from custom_components.dreame_lawn_mower.map_cache import (
     DreameLawnMowerMapCameraCache,
@@ -17,6 +23,15 @@ from dreame_lawn_mower_client.models import (
     DreameLawnMowerMapSummary,
     DreameLawnMowerMapView,
 )
+
+
+def test_primary_map_camera_is_the_only_map_camera_enabled_by_default() -> None:
+    """Users get one useful map entity without enabling diagnostic variants."""
+    enabled_default = "__attr_entity_registry_enabled_default"
+    assert DreameLawnMowerMapCamera.__dict__[enabled_default] is True
+    assert DreameLawnMowerLivePathMapCamera.__dict__[enabled_default] is False
+    assert DreameLawnMowerAllMapsCamera.__dict__[enabled_default] is False
+    assert DreameLawnMowerMapDataCamera.__dict__[enabled_default] is False
 
 
 def test_map_camera_attributes_include_app_map_summary_counts() -> None:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -4,26 +4,12 @@ from __future__ import annotations
 
 import asyncio
 import json
-import sys
 from contextlib import suppress
 from pathlib import Path
-from types import ModuleType, SimpleNamespace
+from types import SimpleNamespace
 from unittest.mock import patch
 
 import pytest
-
-try:
-    import turbojpeg  # noqa: F401
-except ModuleNotFoundError:
-    turbojpeg_stub = ModuleType("turbojpeg")
-
-    class _UnavailableTurboJPEG:
-        def __init__(self) -> None:
-            raise RuntimeError("TurboJPEG is unavailable in the lightweight test job")
-
-    turbojpeg_stub.TurboJPEG = _UnavailableTurboJPEG
-    sys.modules["turbojpeg"] = turbojpeg_stub
-
 from homeassistant.components.camera import CameraEntityFeature
 
 import custom_components.dreame_lawn_mower.video_camera as video_camera_module


### PR DESCRIPTION
## Summary

- enable the primary `Map` camera by default so the active map and live mowing path appear without manual entity-registry setup
- keep `Live Path Map`, `All Maps`, and `Map Diagnostics` opt-in to avoid duplicate and diagnostic camera noise
- migrate existing entries only when Home Assistant disabled the primary map on behalf of the integration, while preserving user-disabled entities and the "disable newly added entities" preference

## Runtime evidence

The existing map engine was verified against the live A2 while it was mowing. The primary `Map` camera and the dedicated `Live Path Map` both returned valid current-session images with the mower marker and mowing track, confirming this was an entity-default problem rather than a missing renderer.

The migration and map-camera defaults are covered by focused Home Assistant tests, and the full integration test suite remains green.

Closes #129