### PR TITLE
Reduce map camera load during active mowing

### DIFF
--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -7,6 +7,7 @@ import logging
 from datetime import timedelta
 from functools import partial
 from pathlib import Path
+from time import monotonic
 from typing import Any
 
 from homeassistant.components.camera import Camera
@@ -54,6 +55,7 @@ from .map_cache import (
     DreameLawnMowerMapCameraCache,
     map_camera_available,
     map_camera_followup_refresh_required,
+    map_camera_refresh_demand_active,
     map_camera_should_refresh,
 )
 from .point_cloud_api import current_point_cloud_api_path
@@ -63,6 +65,7 @@ _LOGGER = logging.getLogger(__name__)
 _MAP_CACHE_TTL = timedelta(seconds=60)
 _MAP_TIMEOUT_SECONDS = 6.0
 _MAP_POLL_INTERVAL_SECONDS = 0.5
+_MAP_ACTIVE_REFRESH_WINDOW_SECONDS = 90.0
 
 
 async def async_setup_entry(
@@ -74,11 +77,12 @@ async def async_setup_entry(
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
     map_cache = DreameLawnMowerMapCameraCache(ttl=_MAP_CACHE_TTL)
     live_map_cache = DreameLawnMowerMapCameraCache(ttl=_MAP_CACHE_TTL)
+    all_maps_cache = DreameLawnMowerMapCameraCache(ttl=_MAP_CACHE_TTL)
     async_add_entities(
         [
             DreameLawnMowerMapCamera(coordinator, map_cache),
             DreameLawnMowerLivePathMapCamera(coordinator, live_map_cache),
-            DreameLawnMowerAllMapsCamera(coordinator, map_cache),
+            DreameLawnMowerAllMapsCamera(coordinator, all_maps_cache),
             DreameLawnMowerMapDataCamera(coordinator, map_cache),
             DreameLawnMowerVideoCamera(coordinator, entry),
         ]
@@ -130,10 +134,12 @@ class DreameLawnMowerMapCamera(
         self._map_refresh_task: asyncio.Task[bytes | None] | None = None
         self._map_refresh_pending = False
         self._last_refresh_context: tuple[Any, ...] | None = None
+        self._last_image_request_at: float | None = None
 
     async def async_added_to_hass(self) -> None:
         """Warm an enabled map camera without delaying entity setup."""
         await super().async_added_to_hass()
+        self._last_refresh_context = self._map_refresh_context
         if self._prewarm_map_image and self.available:
             self._start_map_refresh()
 
@@ -155,6 +161,11 @@ class DreameLawnMowerMapCamera(
             context_changed=context != self._last_refresh_context,
             runtime_active=active,
             manages_cached_view=self._refresh_cached_view_on_coordinator_update,
+            demand_active=map_camera_refresh_demand_active(
+                self._last_image_request_at,
+                now=monotonic(),
+                window_seconds=_MAP_ACTIVE_REFRESH_WINDOW_SECONDS,
+            ),
         ):
             self._last_refresh_context = context
             self._map_cache.invalidate_view()
@@ -222,6 +233,11 @@ class DreameLawnMowerMapCamera(
         del width, height
         if not self.available:
             return None
+        self._last_image_request_at = monotonic()
+        context = self._map_refresh_context
+        if context != self._last_refresh_context:
+            self._last_refresh_context = context
+            self._map_cache.invalidate_view()
         return await self._async_camera_image_impl()
 
     async def _async_camera_image_impl(self) -> bytes | None:
@@ -419,6 +435,7 @@ class DreameLawnMowerLivePathMapCamera(DreameLawnMowerMapCamera):
     _attr_name = "Live Path Map"
     _attr_icon = "mdi:map-marker-path"
     _attr_entity_registry_enabled_default = False
+    _refresh_cached_view_on_coordinator_update = False
 
     def __init__(
         self,
@@ -464,6 +481,7 @@ class DreameLawnMowerMapDataCamera(DreameLawnMowerMapCamera):
     _attr_entity_registry_enabled_default = False
     _requires_map_capability = False
     _prewarm_map_image = False
+    _refresh_cached_view_on_coordinator_update = False
 
     def __init__(
         self,
@@ -560,13 +578,29 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
         self.content_type = "image/jpeg"
 
     async def _async_camera_image_impl(self) -> bytes | None:
-        """Return a JPEG contact sheet for every drawable app map."""
+        """Return cached bytes while one contact-sheet refresh runs."""
+        if self._map_cache.last_image is not None:
+            if not self._map_cache.is_fresh():
+                self._start_map_refresh()
+            return self._map_cache.last_image
+
+        self._start_map_refresh()
+        return await self.hass.async_add_executor_job(
+            partial(
+                map_placeholder_jpeg,
+                title="Dreame all maps loading",
+                detail="The map contact sheet is being prepared in the background.",
+            )
+        )
+
+    async def _async_refresh_and_render_map_image(self) -> bytes | None:
+        """Fetch and cache a contact sheet without blocking camera requests."""
         try:
             app_maps = await self.coordinator.client.async_get_app_maps(
                 include_payload=True,
                 include_objects=False,
             )
-            return await self.hass.async_add_executor_job(
+            image = await self.hass.async_add_executor_job(
                 partial(
                     _all_maps_contact_sheet_from_payload,
                     app_maps,
@@ -574,6 +608,12 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
                     style=self._map_style,
                 )
             )
+            self._map_cache.store_view(
+                DreameLawnMowerMapView(source="app_maps_contact_sheet")
+            )
+            self._map_cache.store_image(image)
+            self.async_write_ha_state()
+            return image
         except Exception as err:
             safe_error = sanitize_diagnostic_text(err)
             _LOGGER.warning(
@@ -585,13 +625,12 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
                 source="map_camera",
                 message=safe_error,
             )
-            return await self.hass.async_add_executor_job(
-                partial(
-                    map_placeholder_jpeg,
-                    title="Dreame all maps unavailable",
-                    detail=safe_error,
-                )
+            self._map_cache.store_error(
+                safe_error,
+                source="app_maps_contact_sheet",
             )
+            self.async_write_ha_state()
+            return self._map_cache.last_image
 
 
 def _all_maps_contact_sheet_from_payload(

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -210,6 +210,7 @@ class DreameLawnMowerMapCamera(
             image_cached=self._map_cache.last_image is not None,
             refreshed_at=self._map_cache.last_refresh_at,
             last_error=self._map_cache.last_error,
+            image_placeholder=self._map_cache.last_image_is_placeholder,
             runtime_status_blob=getattr(
                 self.coordinator,
                 "runtime_status_blob",
@@ -638,7 +639,7 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
                         detail=safe_error,
                     )
                 )
-                self._map_cache.store_image(image)
+                self._map_cache.store_image(image, placeholder=True)
             self.async_write_ha_state()
             return image
 

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -629,8 +629,18 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
                 safe_error,
                 source="app_maps_contact_sheet",
             )
+            image = self._map_cache.last_image
+            if image is None:
+                image = await self.hass.async_add_executor_job(
+                    partial(
+                        map_placeholder_jpeg,
+                        title="Dreame all maps unavailable",
+                        detail=safe_error,
+                    )
+                )
+                self._map_cache.store_image(image)
             self.async_write_ha_state()
-            return self._map_cache.last_image
+            return image
 
 
 def _all_maps_contact_sheet_from_payload(

--- a/custom_components/dreame_lawn_mower/map_attributes.py
+++ b/custom_components/dreame_lawn_mower/map_attributes.py
@@ -51,12 +51,13 @@ def map_camera_attributes(
     refreshed_at: datetime | None,
     last_error: str | None,
     runtime_status_blob: Any = None,
+    image_placeholder: bool = False,
 ) -> dict[str, Any]:
     """Return Home Assistant attributes for a cached map camera view."""
     summary = map_summary_to_dict(None if view is None else view.summary)
     attributes: dict[str, Any] = {
-        "map_cached": image_cached,
-        "map_placeholder": not image_cached,
+        "map_cached": image_cached and not image_placeholder,
+        "map_placeholder": not image_cached or image_placeholder,
         "map_source": None if view is None else view.source,
         "map_has_image": False if view is None else view.has_image,
         "map_error": last_error or (None if view is None else view.error),

--- a/custom_components/dreame_lawn_mower/map_cache.py
+++ b/custom_components/dreame_lawn_mower/map_cache.py
@@ -73,6 +73,7 @@ class DreameLawnMowerMapCameraCache:
     last_image: bytes | None = None
     last_image_source_sha256: str | None = None
     last_image_render_context: Any = None
+    last_image_is_placeholder: bool = False
     last_view: DreameLawnMowerMapView | None = None
     last_refresh_at: datetime | None = None
     last_error: str | None = None
@@ -156,6 +157,7 @@ class DreameLawnMowerMapCameraCache:
         *,
         source_image: bytes | None = None,
         render_context: Any = None,
+        placeholder: bool = False,
     ) -> None:
         """Store rendered JPEG bytes for reuse by both map camera entities."""
         self.last_image = image
@@ -163,6 +165,7 @@ class DreameLawnMowerMapCameraCache:
             sha256(source_image).hexdigest() if source_image is not None else None
         )
         self.last_image_render_context = render_context
+        self.last_image_is_placeholder = placeholder
 
     def invalidate_view(self) -> None:
         """Expire source metadata while preserving the last good image."""

--- a/custom_components/dreame_lawn_mower/map_cache.py
+++ b/custom_components/dreame_lawn_mower/map_cache.py
@@ -19,9 +19,23 @@ def map_camera_should_refresh(
     context_changed: bool,
     runtime_active: bool,
     manages_cached_view: bool = True,
+    demand_active: bool = True,
 ) -> bool:
     """Return whether a coordinator update should refresh a cached map view."""
-    return manages_cached_view and (context_changed or runtime_active)
+    return manages_cached_view and demand_active and (context_changed or runtime_active)
+
+
+def map_camera_refresh_demand_active(
+    last_request_at: float | None,
+    *,
+    now: float,
+    window_seconds: float,
+) -> bool:
+    """Return whether a recent image request warrants background refreshes."""
+    if last_request_at is None or window_seconds <= 0:
+        return False
+    age = now - last_request_at
+    return 0 <= age <= window_seconds
 
 
 def map_camera_followup_refresh_required(

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -6,6 +6,7 @@ import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
+from custom_components.dreame_lawn_mower import camera as camera_module
 from custom_components.dreame_lawn_mower.camera import (
     DreameLawnMowerAllMapsCamera,
     DreameLawnMowerLivePathMapCamera,
@@ -243,6 +244,47 @@ def test_all_maps_camera_serves_stale_image_during_background_refresh() -> None:
 
     assert image == b"cached-contact-sheet"
     assert refresh_calls == 1
+
+
+def test_all_maps_camera_caches_failure_placeholder_until_ttl(monkeypatch) -> None:
+    """A failed cloud fetch must not be retried on every HA camera poll."""
+    cache = DreameLawnMowerMapCameraCache(ttl=timedelta(seconds=60))
+    entity = object.__new__(DreameLawnMowerAllMapsCamera)
+    entity._map_cache = cache
+    cloud_calls = 0
+    refresh_calls = 0
+
+    async def async_get_app_maps(**kwargs: object) -> dict[str, object]:
+        nonlocal cloud_calls
+        del kwargs
+        cloud_calls += 1
+        raise TimeoutError("cloud timeout")
+
+    async def async_add_executor_job(target: object) -> bytes:
+        return target()  # type: ignore[operator]
+
+    def start_refresh() -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+
+    entity.coordinator = SimpleNamespace(
+        client=SimpleNamespace(async_get_app_maps=async_get_app_maps)
+    )
+    entity.hass = SimpleNamespace(async_add_executor_job=async_add_executor_job)
+    entity.async_write_ha_state = lambda: None  # type: ignore[method-assign]
+    monkeypatch.setattr(camera_module, "record_diagnostic_event", lambda *a, **k: None)
+
+    failure_image = asyncio.run(entity._async_refresh_and_render_map_image())
+    entity._start_map_refresh = start_refresh  # type: ignore[method-assign]
+    repeated_image = asyncio.run(entity._async_camera_image_impl())
+
+    assert failure_image is not None
+    assert failure_image.startswith(b"\xff\xd8")
+    assert repeated_image == failure_image
+    assert cache.is_fresh() is True
+    assert cache.last_error == "cloud timeout"
+    assert cloud_calls == 1
+    assert refresh_calls == 0
 
 
 def test_map_camera_queues_new_context_after_inflight_refresh() -> None:

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -17,6 +17,7 @@ from custom_components.dreame_lawn_mower.map_cache import (
     DreameLawnMowerMapCameraCache,
     map_camera_available,
     map_camera_followup_refresh_required,
+    map_camera_refresh_demand_active,
     map_camera_should_refresh,
 )
 from dreame_lawn_mower_client.models import (
@@ -32,6 +33,14 @@ def test_primary_map_camera_is_the_only_map_camera_enabled_by_default() -> None:
     assert DreameLawnMowerLivePathMapCamera.__dict__[enabled_default] is False
     assert DreameLawnMowerAllMapsCamera.__dict__[enabled_default] is False
     assert DreameLawnMowerMapDataCamera.__dict__[enabled_default] is False
+
+
+def test_optional_map_cameras_refresh_only_when_requested() -> None:
+    """Enabling diagnostic map variants must not create background render loops."""
+    refresh_policy = "_refresh_cached_view_on_coordinator_update"
+    assert DreameLawnMowerLivePathMapCamera.__dict__[refresh_policy] is False
+    assert DreameLawnMowerAllMapsCamera.__dict__[refresh_policy] is False
+    assert DreameLawnMowerMapDataCamera.__dict__[refresh_policy] is False
 
 
 def test_map_camera_attributes_include_app_map_summary_counts() -> None:
@@ -138,6 +147,102 @@ def test_all_maps_camera_skips_cached_view_refresh_on_coordinator_updates() -> N
         )
         is False
     )
+
+
+def test_map_camera_background_refresh_requires_recent_viewer_demand() -> None:
+    """Mowing updates alone must not keep an unviewed map renderer active."""
+    assert (
+        map_camera_should_refresh(
+            context_changed=True,
+            runtime_active=True,
+            demand_active=False,
+        )
+        is False
+    )
+    assert (
+        map_camera_should_refresh(
+            context_changed=False,
+            runtime_active=True,
+            demand_active=True,
+        )
+        is True
+    )
+
+
+def test_map_camera_refresh_demand_expires_after_window() -> None:
+    assert (
+        map_camera_refresh_demand_active(
+            100.0,
+            now=190.0,
+            window_seconds=90.0,
+        )
+        is True
+    )
+    assert (
+        map_camera_refresh_demand_active(
+            100.0,
+            now=190.001,
+            window_seconds=90.0,
+        )
+        is False
+    )
+    assert (
+        map_camera_refresh_demand_active(
+            None,
+            now=190.0,
+            window_seconds=90.0,
+        )
+        is False
+    )
+
+
+def test_all_maps_camera_returns_loading_image_while_refresh_starts() -> None:
+    """An empty contact-sheet cache must not block HA's camera response."""
+    cache = DreameLawnMowerMapCameraCache(ttl=timedelta(seconds=60))
+    entity = object.__new__(DreameLawnMowerAllMapsCamera)
+    entity._map_cache = cache
+    refresh_calls = 0
+
+    async def async_add_executor_job(target: object) -> bytes:
+        return target()  # type: ignore[operator]
+
+    def start_refresh() -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+
+    entity.hass = SimpleNamespace(async_add_executor_job=async_add_executor_job)
+    entity._start_map_refresh = start_refresh  # type: ignore[method-assign]
+
+    image = asyncio.run(entity._async_camera_image_impl())
+
+    assert image is not None
+    assert image.startswith(b"\xff\xd8")
+    assert refresh_calls == 1
+    assert cache.last_image is None
+
+
+def test_all_maps_camera_serves_stale_image_during_background_refresh() -> None:
+    """A slow refresh must not blank or delay the last good contact sheet."""
+    cache = DreameLawnMowerMapCameraCache(ttl=timedelta(seconds=60))
+    cache.store_view(
+        DreameLawnMowerMapView(source="app_maps_contact_sheet"),
+        now=datetime(2026, 4, 19, 8, 0, tzinfo=UTC),
+    )
+    cache.store_image(b"cached-contact-sheet")
+    entity = object.__new__(DreameLawnMowerAllMapsCamera)
+    entity._map_cache = cache
+    refresh_calls = 0
+
+    def start_refresh() -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+
+    entity._start_map_refresh = start_refresh  # type: ignore[method-assign]
+
+    image = asyncio.run(entity._async_camera_image_impl())
+
+    assert image == b"cached-contact-sheet"
+    assert refresh_calls == 1
 
 
 def test_map_camera_queues_new_context_after_inflight_refresh() -> None:

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -283,8 +283,30 @@ def test_all_maps_camera_caches_failure_placeholder_until_ttl(monkeypatch) -> No
     assert repeated_image == failure_image
     assert cache.is_fresh() is True
     assert cache.last_error == "cloud timeout"
+    assert cache.last_image_is_placeholder is True
     assert cloud_calls == 1
     assert refresh_calls == 0
+
+    attributes = map_camera_attributes(
+        cache.last_view,
+        image_cached=cache.last_image is not None,
+        image_placeholder=cache.last_image_is_placeholder,
+        refreshed_at=cache.last_refresh_at,
+        last_error=cache.last_error,
+    )
+    assert attributes["map_cached"] is False
+    assert attributes["map_placeholder"] is True
+
+    cache.last_refresh_at = datetime.now(UTC) - timedelta(seconds=61)
+    expired_image = asyncio.run(entity._async_camera_image_impl())
+    assert expired_image == failure_image
+    assert refresh_calls == 1
+
+    cache.store_image(b"last-good-contact-sheet")
+    preserved_image = asyncio.run(entity._async_refresh_and_render_map_image())
+    assert preserved_image == b"last-good-contact-sheet"
+    assert cache.last_image_is_placeholder is False
+    assert cloud_calls == 2
 
 
 def test_map_camera_queues_new_context_after_inflight_refresh() -> None:


### PR DESCRIPTION
## What changes

- prewarm the primary Map once, then run coordinator-driven background renders only while the map has a recent viewer
- make Live Path Map and Map Diagnostics refresh on camera requests instead of every mowing update
- give All Maps its own stale-while-refresh cache, return a loading image immediately, and back off failed fetches for the cache TTL
- keep cached failure placeholders distinct from successful map images in entity attributes

## Why

With all four map cameras enabled during an A2 mowing session, repeated camera requests produced a transient host-memory increase and the All Maps camera repeatedly exceeded Home Assistant's roughly 10-second camera response window. Memory largely recovered after requests stopped, so the evidence points to duplicate concurrent fetch/render pressure rather than a steadily retained leak.

Point-cloud/3D handling remains unchanged: its backend cache is already bounded and the frontend already caps points and disposes Three.js resources.

Related to #129.

## Validation

- Ruff across the repository
- 1,313 tests passed and 1 skipped locally
- read-only live A2 map, camera, point-cloud, latency, and host-memory measurements
- independent cache/task-lifetime review with the identified failure-backoff issue addressed