### PR TITLE
Prevent optional cloud timeout log floods

### DIFF
--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -53,6 +53,7 @@ from .dreame_lawn_mower_client.schedule import (
 from .performance import DreameLawnMowerPerformanceTracker
 from .runtime_cache import DreameLawnMowerRuntimeTelemetryCache
 from .schedule_cache import (
+    ScheduleActionReadBackoff,
     has_complete_schedule_cache,
     invalidate_schedule_slot,
     merge_app_schedule_payload,
@@ -127,6 +128,7 @@ class DreameLawnMowerCoordinator(
         self.voice_settings_refreshed_at: datetime | None = None
         self.schedules: dict[str, Any] | None = None
         self.schedules_refreshed_at: datetime | None = None
+        self._schedule_action_read_backoff = ScheduleActionReadBackoff()
         self._schedule_cache_generation = 0
         self._schedule_read_generation = 0
         self._published_schedule_read_generation = 0
@@ -472,25 +474,49 @@ class DreameLawnMowerCoordinator(
                 if fallback_index not in request_schedule_indices:
                     request_schedule_indices.append(fallback_index)
 
-        try:
-            action_read_generation = self._begin_schedule_read()
-            payload = await self.client.async_get_app_schedules(
-                include_current_task=False,
-                map_indices=request_schedule_indices,
-            )
-        except Exception as err:  # noqa: BLE001 - optional cloud capability
-            _LOGGER.debug("Failed to refresh mower schedules: %s", err)
-            if force:
-                raise
-            return self.schedules
-        if not self._schedule_refresh_is_current(refresh_generation):
-            return self.schedules
-        action_read_succeeded = schedule_payload_has_usable_data(payload)
-        if (
-            action_read_succeeded
-            and not self._schedule_read_can_publish(action_read_generation)
-        ):
-            return self.schedules
+        action_backoff = getattr(self, "_schedule_action_read_backoff", None)
+        if not isinstance(action_backoff, ScheduleActionReadBackoff):
+            action_backoff = ScheduleActionReadBackoff()
+            self._schedule_action_read_backoff = action_backoff
+        attempt_action_read = action_backoff.permits(now, force=force)
+        action_read_generation: int | None = None
+        action_read_succeeded = False
+        payload: Mapping[str, Any] = {
+            "source": "app_action_schedule",
+            "available": False,
+            "schedules": [],
+            "errors": [],
+        }
+        if attempt_action_read:
+            try:
+                action_read_generation = self._begin_schedule_read()
+                payload = await self.client.async_get_app_schedules(
+                    include_current_task=False,
+                    map_indices=request_schedule_indices,
+                )
+            except Exception as err:  # noqa: BLE001 - optional cloud capability
+                action_backoff.record_result(
+                    now,
+                    succeeded=False,
+                    generation=action_read_generation,
+                )
+                _LOGGER.debug("Failed to refresh mower schedules: %s", err)
+                if force:
+                    raise
+            else:
+                if not self._schedule_refresh_is_current(refresh_generation):
+                    return self.schedules
+                action_read_succeeded = schedule_payload_has_usable_data(payload)
+                action_backoff.record_result(
+                    now,
+                    succeeded=action_read_succeeded,
+                    generation=action_read_generation,
+                )
+                if (
+                    action_read_succeeded
+                    and not self._schedule_read_can_publish(action_read_generation)
+                ):
+                    return self.schedules
         app_maps = getattr(self, "app_maps", None)
         known_map_indices = _app_map_index_hints(app_maps)
         map_hints_authoritative = _app_map_hints_are_authoritative(
@@ -508,18 +534,20 @@ class DreameLawnMowerCoordinator(
             known_map_indices,
             map_hints_authoritative=map_hints_authoritative,
         )
-        self.schedules = merge_app_schedule_payload(
-            self.schedules,
-            payload,
-            expected_indices=expected_indices,
-            prune_unexpected_indices=map_hints_authoritative,
-        )
-        if action_read_succeeded:
+        if attempt_action_read:
+            self.schedules = merge_app_schedule_payload(
+                self.schedules,
+                payload,
+                expected_indices=expected_indices,
+                prune_unexpected_indices=map_hints_authoritative,
+            )
+        if action_read_succeeded and action_read_generation is not None:
             self._record_schedule_read_publication(action_read_generation)
         if map_hints_authoritative:
             self._prune_pending_schedule_writes(known_map_indices)
-        self._acknowledge_pending_schedule_plan_states(payload)
-        self._acknowledge_pending_schedule_uploads(payload)
+        if attempt_action_read:
+            self._acknowledge_pending_schedule_plan_states(payload)
+            self._acknowledge_pending_schedule_uploads(payload)
         self._apply_pending_schedule_plan_states()
         self._apply_pending_schedule_uploads()
         action_read_indices = _usable_schedule_indices(payload)
@@ -566,12 +594,13 @@ class DreameLawnMowerCoordinator(
                 known_map_indices = latest_map_indices
                 map_hints_authoritative = latest_map_hints_authoritative
                 expected_indices = latest_expected_indices
-                self.schedules = merge_app_schedule_payload(
-                    self.schedules,
-                    payload,
-                    expected_indices=expected_indices,
-                    prune_unexpected_indices=map_hints_authoritative,
-                )
+                if attempt_action_read:
+                    self.schedules = merge_app_schedule_payload(
+                        self.schedules,
+                        payload,
+                        expected_indices=expected_indices,
+                        prune_unexpected_indices=map_hints_authoritative,
+                    )
                 if map_hints_authoritative:
                     self._prune_pending_schedule_writes(known_map_indices)
                 action_read_complete = set(expected_indices).issubset(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -1035,7 +1035,7 @@ class DreameMowerDreameHomeCloudProtocol:
             or not isinstance(api_response["data"], Mapping)
             or "result" not in api_response["data"]
         ):
-            _LOGGER.warning(
+            _LOGGER.debug(
                 "DreameMowerDreameHomeCloudProtocol.send failed: %s",
                 logged_response,
             )
@@ -1326,7 +1326,7 @@ class DreameMowerDreameHomeCloudProtocol:
                 retries = retries + 1
                 response = None
                 if self._connected:
-                    _LOGGER.warning(
+                    _LOGGER.debug(
                         "DreameMowerDreameHomeCloudProtocol.request: Read timed out. (read timeout=%s): %s",
                         timeout,
                         _cloud_request_log_value(url, data),

--- a/custom_components/dreame_lawn_mower/schedule_cache.py
+++ b/custom_components/dreame_lawn_mower/schedule_cache.py
@@ -3,8 +3,51 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from datetime import datetime
+from dataclasses import dataclass
+from datetime import datetime, timedelta
 from typing import Any
+
+SCHEDULE_ACTION_RETRY_DELAYS = (
+    timedelta(minutes=5),
+    timedelta(minutes=15),
+    timedelta(minutes=30),
+    timedelta(hours=1),
+)
+
+
+@dataclass
+class ScheduleActionReadBackoff:
+    """Bound retries for optional app-action schedule reads."""
+
+    consecutive_failures: int = 0
+    retry_not_before: datetime | None = None
+    latest_generation: int = 0
+
+    def permits(self, now: datetime, *, force: bool = False) -> bool:
+        """Return whether an automatic or explicitly forced read may run."""
+        return force or self.retry_not_before is None or now >= self.retry_not_before
+
+    def record_result(
+        self,
+        now: datetime,
+        *,
+        succeeded: bool,
+        generation: int,
+    ) -> None:
+        """Reset after success or advance the bounded failure cooldown."""
+        if generation < self.latest_generation:
+            return
+        self.latest_generation = generation
+        if succeeded:
+            self.consecutive_failures = 0
+            self.retry_not_before = None
+            return
+
+        self.consecutive_failures += 1
+        delay = SCHEDULE_ACTION_RETRY_DELAYS[
+            min(self.consecutive_failures - 1, len(SCHEDULE_ACTION_RETRY_DELAYS) - 1)
+        ]
+        self.retry_not_before = now + delay
 
 
 def schedule_entry_has_usable_data(value: Any) -> bool:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from threading import Event
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -35,6 +35,7 @@ from custom_components.dreame_lawn_mower.performance import (
     DreameLawnMowerPerformanceTracker,
 )
 from custom_components.dreame_lawn_mower.schedule_cache import (
+    ScheduleActionReadBackoff,
     merge_app_schedule_payload,
     merge_batch_schedule_payload,
 )
@@ -2259,6 +2260,81 @@ def test_schedule_refresh_does_not_mark_all_failed_reads_fresh() -> None:
 
     assert result is not None
     assert coordinator.schedules_refreshed_at is None
+
+
+def test_failed_schedule_action_reads_back_off_automatic_retries() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.schedules = None
+        coordinator.schedules_refreshed_at = None
+        coordinator.selected_map_index = 0
+        coordinator.app_maps = {
+            "current_map_index": 0,
+            "maps": [{"idx": 0, "created": True}],
+        }
+        failed_app_payload = {
+            "source": "app_action_schedule",
+            "available": False,
+            "schedules": [
+                {"idx": -1, "available": False, "error": "timed out"},
+                {"idx": 0, "available": False, "error": "timed out"},
+            ],
+            "errors": [{"stage": "schedule", "error": "timed out"}],
+        }
+        failed_batch_payload = {
+            "source": "batch_device_data_schedule",
+            "available": False,
+            "schedules": [],
+            "errors": [{"stage": "schedule", "error": "missing schedule"}],
+        }
+        coordinator.client = SimpleNamespace(
+            async_get_app_schedules=AsyncMock(return_value=failed_app_payload),
+            async_get_batch_schedules=AsyncMock(return_value=failed_batch_payload),
+        )
+
+        await coordinator.async_refresh_schedules()
+        coordinator._batch_schedule_read_completed_at = 0.0
+        await coordinator.async_refresh_schedules()
+
+        coordinator.client.async_get_app_schedules.assert_awaited_once()
+        assert coordinator._schedule_action_read_backoff.consecutive_failures == 1
+        assert coordinator._schedule_action_read_backoff.retry_not_before is not None
+
+        coordinator.client.async_get_app_schedules.return_value = {
+            "source": "app_action_schedule",
+            "available": True,
+            "schedules": [
+                {"idx": -1, "available": True, "version": 1, "plans": []},
+                {"idx": 0, "available": True, "version": 2, "plans": []},
+            ],
+            "errors": [],
+        }
+        await coordinator.async_refresh_schedules(force=True)
+
+        assert coordinator.client.async_get_app_schedules.await_count == 2
+        assert coordinator._schedule_action_read_backoff.consecutive_failures == 0
+        assert coordinator._schedule_action_read_backoff.retry_not_before is None
+
+    asyncio.run(scenario())
+
+
+def test_schedule_action_backoff_is_bounded_and_resets_after_success() -> None:
+    now = datetime.now(UTC)
+    backoff = ScheduleActionReadBackoff()
+
+    for generation in range(1, 11):
+        backoff.record_result(now, succeeded=False, generation=generation)
+
+    assert backoff.retry_not_before == now + timedelta(hours=1)
+    assert not backoff.permits(now)
+    assert backoff.permits(now, force=True)
+
+    backoff.record_result(now, succeeded=True, generation=11)
+    backoff.record_result(now, succeeded=False, generation=10)
+
+    assert backoff.consecutive_failures == 0
+    assert backoff.retry_not_before is None
+    assert backoff.permits(now)
 
 
 def test_schedule_refresh_does_not_mark_retained_cache_fresh_after_failures() -> None:

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -2,11 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 import time
 from collections.abc import Callable
 from threading import Event, RLock, Thread
 from unittest.mock import Mock
 
+import pytest
 import requests
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
@@ -269,6 +271,63 @@ def test_protocol_disconnects_aliased_cloud_only_once() -> None:
 
     cloud.disconnect.assert_called_once_with()
     assert mower_protocol._connected is False
+
+
+def test_optional_cloud_timeout_details_are_debug_only(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._key_expire = 0
+    cloud._country = "eu"
+    cloud._strings = [f"header-{index}" for index in range(53)]
+    cloud._ti = ""
+    cloud._key = "key"
+    cloud._session = Mock()
+    cloud._connected = True
+    cloud._fail_count = 0
+    cloud._deadline_operation_runs_in_worker = lambda: False
+    monkeypatch.setattr(
+        protocol_cloud,
+        "_post_cloud_response",
+        Mock(side_effect=requests.exceptions.Timeout),
+    )
+
+    with caplog.at_level(logging.DEBUG, logger=protocol_cloud.__name__):
+        result = cloud._request_unlocked(
+            "https://example.invalid",
+            {"data": "optional"},
+            retry_count=0,
+            timeout=0.01,
+        )
+
+    assert result is None
+    warning_records = [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]
+    assert not warning_records
+    assert "Read timed out" in caplog.text
+
+
+def test_missing_optional_cloud_response_is_debug_only(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._host = ""
+    cloud._did = "device-1"
+    cloud._id = 1
+    cloud._strings = [f"value-{index}" for index in range(53)]
+    cloud._api_call = Mock(return_value=None)
+
+    with caplog.at_level(logging.DEBUG, logger=protocol_cloud.__name__):
+        result = cloud._send_unlocked("action", [])
+
+    assert result is None
+    warning_records = [
+        record for record in caplog.records if record.levelno >= logging.WARNING
+    ]
+    assert not warning_records
+    assert "send failed" in caplog.text
 
 
 def _capture_request_error(


### PR DESCRIPTION
## What changes

- keep per-request cloud timeout and missing-response details available at debug level without flooding normal Home Assistant logs
- apply a bounded 5/15/30/60-minute cooldown when optional `SCHDIV2` schedule reads repeatedly return no usable data
- let explicit refreshes bypass the cooldown, reset it immediately after recovery, and ignore stale concurrent results

## Why

The logs in #132 are emitted by optional schedule metadata reads rather than the 3D point-cloud request itself. A nonresponsive mower/cloud path could emit two warnings per probe and retry indefinitely when no fresh schedule cache was established. The fallback data remains available while automatic retries become progressively cheaper for slower Home Assistant hosts.

## Validation

- full pytest suite (one existing skip)
- Ruff and Python compilation

Fixes #132