### PR TITLE
Fix completed mission progress and recognize LiDAX Ultra 2000

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ brand name:
 | Dreame A2 3000 | `dreame.mower.g2568d` | **Field-reported** | Home Assistant discovery, core state entities, and heartbeat docking state on firmware `4.3.6_0625`; broader controls and media still need live validation |
 | Dreame A3 AWD 1000 | `dreame.mower.q2501a` | **Validated** | Core entities, mower state, maps, and cloud live video on firmware `4.3.6_0418` with an EU account |
 | MOVA LiDAX Ultra 1000 | `mova.mower.g2529c` | **Field-reported** | MOVAhome EU login, commands, battery, and model-specific cloud property handling |
+| MOVA LiDAX Ultra 2000 | `mova.mower.g2529f` | **Field-reported** | MOVAhome US login, core state and commands, maps, and cloud live video on firmware `4.3.6_0453` |
 | Dreame A3 AWD Pro 3500 | `dreame.mower.g2541e` | **Recognized** | Model mapping and diagnostics report; broader live confirmation is still needed |
 | Dreame A1 | `dreame.mower.p2255` | **Recognized** | Model mapping and mower-specific state semantics; live video is explicitly unsupported |
 | Dreame A1 Pro | `dreame.mower.g2422` | **Recognized** | Model mapping and mower-specific state semantics; needs fixtures and live validation |

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -59,9 +59,9 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
-    runtime_mission_new_session_event_at,
     runtime_mission_new_session_evidence,
     runtime_mission_session_active,
+    runtime_mission_session_event_at,
     runtime_mission_session_identity,
     runtime_mission_session_started_at,
 )
@@ -335,7 +335,10 @@ class DreameLawnMowerCoordinator(
             ),
             completion_rejected=runtime_mission_completion_rejected(snapshot),
             new_session=runtime_mission_new_session(snapshot),
-            new_session_event_at=runtime_mission_new_session_event_at(snapshot),
+            new_session_event_at=runtime_mission_session_event_at(
+                snapshot,
+                active_session=mission_active,
+            ),
             new_session_evidence=runtime_mission_new_session_evidence(snapshot),
             session_identity=runtime_mission_session_identity(snapshot),
         )
@@ -508,8 +511,9 @@ class DreameLawnMowerCoordinator(
                             snapshot
                         ),
                         new_session=runtime_mission_new_session(snapshot),
-                        new_session_event_at=runtime_mission_new_session_event_at(
-                            snapshot
+                        new_session_event_at=runtime_mission_session_event_at(
+                            snapshot,
+                            active_session=mission_active,
                         ),
                         new_session_evidence=runtime_mission_new_session_evidence(
                             snapshot

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -53,7 +53,11 @@ from .dreame_lawn_mower_client.schedule import (
     encode_schedule_payload_text,
 )
 from .performance import DreameLawnMowerPerformanceTracker
-from .runtime_cache import DreameLawnMowerRuntimeTelemetryCache
+from .runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+    observe_runtime_session_state,
+    runtime_mission_completion_confirmed,
+)
 from .schedule_cache import (
     ScheduleActionReadBackoff,
     has_complete_schedule_cache,
@@ -412,6 +416,14 @@ class DreameLawnMowerCoordinator(
                 self.async_set_updated_data(snapshot)
                 return
             runtime_active = runtime_tracking_active(snapshot)
+            observe_runtime_session_state(
+                getattr(self, "runtime_telemetry_cache", None),
+                active_session=runtime_active,
+                completion_confirmed=runtime_mission_completion_confirmed(
+                    snapshot,
+                    tracking_active=runtime_active,
+                ),
+            )
             runtime_map_index = (
                 self._runtime_map_index()
                 if not runtime_active
@@ -451,6 +463,10 @@ class DreameLawnMowerCoordinator(
                         self.runtime_status_blob,
                         allow_zero=runtime_active,
                         active_session=runtime_active,
+                        completion_confirmed=runtime_mission_completion_confirmed(
+                            snapshot,
+                            tracking_active=runtime_active,
+                        ),
                     )
                     self.client.update_runtime_live_tracking(
                         self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -57,6 +57,8 @@ from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     observe_runtime_session_state,
     runtime_mission_completion_confirmed,
+    runtime_mission_new_session,
+    runtime_mission_session_active,
 )
 from .schedule_cache import (
     ScheduleActionReadBackoff,
@@ -416,13 +418,18 @@ class DreameLawnMowerCoordinator(
                 self.async_set_updated_data(snapshot)
                 return
             runtime_active = runtime_tracking_active(snapshot)
+            mission_active = runtime_mission_session_active(
+                snapshot,
+                tracking_active=runtime_active,
+            )
             observe_runtime_session_state(
                 getattr(self, "runtime_telemetry_cache", None),
-                active_session=runtime_active,
+                active_session=mission_active,
                 completion_confirmed=runtime_mission_completion_confirmed(
                     snapshot,
-                    tracking_active=runtime_active,
+                    tracking_active=mission_active,
                 ),
+                new_session=runtime_mission_new_session(snapshot),
             )
             runtime_map_index = (
                 self._runtime_map_index()
@@ -462,11 +469,12 @@ class DreameLawnMowerCoordinator(
                     self.runtime_telemetry_cache.update(
                         self.runtime_status_blob,
                         allow_zero=runtime_active,
-                        active_session=runtime_active,
+                        active_session=mission_active,
                         completion_confirmed=runtime_mission_completion_confirmed(
                             snapshot,
-                            tracking_active=runtime_active,
+                            tracking_active=mission_active,
                         ),
+                        new_session=runtime_mission_new_session(snapshot),
                     )
                     self.client.update_runtime_live_tracking(
                         self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -59,9 +59,11 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
+    runtime_mission_new_session_event_at,
     runtime_mission_new_session_evidence,
     runtime_mission_session_active,
     runtime_mission_session_identity,
+    runtime_mission_session_started_at,
 )
 from .schedule_cache import (
     ScheduleActionReadBackoff,
@@ -327,9 +329,13 @@ class DreameLawnMowerCoordinator(
             completion_confirmed=runtime_mission_completion_confirmed(
                 snapshot,
                 tracking_active=mission_active,
+                session_started_at=runtime_mission_session_started_at(
+                    getattr(self, "runtime_telemetry_cache", None)
+                ),
             ),
             completion_rejected=runtime_mission_completion_rejected(snapshot),
             new_session=runtime_mission_new_session(snapshot),
+            new_session_event_at=runtime_mission_new_session_event_at(snapshot),
             new_session_evidence=runtime_mission_new_session_evidence(snapshot),
             session_identity=runtime_mission_session_identity(snapshot),
         )
@@ -494,11 +500,17 @@ class DreameLawnMowerCoordinator(
                         completion_confirmed=runtime_mission_completion_confirmed(
                             snapshot,
                             tracking_active=mission_active,
+                            session_started_at=runtime_mission_session_started_at(
+                                self.runtime_telemetry_cache
+                            ),
                         ),
                         completion_rejected=runtime_mission_completion_rejected(
                             snapshot
                         ),
                         new_session=runtime_mission_new_session(snapshot),
+                        new_session_event_at=runtime_mission_new_session_event_at(
+                            snapshot
+                        ),
                         new_session_evidence=runtime_mission_new_session_evidence(
                             snapshot
                         ),

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -56,6 +56,7 @@ from .performance import DreameLawnMowerPerformanceTracker
 from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     observe_runtime_session_state,
+    runtime_mission_cached_session_identity,
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
@@ -319,28 +320,40 @@ class DreameLawnMowerCoordinator(
     ) -> bool | None:
         """Apply one authoritative snapshot to the integration-owned cache."""
         runtime_active = runtime_tracking_active(snapshot)
+        cache = getattr(self, "runtime_telemetry_cache", None)
+        session_started_at = runtime_mission_session_started_at(cache)
+        session_identity = runtime_mission_cached_session_identity(cache)
         mission_active = runtime_mission_session_active(
             snapshot,
             tracking_active=runtime_active,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
         )
         observe_runtime_session_state(
-            getattr(self, "runtime_telemetry_cache", None),
+            cache,
             active_session=mission_active,
             completion_confirmed=runtime_mission_completion_confirmed(
                 snapshot,
                 tracking_active=mission_active,
-                session_started_at=runtime_mission_session_started_at(
-                    getattr(self, "runtime_telemetry_cache", None)
-                ),
+                session_started_at=session_started_at,
+                session_identity=session_identity,
             ),
-            completion_rejected=runtime_mission_completion_rejected(snapshot),
+            completion_rejected=runtime_mission_completion_rejected(
+                snapshot,
+                session_started_at=session_started_at,
+                session_identity=session_identity,
+            ),
             new_session=runtime_mission_new_session(snapshot),
             new_session_event_at=runtime_mission_session_event_at(
                 snapshot,
                 active_session=mission_active,
             ),
             new_session_evidence=runtime_mission_new_session_evidence(snapshot),
-            session_identity=runtime_mission_session_identity(snapshot),
+            session_identity=runtime_mission_session_identity(
+                snapshot,
+                session_started_at=session_started_at,
+                cached_session_identity=session_identity,
+            ),
         )
         return mission_active
 
@@ -456,9 +469,17 @@ class DreameLawnMowerCoordinator(
                 self.async_set_updated_data(snapshot)
                 return
             runtime_active = runtime_tracking_active(snapshot)
+            session_started_at = runtime_mission_session_started_at(
+                self.runtime_telemetry_cache
+            )
+            session_identity = runtime_mission_cached_session_identity(
+                self.runtime_telemetry_cache
+            )
             mission_active = runtime_mission_session_active(
                 snapshot,
                 tracking_active=runtime_active,
+                session_started_at=session_started_at,
+                session_identity=session_identity,
             )
             runtime_map_index = (
                 self._runtime_map_index()
@@ -503,12 +524,13 @@ class DreameLawnMowerCoordinator(
                         completion_confirmed=runtime_mission_completion_confirmed(
                             snapshot,
                             tracking_active=mission_active,
-                            session_started_at=runtime_mission_session_started_at(
-                                self.runtime_telemetry_cache
-                            ),
+                            session_started_at=session_started_at,
+                            session_identity=session_identity,
                         ),
                         completion_rejected=runtime_mission_completion_rejected(
-                            snapshot
+                            snapshot,
+                            session_started_at=session_started_at,
+                            session_identity=session_identity,
                         ),
                         new_session=runtime_mission_new_session(snapshot),
                         new_session_event_at=runtime_mission_session_event_at(
@@ -518,7 +540,11 @@ class DreameLawnMowerCoordinator(
                         new_session_evidence=runtime_mission_new_session_evidence(
                             snapshot
                         ),
-                        session_identity=runtime_mission_session_identity(snapshot),
+                        session_identity=runtime_mission_session_identity(
+                            snapshot,
+                            session_started_at=session_started_at,
+                            cached_session_identity=session_identity,
+                        ),
                     )
                     self.client.update_runtime_live_tracking(
                         self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -422,15 +422,6 @@ class DreameLawnMowerCoordinator(
                 snapshot,
                 tracking_active=runtime_active,
             )
-            observe_runtime_session_state(
-                getattr(self, "runtime_telemetry_cache", None),
-                active_session=mission_active,
-                completion_confirmed=runtime_mission_completion_confirmed(
-                    snapshot,
-                    tracking_active=mission_active,
-                ),
-                new_session=runtime_mission_new_session(snapshot),
-            )
             runtime_map_index = (
                 self._runtime_map_index()
                 if not runtime_active
@@ -463,6 +454,15 @@ class DreameLawnMowerCoordinator(
             if self._device_snapshot_is_stale(snapshot):
                 return
 
+            observe_runtime_session_state(
+                getattr(self, "runtime_telemetry_cache", None),
+                active_session=mission_active,
+                completion_confirmed=runtime_mission_completion_confirmed(
+                    snapshot,
+                    tracking_active=mission_active,
+                ),
+                new_session=runtime_mission_new_session(snapshot),
+            )
             if runtime_status_error is None:
                 try:
                     self.runtime_status_blob = runtime_status_blob

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -57,6 +57,7 @@ from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     observe_runtime_session_state,
     runtime_mission_completion_confirmed,
+    runtime_mission_completion_rejected,
     runtime_mission_new_session,
     runtime_mission_session_active,
 )
@@ -461,6 +462,7 @@ class DreameLawnMowerCoordinator(
                     snapshot,
                     tracking_active=mission_active,
                 ),
+                completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
             )
             if runtime_status_error is None:
@@ -473,6 +475,9 @@ class DreameLawnMowerCoordinator(
                         completion_confirmed=runtime_mission_completion_confirmed(
                             snapshot,
                             tracking_active=mission_active,
+                        ),
+                        completion_rejected=runtime_mission_completion_rejected(
+                            snapshot
                         ),
                         new_session=runtime_mission_new_session(snapshot),
                     )

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -63,6 +63,7 @@ from .runtime_cache import (
     runtime_mission_new_session_evidence,
     runtime_mission_session_active,
     runtime_mission_session_event_at,
+    runtime_mission_session_generation,
     runtime_mission_session_identity,
     runtime_mission_session_started_at,
 )
@@ -469,6 +470,9 @@ class DreameLawnMowerCoordinator(
                 self.async_set_updated_data(snapshot)
                 return
             runtime_active = runtime_tracking_active(snapshot)
+            observed_mission_generation = runtime_mission_session_generation(
+                self.runtime_telemetry_cache
+            )
             session_started_at = runtime_mission_session_started_at(
                 self.runtime_telemetry_cache
             )
@@ -510,7 +514,13 @@ class DreameLawnMowerCoordinator(
             # Both optional reads can yield while a newer authoritative fetch
             # publishes. Commit no runtime or Bluetooth side effects until the
             # cached snapshot is still current after every await.
-            if self._device_snapshot_is_stale(snapshot):
+            if self._device_snapshot_is_stale(snapshot) or (
+                observed_mission_generation is not None
+                and runtime_mission_session_generation(
+                    self.runtime_telemetry_cache
+                )
+                != observed_mission_generation
+            ):
                 return
 
             self._observe_runtime_mission_boundary(snapshot)

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -307,7 +307,33 @@ class DreameLawnMowerCoordinator(
         )
         if generation is not None:
             self._published_device_snapshot_generation = generation
+        if getattr(data, "available", True):
+            self._observe_runtime_mission_boundary(data)
         super().async_set_updated_data(data)
+
+    def _observe_runtime_mission_boundary(
+        self,
+        snapshot: DreameLawnMowerSnapshot,
+    ) -> bool | None:
+        """Apply one authoritative snapshot to the integration-owned cache."""
+        runtime_active = runtime_tracking_active(snapshot)
+        mission_active = runtime_mission_session_active(
+            snapshot,
+            tracking_active=runtime_active,
+        )
+        observe_runtime_session_state(
+            getattr(self, "runtime_telemetry_cache", None),
+            active_session=mission_active,
+            completion_confirmed=runtime_mission_completion_confirmed(
+                snapshot,
+                tracking_active=mission_active,
+            ),
+            completion_rejected=runtime_mission_completion_rejected(snapshot),
+            new_session=runtime_mission_new_session(snapshot),
+            new_session_evidence=runtime_mission_new_session_evidence(snapshot),
+            session_identity=runtime_mission_session_identity(snapshot),
+        )
+        return mission_active
 
     def _retain_feature_capability_evidence(
         self,
@@ -457,18 +483,7 @@ class DreameLawnMowerCoordinator(
             if self._device_snapshot_is_stale(snapshot):
                 return
 
-            observe_runtime_session_state(
-                getattr(self, "runtime_telemetry_cache", None),
-                active_session=mission_active,
-                completion_confirmed=runtime_mission_completion_confirmed(
-                    snapshot,
-                    tracking_active=mission_active,
-                ),
-                completion_rejected=runtime_mission_completion_rejected(snapshot),
-                new_session=runtime_mission_new_session(snapshot),
-                new_session_evidence=runtime_mission_new_session_evidence(snapshot),
-                session_identity=runtime_mission_session_identity(snapshot),
-            )
+            self._observe_runtime_mission_boundary(snapshot)
             if runtime_status_error is None:
                 try:
                     self.runtime_status_blob = runtime_status_blob

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -59,7 +59,9 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
+    runtime_mission_new_session_evidence,
     runtime_mission_session_active,
+    runtime_mission_session_identity,
 )
 from .schedule_cache import (
     ScheduleActionReadBackoff,
@@ -464,6 +466,8 @@ class DreameLawnMowerCoordinator(
                 ),
                 completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
+                new_session_evidence=runtime_mission_new_session_evidence(snapshot),
+                session_identity=runtime_mission_session_identity(snapshot),
             )
             if runtime_status_error is None:
                 try:
@@ -480,6 +484,10 @@ class DreameLawnMowerCoordinator(
                             snapshot
                         ),
                         new_session=runtime_mission_new_session(snapshot),
+                        new_session_evidence=runtime_mission_new_session_evidence(
+                            snapshot
+                        ),
+                        session_identity=runtime_mission_session_identity(snapshot),
                     )
                     self.client.update_runtime_live_tracking(
                         self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -159,6 +159,16 @@ class DreameLawnMowerRefreshMixin:
                 snapshot,
                 tracking_active=runtime_active,
             )
+            if runtime_active:
+                if not await self._async_refresh_active_runtime(cycle, snapshot):
+                    return self._snapshot_for_publication(snapshot)
+            else:
+                self._runtime_map_identity_verified = False
+                self.client.update_runtime_live_tracking(None, active=False)
+
+            # Active runtime hydration yields to app-map and telemetry reads.
+            # Commit the authoritative mission boundary only after those awaits
+            # confirm that this foreground snapshot is still current.
             observe_runtime_session_state(
                 getattr(self, "runtime_telemetry_cache", None),
                 active_session=mission_active,
@@ -171,13 +181,6 @@ class DreameLawnMowerRefreshMixin:
                 new_session_evidence=runtime_mission_new_session_evidence(snapshot),
                 session_identity=runtime_mission_session_identity(snapshot),
             )
-            if runtime_active:
-                if not await self._async_refresh_active_runtime(cycle, snapshot):
-                    return self._snapshot_for_publication(snapshot)
-            else:
-                self._runtime_map_identity_verified = False
-                self.client.update_runtime_live_tracking(None, active=False)
-
             self._schedule_metadata_refresh(
                 refresh_map_and_runtime=not runtime_active,
             )

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -27,7 +27,6 @@ from .performance import (
     format_performance_sample,
 )
 from .runtime_cache import (
-    observe_runtime_session_state,
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
@@ -155,10 +154,6 @@ class DreameLawnMowerRefreshMixin:
             self._record_connectivity_success(snapshot)
 
             runtime_active = runtime_tracking_active(snapshot)
-            mission_active = runtime_mission_session_active(
-                snapshot,
-                tracking_active=runtime_active,
-            )
             if runtime_active:
                 if not await self._async_refresh_active_runtime(cycle, snapshot):
                     return self._snapshot_for_publication(snapshot)
@@ -169,18 +164,7 @@ class DreameLawnMowerRefreshMixin:
             # Active runtime hydration yields to app-map and telemetry reads.
             # Commit the authoritative mission boundary only after those awaits
             # confirm that this foreground snapshot is still current.
-            observe_runtime_session_state(
-                getattr(self, "runtime_telemetry_cache", None),
-                active_session=mission_active,
-                completion_confirmed=runtime_mission_completion_confirmed(
-                    snapshot,
-                    tracking_active=mission_active,
-                ),
-                completion_rejected=runtime_mission_completion_rejected(snapshot),
-                new_session=runtime_mission_new_session(snapshot),
-                new_session_evidence=runtime_mission_new_session_evidence(snapshot),
-                session_identity=runtime_mission_session_identity(snapshot),
-            )
+            self._observe_runtime_mission_boundary(snapshot)
             self._schedule_metadata_refresh(
                 refresh_map_and_runtime=not runtime_active,
             )

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -30,9 +30,11 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
+    runtime_mission_new_session_event_at,
     runtime_mission_new_session_evidence,
     runtime_mission_session_active,
     runtime_mission_session_identity,
+    runtime_mission_session_started_at,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -262,9 +264,13 @@ class DreameLawnMowerRefreshMixin:
                 completion_confirmed=runtime_mission_completion_confirmed(
                     snapshot,
                     tracking_active=mission_active,
+                    session_started_at=runtime_mission_session_started_at(
+                        self.runtime_telemetry_cache
+                    ),
                 ),
                 completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
+                new_session_event_at=runtime_mission_new_session_event_at(snapshot),
                 new_session_evidence=runtime_mission_new_session_evidence(snapshot),
                 session_identity=runtime_mission_session_identity(snapshot),
             )

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -26,6 +26,10 @@ from .performance import (
     DreameLawnMowerPerformanceTracker,
     format_performance_sample,
 )
+from .runtime_cache import (
+    observe_runtime_session_state,
+    runtime_mission_completion_confirmed,
+)
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -146,6 +150,14 @@ class DreameLawnMowerRefreshMixin:
             self._record_connectivity_success(snapshot)
 
             runtime_active = runtime_tracking_active(snapshot)
+            observe_runtime_session_state(
+                getattr(self, "runtime_telemetry_cache", None),
+                active_session=runtime_active,
+                completion_confirmed=runtime_mission_completion_confirmed(
+                    snapshot,
+                    tracking_active=runtime_active,
+                ),
+            )
             if runtime_active:
                 if not await self._async_refresh_active_runtime(cycle, snapshot):
                     return self._snapshot_for_publication(snapshot)
@@ -243,6 +255,10 @@ class DreameLawnMowerRefreshMixin:
                 self.runtime_status_blob,
                 allow_zero=runtime_active,
                 active_session=runtime_active,
+                completion_confirmed=runtime_mission_completion_confirmed(
+                    snapshot,
+                    tracking_active=runtime_active,
+                ),
             )
             self.client.update_runtime_live_tracking(
                 self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -30,9 +30,9 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
-    runtime_mission_new_session_event_at,
     runtime_mission_new_session_evidence,
     runtime_mission_session_active,
+    runtime_mission_session_event_at,
     runtime_mission_session_identity,
     runtime_mission_session_started_at,
 )
@@ -270,7 +270,10 @@ class DreameLawnMowerRefreshMixin:
                 ),
                 completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
-                new_session_event_at=runtime_mission_new_session_event_at(snapshot),
+                new_session_event_at=runtime_mission_session_event_at(
+                    snapshot,
+                    active_session=mission_active,
+                ),
                 new_session_evidence=runtime_mission_new_session_evidence(snapshot),
                 session_identity=runtime_mission_session_identity(snapshot),
             )

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -34,6 +34,7 @@ from .runtime_cache import (
     runtime_mission_new_session_evidence,
     runtime_mission_session_active,
     runtime_mission_session_event_at,
+    runtime_mission_session_generation,
     runtime_mission_session_identity,
     runtime_mission_session_started_at,
 )
@@ -250,6 +251,9 @@ class DreameLawnMowerRefreshMixin:
         session_identity = runtime_mission_cached_session_identity(
             self.runtime_telemetry_cache
         )
+        observed_mission_generation = runtime_mission_session_generation(
+            self.runtime_telemetry_cache
+        )
         mission_active = runtime_mission_session_active(
             snapshot,
             tracking_active=runtime_active,
@@ -263,7 +267,13 @@ class DreameLawnMowerRefreshMixin:
                 refresh=False,
                 include_cloud=True,
             )
-            if self._snapshot_is_stale(snapshot):
+            if self._snapshot_is_stale(snapshot) or (
+                observed_mission_generation is not None
+                and runtime_mission_session_generation(
+                    self.runtime_telemetry_cache
+                )
+                != observed_mission_generation
+            ):
                 return False
             self.runtime_status_blob = runtime_status_blob
             self.runtime_telemetry_cache.update(
@@ -300,7 +310,13 @@ class DreameLawnMowerRefreshMixin:
             )
             return True
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
-            if self._snapshot_is_stale(snapshot):
+            if self._snapshot_is_stale(snapshot) or (
+                observed_mission_generation is not None
+                and runtime_mission_session_generation(
+                    self.runtime_telemetry_cache
+                )
+                != observed_mission_generation
+            ):
                 return False
             _LOGGER.debug("Failed to refresh runtime status blob: %s", err)
             self.runtime_status_blob = None

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -27,6 +27,7 @@ from .performance import (
     format_performance_sample,
 )
 from .runtime_cache import (
+    runtime_mission_cached_session_identity,
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
@@ -243,9 +244,17 @@ class DreameLawnMowerRefreshMixin:
     ) -> bool:
         """Refresh optional runtime telemetry without failing the main snapshot."""
         runtime_active = runtime_tracking_active(snapshot)
+        session_started_at = runtime_mission_session_started_at(
+            self.runtime_telemetry_cache
+        )
+        session_identity = runtime_mission_cached_session_identity(
+            self.runtime_telemetry_cache
+        )
         mission_active = runtime_mission_session_active(
             snapshot,
             tracking_active=runtime_active,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
         )
         if runtime_map_index is None and not runtime_active:
             runtime_map_index = self._runtime_map_index()
@@ -264,18 +273,25 @@ class DreameLawnMowerRefreshMixin:
                 completion_confirmed=runtime_mission_completion_confirmed(
                     snapshot,
                     tracking_active=mission_active,
-                    session_started_at=runtime_mission_session_started_at(
-                        self.runtime_telemetry_cache
-                    ),
+                    session_started_at=session_started_at,
+                    session_identity=session_identity,
                 ),
-                completion_rejected=runtime_mission_completion_rejected(snapshot),
+                completion_rejected=runtime_mission_completion_rejected(
+                    snapshot,
+                    session_started_at=session_started_at,
+                    session_identity=session_identity,
+                ),
                 new_session=runtime_mission_new_session(snapshot),
                 new_session_event_at=runtime_mission_session_event_at(
                     snapshot,
                     active_session=mission_active,
                 ),
                 new_session_evidence=runtime_mission_new_session_evidence(snapshot),
-                session_identity=runtime_mission_session_identity(snapshot),
+                session_identity=runtime_mission_session_identity(
+                    snapshot,
+                    session_started_at=session_started_at,
+                    cached_session_identity=session_identity,
+                ),
             )
             self.client.update_runtime_live_tracking(
                 self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -29,6 +29,8 @@ from .performance import (
 from .runtime_cache import (
     observe_runtime_session_state,
     runtime_mission_completion_confirmed,
+    runtime_mission_new_session,
+    runtime_mission_session_active,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -150,13 +152,18 @@ class DreameLawnMowerRefreshMixin:
             self._record_connectivity_success(snapshot)
 
             runtime_active = runtime_tracking_active(snapshot)
+            mission_active = runtime_mission_session_active(
+                snapshot,
+                tracking_active=runtime_active,
+            )
             observe_runtime_session_state(
                 getattr(self, "runtime_telemetry_cache", None),
-                active_session=runtime_active,
+                active_session=mission_active,
                 completion_confirmed=runtime_mission_completion_confirmed(
                     snapshot,
-                    tracking_active=runtime_active,
+                    tracking_active=mission_active,
                 ),
+                new_session=runtime_mission_new_session(snapshot),
             )
             if runtime_active:
                 if not await self._async_refresh_active_runtime(cycle, snapshot):
@@ -241,6 +248,10 @@ class DreameLawnMowerRefreshMixin:
     ) -> bool:
         """Refresh optional runtime telemetry without failing the main snapshot."""
         runtime_active = runtime_tracking_active(snapshot)
+        mission_active = runtime_mission_session_active(
+            snapshot,
+            tracking_active=runtime_active,
+        )
         if runtime_map_index is None and not runtime_active:
             runtime_map_index = self._runtime_map_index()
         try:
@@ -254,11 +265,12 @@ class DreameLawnMowerRefreshMixin:
             self.runtime_telemetry_cache.update(
                 self.runtime_status_blob,
                 allow_zero=runtime_active,
-                active_session=runtime_active,
+                active_session=mission_active,
                 completion_confirmed=runtime_mission_completion_confirmed(
                     snapshot,
-                    tracking_active=runtime_active,
+                    tracking_active=mission_active,
                 ),
+                new_session=runtime_mission_new_session(snapshot),
             )
             self.client.update_runtime_live_tracking(
                 self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -31,7 +31,9 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
+    runtime_mission_new_session_evidence,
     runtime_mission_session_active,
+    runtime_mission_session_identity,
 )
 
 _LOGGER = logging.getLogger(__name__)
@@ -166,6 +168,8 @@ class DreameLawnMowerRefreshMixin:
                 ),
                 completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
+                new_session_evidence=runtime_mission_new_session_evidence(snapshot),
+                session_identity=runtime_mission_session_identity(snapshot),
             )
             if runtime_active:
                 if not await self._async_refresh_active_runtime(cycle, snapshot):
@@ -274,6 +278,8 @@ class DreameLawnMowerRefreshMixin:
                 ),
                 completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
+                new_session_evidence=runtime_mission_new_session_evidence(snapshot),
+                session_identity=runtime_mission_session_identity(snapshot),
             )
             self.client.update_runtime_live_tracking(
                 self.runtime_status_blob,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -29,6 +29,7 @@ from .performance import (
 from .runtime_cache import (
     observe_runtime_session_state,
     runtime_mission_completion_confirmed,
+    runtime_mission_completion_rejected,
     runtime_mission_new_session,
     runtime_mission_session_active,
 )
@@ -163,6 +164,7 @@ class DreameLawnMowerRefreshMixin:
                     snapshot,
                     tracking_active=mission_active,
                 ),
+                completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
             )
             if runtime_active:
@@ -270,6 +272,7 @@ class DreameLawnMowerRefreshMixin:
                     snapshot,
                     tracking_active=mission_active,
                 ),
+                completion_rejected=runtime_mission_completion_rejected(snapshot),
                 new_session=runtime_mission_new_session(snapshot),
             )
             self.client.update_runtime_live_tracking(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -571,16 +571,14 @@ class DreameLawnMowerClient(
                     ),
                 )
             return False
-        if status_blob is None or getattr(
-            status_blob, "mowing_session_active", None
-        ) is None:
-            return await self._async_call_start_mowing_with_session_identity()
-        if status_blob.mowing_session_active is True:
-            if status_blob.task_status not in {"starting", "mowing"}:
-                await self._async_call_device_method("start_mowing")
+        if (
+            status_blob is not None
+            and status_blob.mowing_session_active is True
+            and status_blob.task_status in {"starting", "mowing"}
+            and await self._async_get_cached_start_mowing_session_identity() is False
+        ):
             return False
-        await self._async_call_device_method("start_mowing")
-        return True
+        return await self._async_call_start_mowing_with_session_identity()
 
     async def async_pause(self) -> None:
         """Pause mowing."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -547,8 +547,8 @@ class DreameLawnMowerClient(
         self._latest_snapshot = snapshot
         return snapshot
 
-    async def async_start_mowing(self) -> bool:
-        """Start mowing and return whether a fresh mission was accepted."""
+    async def async_start_mowing(self) -> bool | None:
+        """Start mowing and report fresh, resumed, or unknown session identity."""
         try:
             status_blob = await self.async_get_status_blob(
                 refresh=True,
@@ -571,6 +571,8 @@ class DreameLawnMowerClient(
                     ),
                 )
             return False
+        if status_blob is None:
+            return await self._async_call_start_mowing_with_session_identity()
         await self._async_call_device_method("start_mowing")
         return True
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -547,8 +547,8 @@ class DreameLawnMowerClient(
         self._latest_snapshot = snapshot
         return snapshot
 
-    async def async_start_mowing(self) -> None:
-        """Start a new task or resume the heartbeat-confirmed paused task."""
+    async def async_start_mowing(self) -> bool:
+        """Start mowing and return whether a fresh mission was accepted."""
         try:
             status_blob = await self.async_get_status_blob(
                 refresh=True,
@@ -570,8 +570,9 @@ class DreameLawnMowerClient(
                         and not getattr(snapshot, "task_resumable", False)
                     ),
                 )
-            return
+            return False
         await self._async_call_device_method("start_mowing")
+        return True
 
     async def async_pause(self) -> None:
         """Pause mowing."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -571,6 +571,12 @@ class DreameLawnMowerClient(
                     ),
                 )
             return False
+        if status_blob is not None and getattr(
+            status_blob,
+            "mowing_session_active",
+            None,
+        ) is True:
+            return False
         if status_blob is None:
             return await self._async_call_start_mowing_with_session_identity()
         await self._async_call_device_method("start_mowing")

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -571,14 +571,14 @@ class DreameLawnMowerClient(
                     ),
                 )
             return False
-        if status_blob is not None and getattr(
-            status_blob,
-            "mowing_session_active",
-            None,
-        ) is True:
-            return False
-        if status_blob is None:
+        if status_blob is None or getattr(
+            status_blob, "mowing_session_active", None
+        ) is None:
             return await self._async_call_start_mowing_with_session_identity()
+        if status_blob.mowing_session_active is True:
+            if status_blob.task_status not in {"starting", "mowing"}:
+                await self._async_call_device_method("start_mowing")
+            return False
         await self._async_call_device_method("start_mowing")
         return True
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -135,6 +135,8 @@ class _DreameLawnMowerClientCoreMixin:
 
         def call_start_mowing() -> Any:
             nonlocal new_session
+            from .device_types import DreameMowerTaskStatus
+
             status = device.status
             resumes_special_task = bool(
                 getattr(status, "fast_mapping_paused", False)
@@ -144,9 +146,12 @@ class _DreameLawnMowerClientCoreMixin:
                     and getattr(status, "cruising_paused", False)
                 )
             )
+            task_status = getattr(status, "task_status", None)
             started = getattr(status, "started", None)
             if resumes_special_task:
                 new_session = False
+            elif task_status is None or task_status is DreameMowerTaskStatus.UNKNOWN:
+                new_session = None
             elif started is not None:
                 # Capture the same value immediately before start_mowing uses
                 # it to decide whether to create or resume a task.

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import time
 from collections.abc import Callable, Mapping, Sequence
+from contextlib import nullcontext
 from dataclasses import replace
 from datetime import UTC, datetime
 from typing import Any
@@ -137,26 +138,36 @@ class _DreameLawnMowerClientCoreMixin:
             nonlocal new_session
             from .device_types import DreameMowerTaskStatus
 
-            status = device.status
-            resumes_special_task = bool(
-                getattr(status, "fast_mapping_paused", False)
-                or getattr(status, "returning_paused", False)
-                or (
-                    getattr(getattr(device, "capability", None), "cruising", False)
-                    and getattr(status, "cruising_paused", False)
+            state_lock = getattr(device, "_state_lock", None)
+            state_context = state_lock if state_lock is not None else nullcontext()
+            with state_context:
+                status = device.status
+                resumes_special_task = bool(
+                    getattr(status, "fast_mapping_paused", False)
+                    or getattr(status, "returning_paused", False)
+                    or (
+                        getattr(
+                            getattr(device, "capability", None),
+                            "cruising",
+                            False,
+                        )
+                        and getattr(status, "cruising_paused", False)
+                    )
                 )
-            )
-            task_status = getattr(status, "task_status", None)
-            started = getattr(status, "started", None)
-            if resumes_special_task:
-                new_session = False
-            elif task_status is None or task_status is DreameMowerTaskStatus.UNKNOWN:
-                new_session = None
-            elif started is not None:
-                # Capture the same value immediately before start_mowing uses
-                # it to decide whether to create or resume a task.
-                new_session = not bool(started)
-            return device.start_mowing()
+                task_status = getattr(status, "task_status", None)
+                started = getattr(status, "started", None)
+                if resumes_special_task:
+                    new_session = False
+                elif (
+                    task_status is None
+                    or task_status is DreameMowerTaskStatus.UNKNOWN
+                ):
+                    new_session = None
+                elif started is not None:
+                    # Keep the identity decision and the device's own branch
+                    # under the same lock used by MQTT state mutations.
+                    new_session = not bool(started)
+                return device.start_mowing()
 
         try:
             await asyncio.to_thread(call_start_mowing)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -69,6 +69,30 @@ from .runtime_state import (
 _MUTATION_CONFIRMATION_DELAYS_SECONDS = (0.5, 1.5, 3.0)
 
 
+def _device_start_session_identity(device: Any) -> bool | None:
+    """Return the cached start-versus-resume branch used by the device."""
+    from .device_types import DreameMowerTaskStatus
+
+    status = device.status
+    resumes_special_task = bool(
+        getattr(status, "fast_mapping_paused", False)
+        or getattr(status, "returning_paused", False)
+        or (
+            getattr(getattr(device, "capability", None), "cruising", False)
+            and getattr(status, "cruising_paused", False)
+        )
+    )
+    task_status = getattr(status, "task_status", None)
+    started = getattr(status, "started", None)
+    if resumes_special_task:
+        return False
+    if task_status is None or task_status is DreameMowerTaskStatus.UNKNOWN:
+        return None
+    if started is not None:
+        return not bool(started)
+    return None
+
+
 class _DreameLawnMowerClientCoreMixin:
     async def async_get_cached_snapshot(self) -> DreameLawnMowerSnapshot:
         """Return a snapshot from the latest in-memory device state."""
@@ -129,6 +153,18 @@ class _DreameLawnMowerClientCoreMixin:
                 predicate,
             )
 
+    async def _async_get_cached_start_mowing_session_identity(self) -> bool | None:
+        """Read the device's current start branch under its MQTT state lock."""
+        device = await asyncio.to_thread(self._ensure_device)
+
+        def read_session_identity() -> bool | None:
+            state_lock = getattr(device, "_state_lock", None)
+            state_context = state_lock if state_lock is not None else nullcontext()
+            with state_context:
+                return _device_start_session_identity(device)
+
+        return await asyncio.to_thread(read_session_identity)
+
     async def _async_call_start_mowing_with_session_identity(self) -> bool | None:
         """Invoke the fallback start and capture its cached-state decision."""
         device = await asyncio.to_thread(self._ensure_device)
@@ -136,37 +172,13 @@ class _DreameLawnMowerClientCoreMixin:
 
         def call_start_mowing() -> Any:
             nonlocal new_session
-            from .device_types import DreameMowerTaskStatus
 
             state_lock = getattr(device, "_state_lock", None)
             state_context = state_lock if state_lock is not None else nullcontext()
             with state_context:
-                status = device.status
-                resumes_special_task = bool(
-                    getattr(status, "fast_mapping_paused", False)
-                    or getattr(status, "returning_paused", False)
-                    or (
-                        getattr(
-                            getattr(device, "capability", None),
-                            "cruising",
-                            False,
-                        )
-                        and getattr(status, "cruising_paused", False)
-                    )
-                )
-                task_status = getattr(status, "task_status", None)
-                started = getattr(status, "started", None)
-                if resumes_special_task:
-                    new_session = False
-                elif (
-                    task_status is None
-                    or task_status is DreameMowerTaskStatus.UNKNOWN
-                ):
-                    new_session = None
-                elif started is not None:
-                    # Keep the identity decision and the device's own branch
-                    # under the same lock used by MQTT state mutations.
-                    new_session = not bool(started)
+                # Keep the identity decision and the device's own branch under
+                # the same lock used by MQTT state mutations.
+                new_session = _device_start_session_identity(device)
                 return device.start_mowing()
 
         try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -128,6 +128,47 @@ class _DreameLawnMowerClientCoreMixin:
                 predicate,
             )
 
+    async def _async_call_start_mowing_with_session_identity(self) -> bool | None:
+        """Invoke the fallback start and capture its cached-state decision."""
+        device = await asyncio.to_thread(self._ensure_device)
+        new_session: bool | None = None
+
+        def call_start_mowing() -> Any:
+            nonlocal new_session
+            status = device.status
+            resumes_special_task = bool(
+                getattr(status, "fast_mapping_paused", False)
+                or getattr(status, "returning_paused", False)
+                or (
+                    getattr(getattr(device, "capability", None), "cruising", False)
+                    and getattr(status, "cruising_paused", False)
+                )
+            )
+            started = getattr(status, "started", None)
+            if resumes_special_task:
+                new_session = False
+            elif started is not None:
+                # Capture the same value immediately before start_mowing uses
+                # it to decide whether to create or resume a task.
+                new_session = not bool(started)
+            return device.start_mowing()
+
+        try:
+            await asyncio.to_thread(call_start_mowing)
+        except DeviceCommandRejectedException as err:
+            raise DreameLawnMowerCommandRejectedError(str(err)) from err
+        except DeviceException as err:
+            await self._async_reconcile_ambiguous_mutation(
+                "start mowing",
+                DreameLawnMowerConnectionError(str(err)),
+                lambda snapshot: bool(
+                    snapshot.started
+                    or snapshot.mowing
+                    or snapshot.mowing_session_active is True
+                ),
+            )
+        return new_session
+
     async def _async_reconcile_ambiguous_mutation(
         self,
         label: str,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
@@ -219,7 +219,12 @@ _A1_MODELS: Final[frozenset[str]] = frozenset(
     }
 )
 _MOVA_MODELS: Final[frozenset[str]] = frozenset(
-    {"mova.mower.g2529c", "g2529c"}
+    {
+        "mova.mower.g2529c",
+        "mova.mower.g2529f",
+        "g2529c",
+        "g2529f",
+    }
 )
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/feature_capabilities.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/feature_capabilities.py
@@ -31,6 +31,9 @@ MODEL_FEATURE_CAPABILITIES: Final[dict[str, dict[str, str]]] = {
     "dreame.mower.q2501a": {
         FEATURE_LIVE_VIDEO: CAPABILITY_SUPPORTED,
     },
+    "mova.mower.g2529f": {
+        FEATURE_LIVE_VIDEO: CAPABILITY_SUPPORTED,
+    },
 }
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -21,6 +21,7 @@ MIN_REMOTE_CONTROL_BATTERY_LEVEL = 20
 REMOTE_CONTROL_STATES = {"remote_control"}
 REALTIME_STATE_PROPERTY_KEY = "2.1"
 REALTIME_ERROR_PROPERTY_KEY = "2.2"
+REALTIME_TASK_STATUS_PROPERTY_KEY = "4.7"
 OPERATIONAL_HUMAN_DETECTION_NOTICE_MODELS = frozenset(
     {"dreame.mower.q2501a", "q2501a"}
 )
@@ -353,6 +354,11 @@ class DreameLawnMowerSnapshot:
     task_status: str | None = None
     task_status_name: str | None = None
     task_status_source: str | None = None
+    task_status_event_at: float | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     mowing_session_active: bool | None = None
     task_resumable: bool | None = None
     error_code: int | None = None
@@ -365,6 +371,16 @@ class DreameLawnMowerSnapshot:
     status_notice_display: str | None = None
     status_notice_tier: str | None = None
     status_notice_source: str | None = None
+    status_notice_event_at: float | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    mission_task_id: int | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     raw_error_code: int | None = None
     realtime_error_code: int | None = None
     _error_suppression_active: bool = field(
@@ -1323,6 +1339,10 @@ def snapshot_from_device(
         battery_level=getattr(device.status, "battery_level", None),
         task_status=task_obj.name.lower() if task_obj is not None else None,
         task_status_name=getattr(device.status, "task_status_name", None),
+        task_status_event_at=_realtime_property_last_seen(
+            device,
+            REALTIME_TASK_STATUS_PROPERTY_KEY,
+        ),
         error_code=error_code,
         error_name=error_name,
         error_text=error_text,
@@ -1364,6 +1384,14 @@ def snapshot_from_device(
             )
         ),
         status_notice_source=status_notice_source,
+        status_notice_event_at=(
+            _realtime_property_last_seen(device, REALTIME_ERROR_PROPERTY_KEY)
+            if (
+                status_notice_code is not None
+                and status_notice_code == realtime_error_code
+            )
+            else None
+        ),
         raw_error_code=raw_error_code,
         realtime_error_code=realtime_error_code,
         _error_suppression_active=error_suppression_active,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -351,6 +351,11 @@ class DreameLawnMowerSnapshot:
     state_name: str
     activity: str
     battery_level: int | None = None
+    state_event_at: float | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     task_status: str | None = None
     task_status_name: str | None = None
     task_status_source: str | None = None
@@ -1337,6 +1342,10 @@ def snapshot_from_device(
         state_name=state_name,
         activity=activity,
         battery_level=getattr(device.status, "battery_level", None),
+        state_event_at=_realtime_property_last_seen(
+            device,
+            REALTIME_STATE_PROPERTY_KEY,
+        ),
         task_status=task_obj.name.lower() if task_obj is not None else None,
         task_status_name=getattr(device.status, "task_status_name", None),
         task_status_event_at=_realtime_property_last_seen(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -33,6 +33,7 @@ MODEL_NAME_MAP = {
     "dreame.mower.g2541e": "A3 AWD Pro 3500",
     "dreame.mower.q2501a": "A3 AWD 1000",
     "mova.mower.g2529c": "LiDAX Ultra 1000",
+    "mova.mower.g2529f": "LiDAX Ultra 2000",
 }
 
 DISPLAY_NAME_ALIASES = {
@@ -45,6 +46,7 @@ DISPLAY_NAME_ALIASES = {
     "lidax ultra 800": "LiDAX Ultra 800",
     "lidax ultra 1000": "LiDAX Ultra 1000",
     "lidax ultra 1200": "LiDAX Ultra 1200",
+    "lidax ultra 2000": "LiDAX Ultra 2000",
     "viax 300": "Viax 300",
     "vivax 250": "Vivax 250",
 }

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -25,6 +25,8 @@ def snapshot_with_heartbeat_task_state(
     """Apply heartbeat-confirmed task and physical docking state."""
     task_status = status_blob.task_status
     changes: dict[str, Any] = {}
+    if status_blob.candidate_runtime_task_id is not None:
+        changes["mission_task_id"] = status_blob.candidate_runtime_task_id
     if task_status is not None:
         changes.update(
             task_status=task_status,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Mapping
 from dataclasses import replace
+from datetime import UTC, datetime
 from typing import Any
 
 from .models import DreameLawnMowerSnapshot, DreameLawnMowerStatusBlob
@@ -32,6 +33,7 @@ def snapshot_with_heartbeat_task_state(
             task_status=task_status,
             task_status_name=task_status.replace("_", " ").title(),
             task_status_source=f"heartbeat_{status_blob.source or 'unknown'}",
+            task_status_event_at=_heartbeat_event_at(status_blob),
             mowing_session_active=status_blob.mowing_session_active,
             task_resumable=status_blob.task_resumable,
         )
@@ -59,6 +61,22 @@ def snapshot_with_heartbeat_task_state(
     if not changes:
         return snapshot
     return replace(snapshot, **changes)
+
+
+def _heartbeat_event_at(status_blob: DreameLawnMowerStatusBlob) -> float | None:
+    """Return the heartbeat property's own reception time when available."""
+    received_at = getattr(status_blob, "received_at", None)
+    if isinstance(received_at, int | float) and not isinstance(received_at, bool):
+        return float(received_at)
+    if not isinstance(received_at, str):
+        return None
+    try:
+        parsed = datetime.fromisoformat(received_at.replace("Z", "+00:00"))
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=UTC)
+    return parsed.timestamp()
 
 
 def snapshot_with_cloud_presence(

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -478,7 +478,6 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         action = self.coordinator.selected_mowing_action
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        session_started_at = time()
         new_session = False
         if action == MOWING_ACTION_EDGE:
             self._ensure_selected_map_matches_active()
@@ -526,7 +525,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             begin_runtime_mission_session(
                 runtime_cache,
                 observed_generation=observed_generation,
-                session_started_at=session_started_at,
+                session_started_at=time(),
             )
         await self.coordinator.async_request_refresh()
 
@@ -549,12 +548,11 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        session_started_at = time()
         await self.coordinator.client.async_start_zone_mowing(normalized)
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
-            session_started_at=session_started_at,
+            session_started_at=time(),
         )
         await self.coordinator.async_request_refresh()
 
@@ -576,12 +574,11 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        session_started_at = time()
         await self.coordinator.client.async_start_spot_mowing(normalized)
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
-            session_started_at=session_started_at,
+            session_started_at=time(),
         )
         await self.coordinator.async_request_refresh()
 
@@ -616,12 +613,11 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        session_started_at = time()
         await self.coordinator.client.async_start_edge_mowing(normalized)
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
-            session_started_at=session_started_at,
+            session_started_at=time(),
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from time import time
 from types import SimpleNamespace
 from typing import Any
 
@@ -477,6 +478,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         action = self.coordinator.selected_mowing_action
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
+        session_started_at = time()
         new_session = False
         if action == MOWING_ACTION_EDGE:
             self._ensure_selected_map_matches_active()
@@ -524,6 +526,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             begin_runtime_mission_session(
                 runtime_cache,
                 observed_generation=observed_generation,
+                session_started_at=session_started_at,
             )
         await self.coordinator.async_request_refresh()
 
@@ -546,10 +549,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
+        session_started_at = time()
         await self.coordinator.client.async_start_zone_mowing(normalized)
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
+            session_started_at=session_started_at,
         )
         await self.coordinator.async_request_refresh()
 
@@ -571,10 +576,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
+        session_started_at = time()
         await self.coordinator.client.async_start_spot_mowing(normalized)
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
+            session_started_at=session_started_at,
         )
         await self.coordinator.async_request_refresh()
 
@@ -609,10 +616,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
+        session_started_at = time()
         await self.coordinator.client.async_start_edge_mowing(normalized)
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
+            session_started_at=session_started_at,
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -50,6 +50,7 @@ from .dreame_lawn_mower_client.mowing_preferences import (
 )
 from .entity import DreameLawnMowerEntity
 from .mowing_preference_control import async_update_selected_mowing_preference
+from .runtime_cache import begin_runtime_mission_session
 from .services import (
     ATTR_CONFIRM_PREFERENCE_WRITE,
     ATTR_EXECUTE,
@@ -471,6 +472,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
     async def async_start_mowing(self) -> None:
         """Start or resume mowing."""
         action = self.coordinator.selected_mowing_action
+        new_session = False
         if action == MOWING_ACTION_EDGE:
             self._ensure_selected_map_matches_active()
             contour_entries = current_contour_entries(
@@ -485,6 +487,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                     "No current-map edge contour is available to start."
                 )
             await self.coordinator.client.async_start_edge_mowing([list(contour_id)])
+            new_session = True
         elif action == MOWING_ACTION_ZONE:
             self._ensure_selected_map_matches_active()
             zone_entries = current_zone_entries(
@@ -497,6 +500,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             if zone_id is None:
                 raise HomeAssistantError("No current-map zone is available to start.")
             await self.coordinator.client.async_start_zone_mowing([zone_id])
+            new_session = True
         elif action == MOWING_ACTION_SPOT:
             self._ensure_selected_map_matches_active()
             spot_entries = current_spot_entries(
@@ -508,8 +512,13 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             if spot_id is None:
                 raise HomeAssistantError("No current-map spot is available to start.")
             await self.coordinator.client.async_start_spot_mowing([spot_id])
+            new_session = True
         else:
-            await self.coordinator.client.async_start_mowing()
+            new_session = await self.coordinator.client.async_start_mowing()
+        if new_session is True:
+            begin_runtime_mission_session(
+                getattr(self.coordinator, "runtime_telemetry_cache", None)
+            )
         await self.coordinator.async_request_refresh()
 
     async def async_start_zone_mowing(self, zone_ids: list[int]) -> None:
@@ -530,6 +539,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             target_name="Zone",
         )
         await self.coordinator.client.async_start_zone_mowing(normalized)
+        begin_runtime_mission_session(
+            getattr(self.coordinator, "runtime_telemetry_cache", None)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_start_spot_mowing(self, spot_ids: list[int]) -> None:
@@ -549,6 +561,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             target_name="Spot",
         )
         await self.coordinator.client.async_start_spot_mowing(normalized)
+        begin_runtime_mission_session(
+            getattr(self.coordinator, "runtime_telemetry_cache", None)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_start_edge_mowing(self, contour_ids: list[list[int]]) -> None:
@@ -581,6 +596,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 f"Available contour ids: {available_text or 'none'}."
             )
         await self.coordinator.client.async_start_edge_mowing(normalized)
+        begin_runtime_mission_session(
+            getattr(self.coordinator, "runtime_telemetry_cache", None)
+        )
         await self.coordinator.async_request_refresh()
 
     async def async_switch_current_map(self, map_index: int) -> None:

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -50,7 +50,10 @@ from .dreame_lawn_mower_client.mowing_preferences import (
 )
 from .entity import DreameLawnMowerEntity
 from .mowing_preference_control import async_update_selected_mowing_preference
-from .runtime_cache import begin_runtime_mission_session
+from .runtime_cache import (
+    begin_runtime_mission_session,
+    runtime_mission_session_generation,
+)
 from .services import (
     ATTR_CONFIRM_PREFERENCE_WRITE,
     ATTR_EXECUTE,
@@ -472,6 +475,8 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
     async def async_start_mowing(self) -> None:
         """Start or resume mowing."""
         action = self.coordinator.selected_mowing_action
+        runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
+        observed_generation = runtime_mission_session_generation(runtime_cache)
         new_session = False
         if action == MOWING_ACTION_EDGE:
             self._ensure_selected_map_matches_active()
@@ -517,7 +522,8 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             new_session = await self.coordinator.client.async_start_mowing()
         if new_session is True:
             begin_runtime_mission_session(
-                getattr(self.coordinator, "runtime_telemetry_cache", None)
+                runtime_cache,
+                observed_generation=observed_generation,
             )
         await self.coordinator.async_request_refresh()
 
@@ -538,9 +544,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             available_ids=[int(entry["area_id"]) for entry in zone_entries],
             target_name="Zone",
         )
+        runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
+        observed_generation = runtime_mission_session_generation(runtime_cache)
         await self.coordinator.client.async_start_zone_mowing(normalized)
         begin_runtime_mission_session(
-            getattr(self.coordinator, "runtime_telemetry_cache", None)
+            runtime_cache,
+            observed_generation=observed_generation,
         )
         await self.coordinator.async_request_refresh()
 
@@ -560,9 +569,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             available_ids=[int(entry["spot_id"]) for entry in spot_entries],
             target_name="Spot",
         )
+        runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
+        observed_generation = runtime_mission_session_generation(runtime_cache)
         await self.coordinator.client.async_start_spot_mowing(normalized)
         begin_runtime_mission_session(
-            getattr(self.coordinator, "runtime_telemetry_cache", None)
+            runtime_cache,
+            observed_generation=observed_generation,
         )
         await self.coordinator.async_request_refresh()
 
@@ -595,9 +607,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 f"Edge contour {missing_text} is not available on the active map. "
                 f"Available contour ids: {available_text or 'none'}."
             )
+        runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
+        observed_generation = runtime_mission_session_generation(runtime_cache)
         await self.coordinator.client.async_start_edge_mowing(normalized)
         begin_runtime_mission_session(
-            getattr(self.coordinator, "runtime_telemetry_cache", None)
+            runtime_cache,
+            observed_generation=observed_generation,
         )
         await self.coordinator.async_request_refresh()
 

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -25,7 +25,7 @@ _RESUME_STATUS_NOTICES = frozenset(
     {"mowing_resumed_after_charging", "resuming_unfinished_task"}
 )
 _INACTIVE_PHYSICAL_STATES = frozenset(
-    {"error", "idle", "standby", "waiting_for_task", "water_tank_drying"}
+    {"idle", "standby", "waiting_for_task", "water_tank_drying"}
 )
 
 
@@ -73,21 +73,33 @@ def runtime_mission_completion_confirmed(
         return False
     if mission_active is None:
         return cached_completion_confirmed
-    if getattr(snapshot, "task_status", None) in _UNSUCCESSFUL_TASK_STATUSES:
+    if (
+        getattr(snapshot, "task_status", None) in _UNSUCCESSFUL_TASK_STATUSES
+        and _runtime_terminal_state_is_current(
+            snapshot,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
+    ):
         return False
     if cached_completion_confirmed:
         return True
-    if getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES:
+    if (
+        getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES
+        and _runtime_terminal_state_is_current(
+            snapshot,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
+    ):
         return True
     if getattr(snapshot, "status_notice_name", None) not in _COMPLETED_STATUS_NOTICES:
         return False
     notice_event_at = _event_timestamp(
         getattr(snapshot, "status_notice_event_at", None)
     )
-    if (
-        notice_event_at is not None
-        and session_started_at is not None
-        and notice_event_at <= session_started_at
+    if session_started_at is not None and (
+        notice_event_at is None or notice_event_at <= session_started_at
     ):
         return False
     return True
@@ -127,6 +139,7 @@ def runtime_mission_session_active(
     if snapshot is None:
         return tracking_active
     task_status = getattr(snapshot, "task_status", None)
+    heartbeat_state_superseded = _runtime_heartbeat_state_is_superseded(snapshot)
     if (
         task_status in _TERMINAL_TASK_STATUSES
         and not _runtime_terminal_state_is_current(
@@ -134,17 +147,13 @@ def runtime_mission_session_active(
             session_started_at=session_started_at,
             session_identity=session_identity,
         )
+        and not heartbeat_state_superseded
     ):
         return True
     session_active = getattr(snapshot, "mowing_session_active", None)
     terminal_event_at = _runtime_terminal_evidence_event_at(snapshot)
-    heartbeat_event_at = _event_timestamp(
-        getattr(snapshot, "task_status_event_at", None)
-    )
     active_heartbeat_superseded = bool(
-        session_active is True
-        and terminal_event_at is not None
-        and (heartbeat_event_at is None or terminal_event_at > heartbeat_event_at)
+        session_active is True and heartbeat_state_superseded
     )
     if session_active is not None and not active_heartbeat_superseded:
         return bool(session_active)
@@ -170,6 +179,14 @@ def runtime_mission_session_active(
             and notice_event_at > state_event_at
         ):
             return True
+    if (
+        terminal_event_at is None
+        and getattr(snapshot, "activity", None) == "error"
+        and getattr(snapshot, "started", False)
+        and getattr(snapshot, "state", None)
+        in {"error", "monitoring_paused", "paused"}
+    ):
+        return None
     if task_status in _COMPLETED_TASK_STATUSES:
         return False
     if getattr(snapshot, "state", None) in {
@@ -246,6 +263,17 @@ def _runtime_terminal_evidence_event_at(snapshot: Any) -> float | None:
         if notice_event_at is not None:
             candidates.append(notice_event_at)
     return max(candidates, default=None)
+
+
+def _runtime_heartbeat_state_is_superseded(snapshot: Any) -> bool:
+    """Return whether newer non-heartbeat terminal evidence wins ordering."""
+    terminal_event_at = _runtime_terminal_evidence_event_at(snapshot)
+    if terminal_event_at is None:
+        return False
+    heartbeat_event_at = _event_timestamp(
+        getattr(snapshot, "task_status_event_at", None)
+    )
+    return heartbeat_event_at is None or terminal_event_at > heartbeat_event_at
 
 
 def runtime_mission_new_session_event_at(snapshot: Any) -> float | None:

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -129,6 +129,40 @@ def runtime_mission_new_session(snapshot: Any) -> bool:
     )
 
 
+def runtime_mission_session_identity(snapshot: Any) -> int | None:
+    """Return the heartbeat task id that identifies the current mission."""
+    task_id = getattr(snapshot, "mission_task_id", None)
+    if isinstance(task_id, int) and not isinstance(task_id, bool):
+        return task_id
+    return None
+
+
+def runtime_mission_new_session_evidence(snapshot: Any) -> tuple[Any, ...] | None:
+    """Return stable evidence that distinguishes repeated start snapshots."""
+    if snapshot is None or not runtime_mission_new_session(snapshot):
+        return None
+    task_id = runtime_mission_session_identity(snapshot)
+    if task_id is not None:
+        return ("task", task_id)
+    task_status = getattr(snapshot, "task_status", None)
+    task_status_event_at = getattr(snapshot, "task_status_event_at", None)
+    if (
+        task_status in _NEW_SESSION_TASK_STATUSES
+        and isinstance(task_status_event_at, int | float)
+        and not isinstance(task_status_event_at, bool)
+    ):
+        return ("task_status", task_status, float(task_status_event_at))
+    notice_name = getattr(snapshot, "status_notice_name", None)
+    notice_event_at = getattr(snapshot, "status_notice_event_at", None)
+    if (
+        notice_name in _NEW_SESSION_STATUS_NOTICES
+        and isinstance(notice_event_at, int | float)
+        and not isinstance(notice_event_at, bool)
+    ):
+        return ("notice", notice_name, float(notice_event_at))
+    return None
+
+
 def runtime_mission_progress_percent(
     blob: Any,
     *,
@@ -155,16 +189,27 @@ class DreameLawnMowerRuntimeTelemetryCache:
     _metric_signature: tuple[Any, ...] | None = None
     _session_active: bool = False
     _session_generation: int = 0
+    _session_identity: int | None = None
     _new_session_signal_seen: bool = False
+    _new_session_evidence: tuple[Any, ...] | None = None
+    _new_session_evidence_pending: bool = False
     _new_session_pending_activation: bool = False
 
-    def _invalidate_for_new_session(self) -> None:
+    def _invalidate_for_new_session(
+        self,
+        *,
+        session_identity: int | None = None,
+    ) -> None:
         self.blob = None
         self.captured_at = None
         self.completion_confirmed = False
         self._metric_signature = None
         self._session_active = True
         self._session_generation += 1
+        self._session_identity = session_identity
+        self._new_session_signal_seen = False
+        self._new_session_evidence = None
+        self._new_session_evidence_pending = False
         self._new_session_pending_activation = False
 
     def begin_new_session(self, *, observed_generation: int | None = None) -> None:
@@ -177,10 +222,12 @@ class DreameLawnMowerRuntimeTelemetryCache:
             # mission while the command awaited its device response. Keep any
             # telemetry that callback captured instead of resetting it again.
             self._new_session_signal_seen = True
+            self._new_session_evidence_pending = self._new_session_evidence is None
             self._new_session_pending_activation = False
             return
         self._invalidate_for_new_session()
         self._new_session_signal_seen = True
+        self._new_session_evidence_pending = True
         self._new_session_pending_activation = True
 
     def observe_session_state(
@@ -190,11 +237,41 @@ class DreameLawnMowerRuntimeTelemetryCache:
         completion_confirmed: bool = False,
         completion_rejected: bool = False,
         new_session: bool = False,
+        new_session_evidence: tuple[Any, ...] | None = None,
+        session_identity: int | None = None,
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
-        if new_session and not self._new_session_signal_seen:
-            self._invalidate_for_new_session()
+        invalidated = False
+        if (
+            active_session
+            and session_identity is not None
+            and self._session_identity is not None
+            and session_identity != self._session_identity
+        ):
+            self._invalidate_for_new_session(session_identity=session_identity)
+            invalidated = True
         if new_session:
+            if (
+                new_session_evidence is not None
+                and new_session_evidence != self._new_session_evidence
+            ):
+                if self._new_session_evidence_pending:
+                    self._new_session_evidence_pending = False
+                elif not invalidated:
+                    self._invalidate_for_new_session(
+                        session_identity=session_identity,
+                    )
+                    invalidated = True
+                self._new_session_evidence = new_session_evidence
+            elif (
+                new_session_evidence is None
+                and not self._new_session_signal_seen
+                and not invalidated
+            ):
+                self._invalidate_for_new_session(
+                    session_identity=session_identity,
+                )
+                invalidated = True
             self._new_session_signal_seen = True
             self._new_session_pending_activation = False
             active_session = True
@@ -202,7 +279,9 @@ class DreameLawnMowerRuntimeTelemetryCache:
             return
         if active_session:
             if not self._session_active:
-                self._invalidate_for_new_session()
+                self._invalidate_for_new_session(session_identity=session_identity)
+            elif session_identity is not None:
+                self._session_identity = session_identity
             self.completion_confirmed = False
             self._session_active = True
             self._new_session_pending_activation = False
@@ -212,7 +291,10 @@ class DreameLawnMowerRuntimeTelemetryCache:
         ):
             return
         self._session_active = False
+        self._session_identity = None
         self._new_session_signal_seen = False
+        self._new_session_evidence = None
+        self._new_session_evidence_pending = False
         self._new_session_pending_activation = False
         if completion_rejected:
             self.completion_confirmed = False
@@ -229,6 +311,8 @@ class DreameLawnMowerRuntimeTelemetryCache:
         completion_confirmed: bool = False,
         completion_rejected: bool = False,
         new_session: bool = False,
+        new_session_evidence: tuple[Any, ...] | None = None,
+        session_identity: int | None = None,
     ) -> bool:
         """Store a useful runtime payload without erasing it with empty polls."""
         self.observe_session_state(
@@ -236,6 +320,8 @@ class DreameLawnMowerRuntimeTelemetryCache:
             completion_confirmed=completion_confirmed,
             completion_rejected=completion_rejected,
             new_session=new_session,
+            new_session_evidence=new_session_evidence,
+            session_identity=session_identity,
         )
         if not runtime_blob_has_session_metrics(blob):
             return False
@@ -261,6 +347,8 @@ def observe_runtime_session_state(
     completion_confirmed: bool = False,
     completion_rejected: bool = False,
     new_session: bool = False,
+    new_session_evidence: tuple[Any, ...] | None = None,
+    session_identity: int | None = None,
 ) -> None:
     """Apply authoritative session state when the integration owns this cache."""
     if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
@@ -269,6 +357,8 @@ def observe_runtime_session_state(
             completion_confirmed=completion_confirmed,
             completion_rejected=completion_rejected,
             new_session=new_session,
+            new_session_evidence=new_session_evidence,
+            session_identity=session_identity,
         )
 
 

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -55,6 +55,7 @@ def runtime_mission_completion_confirmed(
     *,
     tracking_active: bool | None,
     cached_completion_confirmed: bool = False,
+    session_started_at: float | None = None,
 ) -> bool:
     """Return whether an inactive mission has an explicit completion signal."""
     mission_active = runtime_mission_session_active(
@@ -67,11 +68,22 @@ def runtime_mission_completion_confirmed(
         return cached_completion_confirmed
     if getattr(snapshot, "task_status", None) in _UNSUCCESSFUL_TASK_STATUSES:
         return False
-    return (
-        cached_completion_confirmed
-        or getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES
-        or getattr(snapshot, "status_notice_name", None) in _COMPLETED_STATUS_NOTICES
+    if cached_completion_confirmed:
+        return True
+    if getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES:
+        return True
+    if getattr(snapshot, "status_notice_name", None) not in _COMPLETED_STATUS_NOTICES:
+        return False
+    notice_event_at = _event_timestamp(
+        getattr(snapshot, "status_notice_event_at", None)
     )
+    if (
+        notice_event_at is not None
+        and session_started_at is not None
+        and notice_event_at <= session_started_at
+    ):
+        return False
+    return True
 
 
 def runtime_mission_completion_rejected(snapshot: Any) -> bool:
@@ -131,11 +143,53 @@ def runtime_mission_new_session(snapshot: Any) -> bool:
     """Return whether a snapshot explicitly announces a fresh mower mission."""
     if snapshot is None:
         return False
-    return (
-        getattr(snapshot, "task_status", None) in _NEW_SESSION_TASK_STATUSES
-        or getattr(snapshot, "status_notice_name", None)
-        in _NEW_SESSION_STATUS_NOTICES
+    if getattr(snapshot, "task_status", None) in _NEW_SESSION_TASK_STATUSES:
+        return True
+    if getattr(snapshot, "status_notice_name", None) not in _NEW_SESSION_STATUS_NOTICES:
+        return False
+    if getattr(snapshot, "mowing_session_active", None) is not False:
+        return True
+    notice_event_at = _event_timestamp(
+        getattr(snapshot, "status_notice_event_at", None)
     )
+    physical_event_at = max(
+        (
+            event_at
+            for event_at in (
+                _event_timestamp(getattr(snapshot, "state_event_at", None)),
+                _event_timestamp(getattr(snapshot, "task_status_event_at", None)),
+            )
+            if event_at is not None
+        ),
+        default=None,
+    )
+    return (
+        notice_event_at is not None
+        and physical_event_at is not None
+        and notice_event_at > physical_event_at
+    )
+
+
+def _event_timestamp(value: Any) -> float | None:
+    """Return a comparable realtime event timestamp when available."""
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return float(value)
+    return None
+
+
+def runtime_mission_new_session_event_at(snapshot: Any) -> float | None:
+    """Return ordered realtime evidence for the current mission start."""
+    if snapshot is None or not runtime_mission_new_session(snapshot):
+        return None
+    task_status = getattr(snapshot, "task_status", None)
+    if task_status in _NEW_SESSION_TASK_STATUSES:
+        event_at = _event_timestamp(getattr(snapshot, "task_status_event_at", None))
+        if event_at is not None:
+            return event_at
+    notice_name = getattr(snapshot, "status_notice_name", None)
+    if notice_name in _NEW_SESSION_STATUS_NOTICES:
+        return _event_timestamp(getattr(snapshot, "status_notice_event_at", None))
+    return None
 
 
 def runtime_mission_session_identity(snapshot: Any) -> int | None:
@@ -199,6 +253,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
     _session_active: bool = False
     _session_generation: int = 0
     _session_identity: int | None = None
+    _session_started_at: float | None = None
     _new_session_signal_seen: bool = False
     _new_session_evidence: tuple[Any, ...] | None = None
     _new_session_evidence_pending: bool = False
@@ -208,6 +263,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self,
         *,
         session_identity: int | None = None,
+        session_started_at: float | None = None,
     ) -> None:
         self.blob = None
         self.captured_at = None
@@ -216,6 +272,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self._session_active = True
         self._session_generation += 1
         self._session_identity = session_identity
+        self._session_started_at = session_started_at
         self._new_session_signal_seen = False
         self._new_session_evidence = None
         self._new_session_evidence_pending = False
@@ -247,6 +304,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         completion_rejected: bool = False,
         new_session: bool = False,
         new_session_evidence: tuple[Any, ...] | None = None,
+        new_session_event_at: float | None = None,
         session_identity: int | None = None,
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
@@ -257,7 +315,10 @@ class DreameLawnMowerRuntimeTelemetryCache:
             and self._session_identity is not None
             and session_identity != self._session_identity
         ):
-            self._invalidate_for_new_session(session_identity=session_identity)
+            self._invalidate_for_new_session(
+                session_identity=session_identity,
+                session_started_at=new_session_event_at,
+            )
             invalidated = True
         if new_session:
             if (
@@ -269,9 +330,12 @@ class DreameLawnMowerRuntimeTelemetryCache:
                 elif not invalidated:
                     self._invalidate_for_new_session(
                         session_identity=session_identity,
+                        session_started_at=new_session_event_at,
                     )
                     invalidated = True
                 self._new_session_evidence = new_session_evidence
+                if new_session_event_at is not None:
+                    self._session_started_at = new_session_event_at
             elif (
                 new_session_evidence is None
                 and not self._new_session_signal_seen
@@ -279,6 +343,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
             ):
                 self._invalidate_for_new_session(
                     session_identity=session_identity,
+                    session_started_at=new_session_event_at,
                 )
                 invalidated = True
             self._new_session_signal_seen = True
@@ -321,6 +386,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         completion_rejected: bool = False,
         new_session: bool = False,
         new_session_evidence: tuple[Any, ...] | None = None,
+        new_session_event_at: float | None = None,
         session_identity: int | None = None,
     ) -> bool:
         """Store a useful runtime payload without erasing it with empty polls."""
@@ -330,6 +396,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
             completion_rejected=completion_rejected,
             new_session=new_session,
             new_session_evidence=new_session_evidence,
+            new_session_event_at=new_session_event_at,
             session_identity=session_identity,
         )
         if not runtime_blob_has_session_metrics(blob):
@@ -357,6 +424,7 @@ def observe_runtime_session_state(
     completion_rejected: bool = False,
     new_session: bool = False,
     new_session_evidence: tuple[Any, ...] | None = None,
+    new_session_event_at: float | None = None,
     session_identity: int | None = None,
 ) -> None:
     """Apply authoritative session state when the integration owns this cache."""
@@ -367,6 +435,7 @@ def observe_runtime_session_state(
             completion_rejected=completion_rejected,
             new_session=new_session,
             new_session_evidence=new_session_evidence,
+            new_session_event_at=new_session_event_at,
             session_identity=session_identity,
         )
 
@@ -375,6 +444,13 @@ def runtime_mission_session_generation(cache: Any) -> int | None:
     """Return the current integration-owned mission generation."""
     if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
         return cache._session_generation
+    return None
+
+
+def runtime_mission_session_started_at(cache: Any) -> float | None:
+    """Return ordered evidence for the current cached mission boundary."""
+    if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
+        return cache._session_started_at
     return None
 
 

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -14,6 +14,7 @@ _SESSION_METRIC_FIELDS = (
 )
 _COMPLETED_TASK_STATUSES = frozenset({"finished"})
 _COMPLETED_STATUS_NOTICES = frozenset({"mowing_task_completed"})
+_UNSUCCESSFUL_TASK_STATUSES = frozenset({"failed", "exit"})
 _NEW_SESSION_TASK_STATUSES = frozenset({"starting"})
 _NEW_SESSION_STATUS_NOTICES = frozenset(
     {"mowing_started", "mowing_task_started", "scheduled_mowing_started"}
@@ -64,10 +65,20 @@ def runtime_mission_completion_confirmed(
         return False
     if mission_active is None:
         return cached_completion_confirmed
+    if getattr(snapshot, "task_status", None) in _UNSUCCESSFUL_TASK_STATUSES:
+        return False
     return (
         cached_completion_confirmed
         or getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES
         or getattr(snapshot, "status_notice_name", None) in _COMPLETED_STATUS_NOTICES
+    )
+
+
+def runtime_mission_completion_rejected(snapshot: Any) -> bool:
+    """Return whether the mower explicitly ended the mission unsuccessfully."""
+    return (
+        snapshot is not None
+        and getattr(snapshot, "task_status", None) in _UNSUCCESSFUL_TASK_STATUSES
     )
 
 
@@ -165,6 +176,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         *,
         active_session: bool | None,
         completion_confirmed: bool = False,
+        completion_rejected: bool = False,
         new_session: bool = False,
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
@@ -183,12 +195,16 @@ class DreameLawnMowerRuntimeTelemetryCache:
             self._session_active = True
             self._new_session_pending_activation = False
             return
-        if self._new_session_pending_activation and not completion_confirmed:
+        if self._new_session_pending_activation and not (
+            completion_confirmed or completion_rejected
+        ):
             return
         self._session_active = False
         self._new_session_signal_seen = False
         self._new_session_pending_activation = False
-        if completion_confirmed:
+        if completion_rejected:
+            self.completion_confirmed = False
+        elif completion_confirmed:
             self.completion_confirmed = True
 
     def update(
@@ -199,12 +215,14 @@ class DreameLawnMowerRuntimeTelemetryCache:
         allow_zero: bool = True,
         active_session: bool | None = False,
         completion_confirmed: bool = False,
+        completion_rejected: bool = False,
         new_session: bool = False,
     ) -> bool:
         """Store a useful runtime payload without erasing it with empty polls."""
         self.observe_session_state(
             active_session=active_session,
             completion_confirmed=completion_confirmed,
+            completion_rejected=completion_rejected,
             new_session=new_session,
         )
         if not runtime_blob_has_session_metrics(blob):
@@ -229,6 +247,7 @@ def observe_runtime_session_state(
     *,
     active_session: bool | None,
     completion_confirmed: bool = False,
+    completion_rejected: bool = False,
     new_session: bool = False,
 ) -> None:
     """Apply authoritative session state when the integration owns this cache."""
@@ -236,6 +255,7 @@ def observe_runtime_session_state(
         cache.observe_session_state(
             active_session=active_session,
             completion_confirmed=completion_confirmed,
+            completion_rejected=completion_rejected,
             new_session=new_session,
         )
 

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -154,6 +154,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
     completion_confirmed: bool = False
     _metric_signature: tuple[Any, ...] | None = None
     _session_active: bool = False
+    _session_generation: int = 0
     _new_session_signal_seen: bool = False
     _new_session_pending_activation: bool = False
 
@@ -163,10 +164,21 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self.completion_confirmed = False
         self._metric_signature = None
         self._session_active = True
+        self._session_generation += 1
         self._new_session_pending_activation = False
 
-    def begin_new_session(self) -> None:
+    def begin_new_session(self, *, observed_generation: int | None = None) -> None:
         """Invalidate prior telemetry after a fresh mission is accepted."""
+        if (
+            observed_generation is not None
+            and self._session_generation != observed_generation
+        ):
+            # A realtime callback already observed and invalidated the new
+            # mission while the command awaited its device response. Keep any
+            # telemetry that callback captured instead of resetting it again.
+            self._new_session_signal_seen = True
+            self._new_session_pending_activation = False
+            return
         self._invalidate_for_new_session()
         self._new_session_signal_seen = True
         self._new_session_pending_activation = True
@@ -260,7 +272,18 @@ def observe_runtime_session_state(
         )
 
 
-def begin_runtime_mission_session(cache: Any) -> None:
+def runtime_mission_session_generation(cache: Any) -> int | None:
+    """Return the current integration-owned mission generation."""
+    if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
+        return cache._session_generation
+    return None
+
+
+def begin_runtime_mission_session(
+    cache: Any,
+    *,
+    observed_generation: int | None = None,
+) -> None:
     """Invalidate prior telemetry when an integration-owned start succeeds."""
     if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
-        cache.begin_new_session()
+        cache.begin_new_session(observed_generation=observed_generation)

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -143,7 +143,8 @@ class DreameLawnMowerRuntimeTelemetryCache:
     completion_confirmed: bool = False
     _metric_signature: tuple[Any, ...] | None = None
     _session_active: bool = False
-    _new_session_signal_active: bool = False
+    _new_session_signal_seen: bool = False
+    _new_session_pending_activation: bool = False
 
     def _invalidate_for_new_session(self) -> None:
         self.blob = None
@@ -151,11 +152,13 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self.completion_confirmed = False
         self._metric_signature = None
         self._session_active = True
+        self._new_session_pending_activation = False
 
     def begin_new_session(self) -> None:
         """Invalidate prior telemetry after a fresh mission is accepted."""
         self._invalidate_for_new_session()
-        self._new_session_signal_active = True
+        self._new_session_signal_seen = True
+        self._new_session_pending_activation = True
 
     def observe_session_state(
         self,
@@ -165,10 +168,11 @@ class DreameLawnMowerRuntimeTelemetryCache:
         new_session: bool = False,
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
-        if new_session and not self._new_session_signal_active:
+        if new_session and not self._new_session_signal_seen:
             self._invalidate_for_new_session()
-        self._new_session_signal_active = new_session
         if new_session:
+            self._new_session_signal_seen = True
+            self._new_session_pending_activation = False
             active_session = True
         if active_session is None:
             return
@@ -177,8 +181,13 @@ class DreameLawnMowerRuntimeTelemetryCache:
                 self._invalidate_for_new_session()
             self.completion_confirmed = False
             self._session_active = True
+            self._new_session_pending_activation = False
+            return
+        if self._new_session_pending_activation and not completion_confirmed:
             return
         self._session_active = False
+        self._new_session_signal_seen = False
+        self._new_session_pending_activation = False
         if completion_confirmed:
             self.completion_confirmed = True
 

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -52,15 +52,18 @@ def runtime_blob_has_nonzero_session_metrics(blob: Any) -> bool:
 def runtime_mission_completion_confirmed(
     snapshot: Any,
     *,
-    tracking_active: bool,
+    tracking_active: bool | None,
     cached_completion_confirmed: bool = False,
 ) -> bool:
     """Return whether an inactive mission has an explicit completion signal."""
-    if snapshot is None or runtime_mission_session_active(
+    mission_active = runtime_mission_session_active(
         snapshot,
         tracking_active=tracking_active,
-    ):
+    )
+    if snapshot is None or mission_active is True:
         return False
+    if mission_active is None:
+        return cached_completion_confirmed
     return (
         cached_completion_confirmed
         or getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES
@@ -71,9 +74,16 @@ def runtime_mission_completion_confirmed(
 def runtime_mission_session_active(
     snapshot: Any,
     *,
-    tracking_active: bool,
-) -> bool:
-    """Return whether telemetry belongs to a continuing mower mission."""
+    tracking_active: bool | None,
+) -> bool | None:
+    """Return whether telemetry belongs to a continuing mower mission.
+
+    ``None`` preserves the prior cache boundary when a docked device snapshot
+    is missing the optional heartbeat fields that distinguish a charging pause
+    from an inactive mower.
+    """
+    if snapshot is None:
+        return tracking_active
     session_active = getattr(snapshot, "mowing_session_active", None)
     if session_active is not None:
         return bool(session_active)
@@ -85,7 +95,16 @@ def runtime_mission_session_active(
         return True
     if runtime_mission_new_session(snapshot):
         return True
-    return tracking_active
+    if tracking_active:
+        return True
+    if getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES:
+        return False
+    if getattr(snapshot, "docked", False) or getattr(snapshot, "state", None) in {
+        "charging",
+        "charging_completed",
+    }:
+        return None
+    return False
 
 
 def runtime_mission_new_session(snapshot: Any) -> bool:
@@ -141,7 +160,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
     def observe_session_state(
         self,
         *,
-        active_session: bool,
+        active_session: bool | None,
         completion_confirmed: bool = False,
         new_session: bool = False,
     ) -> None:
@@ -151,6 +170,8 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self._new_session_signal_active = new_session
         if new_session:
             active_session = True
+        if active_session is None:
+            return
         if active_session:
             if not self._session_active:
                 self._invalidate_for_new_session()
@@ -167,7 +188,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         *,
         now: datetime | None = None,
         allow_zero: bool = True,
-        active_session: bool = False,
+        active_session: bool | None = False,
         completion_confirmed: bool = False,
         new_session: bool = False,
     ) -> bool:
@@ -197,7 +218,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
 def observe_runtime_session_state(
     cache: Any,
     *,
-    active_session: bool,
+    active_session: bool | None,
     completion_confirmed: bool = False,
     new_session: bool = False,
 ) -> None:

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -102,12 +102,21 @@ def runtime_mission_session_active(
         return True
     if getattr(snapshot, "task_status", None) in _RESUMABLE_TASK_STATUSES:
         return True
-    if getattr(snapshot, "status_notice_name", None) in _RESUME_STATUS_NOTICES:
-        return True
     if runtime_mission_new_session(snapshot):
         return True
     if tracking_active:
         return True
+    if getattr(snapshot, "status_notice_name", None) in _RESUME_STATUS_NOTICES:
+        notice_event_at = getattr(snapshot, "status_notice_event_at", None)
+        state_event_at = getattr(snapshot, "state_event_at", None)
+        if (
+            isinstance(notice_event_at, int | float)
+            and not isinstance(notice_event_at, bool)
+            and isinstance(state_event_at, int | float)
+            and not isinstance(state_event_at, bool)
+            and notice_event_at > state_event_at
+        ):
+            return True
     if getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES:
         return False
     if getattr(snapshot, "state", None) in {

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -192,6 +192,28 @@ def runtime_mission_new_session_event_at(snapshot: Any) -> float | None:
     return None
 
 
+def runtime_mission_session_event_at(
+    snapshot: Any,
+    *,
+    active_session: bool | None,
+) -> float | None:
+    """Return the best ordered boundary for a newly observed active mission."""
+    explicit_start_at = runtime_mission_new_session_event_at(snapshot)
+    if explicit_start_at is not None or active_session is not True:
+        return explicit_start_at
+    return max(
+        (
+            event_at
+            for event_at in (
+                _event_timestamp(getattr(snapshot, "state_event_at", None)),
+                _event_timestamp(getattr(snapshot, "task_status_event_at", None)),
+            )
+            if event_at is not None
+        ),
+        default=None,
+    )
+
+
 def runtime_mission_session_identity(snapshot: Any) -> int | None:
     """Return the heartbeat task id that identifies the current mission."""
     task_id = getattr(snapshot, "mission_task_id", None)
@@ -278,7 +300,12 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self._new_session_evidence_pending = False
         self._new_session_pending_activation = False
 
-    def begin_new_session(self, *, observed_generation: int | None = None) -> None:
+    def begin_new_session(
+        self,
+        *,
+        observed_generation: int | None = None,
+        session_started_at: float | None = None,
+    ) -> None:
         """Invalidate prior telemetry after a fresh mission is accepted."""
         if (
             observed_generation is not None
@@ -290,8 +317,10 @@ class DreameLawnMowerRuntimeTelemetryCache:
             self._new_session_signal_seen = True
             self._new_session_evidence_pending = self._new_session_evidence is None
             self._new_session_pending_activation = False
+            if self._session_started_at is None:
+                self._session_started_at = session_started_at
             return
-        self._invalidate_for_new_session()
+        self._invalidate_for_new_session(session_started_at=session_started_at)
         self._new_session_signal_seen = True
         self._new_session_evidence_pending = True
         self._new_session_pending_activation = True
@@ -353,7 +382,10 @@ class DreameLawnMowerRuntimeTelemetryCache:
             return
         if active_session:
             if not self._session_active:
-                self._invalidate_for_new_session(session_identity=session_identity)
+                self._invalidate_for_new_session(
+                    session_identity=session_identity,
+                    session_started_at=new_session_event_at,
+                )
             elif session_identity is not None:
                 self._session_identity = session_identity
             self.completion_confirmed = False
@@ -458,7 +490,11 @@ def begin_runtime_mission_session(
     cache: Any,
     *,
     observed_generation: int | None = None,
+    session_started_at: float | None = None,
 ) -> None:
     """Invalidate prior telemetry when an integration-owned start succeeds."""
     if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
-        cache.begin_new_session(observed_generation=observed_generation)
+        cache.begin_new_session(
+            observed_generation=observed_generation,
+            session_started_at=session_started_at,
+        )

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -179,12 +179,15 @@ def runtime_mission_session_active(
             and notice_event_at > state_event_at
         ):
             return True
+    fault_event_at = _event_timestamp(getattr(snapshot, "state_event_at", None))
     if (
-        terminal_event_at is None
-        and getattr(snapshot, "activity", None) == "error"
+        getattr(snapshot, "activity", None) == "error"
         and getattr(snapshot, "started", False)
-        and getattr(snapshot, "state", None)
-        in {"error", "monitoring_paused", "paused"}
+        and getattr(snapshot, "state", None) in {"error", "monitoring_paused", "paused"}
+        and (
+            terminal_event_at is None
+            or (fault_event_at is not None and fault_event_at > terminal_event_at)
+        )
     ):
         return None
     if task_status in _COMPLETED_TASK_STATUSES:
@@ -321,6 +324,12 @@ def runtime_mission_session_identity(
 ) -> int | None:
     """Return a heartbeat task id only when it can belong to this mission."""
     task_id = _snapshot_mission_session_identity(snapshot)
+    if task_id is None:
+        return None
+    if runtime_mission_new_session(
+        snapshot
+    ) and not _runtime_start_task_identity_is_current(snapshot):
+        return None
     if (
         getattr(snapshot, "task_status", None) in _TERMINAL_TASK_STATUSES
         and (session_started_at is not None or cached_session_identity is not None)
@@ -332,6 +341,38 @@ def runtime_mission_session_identity(
     ):
         return None
     return task_id
+
+
+def _runtime_start_task_identity_is_current(snapshot: Any) -> bool:
+    """Return whether a heartbeat task id belongs to announced start evidence."""
+    notice_name = getattr(snapshot, "status_notice_name", None)
+    if notice_name not in _NEW_SESSION_STATUS_NOTICES:
+        return True
+    task_status = getattr(snapshot, "task_status", None)
+    if (
+        getattr(snapshot, "mowing_session_active", None) is False
+        or task_status in _TERMINAL_TASK_STATUSES
+        or task_status == "idle"
+    ):
+        return False
+    notice_event_at = _event_timestamp(
+        getattr(snapshot, "status_notice_event_at", None)
+    )
+    if notice_event_at is None:
+        # Timestamp-less cloud snapshots are still useful after a command when
+        # their heartbeat itself reports an active/startable task.
+        return (
+            task_status
+            in {
+                "mowing",
+                "paused",
+                "returning_to_dock",
+                "starting",
+            }
+            or getattr(snapshot, "mowing_session_active", None) is True
+        )
+    task_event_at = _event_timestamp(getattr(snapshot, "task_status_event_at", None))
+    return task_event_at is not None and task_event_at >= notice_event_at
 
 
 def _snapshot_mission_session_identity(snapshot: Any) -> int | None:
@@ -493,6 +534,18 @@ class DreameLawnMowerRuntimeTelemetryCache:
                 new_session_event_at is not None
                 and new_session_event_at > self._new_session_evidence_after
             )
+        )
+        timestamp_less_command_identity_is_current = bool(
+            self._new_session_evidence_pending
+            and self._new_session_evidence_after is not None
+            and active_session is True
+            and new_session
+            and new_session_event_at is None
+            and session_identity is not None
+            and new_session_evidence == ("task", session_identity)
+        )
+        ordered_evidence_is_current = bool(
+            ordered_evidence_is_current or timestamp_less_command_identity_is_current
         )
         if (
             active_session

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -15,6 +15,7 @@ _SESSION_METRIC_FIELDS = (
 _COMPLETED_TASK_STATUSES = frozenset({"finished"})
 _COMPLETED_STATUS_NOTICES = frozenset({"mowing_task_completed"})
 _UNSUCCESSFUL_TASK_STATUSES = frozenset({"failed", "exit"})
+_TERMINAL_TASK_STATUSES = _COMPLETED_TASK_STATUSES | _UNSUCCESSFUL_TASK_STATUSES
 _NEW_SESSION_TASK_STATUSES = frozenset({"starting"})
 _NEW_SESSION_STATUS_NOTICES = frozenset(
     {"mowing_started", "mowing_task_started", "scheduled_mowing_started"}
@@ -56,11 +57,14 @@ def runtime_mission_completion_confirmed(
     tracking_active: bool | None,
     cached_completion_confirmed: bool = False,
     session_started_at: float | None = None,
+    session_identity: int | None = None,
 ) -> bool:
     """Return whether an inactive mission has an explicit completion signal."""
     mission_active = runtime_mission_session_active(
         snapshot,
         tracking_active=tracking_active,
+        session_started_at=session_started_at,
+        session_identity=session_identity,
     )
     if snapshot is None or mission_active is True:
         return False
@@ -86,11 +90,21 @@ def runtime_mission_completion_confirmed(
     return True
 
 
-def runtime_mission_completion_rejected(snapshot: Any) -> bool:
+def runtime_mission_completion_rejected(
+    snapshot: Any,
+    *,
+    session_started_at: float | None = None,
+    session_identity: int | None = None,
+) -> bool:
     """Return whether the mower explicitly ended the mission unsuccessfully."""
     return (
         snapshot is not None
         and getattr(snapshot, "task_status", None) in _UNSUCCESSFUL_TASK_STATUSES
+        and _runtime_terminal_state_is_current(
+            snapshot,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
     )
 
 
@@ -98,6 +112,8 @@ def runtime_mission_session_active(
     snapshot: Any,
     *,
     tracking_active: bool | None,
+    session_started_at: float | None = None,
+    session_identity: int | None = None,
 ) -> bool | None:
     """Return whether telemetry belongs to a continuing mower mission.
 
@@ -107,12 +123,22 @@ def runtime_mission_session_active(
     """
     if snapshot is None:
         return tracking_active
+    task_status = getattr(snapshot, "task_status", None)
+    if (
+        task_status in _TERMINAL_TASK_STATUSES
+        and not _runtime_terminal_state_is_current(
+            snapshot,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
+    ):
+        return True
     session_active = getattr(snapshot, "mowing_session_active", None)
     if session_active is not None:
         return bool(session_active)
     if getattr(snapshot, "task_resumable", None) is True:
         return True
-    if getattr(snapshot, "task_status", None) in _RESUMABLE_TASK_STATUSES:
+    if task_status in _RESUMABLE_TASK_STATUSES:
         return True
     if runtime_mission_new_session(snapshot):
         return True
@@ -129,7 +155,7 @@ def runtime_mission_session_active(
             and notice_event_at > state_event_at
         ):
             return True
-    if getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES:
+    if task_status in _COMPLETED_TASK_STATUSES:
         return False
     if getattr(snapshot, "state", None) in {
         "charging",
@@ -214,12 +240,55 @@ def runtime_mission_session_event_at(
     )
 
 
-def runtime_mission_session_identity(snapshot: Any) -> int | None:
-    """Return the heartbeat task id that identifies the current mission."""
+def runtime_mission_session_identity(
+    snapshot: Any,
+    *,
+    session_started_at: float | None = None,
+    cached_session_identity: int | None = None,
+) -> int | None:
+    """Return a heartbeat task id only when it can belong to this mission."""
+    task_id = _snapshot_mission_session_identity(snapshot)
+    if (
+        getattr(snapshot, "task_status", None) in _TERMINAL_TASK_STATUSES
+        and (session_started_at is not None or cached_session_identity is not None)
+        and not _runtime_terminal_state_is_current(
+            snapshot,
+            session_started_at=session_started_at,
+            session_identity=cached_session_identity,
+        )
+    ):
+        return None
+    return task_id
+
+
+def _snapshot_mission_session_identity(snapshot: Any) -> int | None:
+    """Return the raw heartbeat task id carried by a snapshot."""
     task_id = getattr(snapshot, "mission_task_id", None)
     if isinstance(task_id, int) and not isinstance(task_id, bool):
         return task_id
     return None
+
+
+def _runtime_terminal_state_is_current(
+    snapshot: Any,
+    *,
+    session_started_at: float | None,
+    session_identity: int | None,
+) -> bool:
+    """Return whether terminal task evidence belongs to the cached mission."""
+    if session_started_at is None and session_identity is None:
+        return True
+    snapshot_identity = _snapshot_mission_session_identity(snapshot)
+    if session_identity is not None and snapshot_identity is not None:
+        return snapshot_identity == session_identity
+    terminal_event_at = _event_timestamp(
+        getattr(snapshot, "task_status_event_at", None)
+    )
+    return (
+        session_started_at is not None
+        and terminal_event_at is not None
+        and terminal_event_at > session_started_at
+    )
 
 
 def runtime_mission_new_session_evidence(snapshot: Any) -> tuple[Any, ...] | None:
@@ -483,6 +552,13 @@ def runtime_mission_session_started_at(cache: Any) -> float | None:
     """Return ordered evidence for the current cached mission boundary."""
     if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
         return cache._session_started_at
+    return None
+
+
+def runtime_mission_cached_session_identity(cache: Any) -> int | None:
+    """Return the current integration-owned heartbeat task identity."""
+    if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
+        return cache._session_identity
     return None
 
 

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -99,7 +99,7 @@ def runtime_mission_session_active(
         return True
     if getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES:
         return False
-    if getattr(snapshot, "docked", False) or getattr(snapshot, "state", None) in {
+    if getattr(snapshot, "state", None) in {
         "charging",
         "charging_completed",
     }:

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -12,7 +12,7 @@ _SESSION_METRIC_FIELDS = (
     "candidate_runtime_current_area_sqm",
     "candidate_runtime_total_area_sqm",
 )
-_COMPLETED_TASK_STATUSES = frozenset({"completed", "finished"})
+_COMPLETED_TASK_STATUSES = frozenset({"finished"})
 _COMPLETED_STATUS_NOTICES = frozenset({"mowing_task_completed"})
 
 
@@ -81,6 +81,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
     captured_at: datetime | None = None
     completion_confirmed: bool = False
     _metric_signature: tuple[Any, ...] | None = None
+    _session_active: bool = False
 
     def observe_session_state(
         self,
@@ -90,8 +91,15 @@ class DreameLawnMowerRuntimeTelemetryCache:
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
         if active_session:
+            if not self._session_active:
+                self.blob = None
+                self.captured_at = None
+                self._metric_signature = None
             self.completion_confirmed = False
-        elif completion_confirmed:
+            self._session_active = True
+            return
+        self._session_active = False
+        if completion_confirmed:
             self.completion_confirmed = True
 
     def update(

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -24,6 +24,9 @@ _RESUMABLE_TASK_STATUSES = frozenset({"paused"})
 _RESUME_STATUS_NOTICES = frozenset(
     {"mowing_resumed_after_charging", "resuming_unfinished_task"}
 )
+_INACTIVE_PHYSICAL_STATES = frozenset(
+    {"error", "idle", "standby", "waiting_for_task", "water_tank_drying"}
+)
 
 
 def _session_metric_signature(blob: Any) -> tuple[Any, ...]:
@@ -134,15 +137,27 @@ def runtime_mission_session_active(
     ):
         return True
     session_active = getattr(snapshot, "mowing_session_active", None)
-    if session_active is not None:
+    terminal_event_at = _runtime_terminal_evidence_event_at(snapshot)
+    heartbeat_event_at = _event_timestamp(
+        getattr(snapshot, "task_status_event_at", None)
+    )
+    active_heartbeat_superseded = bool(
+        session_active is True
+        and terminal_event_at is not None
+        and (heartbeat_event_at is None or terminal_event_at > heartbeat_event_at)
+    )
+    if session_active is not None and not active_heartbeat_superseded:
         return bool(session_active)
-    if getattr(snapshot, "task_resumable", None) is True:
+    if (
+        getattr(snapshot, "task_resumable", None) is True
+        and not active_heartbeat_superseded
+    ):
         return True
-    if task_status in _RESUMABLE_TASK_STATUSES:
+    if task_status in _RESUMABLE_TASK_STATUSES and not active_heartbeat_superseded:
         return True
     if runtime_mission_new_session(snapshot):
         return True
-    if tracking_active:
+    if tracking_active and not active_heartbeat_superseded:
         return True
     if getattr(snapshot, "status_notice_name", None) in _RESUME_STATUS_NOTICES:
         notice_event_at = getattr(snapshot, "status_notice_event_at", None)
@@ -169,15 +184,29 @@ def runtime_mission_new_session(snapshot: Any) -> bool:
     """Return whether a snapshot explicitly announces a fresh mower mission."""
     if snapshot is None:
         return False
-    if getattr(snapshot, "task_status", None) in _NEW_SESSION_TASK_STATUSES:
+    terminal_event_at = _runtime_terminal_evidence_event_at(snapshot)
+    task_status = getattr(snapshot, "task_status", None)
+    task_status_event_at = _event_timestamp(
+        getattr(snapshot, "task_status_event_at", None)
+    )
+    if task_status in _NEW_SESSION_TASK_STATUSES and (
+        terminal_event_at is None
+        or (
+            task_status_event_at is not None
+            and task_status_event_at > terminal_event_at
+        )
+    ):
         return True
     if getattr(snapshot, "status_notice_name", None) not in _NEW_SESSION_STATUS_NOTICES:
         return False
-    if getattr(snapshot, "mowing_session_active", None) is not False:
-        return True
     notice_event_at = _event_timestamp(
         getattr(snapshot, "status_notice_event_at", None)
     )
+    if getattr(snapshot, "mowing_session_active", None) is not False:
+        return bool(
+            terminal_event_at is None
+            or (notice_event_at is not None and notice_event_at > terminal_event_at)
+        )
     physical_event_at = max(
         (
             event_at
@@ -201,6 +230,22 @@ def _event_timestamp(value: Any) -> float | None:
     if isinstance(value, int | float) and not isinstance(value, bool):
         return float(value)
     return None
+
+
+def _runtime_terminal_evidence_event_at(snapshot: Any) -> float | None:
+    """Return the newest ordered non-heartbeat evidence that a mission ended."""
+    candidates: list[float] = []
+    if getattr(snapshot, "state", None) in _INACTIVE_PHYSICAL_STATES:
+        state_event_at = _event_timestamp(getattr(snapshot, "state_event_at", None))
+        if state_event_at is not None:
+            candidates.append(state_event_at)
+    if getattr(snapshot, "status_notice_name", None) in _COMPLETED_STATUS_NOTICES:
+        notice_event_at = _event_timestamp(
+            getattr(snapshot, "status_notice_event_at", None)
+        )
+        if notice_event_at is not None:
+            candidates.append(notice_event_at)
+    return max(candidates, default=None)
 
 
 def runtime_mission_new_session_event_at(snapshot: Any) -> float | None:
@@ -348,6 +393,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
     _new_session_signal_seen: bool = False
     _new_session_evidence: tuple[Any, ...] | None = None
     _new_session_evidence_pending: bool = False
+    _new_session_evidence_after: float | None = None
     _new_session_pending_activation: bool = False
 
     def _invalidate_for_new_session(
@@ -367,6 +413,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self._new_session_signal_seen = False
         self._new_session_evidence = None
         self._new_session_evidence_pending = False
+        self._new_session_evidence_after = None
         self._new_session_pending_activation = False
 
     def begin_new_session(
@@ -385,6 +432,9 @@ class DreameLawnMowerRuntimeTelemetryCache:
             # telemetry that callback captured instead of resetting it again.
             self._new_session_signal_seen = True
             self._new_session_evidence_pending = self._new_session_evidence is None
+            self._new_session_evidence_after = (
+                session_started_at if self._new_session_evidence_pending else None
+            )
             self._new_session_pending_activation = False
             if self._session_started_at is None:
                 self._session_started_at = session_started_at
@@ -392,6 +442,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self._invalidate_for_new_session(session_started_at=session_started_at)
         self._new_session_signal_seen = True
         self._new_session_evidence_pending = True
+        self._new_session_evidence_after = session_started_at
         self._new_session_pending_activation = True
 
     def observe_session_state(
@@ -407,8 +458,17 @@ class DreameLawnMowerRuntimeTelemetryCache:
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
         invalidated = False
+        ordered_evidence_is_current = bool(
+            not self._new_session_evidence_pending
+            or self._new_session_evidence_after is None
+            or (
+                new_session_event_at is not None
+                and new_session_event_at > self._new_session_evidence_after
+            )
+        )
         if (
             active_session
+            and ordered_evidence_is_current
             and session_identity is not None
             and self._session_identity is not None
             and session_identity != self._session_identity
@@ -423,17 +483,19 @@ class DreameLawnMowerRuntimeTelemetryCache:
                 new_session_evidence is not None
                 and new_session_evidence != self._new_session_evidence
             ):
-                if self._new_session_evidence_pending:
+                if self._new_session_evidence_pending and ordered_evidence_is_current:
                     self._new_session_evidence_pending = False
-                elif not invalidated:
+                    self._new_session_evidence_after = None
+                elif not self._new_session_evidence_pending and not invalidated:
                     self._invalidate_for_new_session(
                         session_identity=session_identity,
                         session_started_at=new_session_event_at,
                     )
                     invalidated = True
-                self._new_session_evidence = new_session_evidence
-                if new_session_event_at is not None:
-                    self._session_started_at = new_session_event_at
+                if not self._new_session_evidence_pending:
+                    self._new_session_evidence = new_session_evidence
+                    if new_session_event_at is not None:
+                        self._session_started_at = new_session_event_at
             elif (
                 new_session_evidence is None
                 and not self._new_session_signal_seen
@@ -455,7 +517,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
                     session_identity=session_identity,
                     session_started_at=new_session_event_at,
                 )
-            elif session_identity is not None:
+            elif session_identity is not None and ordered_evidence_is_current:
                 self._session_identity = session_identity
             self.completion_confirmed = False
             self._session_active = True
@@ -470,6 +532,7 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self._new_session_signal_seen = False
         self._new_session_evidence = None
         self._new_session_evidence_pending = False
+        self._new_session_evidence_after = None
         self._new_session_pending_activation = False
         if completion_rejected:
             self.completion_confirmed = False

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -16,7 +16,7 @@ _COMPLETED_TASK_STATUSES = frozenset({"finished"})
 _COMPLETED_STATUS_NOTICES = frozenset({"mowing_task_completed"})
 _NEW_SESSION_TASK_STATUSES = frozenset({"starting"})
 _NEW_SESSION_STATUS_NOTICES = frozenset(
-    {"mowing_started", "scheduled_mowing_started"}
+    {"mowing_started", "mowing_task_started", "scheduled_mowing_started"}
 )
 _RESUMABLE_TASK_STATUSES = frozenset({"paused"})
 _RESUME_STATUS_NOTICES = frozenset(

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -14,6 +14,14 @@ _SESSION_METRIC_FIELDS = (
 )
 _COMPLETED_TASK_STATUSES = frozenset({"finished"})
 _COMPLETED_STATUS_NOTICES = frozenset({"mowing_task_completed"})
+_NEW_SESSION_TASK_STATUSES = frozenset({"starting"})
+_NEW_SESSION_STATUS_NOTICES = frozenset(
+    {"mowing_started", "scheduled_mowing_started"}
+)
+_RESUMABLE_TASK_STATUSES = frozenset({"paused"})
+_RESUME_STATUS_NOTICES = frozenset(
+    {"mowing_resumed_after_charging", "resuming_unfinished_task"}
+)
 
 
 def _session_metric_signature(blob: Any) -> tuple[Any, ...]:
@@ -48,12 +56,46 @@ def runtime_mission_completion_confirmed(
     cached_completion_confirmed: bool = False,
 ) -> bool:
     """Return whether an inactive mission has an explicit completion signal."""
-    if snapshot is None or tracking_active:
+    if snapshot is None or runtime_mission_session_active(
+        snapshot,
+        tracking_active=tracking_active,
+    ):
         return False
     return (
         cached_completion_confirmed
         or getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES
         or getattr(snapshot, "status_notice_name", None) in _COMPLETED_STATUS_NOTICES
+    )
+
+
+def runtime_mission_session_active(
+    snapshot: Any,
+    *,
+    tracking_active: bool,
+) -> bool:
+    """Return whether telemetry belongs to a continuing mower mission."""
+    session_active = getattr(snapshot, "mowing_session_active", None)
+    if session_active is not None:
+        return bool(session_active)
+    if getattr(snapshot, "task_resumable", None) is True:
+        return True
+    if getattr(snapshot, "task_status", None) in _RESUMABLE_TASK_STATUSES:
+        return True
+    if getattr(snapshot, "status_notice_name", None) in _RESUME_STATUS_NOTICES:
+        return True
+    if runtime_mission_new_session(snapshot):
+        return True
+    return tracking_active
+
+
+def runtime_mission_new_session(snapshot: Any) -> bool:
+    """Return whether a snapshot explicitly announces a fresh mower mission."""
+    if snapshot is None:
+        return False
+    return (
+        getattr(snapshot, "task_status", None) in _NEW_SESSION_TASK_STATUSES
+        or getattr(snapshot, "status_notice_name", None)
+        in _NEW_SESSION_STATUS_NOTICES
     )
 
 
@@ -82,19 +124,36 @@ class DreameLawnMowerRuntimeTelemetryCache:
     completion_confirmed: bool = False
     _metric_signature: tuple[Any, ...] | None = None
     _session_active: bool = False
+    _new_session_signal_active: bool = False
+
+    def _invalidate_for_new_session(self) -> None:
+        self.blob = None
+        self.captured_at = None
+        self.completion_confirmed = False
+        self._metric_signature = None
+        self._session_active = True
+
+    def begin_new_session(self) -> None:
+        """Invalidate prior telemetry after a fresh mission is accepted."""
+        self._invalidate_for_new_session()
+        self._new_session_signal_active = True
 
     def observe_session_state(
         self,
         *,
         active_session: bool,
         completion_confirmed: bool = False,
+        new_session: bool = False,
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
+        if new_session and not self._new_session_signal_active:
+            self._invalidate_for_new_session()
+        self._new_session_signal_active = new_session
+        if new_session:
+            active_session = True
         if active_session:
             if not self._session_active:
-                self.blob = None
-                self.captured_at = None
-                self._metric_signature = None
+                self._invalidate_for_new_session()
             self.completion_confirmed = False
             self._session_active = True
             return
@@ -110,11 +169,13 @@ class DreameLawnMowerRuntimeTelemetryCache:
         allow_zero: bool = True,
         active_session: bool = False,
         completion_confirmed: bool = False,
+        new_session: bool = False,
     ) -> bool:
         """Store a useful runtime payload without erasing it with empty polls."""
         self.observe_session_state(
             active_session=active_session,
             completion_confirmed=completion_confirmed,
+            new_session=new_session,
         )
         if not runtime_blob_has_session_metrics(blob):
             return False
@@ -138,10 +199,18 @@ def observe_runtime_session_state(
     *,
     active_session: bool,
     completion_confirmed: bool = False,
+    new_session: bool = False,
 ) -> None:
     """Apply authoritative session state when the integration owns this cache."""
     if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
         cache.observe_session_state(
             active_session=active_session,
             completion_confirmed=completion_confirmed,
+            new_session=new_session,
         )
+
+
+def begin_runtime_mission_session(cache: Any) -> None:
+    """Invalidate prior telemetry when an integration-owned start succeeds."""
+    if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
+        cache.begin_new_session()

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -12,6 +12,8 @@ _SESSION_METRIC_FIELDS = (
     "candidate_runtime_current_area_sqm",
     "candidate_runtime_total_area_sqm",
 )
+_COMPLETED_TASK_STATUSES = frozenset({"completed", "finished"})
+_COMPLETED_STATUS_NOTICES = frozenset({"mowing_task_completed"})
 
 
 def _session_metric_signature(blob: Any) -> tuple[Any, ...]:
@@ -39,13 +41,58 @@ def runtime_blob_has_nonzero_session_metrics(blob: Any) -> bool:
     )
 
 
+def runtime_mission_completion_confirmed(
+    snapshot: Any,
+    *,
+    tracking_active: bool,
+    cached_completion_confirmed: bool = False,
+) -> bool:
+    """Return whether an inactive mission has an explicit completion signal."""
+    if snapshot is None or tracking_active:
+        return False
+    return (
+        cached_completion_confirmed
+        or getattr(snapshot, "task_status", None) in _COMPLETED_TASK_STATUSES
+        or getattr(snapshot, "status_notice_name", None) in _COMPLETED_STATUS_NOTICES
+    )
+
+
+def runtime_mission_progress_percent(
+    blob: Any,
+    *,
+    completion_confirmed: bool,
+) -> float | int | None:
+    """Return measured mission progress, normalized after confirmed completion."""
+    area_progress = getattr(blob, "candidate_runtime_area_progress_percent", None)
+    progress = getattr(blob, "candidate_runtime_progress_percent", None)
+    measured = area_progress if isinstance(area_progress, int | float) else progress
+    if not isinstance(measured, int | float):
+        return None
+    if completion_confirmed:
+        return 100.0
+    return measured
+
+
 @dataclass(slots=True)
 class DreameLawnMowerRuntimeTelemetryCache:
     """Preserve the latest useful mission metrics after a session ends."""
 
     blob: Any = None
     captured_at: datetime | None = None
+    completion_confirmed: bool = False
     _metric_signature: tuple[Any, ...] | None = None
+
+    def observe_session_state(
+        self,
+        *,
+        active_session: bool,
+        completion_confirmed: bool = False,
+    ) -> None:
+        """Apply authoritative mission state before optional telemetry work."""
+        if active_session:
+            self.completion_confirmed = False
+        elif completion_confirmed:
+            self.completion_confirmed = True
 
     def update(
         self,
@@ -54,8 +101,13 @@ class DreameLawnMowerRuntimeTelemetryCache:
         now: datetime | None = None,
         allow_zero: bool = True,
         active_session: bool = False,
+        completion_confirmed: bool = False,
     ) -> bool:
         """Store a useful runtime payload without erasing it with empty polls."""
+        self.observe_session_state(
+            active_session=active_session,
+            completion_confirmed=completion_confirmed,
+        )
         if not runtime_blob_has_session_metrics(blob):
             return False
         if not allow_zero and not runtime_blob_has_nonzero_session_metrics(blob):
@@ -71,3 +123,17 @@ class DreameLawnMowerRuntimeTelemetryCache:
         self.captured_at = now or datetime.now(UTC)
         self._metric_signature = signature
         return True
+
+
+def observe_runtime_session_state(
+    cache: Any,
+    *,
+    active_session: bool,
+    completion_confirmed: bool = False,
+) -> None:
+    """Apply authoritative session state when the integration owns this cache."""
+    if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
+        cache.observe_session_state(
+            active_session=active_session,
+            completion_confirmed=completion_confirmed,
+        )

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -193,6 +193,7 @@ from .sensor_runtime import (  # noqa: F401
     _runtime_progress_available_for_snapshot,
     _runtime_session_attributes,
     _runtime_session_blob,
+    _runtime_session_completion_confirmed,
     _runtime_status_blob_current_area_sqm,
     _runtime_status_blob_heading_deg,
     _runtime_status_blob_pose_x,

--- a/custom_components/dreame_lawn_mower/sensor_runtime.py
+++ b/custom_components/dreame_lawn_mower/sensor_runtime.py
@@ -11,6 +11,7 @@ from .coordinator import DreameLawnMowerCoordinator, runtime_tracking_active
 from .entity import DreameLawnMowerEntity
 from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
+    runtime_mission_cached_session_identity,
     runtime_mission_completion_confirmed,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
@@ -501,6 +502,8 @@ def _runtime_session_completion_confirmed(
     mission_active = runtime_mission_session_active(
         snapshot,
         tracking_active=tracking_active,
+        session_started_at=runtime_mission_session_started_at(cache),
+        session_identity=runtime_mission_cached_session_identity(cache),
     )
     return runtime_mission_completion_confirmed(
         snapshot,
@@ -511,6 +514,7 @@ def _runtime_session_completion_confirmed(
             else False
         ),
         session_started_at=runtime_mission_session_started_at(cache),
+        session_identity=runtime_mission_cached_session_identity(cache),
     )
 
 

--- a/custom_components/dreame_lawn_mower/sensor_runtime.py
+++ b/custom_components/dreame_lawn_mower/sensor_runtime.py
@@ -9,7 +9,11 @@ from homeassistant.helpers.entity import EntityCategory
 
 from .coordinator import DreameLawnMowerCoordinator, runtime_tracking_active
 from .entity import DreameLawnMowerEntity
-from .runtime_cache import DreameLawnMowerRuntimeTelemetryCache
+from .runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+    runtime_mission_completion_confirmed,
+    runtime_mission_progress_percent,
+)
 from .sensor_map_data import (
     _coordinate_path_length_m,
     _current_app_map_summary,
@@ -116,8 +120,16 @@ class DreameLawnMowerRuntimeMissionProgressSensor(
     @property
     def native_value(self) -> float | int | None:
         """Return live or last-known mission progress from runtime telemetry."""
-        return _runtime_status_blob_progress_percent(
-            _runtime_session_blob(self.coordinator)
+        snapshot = getattr(self.coordinator, "data", None)
+        tracking_active = (
+            snapshot is not None and _runtime_progress_available_for_snapshot(snapshot)
+        )
+        return runtime_mission_progress_percent(
+            _runtime_session_blob(self.coordinator),
+            completion_confirmed=_runtime_session_completion_confirmed(
+                self.coordinator,
+                tracking_active=tracking_active,
+            ),
         )
 
     @property
@@ -451,6 +463,8 @@ def _runtime_session_attributes(coordinator: Any) -> dict[str, Any]:
     attributes = _runtime_status_blob_summary(blob)
     if not attributes:
         return {}
+    if _runtime_session_completion_confirmed(coordinator, tracking_active=live):
+        attributes["completion_confirmed"] = True
     cache = getattr(coordinator, "runtime_telemetry_cache", None)
     captured_at = (
         cache.captured_at
@@ -472,6 +486,24 @@ def _runtime_session_attributes(coordinator: Any) -> dict[str, Any]:
             captured_at.isoformat() if captured_at is not None else None
         )
     return {key: value for key, value in attributes.items() if value is not None}
+
+
+def _runtime_session_completion_confirmed(
+    coordinator: Any,
+    *,
+    tracking_active: bool,
+) -> bool:
+    """Return live or cached completion evidence for the current mission."""
+    cache = getattr(coordinator, "runtime_telemetry_cache", None)
+    return runtime_mission_completion_confirmed(
+        getattr(coordinator, "data", None),
+        tracking_active=tracking_active,
+        cached_completion_confirmed=(
+            cache.completion_confirmed
+            if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache)
+            else False
+        ),
+    )
 
 
 def _runtime_status_blob_summary(blob: Any) -> dict[str, Any]:
@@ -521,11 +553,8 @@ def _runtime_status_blob_summary(blob: Any) -> dict[str, Any]:
 
 
 def _runtime_status_blob_progress_percent(blob: Any) -> float | int | None:
-    area_progress = getattr(blob, "candidate_runtime_area_progress_percent", None)
-    if isinstance(area_progress, int | float):
-        return area_progress
-    progress = getattr(blob, "candidate_runtime_progress_percent", None)
-    return progress if isinstance(progress, int | float) else None
+    """Return raw measured progress for historical direct imports."""
+    return runtime_mission_progress_percent(blob, completion_confirmed=False)
 
 
 def _runtime_status_blob_current_area_sqm(blob: Any) -> float | int | None:

--- a/custom_components/dreame_lawn_mower/sensor_runtime.py
+++ b/custom_components/dreame_lawn_mower/sensor_runtime.py
@@ -14,6 +14,7 @@ from .runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
+    runtime_mission_session_started_at,
 )
 from .sensor_map_data import (
     _coordinate_path_length_m,
@@ -509,6 +510,7 @@ def _runtime_session_completion_confirmed(
             if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache)
             else False
         ),
+        session_started_at=runtime_mission_session_started_at(cache),
     )
 
 

--- a/custom_components/dreame_lawn_mower/sensor_runtime.py
+++ b/custom_components/dreame_lawn_mower/sensor_runtime.py
@@ -13,6 +13,7 @@ from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     runtime_mission_completion_confirmed,
     runtime_mission_progress_percent,
+    runtime_mission_session_active,
 )
 from .sensor_map_data import (
     _coordinate_path_length_m,
@@ -495,9 +496,14 @@ def _runtime_session_completion_confirmed(
 ) -> bool:
     """Return live or cached completion evidence for the current mission."""
     cache = getattr(coordinator, "runtime_telemetry_cache", None)
-    return runtime_mission_completion_confirmed(
-        getattr(coordinator, "data", None),
+    snapshot = getattr(coordinator, "data", None)
+    mission_active = runtime_mission_session_active(
+        snapshot,
         tracking_active=tracking_active,
+    )
+    return runtime_mission_completion_confirmed(
+        snapshot,
+        tracking_active=mission_active,
         cached_completion_confirmed=(
             cache.completion_confirmed
             if isinstance(cache, DreameLawnMowerRuntimeTelemetryCache)

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -614,7 +614,16 @@ def test_newer_video_safety_state_wins_over_delayed_cached_mqtt_update() -> None
         coordinator.app_maps = {"current_map_index": 2}
         coordinator.selected_map_index = 2
         coordinator.runtime_status_blob = None
-        coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+        completed_blob = SimpleNamespace(
+            candidate_runtime_area_progress_percent=99.7
+        )
+        coordinator.runtime_telemetry_cache = (
+            DreameLawnMowerRuntimeTelemetryCache()
+        )
+        assert coordinator.runtime_telemetry_cache.update(
+            completed_blob,
+            completion_confirmed=True,
+        ) is True
         coordinator.bluetooth_connected = None
         coordinator.client = SimpleNamespace(
             async_get_cached_snapshot=AsyncMock(return_value=cached_snapshot),
@@ -642,7 +651,8 @@ def test_newer_video_safety_state_wins_over_delayed_cached_mqtt_update() -> None
         assert result is video_snapshot
         publish.assert_called_once_with(video_snapshot)
         assert coordinator.runtime_status_blob is None
-        coordinator.runtime_telemetry_cache.update.assert_not_called()
+        assert coordinator.runtime_telemetry_cache.blob is completed_blob
+        assert coordinator.runtime_telemetry_cache.completion_confirmed is True
         coordinator.client.update_runtime_live_tracking.assert_not_called()
         assert coordinator.bluetooth_connected is None
 

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -366,6 +366,54 @@ def test_cached_completion_survives_runtime_failure_and_later_idle_refresh() -> 
     assert cache.blob is blob
 
 
+def test_new_session_discards_prior_telemetry_before_completion() -> None:
+    """A later success event cannot relabel a prior mission's measurements."""
+    active = SimpleNamespace(
+        available=True,
+        mowing_session_active=True,
+        activity="mowing",
+        docked=False,
+        task_status="mowing",
+        status_notice_name=None,
+    )
+    completed = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        docked=True,
+        task_status="idle",
+        status_notice_name="mowing_task_completed",
+    )
+    previous_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous_blob, completion_confirmed=True) is True
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator.app_maps = {"current_map_index": 2}
+    coordinator.selected_map_index = 2
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = cache
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(side_effect=(active, completed)),
+        async_get_runtime_status_blob=AsyncMock(
+            side_effect=RuntimeError("telemetry unavailable")
+        ),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.blob is None
+    assert cache.completion_confirmed is False
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.blob is None
+    assert cache.completion_confirmed is True
+
+
 def test_cached_device_update_does_not_confirm_connectivity() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     confirmed = SimpleNamespace(

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -313,6 +313,7 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
         completion_confirmed=False,
         completion_rejected=False,
         new_session=False,
+        new_session_event_at=None,
         new_session_evidence=None,
         session_identity=None,
     )

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -417,8 +417,18 @@ def test_new_session_discards_prior_telemetry_before_completion() -> None:
 
 
 def test_resumed_charging_session_preserves_current_telemetry() -> None:
-    """Leaving the charger does not look like a brand-new mower mission."""
-    charging = SimpleNamespace(
+    """Missing and paused heartbeats cannot split one charging mission."""
+    missing_heartbeat = SimpleNamespace(
+        available=True,
+        mowing_session_active=None,
+        activity="docked",
+        state="charging",
+        docked=True,
+        task_status=None,
+        task_resumable=None,
+        status_notice_name=None,
+    )
+    paused_heartbeat = SimpleNamespace(
         available=True,
         mowing_session_active=None,
         activity="docked",
@@ -438,6 +448,16 @@ def test_resumed_charging_session_preserves_current_telemetry() -> None:
         task_resumable=False,
         status_notice_name=None,
     )
+    completed = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        state="charging",
+        docked=True,
+        task_status="finished",
+        task_resumable=False,
+        status_notice_name="mowing_task_completed",
+    )
     current_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
     cache = DreameLawnMowerRuntimeTelemetryCache()
     assert cache.update(current_blob, active_session=True) is True
@@ -450,7 +470,14 @@ def test_resumed_charging_session_preserves_current_telemetry() -> None:
     coordinator.runtime_telemetry_cache = cache
     coordinator.bluetooth_connected = None
     coordinator.client = SimpleNamespace(
-        async_get_cached_snapshot=AsyncMock(side_effect=(charging, resumed)),
+        async_get_cached_snapshot=AsyncMock(
+            side_effect=(
+                missing_heartbeat,
+                paused_heartbeat,
+                resumed,
+                completed,
+            )
+        ),
         async_get_runtime_status_blob=AsyncMock(
             side_effect=RuntimeError("telemetry unavailable")
         ),
@@ -467,17 +494,25 @@ def test_resumed_charging_session_preserves_current_telemetry() -> None:
     assert cache.blob is current_blob
     assert cache.completion_confirmed is False
 
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.blob is current_blob
+    assert cache.completion_confirmed is False
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.blob is current_blob
+    assert cache.completion_confirmed is True
+
 
 def test_foreground_charging_snapshot_preserves_current_session_cache() -> None:
-    """Foreground refresh uses resumable evidence absent heartbeat annotation."""
+    """Foreground refresh preserves cache when heartbeat enrichment fails."""
     charging = SimpleNamespace(
         available=True,
         mowing_session_active=None,
         activity="docked",
         state="charging",
         docked=True,
-        task_status="paused",
-        task_resumable=True,
+        task_status=None,
+        task_resumable=None,
         status_notice_name="mowing_task_completed",
     )
     current_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -311,6 +311,7 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
         allow_zero=True,
         active_session=True,
         completion_confirmed=False,
+        completion_rejected=False,
         new_session=False,
     )
     assert tracking_updates == [(status_blob, True, 2)]

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -663,6 +663,65 @@ def test_newer_video_safety_state_wins_over_delayed_cached_mqtt_update() -> None
     asyncio.run(scenario())
 
 
+def test_command_boundary_blocks_delayed_cached_mqtt_runtime_side_effects() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        snapshot = SimpleNamespace(
+            available=True,
+            mowing_session_active=False,
+            activity="idle",
+        )
+        runtime_started = asyncio.Event()
+        release_runtime = asyncio.Event()
+        stale_runtime = SimpleNamespace(
+            candidate_runtime_area_progress_percent=100.0
+        )
+        cache = DreameLawnMowerRuntimeTelemetryCache()
+        assert cache.update(stale_runtime, completion_confirmed=True) is True
+
+        async def runtime_status(*, refresh: bool, include_cloud: bool) -> object:
+            assert refresh is False
+            assert include_cloud is False
+            runtime_started.set()
+            await release_runtime.wait()
+            return stale_runtime
+
+        coordinator._client_update_task = Mock()
+        coordinator._client_update_pending = False
+        coordinator._shutting_down = False
+        coordinator._runtime_map_identity_verified = True
+        coordinator._device_refresh_lock = asyncio.Lock()
+        coordinator._device_snapshot_generation = 0
+        coordinator._published_device_snapshot_generation = 0
+        coordinator._device_snapshot_generations = {}
+        coordinator.app_maps = {"current_map_index": 2}
+        coordinator.selected_map_index = 2
+        coordinator.runtime_status_blob = None
+        coordinator.runtime_telemetry_cache = cache
+        coordinator.bluetooth_connected = None
+        coordinator.client = SimpleNamespace(
+            async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+            async_get_runtime_status_blob=runtime_status,
+            async_get_bluetooth_connected=AsyncMock(return_value=True),
+            update_runtime_live_tracking=Mock(),
+        )
+        coordinator.async_set_updated_data = Mock()
+
+        update_task = asyncio.create_task(coordinator._async_process_client_update())
+        await asyncio.wait_for(runtime_started.wait(), timeout=1)
+        cache.begin_new_session(session_started_at=20.0)
+        release_runtime.set()
+        await update_task
+
+        assert cache.blob is None
+        assert coordinator.runtime_status_blob is None
+        assert coordinator.bluetooth_connected is None
+        coordinator.client.update_runtime_live_tracking.assert_not_called()
+        coordinator.async_set_updated_data.assert_not_called()
+
+    asyncio.run(scenario())
+
+
 def test_cached_device_update_waits_for_verified_active_map_identity() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     snapshot = SimpleNamespace(

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -311,6 +311,7 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
         allow_zero=True,
         active_session=True,
         completion_confirmed=False,
+        new_session=False,
     )
     assert tracking_updates == [(status_blob, True, 2)]
     assert coordinator.runtime_status_blob is status_blob
@@ -370,10 +371,11 @@ def test_new_session_discards_prior_telemetry_before_completion() -> None:
     """A later success event cannot relabel a prior mission's measurements."""
     active = SimpleNamespace(
         available=True,
-        mowing_session_active=True,
+        mowing_session_active=None,
         activity="mowing",
         docked=False,
-        task_status="mowing",
+        task_status="starting",
+        task_resumable=False,
         status_notice_name=None,
     )
     completed = SimpleNamespace(
@@ -386,7 +388,7 @@ def test_new_session_discards_prior_telemetry_before_completion() -> None:
     )
     previous_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
     cache = DreameLawnMowerRuntimeTelemetryCache()
-    assert cache.update(previous_blob, completion_confirmed=True) is True
+    assert cache.update(previous_blob, active_session=True) is True
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
@@ -413,6 +415,93 @@ def test_new_session_discards_prior_telemetry_before_completion() -> None:
     assert cache.blob is None
     assert cache.completion_confirmed is True
 
+
+def test_resumed_charging_session_preserves_current_telemetry() -> None:
+    """Leaving the charger does not look like a brand-new mower mission."""
+    charging = SimpleNamespace(
+        available=True,
+        mowing_session_active=None,
+        activity="docked",
+        state="charging",
+        docked=True,
+        task_status="paused",
+        task_resumable=True,
+        status_notice_name=None,
+    )
+    resumed = SimpleNamespace(
+        available=True,
+        mowing_session_active=None,
+        activity="mowing",
+        state="mowing",
+        docked=False,
+        task_status="mowing",
+        task_resumable=False,
+        status_notice_name=None,
+    )
+    current_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(current_blob, active_session=True) is True
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator.app_maps = {"current_map_index": 2}
+    coordinator.selected_map_index = 2
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = cache
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(side_effect=(charging, resumed)),
+        async_get_runtime_status_blob=AsyncMock(
+            side_effect=RuntimeError("telemetry unavailable")
+        ),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.blob is current_blob
+    assert cache.completion_confirmed is False
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.blob is current_blob
+    assert cache.completion_confirmed is False
+
+
+def test_foreground_charging_snapshot_preserves_current_session_cache() -> None:
+    """Foreground refresh uses resumable evidence absent heartbeat annotation."""
+    charging = SimpleNamespace(
+        available=True,
+        mowing_session_active=None,
+        activity="docked",
+        state="charging",
+        docked=True,
+        task_status="paused",
+        task_resumable=True,
+        status_notice_name="mowing_task_completed",
+    )
+    current_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(current_blob, active_session=True) is True
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = cache
+    coordinator._runtime_map_identity_verified = True
+    coordinator._schedule_metadata_refresh = Mock()
+    coordinator.client = SimpleNamespace(
+        async_refresh=AsyncMock(return_value=charging),
+        update_runtime_live_tracking=Mock(),
+    )
+
+    result = asyncio.run(coordinator._async_update_data())
+
+    assert result is charging
+    assert cache.blob is current_blob
+    assert cache.completion_confirmed is False
+    coordinator.client.update_runtime_live_tracking.assert_called_once_with(
+        None,
+        active=False,
+    )
 
 def test_cached_device_update_does_not_confirm_connectivity() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -313,6 +313,8 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
         completion_confirmed=False,
         completion_rejected=False,
         new_session=False,
+        new_session_evidence=None,
+        session_identity=None,
     )
     assert tracking_updates == [(status_blob, True, 2)]
     assert coordinator.runtime_status_blob is status_blob

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -19,6 +19,9 @@ from custom_components.dreame_lawn_mower.coordinator_connectivity import (
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     FEATURE_LIVE_VIDEO,
 )
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
 
 
 def test_feature_capability_evidence_survives_sparse_snapshots() -> None:
@@ -226,7 +229,9 @@ def test_active_runtime_tracking_survives_status_blob_failure() -> None:
     coordinator.app_maps_refreshed_at = datetime(2026, 7, 24, 10, tzinfo=UTC)
     coordinator.selected_map_index = 2
     coordinator.runtime_status_blob = SimpleNamespace(status="old")
-    coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+    coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache(
+        completion_confirmed=True,
+    )
     coordinator.client = SimpleNamespace(
         async_refresh=AsyncMock(return_value=snapshot),
         async_get_runtime_status_blob=AsyncMock(
@@ -261,6 +266,7 @@ def test_active_runtime_tracking_survives_status_blob_failure() -> None:
 
     assert result is snapshot
     assert coordinator.runtime_status_blob is None
+    assert coordinator.runtime_telemetry_cache.completion_confirmed is False
     assert tracking_updates == [(None, True, 2)]
 
 
@@ -304,12 +310,60 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
         status_blob,
         allow_zero=True,
         active_session=True,
+        completion_confirmed=False,
     )
     assert tracking_updates == [(status_blob, True, 2)]
     assert coordinator.runtime_status_blob is status_blob
     assert coordinator.bluetooth_connected is True
     coordinator.async_set_updated_data.assert_called_once_with(snapshot)
     assert coordinator._client_update_task is None
+
+
+def test_cached_completion_survives_runtime_failure_and_later_idle_refresh() -> None:
+    """A transient completion event is cached before optional telemetry reads."""
+    completed = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        docked=True,
+        task_status="idle",
+        status_notice_name="mowing_task_completed",
+    )
+    idle = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        docked=True,
+        task_status="idle",
+        status_notice_name=None,
+    )
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(blob) is True
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator.app_maps = {"current_map_index": 2}
+    coordinator.selected_map_index = 2
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = cache
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(side_effect=(completed, idle)),
+        async_get_runtime_status_blob=AsyncMock(
+            side_effect=RuntimeError("telemetry unavailable")
+        ),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.completion_confirmed is True
+
+    asyncio.run(coordinator._async_process_client_update())
+    assert cache.completion_confirmed is True
+    assert cache.blob is blob
 
 
 def test_cached_device_update_does_not_confirm_connectivity() -> None:

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -229,6 +229,43 @@ def test_video_safety_refresh_retries_snapshot_that_is_already_stale() -> None:
     asyncio.run(scenario())
 
 
+def test_video_safety_refresh_applies_replacement_mission_boundary() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+        cache = DreameLawnMowerRuntimeTelemetryCache()
+        assert cache.update(previous, active_session=True) is True
+        replacement = SimpleNamespace(
+            available=True,
+            mowing_session_active=True,
+            activity="mowing",
+            state="mowing",
+            docked=False,
+            task_status="mowing",
+            task_resumable=False,
+            status_notice_name="mowing_task_started",
+            status_notice_event_at=2.0,
+            mission_task_id=None,
+        )
+        coordinator._device_refresh_lock = asyncio.Lock()
+        coordinator._device_snapshot_generation = 0
+        coordinator._published_device_snapshot_generation = 0
+        coordinator._device_snapshot_generations = {}
+        coordinator.runtime_telemetry_cache = cache
+        coordinator.client = SimpleNamespace(
+            async_refresh_authoritative_snapshot=AsyncMock(return_value=replacement),
+        )
+
+        with patch.object(DataUpdateCoordinator, "async_set_updated_data") as publish:
+            result = await coordinator.async_refresh_video_safety_state()
+
+        assert result is replacement
+        assert cache.blob is None
+        publish.assert_called_once_with(replacement)
+
+    asyncio.run(scenario())
+
+
 def test_newer_video_safety_snapshot_blocks_foreground_runtime_side_effects() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -34,6 +34,9 @@ from custom_components.dreame_lawn_mower.coordinator import (
 from custom_components.dreame_lawn_mower.performance import (
     DreameLawnMowerPerformanceTracker,
 )
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
 from custom_components.dreame_lawn_mower.schedule_cache import (
     ScheduleActionReadBackoff,
     merge_app_schedule_payload,
@@ -246,6 +249,14 @@ def test_newer_video_safety_snapshot_blocks_foreground_runtime_side_effects() ->
         runtime_started = asyncio.Event()
         release_runtime = asyncio.Event()
         retained_runtime = SimpleNamespace(source="newer-state")
+        completed_blob = SimpleNamespace(
+            candidate_runtime_area_progress_percent=100.0
+        )
+        runtime_cache = DreameLawnMowerRuntimeTelemetryCache()
+        assert runtime_cache.update(
+            completed_blob,
+            completion_confirmed=True,
+        ) is True
 
         async def refresh_snapshot() -> object:
             return next(snapshots)
@@ -276,7 +287,7 @@ def test_newer_video_safety_snapshot_blocks_foreground_runtime_side_effects() ->
         coordinator.app_maps_refresh_succeeded = False
         coordinator.selected_map_index = 2
         coordinator.runtime_status_blob = retained_runtime
-        coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+        coordinator.runtime_telemetry_cache = runtime_cache
         coordinator.client = SimpleNamespace(
             async_refresh=refresh_snapshot,
             async_refresh_authoritative_snapshot=refresh_snapshot,
@@ -307,7 +318,8 @@ def test_newer_video_safety_snapshot_blocks_foreground_runtime_side_effects() ->
         publish.assert_called_with(video_snapshots[-1])
         assert coordinator.runtime_status_blob is retained_runtime
         assert coordinator._runtime_map_identity_verified is False
-        coordinator.runtime_telemetry_cache.update.assert_not_called()
+        assert runtime_cache.blob is completed_blob
+        assert runtime_cache.completion_confirmed is True
         coordinator.client.update_runtime_live_tracking.assert_not_called()
         coordinator._schedule_metadata_refresh.assert_not_called()
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -363,6 +363,54 @@ def test_newer_video_safety_snapshot_blocks_foreground_runtime_side_effects() ->
     asyncio.run(scenario())
 
 
+def test_command_boundary_blocks_delayed_foreground_runtime_side_effects() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        snapshot = SimpleNamespace(
+            mowing_session_active=False,
+            activity="idle",
+        )
+        runtime_started = asyncio.Event()
+        release_runtime = asyncio.Event()
+        retained_runtime = SimpleNamespace(source="retained")
+        stale_runtime = SimpleNamespace(
+            candidate_runtime_area_progress_percent=100.0
+        )
+        cache = DreameLawnMowerRuntimeTelemetryCache()
+        assert cache.update(stale_runtime, completion_confirmed=True) is True
+
+        async def refresh_runtime(*, refresh: bool, include_cloud: bool) -> object:
+            assert refresh is False
+            assert include_cloud is True
+            runtime_started.set()
+            await release_runtime.wait()
+            return stale_runtime
+
+        coordinator.runtime_status_blob = retained_runtime
+        coordinator.runtime_telemetry_cache = cache
+        coordinator.client = SimpleNamespace(
+            async_get_runtime_status_blob=refresh_runtime,
+            update_runtime_live_tracking=Mock(),
+        )
+
+        refresh_task = asyncio.create_task(
+            coordinator._async_refresh_runtime_status(
+                snapshot,
+                runtime_map_index=2,
+            )
+        )
+        await asyncio.wait_for(runtime_started.wait(), timeout=1)
+        cache.begin_new_session(session_started_at=20.0)
+        release_runtime.set()
+
+        assert await refresh_task is False
+        assert cache.blob is None
+        assert coordinator.runtime_status_blob is retained_runtime
+        coordinator.client.update_runtime_live_tracking.assert_not_called()
+
+    asyncio.run(scenario())
+
+
 def test_first_refresh_does_not_wait_for_optional_metadata() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -954,8 +954,11 @@ def test_lawn_mower_start_uses_selected_edge() -> None:
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
-def test_lawn_mower_resume_preserves_runtime_session_cache() -> None:
-    client = SimpleNamespace(async_start_mowing=AsyncMock(return_value=False))
+@pytest.mark.parametrize("start_result", (False, None))
+def test_lawn_mower_resume_or_unknown_preserves_runtime_session_cache(
+    start_result: bool | None,
+) -> None:
+    client = SimpleNamespace(async_start_mowing=AsyncMock(return_value=start_result))
     previous_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
     cache = DreameLawnMowerRuntimeTelemetryCache()
     assert cache.update(previous_blob, active_session=True) is True

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, Mock
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from homeassistant.components.lawn_mower import LawnMowerActivity
@@ -1005,6 +1005,37 @@ def test_lawn_mower_start_preserves_callback_telemetry_before_command_return() -
 
     assert cache.blob is current_blob
     entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_lawn_mower_records_command_boundary_after_acceptance() -> None:
+    """A delayed prior notice cannot postdate the accepted mission boundary."""
+    command_accepted = False
+
+    async def accept_start() -> bool:
+        nonlocal command_accepted
+        command_accepted = True
+        return True
+
+    def accepted_at() -> float:
+        assert command_accepted is True
+        return 20.0
+
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=SimpleNamespace(async_start_mowing=AsyncMock(side_effect=accept_start)),
+        selected_mowing_action="all_area",
+        runtime_telemetry_cache=cache,
+        async_request_refresh=AsyncMock(),
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.lawn_mower.time",
+        side_effect=accepted_at,
+    ):
+        asyncio.run(entity.async_start_mowing())
+
+    assert runtime_mission_session_started_at(cache) == 20.0
 
 
 def test_lawn_mower_start_edge_service_uses_explicit_contours() -> None:

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -23,6 +23,7 @@ from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoord
 from custom_components.dreame_lawn_mower.lawn_mower import DreameLawnMower
 from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
+    runtime_mission_session_started_at,
 )
 from custom_components.dreame_lawn_mower.select import (
     DreameLawnMowerEdgeSelect,
@@ -951,6 +952,7 @@ def test_lawn_mower_start_uses_selected_edge() -> None:
     client.async_start_spot_mowing.assert_not_called()
     client.async_start_mowing.assert_not_called()
     assert cache.blob is None
+    assert runtime_mission_session_started_at(cache) is not None
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -976,6 +976,35 @@ def test_lawn_mower_resume_or_unknown_preserves_runtime_session_cache(
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
+def test_lawn_mower_start_preserves_callback_telemetry_before_command_return() -> None:
+    """Command acceptance cannot erase a mission already observed by MQTT."""
+    previous_blob = SimpleNamespace(candidate_runtime_area_progress_percent=100.0)
+    current_blob = SimpleNamespace(candidate_runtime_area_progress_percent=3.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous_blob, completion_confirmed=True) is True
+
+    async def accept_after_callback() -> bool:
+        cache.observe_session_state(active_session=True)
+        assert cache.update(current_blob, active_session=True) is True
+        return True
+
+    client = SimpleNamespace(
+        async_start_mowing=AsyncMock(side_effect=accept_after_callback)
+    )
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        selected_mowing_action="all_area",
+        runtime_telemetry_cache=cache,
+        async_request_refresh=AsyncMock(),
+    )
+
+    asyncio.run(entity.async_start_mowing())
+
+    assert cache.blob is current_blob
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
 def test_lawn_mower_start_edge_service_uses_explicit_contours() -> None:
     client = SimpleNamespace(
         async_start_edge_mowing=AsyncMock(),

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -21,6 +21,9 @@ from custom_components.dreame_lawn_mower.control_options import (
 )
 from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
 from custom_components.dreame_lawn_mower.lawn_mower import DreameLawnMower
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
 from custom_components.dreame_lawn_mower.select import (
     DreameLawnMowerEdgeSelect,
     DreameLawnMowerMapSelect,
@@ -924,6 +927,9 @@ def test_lawn_mower_start_uses_selected_edge() -> None:
         async_start_mowing=AsyncMock(),
     )
     entity = object.__new__(DreameLawnMower)
+    previous_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous_blob, active_session=True) is True
     entity.coordinator = SimpleNamespace(
         client=client,
         selected_mowing_action=MOWING_ACTION_EDGE,
@@ -934,6 +940,7 @@ def test_lawn_mower_start_uses_selected_edge() -> None:
         vector_map_details=_vector_map_details(),
         batch_device_data=_batch_device_data(),
         app_maps=_app_maps(),
+        runtime_telemetry_cache=cache,
         async_request_refresh=AsyncMock(),
     )
 
@@ -943,6 +950,26 @@ def test_lawn_mower_start_uses_selected_edge() -> None:
     client.async_start_zone_mowing.assert_not_called()
     client.async_start_spot_mowing.assert_not_called()
     client.async_start_mowing.assert_not_called()
+    assert cache.blob is None
+    entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_lawn_mower_resume_preserves_runtime_session_cache() -> None:
+    client = SimpleNamespace(async_start_mowing=AsyncMock(return_value=False))
+    previous_blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous_blob, active_session=True) is True
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        selected_mowing_action="all_area",
+        runtime_telemetry_cache=cache,
+        async_request_refresh=AsyncMock(),
+    )
+
+    asyncio.run(entity.async_start_mowing())
+
+    assert cache.blob is previous_blob
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -179,7 +179,7 @@ def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
     client._sync_resume_mowing = Mock(return_value={"r": 0})
     client._async_call_device_method = AsyncMock()
 
-    asyncio.run(client.async_start_mowing())
+    started_new_session = asyncio.run(client.async_start_mowing())
 
     client.async_get_status_blob.assert_awaited_once_with(
         refresh=True,
@@ -187,6 +187,7 @@ def test_start_resumes_heartbeat_confirmed_paused_session() -> None:
     )
     client._sync_resume_mowing.assert_called_once_with()
     client._async_call_device_method.assert_not_awaited()
+    assert started_new_session is False
 
 
 def test_lost_resume_acknowledgement_requires_transition_out_of_paused() -> None:
@@ -263,7 +264,7 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
     client._sync_resume_mowing = Mock()
     client._async_call_device_method = AsyncMock()
 
-    asyncio.run(client.async_start_mowing())
+    started_new_session = asyncio.run(client.async_start_mowing())
 
     client.async_get_status_blob.assert_awaited_once_with(
         refresh=True,
@@ -271,6 +272,7 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
     )
     client._sync_resume_mowing.assert_not_called()
     client._async_call_device_method.assert_awaited_once_with("start_mowing")
+    assert started_new_session is True
 
 
 def test_lost_start_acknowledgement_reconciles_without_resending() -> None:

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -12,6 +12,9 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import 
     DreameLawnMowerClient,
     DreameLawnMowerConnectionError,
 )
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device_types import (
+    DreameMowerTaskStatus,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.docking import (
     async_stop_then_dock,
 )
@@ -259,7 +262,11 @@ def test_lost_resume_acknowledgement_accepts_active_mowing_transition() -> None:
 def test_start_uses_fresh_action_without_resumable_session() -> None:
     client = object.__new__(DreameLawnMowerClient)
     client.async_get_status_blob = AsyncMock(
-        return_value=SimpleNamespace(task_resumable=False)
+        return_value=SimpleNamespace(
+            task_status="idle",
+            task_resumable=False,
+            mowing_session_active=False,
+        )
     )
     client._sync_resume_mowing = Mock()
     client._async_call_device_method = AsyncMock()
@@ -280,6 +287,7 @@ def test_duplicate_start_preserves_active_mission_identity() -> None:
     client = object.__new__(DreameLawnMowerClient)
     client.async_get_status_blob = AsyncMock(
         return_value=SimpleNamespace(
+            task_status="mowing",
             task_resumable=False,
             mowing_session_active=True,
         )
@@ -290,6 +298,44 @@ def test_duplicate_start_preserves_active_mission_identity() -> None:
 
     client._async_call_device_method.assert_not_awaited()
     assert started_new_session is False
+
+
+def test_start_while_returning_forwards_resume_without_new_session() -> None:
+    """Start can abort a return-to-dock without replacing mission identity."""
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(
+            task_status="returning_to_dock",
+            task_resumable=False,
+            mowing_session_active=True,
+        )
+    )
+    client._async_call_device_method = AsyncMock()
+
+    started_new_session = asyncio.run(client.async_start_mowing())
+
+    client._async_call_device_method.assert_awaited_once_with("start_mowing")
+    assert started_new_session is False
+
+
+def test_start_with_unrecognized_heartbeat_uses_cached_identity() -> None:
+    """A decoded blob without task state cannot declare a fresh mission."""
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(
+            task_status=None,
+            task_resumable=None,
+            mowing_session_active=None,
+        )
+    )
+    client._async_call_start_mowing_with_session_identity = AsyncMock(
+        return_value=None
+    )
+
+    result = asyncio.run(client.async_start_mowing())
+
+    client._async_call_start_mowing_with_session_identity.assert_awaited_once_with()
+    assert result is None
 
 
 @pytest.mark.parametrize("expected_new_session", (False, True, None))
@@ -312,10 +358,16 @@ def test_start_without_heartbeat_preserves_cached_session_identity(
 
 
 @pytest.mark.parametrize(
-    ("started", "expected_new_session"),
-    ((True, False), (False, True), (None, None)),
+    ("task_status", "started", "expected_new_session"),
+    (
+        (DreameMowerTaskStatus.AUTO_CLEANING, True, False),
+        (DreameMowerTaskStatus.COMPLETED, False, True),
+        (DreameMowerTaskStatus.UNKNOWN, True, None),
+        (None, None, None),
+    ),
 )
 def test_fallback_start_captures_device_session_decision(
+    task_status: DreameMowerTaskStatus | None,
     started: bool | None,
     expected_new_session: bool | None,
 ) -> None:
@@ -324,7 +376,7 @@ def test_fallback_start_captures_device_session_decision(
     client = object.__new__(DreameLawnMowerClient)
     client._ensure_device = Mock(
         return_value=SimpleNamespace(
-            status=SimpleNamespace(started=started),
+            status=SimpleNamespace(task_status=task_status, started=started),
             start_mowing=start_mowing,
         )
     )

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -387,6 +387,50 @@ def test_fallback_start_captures_device_session_decision(
     assert result is expected_new_session
 
 
+def test_fallback_start_locks_identity_decision_through_dispatch() -> None:
+    """MQTT cannot change the start branch between inspection and dispatch."""
+
+    class StateLock:
+        held = False
+
+        def __enter__(self) -> None:
+            self.held = True
+
+        def __exit__(self, *_args: object) -> None:
+            self.held = False
+
+    state_lock = StateLock()
+
+    class LockedStatus:
+        @property
+        def task_status(self) -> DreameMowerTaskStatus:
+            assert state_lock.held
+            return DreameMowerTaskStatus.COMPLETED
+
+        @property
+        def started(self) -> bool:
+            assert state_lock.held
+            return False
+
+    def start_mowing() -> dict[str, int]:
+        assert state_lock.held
+        return {"result": 0}
+
+    client = object.__new__(DreameLawnMowerClient)
+    client._ensure_device = Mock(
+        return_value=SimpleNamespace(
+            _state_lock=state_lock,
+            status=LockedStatus(),
+            start_mowing=start_mowing,
+        )
+    )
+
+    result = asyncio.run(client._async_call_start_mowing_with_session_identity())
+
+    assert result is True
+    assert state_lock.held is False
+
+
 def test_fallback_start_does_not_reclassify_paused_return_to_dock() -> None:
     """A special resume branch remains part of the existing mower task."""
     start_mowing = Mock(return_value={"result": 0})

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -275,6 +275,66 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
     assert started_new_session is True
 
 
+@pytest.mark.parametrize("expected_new_session", (False, True, None))
+def test_start_without_heartbeat_preserves_cached_session_identity(
+    expected_new_session: bool | None,
+) -> None:
+    """Heartbeat failure returns the fallback command's session identity."""
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        side_effect=DreameLawnMowerConnectionError("status unavailable")
+    )
+    client._async_call_start_mowing_with_session_identity = AsyncMock(
+        return_value=expected_new_session
+    )
+
+    started_new_session = asyncio.run(client.async_start_mowing())
+
+    client._async_call_start_mowing_with_session_identity.assert_awaited_once_with()
+    assert started_new_session is expected_new_session
+
+
+@pytest.mark.parametrize(
+    ("started", "expected_new_session"),
+    ((True, False), (False, True), (None, None)),
+)
+def test_fallback_start_captures_device_session_decision(
+    started: bool | None,
+    expected_new_session: bool | None,
+) -> None:
+    """The fallback result mirrors device.start_mowing's cached-state branch."""
+    start_mowing = Mock(return_value={"result": 0})
+    client = object.__new__(DreameLawnMowerClient)
+    client._ensure_device = Mock(
+        return_value=SimpleNamespace(
+            status=SimpleNamespace(started=started),
+            start_mowing=start_mowing,
+        )
+    )
+
+    result = asyncio.run(client._async_call_start_mowing_with_session_identity())
+
+    start_mowing.assert_called_once_with()
+    assert result is expected_new_session
+
+
+def test_fallback_start_does_not_reclassify_paused_return_to_dock() -> None:
+    """A special resume branch remains part of the existing mower task."""
+    start_mowing = Mock(return_value={"result": 0})
+    client = object.__new__(DreameLawnMowerClient)
+    client._ensure_device = Mock(
+        return_value=SimpleNamespace(
+            status=SimpleNamespace(started=False, returning_paused=True),
+            start_mowing=start_mowing,
+        )
+    )
+
+    result = asyncio.run(client._async_call_start_mowing_with_session_identity())
+
+    start_mowing.assert_called_once_with()
+    assert result is False
+
+
 def test_lost_start_acknowledgement_reconciles_without_resending() -> None:
     client = object.__new__(DreameLawnMowerClient)
     start = Mock(

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -275,6 +275,23 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
     assert started_new_session is True
 
 
+def test_duplicate_start_preserves_active_mission_identity() -> None:
+    """Starting an already active mower is not a fresh mission boundary."""
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(
+            task_resumable=False,
+            mowing_session_active=True,
+        )
+    )
+    client._async_call_device_method = AsyncMock()
+
+    started_new_session = asyncio.run(client.async_start_mowing())
+
+    client._async_call_device_method.assert_not_awaited()
+    assert started_new_session is False
+
+
 @pytest.mark.parametrize("expected_new_session", (False, True, None))
 def test_start_without_heartbeat_preserves_cached_session_identity(
     expected_new_session: bool | None,

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -269,7 +269,9 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
         )
     )
     client._sync_resume_mowing = Mock()
-    client._async_call_device_method = AsyncMock()
+    client._async_call_start_mowing_with_session_identity = AsyncMock(
+        return_value=True
+    )
 
     started_new_session = asyncio.run(client.async_start_mowing())
 
@@ -278,7 +280,7 @@ def test_start_uses_fresh_action_without_resumable_session() -> None:
         include_cloud=True,
     )
     client._sync_resume_mowing.assert_not_called()
-    client._async_call_device_method.assert_awaited_once_with("start_mowing")
+    client._async_call_start_mowing_with_session_identity.assert_awaited_once_with()
     assert started_new_session is True
 
 
@@ -292,11 +294,14 @@ def test_duplicate_start_preserves_active_mission_identity() -> None:
             mowing_session_active=True,
         )
     )
-    client._async_call_device_method = AsyncMock()
+    client._async_get_cached_start_mowing_session_identity = AsyncMock(
+        return_value=False
+    )
+    client._async_call_start_mowing_with_session_identity = AsyncMock()
 
     started_new_session = asyncio.run(client.async_start_mowing())
 
-    client._async_call_device_method.assert_not_awaited()
+    client._async_call_start_mowing_with_session_identity.assert_not_awaited()
     assert started_new_session is False
 
 
@@ -310,12 +315,68 @@ def test_start_while_returning_forwards_resume_without_new_session() -> None:
             mowing_session_active=True,
         )
     )
-    client._async_call_device_method = AsyncMock()
+    client._async_call_start_mowing_with_session_identity = AsyncMock(
+        return_value=False
+    )
 
     started_new_session = asyncio.run(client.async_start_mowing())
 
-    client._async_call_device_method.assert_awaited_once_with("start_mowing")
+    client._async_call_start_mowing_with_session_identity.assert_awaited_once_with()
     assert started_new_session is False
+
+
+def test_stale_inactive_heartbeat_uses_device_start_identity() -> None:
+    """A retained inactive blob cannot reset a mission already in progress."""
+    start_mowing = Mock(return_value={"result": 0})
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(
+            task_status="idle",
+            task_resumable=False,
+            mowing_session_active=False,
+        )
+    )
+    client._ensure_device = Mock(
+        return_value=SimpleNamespace(
+            status=SimpleNamespace(
+                task_status=DreameMowerTaskStatus.AUTO_CLEANING,
+                started=True,
+            ),
+            start_mowing=start_mowing,
+        )
+    )
+
+    started_new_session = asyncio.run(client.async_start_mowing())
+
+    start_mowing.assert_called_once_with()
+    assert started_new_session is False
+
+
+def test_stale_active_heartbeat_cannot_hide_fresh_device_start() -> None:
+    """A cached active blob is skipped only when device state still agrees."""
+    start_mowing = Mock(return_value={"result": 0})
+    client = object.__new__(DreameLawnMowerClient)
+    client.async_get_status_blob = AsyncMock(
+        return_value=SimpleNamespace(
+            task_status="mowing",
+            task_resumable=False,
+            mowing_session_active=True,
+        )
+    )
+    client._ensure_device = Mock(
+        return_value=SimpleNamespace(
+            status=SimpleNamespace(
+                task_status=DreameMowerTaskStatus.COMPLETED,
+                started=False,
+            ),
+            start_mowing=start_mowing,
+        )
+    )
+
+    started_new_session = asyncio.run(client.async_start_mowing())
+
+    start_mowing.assert_called_once_with()
+    assert started_new_session is True
 
 
 def test_start_with_unrecognized_heartbeat_uses_cached_identity() -> None:

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -208,6 +208,23 @@ def test_descriptor_maps_lidax_ultra_1000_model_name() -> None:
     assert descriptor.title == "Mowercedes (LiDAX Ultra 1000)"
 
 
+def test_descriptor_maps_lidax_ultra_2000_model_name() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-6",
+            "model": "mova.mower.g2529f",
+            "customName": "Back Lawn",
+            "deviceInfo": {"displayName": "Lidax Ultra 2000"},
+        },
+        account_type="mova",
+        country="us",
+    )
+
+    assert descriptor is not None
+    assert descriptor.display_model == "LiDAX Ultra 2000"
+    assert descriptor.title == "Back Lawn (LiDAX Ultra 2000)"
+
+
 def test_descriptor_maps_a3_awd_pro_3500_model_name() -> None:
     descriptor = descriptor_from_cloud_record(
         {

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -1746,6 +1746,46 @@ def test_runtime_mission_sensors_preserve_last_session_after_docking() -> None:
     assert "track_length_m" not in progress.extra_state_attributes
 
 
+def test_runtime_mission_progress_normalizes_confirmed_completion() -> None:
+    """A completed mission displays 100 while retaining its measured ratio."""
+    captured_at = datetime(2026, 8, 9, 10, 57, tzinfo=UTC)
+    blob = SimpleNamespace(
+        source="cloud",
+        candidate_runtime_progress_percent=None,
+        candidate_runtime_area_progress_percent=99.7,
+        candidate_runtime_current_area_sqm=529.41,
+        candidate_runtime_total_area_sqm=531.0,
+        candidate_runtime_track_segments=(),
+        notes=(),
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert (
+        cache.update(
+            blob,
+            now=captured_at,
+            completion_confirmed=True,
+        )
+        is True
+    )
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            activity="docked",
+            docked=True,
+            task_status="idle",
+            status_notice_name=None,
+        ),
+        runtime_status_blob=None,
+        runtime_telemetry_cache=cache,
+    )
+    progress = object.__new__(DreameLawnMowerRuntimeMissionProgressSensor)
+    progress.coordinator = coordinator
+
+    assert progress.native_value == 100.0
+    assert progress.extra_state_attributes["area_progress_percent"] == 99.7
+    assert progress.extra_state_attributes["completion_confirmed"] is True
+    assert progress.extra_state_attributes["cached"] is True
+
+
 def test_runtime_mission_sensor_uses_live_blob_for_heartbeat_active_session() -> None:
     """Explicit heartbeat state wins while legacy activity still looks docked."""
     cached_blob = SimpleNamespace(

--- a/tests/test_feature_capabilities.py
+++ b/tests/test_feature_capabilities.py
@@ -61,6 +61,16 @@ def test_validated_a3_is_video_supported_before_metadata_arrives() -> None:
     assert capability.source == CAPABILITY_SOURCE_MODEL
 
 
+def test_field_confirmed_lidax_2000_video_is_available_before_metadata() -> None:
+    capability = resolve_feature_capability(
+        FEATURE_LIVE_VIDEO,
+        snapshot=_snapshot("mova.mower.g2529f"),
+    )
+
+    assert capability.state == CAPABILITY_SUPPORTED
+    assert capability.source == CAPABILITY_SOURCE_MODEL
+
+
 def test_unknown_model_without_evidence_remains_unknown() -> None:
     capability = resolve_feature_capability(
         FEATURE_LIVE_VIDEO,

--- a/tests/test_ha_compatibility.py
+++ b/tests/test_ha_compatibility.py
@@ -131,6 +131,17 @@ def test_sensor_facade_preserves_split_implementation_exports() -> None:
             assert getattr(sensor_module, name) is value
 
 
+def test_sensor_facade_preserves_runtime_progress_helper() -> None:
+    """Keep the historical raw runtime-progress helper importable."""
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+
+    assert (
+        sensor_module._runtime_status_blob_progress_percent
+        is sensor_runtime._runtime_status_blob_progress_percent
+    )
+    assert sensor_module._runtime_status_blob_progress_percent(blob) == 99.7
+
+
 def test_sensor_facade_preserves_historical_domain_exports() -> None:
     """Keep domain dependencies historically exposed by the platform importable."""
     expected_exports = {

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -561,6 +561,11 @@ def test_model_overrides_prevent_cross_model_code_guesses() -> None:
         == "robot_lifted"
     )
     assert mower_fault_active(0, model="mova.mower.g2529c") is True
+    for model in ("mova.mower.g2529f", "g2529f"):
+        assert mower_device_code_name(0, model=model) == "robot_lifted"
+        assert mower_fault_active(0, model=model) is True
+        assert mower_device_code_name(55, model=model) == "cannot_start_low_battery"
+        assert mower_fault_active(55, model=model) is True
     assert (
         mower_device_code_name(0, model="mova.mower.x1234")
         == "no_device_code"

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -147,6 +147,19 @@ def test_a2_3000_uses_a2_maintenance_point_notice_catalog() -> None:
     assert snapshot.status_notice_display == "Maintenance point reached"
 
 
+def test_realtime_start_notice_retains_event_time_for_session_identity() -> None:
+    snapshot = _snapshot(
+        53,
+        "unknown",
+        realtime_error_code=53,
+        realtime_error_last_seen=123.5,
+        state="MOWING",
+    )
+
+    assert snapshot.status_notice_name == "scheduled_mowing_started"
+    assert snapshot.status_notice_event_at == 123.5
+
+
 @pytest.mark.parametrize(
     ("code", "inherited_name", "state", "expected_activity", "expected_notice"),
     [

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -153,11 +153,13 @@ def test_realtime_start_notice_retains_event_time_for_session_identity() -> None
         "unknown",
         realtime_error_code=53,
         realtime_error_last_seen=123.5,
+        realtime_state_last_seen=120.0,
         state="MOWING",
     )
 
     assert snapshot.status_notice_name == "scheduled_mowing_started"
     assert snapshot.status_notice_event_at == 123.5
+    assert snapshot.state_event_at == 120.0
 
 
 @pytest.mark.parametrize(

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -423,6 +423,48 @@ def test_command_start_deduplicates_noncontiguous_start_notice() -> None:
     assert cache.blob is None
 
 
+def test_command_start_ignores_retained_prior_start_evidence() -> None:
+    """Only start evidence newer than command acceptance consumes its latch."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=12.5)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session(session_started_at=20.0)
+    generation = runtime_mission_session_generation(cache)
+
+    assert (
+        cache.update(
+            current,
+            active_session=True,
+            new_session=True,
+            new_session_evidence=("task", 100),
+            new_session_event_at=10.0,
+            session_identity=100,
+        )
+        is True
+    )
+    assert runtime_mission_cached_session_identity(cache) is None
+    assert runtime_mission_session_started_at(cache) == 20.0
+
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task", 101),
+        new_session_event_at=30.0,
+        session_identity=101,
+    )
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task", 101),
+        new_session_event_at=30.0,
+        session_identity=101,
+    )
+
+    assert runtime_mission_session_generation(cache) == generation
+    assert runtime_mission_cached_session_identity(cache) == 101
+    assert runtime_mission_session_started_at(cache) == 30.0
+    assert cache.blob is current
+
+
 def test_coalesced_replacement_start_advances_mission_identity() -> None:
     """A replacement task id resets cache without an inactive snapshot."""
     prior = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
@@ -490,6 +532,12 @@ def test_command_acceptance_preserves_callback_telemetry_from_new_generation() -
     cache.begin_new_session(
         observed_generation=observed_generation,
         session_started_at=20.0,
+    )
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task_status", "starting", 30.0),
+        new_session_event_at=30.0,
     )
 
     assert cache.blob is current
@@ -602,6 +650,59 @@ def test_retained_start_notice_cannot_override_explicit_inactive_heartbeat() -> 
     assert runtime_mission_new_session(snapshot) is False
     assert runtime_mission_new_session_event_at(snapshot) is None
     assert runtime_mission_session_active(snapshot, tracking_active=False) is False
+
+
+def test_newer_idle_state_supersedes_retained_active_heartbeat() -> None:
+    """A newer physical stop wins over independently retained heartbeat state."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=True,
+        task_resumable=False,
+        task_status="mowing",
+        task_status_event_at=10.0,
+        state="idle",
+        state_event_at=20.0,
+        status_notice_name=None,
+        status_notice_event_at=None,
+    )
+
+    assert runtime_mission_new_session(snapshot) is False
+    assert runtime_mission_session_active(snapshot, tracking_active=False) is False
+
+
+def test_newer_completion_notice_supersedes_retained_active_heartbeat() -> None:
+    """A current completion property wins over a stale active heartbeat."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=True,
+        task_resumable=False,
+        task_status="mowing",
+        task_status_event_at=10.0,
+        state="mowing",
+        state_event_at=5.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=20.0,
+    )
+
+    assert runtime_mission_session_active(snapshot, tracking_active=True) is False
+    assert runtime_mission_completion_confirmed(snapshot, tracking_active=True) is True
+
+
+def test_older_terminal_property_does_not_supersede_active_heartbeat() -> None:
+    """Fresh heartbeat activity remains authoritative over retained properties."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=True,
+        task_resumable=False,
+        task_status="mowing",
+        task_status_event_at=20.0,
+        state="idle",
+        state_event_at=10.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=10.0,
+    )
+
+    assert runtime_mission_session_active(snapshot, tracking_active=False) is True
+    assert (
+        runtime_mission_completion_confirmed(snapshot, tracking_active=False) is False
+    )
 
 
 def test_newer_start_notice_can_precede_lagging_inactive_heartbeat() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -15,6 +15,7 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
     runtime_mission_new_session_evidence,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
+    runtime_mission_session_event_at,
     runtime_mission_session_generation,
     runtime_mission_session_identity,
     runtime_mission_session_started_at,
@@ -401,6 +402,71 @@ def test_command_acceptance_still_resets_unidentified_active_telemetry() -> None
 
     assert cache.blob is None
     assert cache.completion_confirmed is False
+
+
+def test_command_owned_start_rejects_retained_prior_completion_notice() -> None:
+    """A missed start callback still establishes an ordered mission boundary."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    stopped = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="idle",
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=10.0,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session(session_started_at=20.0)
+    assert cache.update(current, active_session=True) is True
+
+    completion_confirmed = runtime_mission_completion_confirmed(
+        stopped,
+        tracking_active=False,
+        session_started_at=runtime_mission_session_started_at(cache),
+    )
+    cache.observe_session_state(
+        active_session=False,
+        completion_confirmed=completion_confirmed,
+    )
+
+    assert completion_confirmed is False
+    assert cache.completion_confirmed is False
+    assert cache.blob is current
+    assert (
+        runtime_mission_completion_confirmed(
+            SimpleNamespace(
+                mowing_session_active=False,
+                task_status="idle",
+                status_notice_name="mowing_task_completed",
+                status_notice_event_at=30.0,
+            ),
+            tracking_active=False,
+            session_started_at=runtime_mission_session_started_at(cache),
+        )
+        is True
+    )
+
+
+def test_active_transition_uses_physical_event_as_external_start_boundary() -> None:
+    """An app-owned start remains ordered when its explicit notice is missed."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=True,
+        state_event_at=20.0,
+        task_status="mowing",
+        task_status_event_at=21.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=10.0,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    mission_active = runtime_mission_session_active(snapshot, tracking_active=True)
+    cache.observe_session_state(
+        active_session=mission_active,
+        new_session=False,
+        new_session_event_at=runtime_mission_session_event_at(
+            snapshot,
+            active_session=mission_active,
+        ),
+    )
+
+    assert runtime_mission_session_started_at(cache) == 21.0
 
 
 def test_all_area_start_notice_announces_a_new_session() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -13,6 +13,7 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
     runtime_mission_new_session,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
+    runtime_mission_session_generation,
 )
 
 
@@ -279,6 +280,37 @@ def test_command_start_deduplicates_noncontiguous_start_notice() -> None:
     cache.observe_session_state(active_session=True, new_session=True)
 
     assert cache.blob is None
+
+
+def test_command_acceptance_preserves_callback_telemetry_from_new_generation() -> None:
+    """A callback-observed mission is not invalidated again on command return."""
+    previous = SimpleNamespace(candidate_runtime_area_progress_percent=100.0)
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=4.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous, completion_confirmed=True) is True
+    observed_generation = runtime_mission_session_generation(cache)
+
+    cache.observe_session_state(active_session=True)
+    assert cache.update(current, active_session=True) is True
+    cache.begin_new_session(observed_generation=observed_generation)
+
+    assert cache.blob is current
+    assert cache.completion_confirmed is False
+
+
+def test_command_acceptance_still_resets_unidentified_active_telemetry() -> None:
+    """An active update without a new boundary cannot mask a fresh command."""
+    previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=43.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous, active_session=True) is True
+    observed_generation = runtime_mission_session_generation(cache)
+
+    assert cache.update(current, active_session=True) is True
+    cache.begin_new_session(observed_generation=observed_generation)
+
+    assert cache.blob is None
+    assert cache.completion_confirmed is False
 
 
 def test_all_area_start_notice_announces_a_new_session() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -9,7 +9,9 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     runtime_blob_has_session_metrics,
     runtime_mission_completion_confirmed,
+    runtime_mission_new_session,
     runtime_mission_progress_percent,
+    runtime_mission_session_active,
 )
 
 
@@ -133,6 +135,60 @@ def test_finished_heartbeat_normalizes_rounded_area_progress() -> None:
         )
         == 100.0
     )
+
+
+def test_docked_active_mission_remains_the_same_session() -> None:
+    """Charging pauses tracking without ending a resumable mission."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="charging",
+        task_status="paused",
+        task_resumable=True,
+        status_notice_name="mowing_task_completed",
+    )
+
+    assert (
+        runtime_mission_session_active(snapshot, tracking_active=False) is True
+    )
+    assert (
+        runtime_mission_completion_confirmed(snapshot, tracking_active=False)
+        is False
+    )
+
+
+def test_starting_signal_resets_an_already_active_prior_session_once() -> None:
+    """Coalesced stop/start callbacks cannot reuse the prior mission blob."""
+    previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=1.0)
+    starting = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="charging",
+        task_status="starting",
+        status_notice_name=None,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous, active_session=True) is True
+
+    mission_active = runtime_mission_session_active(
+        starting,
+        tracking_active=False,
+    )
+    assert mission_active is True
+    cache.observe_session_state(
+        active_session=mission_active,
+        new_session=runtime_mission_new_session(starting),
+    )
+    assert cache.blob is None
+    assert cache.update(
+        current,
+        active_session=mission_active,
+        new_session=runtime_mission_new_session(starting),
+    ) is True
+    cache.observe_session_state(active_session=True, new_session=False)
+
+    assert cache.blob is current
 
 
 def test_active_or_incomplete_mission_keeps_measured_progress() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -236,6 +236,28 @@ def test_starting_signal_resets_an_already_active_prior_session_once() -> None:
     assert cache.blob is current
 
 
+def test_command_start_deduplicates_noncontiguous_start_notice() -> None:
+    """A delayed start notice cannot erase telemetry from the same mission."""
+    previous = SimpleNamespace(candidate_runtime_area_progress_percent=100.0)
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=12.5)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous, completion_confirmed=True) is True
+
+    cache.begin_new_session()
+    cache.observe_session_state(active_session=False, new_session=False)
+    assert cache.update(current, active_session=True, new_session=False) is True
+    cache.observe_session_state(active_session=True, new_session=False)
+    cache.observe_session_state(active_session=True, new_session=True)
+
+    assert cache.blob is current
+    assert cache.completion_confirmed is False
+
+    cache.observe_session_state(active_session=False)
+    cache.observe_session_state(active_session=True, new_session=True)
+
+    assert cache.blob is None
+
+
 def test_all_area_start_notice_announces_a_new_session() -> None:
     """The emitted base-model start notice resets coalesced prior telemetry."""
     snapshot = SimpleNamespace(

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -228,6 +228,38 @@ def test_missing_idle_heartbeat_ends_active_session_boundary() -> None:
     assert cache.blob is None
 
 
+def test_stale_resume_notice_cannot_override_newer_idle_state() -> None:
+    """A retained property 2.2 notice cannot keep an ended mission active."""
+    idle = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="idle",
+        state_event_at=2.0,
+        task_status=None,
+        task_resumable=None,
+        status_notice_name="mowing_resumed_after_charging",
+        status_notice_event_at=1.0,
+    )
+
+    assert runtime_mission_session_active(idle, tracking_active=False) is False
+
+
+def test_newer_resume_notice_can_precede_lagging_physical_state() -> None:
+    """Ordered realtime evidence can retain a resumed charging mission."""
+    resuming = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="charging",
+        state_event_at=1.0,
+        task_status=None,
+        task_resumable=None,
+        status_notice_name="mowing_resumed_after_charging",
+        status_notice_event_at=2.0,
+    )
+
+    assert runtime_mission_session_active(resuming, tracking_active=False) is True
+
+
 def test_starting_signal_resets_an_already_active_prior_session_once() -> None:
     """Coalesced stop/start callbacks cannot reuse the prior mission blob."""
     previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -202,6 +202,28 @@ def test_missing_charging_heartbeat_preserves_active_session_boundary() -> None:
     assert cache.completion_confirmed is False
 
 
+def test_missing_idle_heartbeat_ends_active_session_boundary() -> None:
+    """A docked idle snapshot cannot join the next mission to the prior one."""
+    previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    idle = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="idle",
+        task_status=None,
+        task_resumable=None,
+        status_notice_name=None,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(previous, active_session=True) is True
+
+    idle_active = runtime_mission_session_active(idle, tracking_active=False)
+    assert idle_active is False
+    cache.observe_session_state(active_session=idle_active)
+    cache.observe_session_state(active_session=True)
+
+    assert cache.blob is None
+
+
 def test_starting_signal_resets_an_already_active_prior_session_once() -> None:
     """Coalesced stop/start callbacks cannot reuse the prior mission blob."""
     previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -8,6 +8,8 @@ from types import SimpleNamespace
 from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     runtime_blob_has_session_metrics,
+    runtime_mission_completion_confirmed,
+    runtime_mission_progress_percent,
 )
 
 
@@ -92,3 +94,108 @@ def test_active_zero_blob_starts_a_new_session() -> None:
 
     assert cache.update(idle, allow_zero=True) is True
     assert cache.blob is idle
+
+
+def test_completed_mission_normalizes_rounded_area_progress() -> None:
+    """Explicit completion wins over a slightly short measured area ratio."""
+    snapshot = SimpleNamespace(
+        task_status="idle",
+        status_notice_name="mowing_task_completed",
+    )
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+
+    completion_confirmed = runtime_mission_completion_confirmed(
+        snapshot,
+        tracking_active=False,
+    )
+    assert (
+        runtime_mission_progress_percent(
+            blob,
+            completion_confirmed=completion_confirmed,
+        )
+        == 100.0
+    )
+    assert completion_confirmed is True
+
+
+def test_finished_heartbeat_normalizes_rounded_area_progress() -> None:
+    """The heartbeat's terminal task state is also authoritative completion."""
+    snapshot = SimpleNamespace(task_status="finished", status_notice_name=None)
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+
+    assert (
+        runtime_mission_progress_percent(
+            blob,
+            completion_confirmed=runtime_mission_completion_confirmed(
+                snapshot,
+                tracking_active=False,
+            ),
+        )
+        == 100.0
+    )
+
+
+def test_active_or_incomplete_mission_keeps_measured_progress() -> None:
+    """Returns, pauses, and new sessions must not be presented as complete."""
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=73.3)
+    returning = SimpleNamespace(
+        task_status="returning_to_dock",
+        status_notice_name="low_battery_returning",
+    )
+    stale_notice = SimpleNamespace(
+        task_status="mowing",
+        status_notice_name="mowing_task_completed",
+    )
+
+    assert (
+        runtime_mission_progress_percent(
+            blob,
+            completion_confirmed=runtime_mission_completion_confirmed(
+                returning,
+                tracking_active=False,
+            ),
+        )
+        == 73.3
+    )
+    assert (
+        runtime_mission_progress_percent(
+            blob,
+            completion_confirmed=runtime_mission_completion_confirmed(
+                stale_notice,
+                tracking_active=True,
+            ),
+        )
+        == 73.3
+    )
+
+
+def test_completion_without_runtime_measurement_remains_unavailable() -> None:
+    """A completion event alone must not invent runtime telemetry."""
+    snapshot = SimpleNamespace(
+        task_status="finished",
+        status_notice_name="mowing_task_completed",
+    )
+
+    assert (
+        runtime_mission_progress_percent(
+            SimpleNamespace(),
+            completion_confirmed=runtime_mission_completion_confirmed(
+                snapshot,
+                tracking_active=False,
+            ),
+        )
+        is None
+    )
+
+
+def test_cache_preserves_completion_until_the_next_active_session() -> None:
+    """Transient completion evidence remains attached to the cached mission."""
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+
+    assert cache.update(blob, completion_confirmed=True) is True
+    assert cache.completion_confirmed is True
+    assert cache.update(SimpleNamespace()) is False
+    assert cache.completion_confirmed is True
+    assert cache.update(SimpleNamespace(), active_session=True) is False
+    assert cache.completion_confirmed is False

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -11,9 +11,11 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
+    runtime_mission_new_session_evidence,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
     runtime_mission_session_generation,
+    runtime_mission_session_identity,
 )
 
 
@@ -282,6 +284,60 @@ def test_command_start_deduplicates_noncontiguous_start_notice() -> None:
     assert cache.blob is None
 
 
+def test_coalesced_replacement_start_advances_mission_identity() -> None:
+    """A replacement task id resets cache without an inactive snapshot."""
+    prior = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task", 100),
+        session_identity=100,
+    )
+    assert cache.update(
+        prior,
+        active_session=True,
+        session_identity=100,
+    ) is True
+
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task", 101),
+        session_identity=101,
+    )
+
+    assert cache.blob is None
+
+
+def test_coalesced_replacement_notice_uses_realtime_event_identity() -> None:
+    """A newer same-code notice resets cache after the command notice is consumed."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=12.5)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session()
+    assert cache.update(current, active_session=True) is True
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("notice", "mowing_task_started", 1.0),
+    )
+    assert cache.blob is current
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("notice", "mowing_task_started", 1.0),
+    )
+    assert cache.blob is current
+
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("notice", "mowing_task_started", 2.0),
+    )
+
+    assert cache.blob is None
+
+
 def test_command_acceptance_preserves_callback_telemetry_from_new_generation() -> None:
     """A callback-observed mission is not invalidated again on command return."""
     previous = SimpleNamespace(candidate_runtime_area_progress_percent=100.0)
@@ -321,6 +377,34 @@ def test_all_area_start_notice_announces_a_new_session() -> None:
     )
 
     assert runtime_mission_new_session(snapshot) is True
+
+
+def test_new_session_evidence_prefers_stable_heartbeat_task_identity() -> None:
+    """Task identity deduplicates repeated snapshots and separates missions."""
+    snapshot = SimpleNamespace(
+        task_status="mowing",
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=20.0,
+        mission_task_id=101,
+    )
+
+    assert runtime_mission_session_identity(snapshot) == 101
+    assert runtime_mission_new_session_evidence(snapshot) == ("task", 101)
+
+
+def test_new_session_evidence_uses_starting_property_event_without_task_id() -> None:
+    snapshot = SimpleNamespace(
+        task_status="starting",
+        task_status_event_at=21.0,
+        status_notice_name=None,
+        mission_task_id=None,
+    )
+
+    assert runtime_mission_new_session_evidence(snapshot) == (
+        "task_status",
+        "starting",
+        21.0,
+    )
 
 
 def test_active_or_incomplete_mission_keeps_measured_progress() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -157,6 +157,51 @@ def test_docked_active_mission_remains_the_same_session() -> None:
     )
 
 
+def test_missing_charging_heartbeat_preserves_active_session_boundary() -> None:
+    """A failed heartbeat cannot turn a charging pause into a session end."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    missing_heartbeat = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="charging",
+        task_status=None,
+        task_resumable=None,
+        status_notice_name="mowing_task_completed",
+    )
+    paused_heartbeat = SimpleNamespace(
+        mowing_session_active=None,
+        docked=True,
+        state="charging",
+        task_status="paused",
+        task_resumable=True,
+        status_notice_name=None,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(current, active_session=True) is True
+
+    missing_active = runtime_mission_session_active(
+        missing_heartbeat,
+        tracking_active=False,
+    )
+    assert missing_active is None
+    cache.observe_session_state(
+        active_session=missing_active,
+        completion_confirmed=runtime_mission_completion_confirmed(
+            missing_heartbeat,
+            tracking_active=missing_active,
+        ),
+    )
+    cache.observe_session_state(
+        active_session=runtime_mission_session_active(
+            paused_heartbeat,
+            tracking_active=False,
+        ),
+    )
+
+    assert cache.blob is current
+    assert cache.completion_confirmed is False
+
+
 def test_starting_signal_resets_an_already_active_prior_session_once() -> None:
     """Coalesced stop/start callbacks cannot reuse the prior mission blob."""
     previous = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -11,11 +11,13 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
+    runtime_mission_new_session_event_at,
     runtime_mission_new_session_evidence,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
     runtime_mission_session_generation,
     runtime_mission_session_identity,
+    runtime_mission_session_started_at,
 )
 
 
@@ -409,6 +411,90 @@ def test_all_area_start_notice_announces_a_new_session() -> None:
     )
 
     assert runtime_mission_new_session(snapshot) is True
+
+
+def test_retained_start_notice_cannot_override_explicit_inactive_heartbeat() -> None:
+    """An older start property cannot keep a manually stopped mission active."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=False,
+        state="idle",
+        state_event_at=30.0,
+        task_status="idle",
+        task_status_event_at=30.0,
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=10.0,
+    )
+
+    assert runtime_mission_new_session(snapshot) is False
+    assert runtime_mission_new_session_event_at(snapshot) is None
+    assert runtime_mission_session_active(snapshot, tracking_active=False) is False
+
+
+def test_newer_start_notice_can_precede_lagging_inactive_heartbeat() -> None:
+    """A newly emitted start notice wins over older physical-state evidence."""
+    snapshot = SimpleNamespace(
+        mowing_session_active=False,
+        state="idle",
+        state_event_at=30.0,
+        task_status="idle",
+        task_status_event_at=30.0,
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=40.0,
+    )
+
+    assert runtime_mission_new_session(snapshot) is True
+    assert runtime_mission_new_session_event_at(snapshot) == 40.0
+    assert runtime_mission_session_active(snapshot, tracking_active=False) is False
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.observe_session_state(
+        active_session=False,
+        new_session=True,
+        new_session_event_at=runtime_mission_new_session_event_at(snapshot),
+    )
+    assert runtime_mission_session_generation(cache) == 1
+
+
+def test_completion_notice_older_than_current_mission_is_rejected() -> None:
+    """A retained prior success cannot complete a later manually stopped mission."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    starting = SimpleNamespace(
+        mowing_session_active=True,
+        task_status="starting",
+        task_status_event_at=20.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=10.0,
+    )
+    stopped = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="idle",
+        task_status_event_at=30.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=10.0,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.observe_session_state(
+        active_session=True,
+        new_session=runtime_mission_new_session(starting),
+        new_session_evidence=runtime_mission_new_session_evidence(starting),
+        new_session_event_at=runtime_mission_new_session_event_at(starting),
+    )
+    assert cache.update(current, active_session=True) is True
+
+    completion_confirmed = runtime_mission_completion_confirmed(
+        stopped,
+        tracking_active=False,
+        session_started_at=runtime_mission_session_started_at(cache),
+    )
+    cache.observe_session_state(
+        active_session=False,
+        completion_confirmed=completion_confirmed,
+        new_session=runtime_mission_new_session(stopped),
+        new_session_event_at=runtime_mission_new_session_event_at(stopped),
+    )
+
+    assert completion_confirmed is False
+    assert cache.completion_confirmed is False
+    assert cache.blob is current
 
 
 def test_new_session_evidence_prefers_stable_heartbeat_task_identity() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -456,6 +456,36 @@ def test_recoverable_fault_pause_preserves_active_session_boundary() -> None:
     assert cache.blob is current
 
 
+def test_newer_recoverable_fault_supersedes_retained_completion_notice() -> None:
+    """An old completion notice cannot end a newer fault-paused mission."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(current, active_session=True) is True
+    generation = runtime_mission_session_generation(cache)
+    faulted = SimpleNamespace(
+        mowing_session_active=None,
+        activity="error",
+        state="paused",
+        state_event_at=20.0,
+        started=True,
+        task_status="unknown",
+        task_resumable=None,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=10.0,
+    )
+
+    mission_active = runtime_mission_session_active(
+        faulted,
+        tracking_active=False,
+    )
+    cache.observe_session_state(active_session=mission_active)
+    cache.observe_session_state(active_session=True)
+
+    assert mission_active is None
+    assert runtime_mission_session_generation(cache) == generation
+    assert cache.blob is current
+
+
 def test_stale_resume_notice_cannot_override_newer_idle_state() -> None:
     """A retained property 2.2 notice cannot keep an ended mission active."""
     idle = SimpleNamespace(
@@ -584,6 +614,53 @@ def test_command_start_ignores_retained_prior_start_evidence() -> None:
     assert runtime_mission_cached_session_identity(cache) == 101
     assert runtime_mission_session_started_at(cache) == 30.0
     assert cache.blob is current
+
+
+def test_command_start_accepts_timestamp_less_cloud_task_identity() -> None:
+    """A refreshed cloud task id can settle a command-owned start latch."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=12.5)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session(session_started_at=20.0)
+    generation = runtime_mission_session_generation(cache)
+    active = SimpleNamespace(
+        mowing_session_active=True,
+        task_status="mowing",
+        task_status_event_at=None,
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=None,
+        mission_task_id=101,
+    )
+
+    cache.observe_session_state(
+        active_session=True,
+        new_session=runtime_mission_new_session(active),
+        new_session_evidence=runtime_mission_new_session_evidence(active),
+        new_session_event_at=runtime_mission_new_session_event_at(active),
+        session_identity=runtime_mission_session_identity(active),
+    )
+    assert cache.update(current, active_session=True, session_identity=101) is True
+
+    finished = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=None,
+        status_notice_name=None,
+        mission_task_id=101,
+    )
+    session_started_at = runtime_mission_session_started_at(cache)
+    session_identity = runtime_mission_cached_session_identity(cache)
+
+    assert runtime_mission_session_generation(cache) == generation
+    assert session_identity == 101
+    assert (
+        runtime_mission_completion_confirmed(
+            finished,
+            tracking_active=False,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
+        is True
+    )
 
 
 def test_coalesced_replacement_start_advances_mission_identity() -> None:
@@ -897,6 +974,7 @@ def test_new_session_evidence_prefers_stable_heartbeat_task_identity() -> None:
     """Task identity deduplicates repeated snapshots and separates missions."""
     snapshot = SimpleNamespace(
         task_status="mowing",
+        task_status_event_at=20.0,
         status_notice_name="mowing_task_started",
         status_notice_event_at=20.0,
         mission_task_id=101,
@@ -904,6 +982,52 @@ def test_new_session_evidence_prefers_stable_heartbeat_task_identity() -> None:
 
     assert runtime_mission_session_identity(snapshot) == 101
     assert runtime_mission_new_session_evidence(snapshot) == ("task", 101)
+
+
+def test_newer_start_notice_rejects_superseded_inactive_heartbeat_identity() -> None:
+    """A retained prior task id cannot identify a newer replacement start."""
+    prior = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=1.0)
+    snapshot = SimpleNamespace(
+        mowing_session_active=False,
+        state="idle",
+        state_event_at=30.0,
+        task_status="idle",
+        task_status_event_at=30.0,
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=40.0,
+        mission_task_id=100,
+    )
+
+    assert runtime_mission_new_session(snapshot) is True
+    assert runtime_mission_session_identity(snapshot) is None
+    assert runtime_mission_new_session_evidence(snapshot) == (
+        "notice",
+        "mowing_task_started",
+        40.0,
+    )
+
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.observe_session_state(active_session=True, session_identity=100)
+    assert cache.update(prior, active_session=True, session_identity=100) is True
+    generation = runtime_mission_session_generation(cache)
+    cache.observe_session_state(
+        active_session=False,
+        new_session=True,
+        new_session_evidence=runtime_mission_new_session_evidence(snapshot),
+        new_session_event_at=runtime_mission_new_session_event_at(snapshot),
+        session_identity=runtime_mission_session_identity(snapshot),
+    )
+    replacement_generation = runtime_mission_session_generation(cache)
+    assert replacement_generation == generation + 1
+    assert cache.blob is None
+
+    cache.observe_session_state(active_session=True, session_identity=101)
+    assert cache.update(current, active_session=True, session_identity=101) is True
+
+    assert runtime_mission_session_generation(cache) == replacement_generation
+    assert runtime_mission_cached_session_identity(cache) == 101
+    assert cache.blob is current
 
 
 def test_new_session_evidence_uses_starting_property_event_without_task_id() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     runtime_blob_has_session_metrics,
+    runtime_mission_cached_session_identity,
     runtime_mission_completion_confirmed,
     runtime_mission_completion_rejected,
     runtime_mission_new_session,
@@ -141,6 +142,109 @@ def test_finished_heartbeat_normalizes_rounded_area_progress() -> None:
             ),
         )
         == 100.0
+    )
+
+
+def test_stale_terminal_heartbeat_cannot_end_the_current_mission() -> None:
+    """A retained prior heartbeat cannot complete or reject the new mission."""
+    stale_finished = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=10.0,
+        mission_task_id=100,
+        status_notice_name="mowing_task_completed",
+    )
+    stale_failed = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="failed",
+        task_status_event_at=10.0,
+        mission_task_id=100,
+        status_notice_name=None,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.observe_session_state(
+        active_session=True,
+        session_identity=101,
+        new_session_event_at=20.0,
+    )
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    assert cache.update(current, active_session=True, session_identity=101) is True
+    session_started_at = runtime_mission_session_started_at(cache)
+    session_identity = runtime_mission_cached_session_identity(cache)
+    generation = runtime_mission_session_generation(cache)
+
+    for stale_terminal in (stale_finished, stale_failed):
+        assert (
+            runtime_mission_session_active(
+                stale_terminal,
+                tracking_active=False,
+                session_started_at=session_started_at,
+                session_identity=session_identity,
+            )
+            is True
+        )
+    assert (
+        runtime_mission_completion_confirmed(
+            stale_finished,
+            tracking_active=False,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
+        is False
+    )
+    assert (
+        runtime_mission_completion_rejected(
+            stale_failed,
+            session_started_at=session_started_at,
+            session_identity=session_identity,
+        )
+        is False
+    )
+    cache.observe_session_state(
+        active_session=True,
+        session_identity=runtime_mission_session_identity(
+            stale_finished,
+            session_started_at=session_started_at,
+            cached_session_identity=session_identity,
+        ),
+    )
+    assert runtime_mission_session_generation(cache) == generation
+    assert cache.blob is current
+
+
+def test_current_terminal_heartbeat_can_end_the_current_mission() -> None:
+    """Matching identity or newer timing accepts terminal heartbeat evidence."""
+    matching = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=10.0,
+        mission_task_id=101,
+        status_notice_name=None,
+    )
+    newer = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=30.0,
+        mission_task_id=None,
+        status_notice_name=None,
+    )
+
+    assert (
+        runtime_mission_completion_confirmed(
+            matching,
+            tracking_active=False,
+            session_started_at=20.0,
+            session_identity=101,
+        )
+        is True
+    )
+    assert (
+        runtime_mission_completion_confirmed(
+            newer,
+            tracking_active=False,
+            session_started_at=20.0,
+        )
+        is True
     )
 
 

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -485,12 +485,16 @@ def test_command_acceptance_preserves_callback_telemetry_from_new_generation() -
     assert cache.update(previous, completion_confirmed=True) is True
     observed_generation = runtime_mission_session_generation(cache)
 
-    cache.observe_session_state(active_session=True)
+    cache.observe_session_state(active_session=True, new_session_event_at=30.0)
     assert cache.update(current, active_session=True) is True
-    cache.begin_new_session(observed_generation=observed_generation)
+    cache.begin_new_session(
+        observed_generation=observed_generation,
+        session_started_at=20.0,
+    )
 
     assert cache.blob is current
     assert cache.completion_confirmed is False
+    assert runtime_mission_session_started_at(cache) == 30.0
 
 
 def test_command_acceptance_still_resets_unidentified_active_telemetry() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -9,6 +9,7 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     runtime_blob_has_session_metrics,
     runtime_mission_completion_confirmed,
+    runtime_mission_completion_rejected,
     runtime_mission_new_session,
     runtime_mission_progress_percent,
     runtime_mission_session_active,
@@ -316,6 +317,20 @@ def test_active_or_incomplete_mission_keeps_measured_progress() -> None:
         )
         == 73.3
     )
+    for unsuccessful_status in ("failed", "exit"):
+        assert (
+            runtime_mission_progress_percent(
+                blob,
+                completion_confirmed=runtime_mission_completion_confirmed(
+                    SimpleNamespace(
+                        task_status=unsuccessful_status,
+                        status_notice_name="mowing_task_completed",
+                    ),
+                    tracking_active=False,
+                ),
+            )
+            == 73.3
+        )
     assert (
         runtime_mission_progress_percent(
             blob,
@@ -355,6 +370,29 @@ def test_completion_without_runtime_measurement_remains_unavailable() -> None:
         )
         is None
     )
+
+
+def test_explicit_failure_clears_cached_completion_latch() -> None:
+    """A later failed heartbeat cannot leave stale success attached."""
+    blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+    failed = SimpleNamespace(
+        task_status="failed",
+        status_notice_name="mowing_task_completed",
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(blob, completion_confirmed=True) is True
+
+    cache.observe_session_state(
+        active_session=False,
+        completion_confirmed=runtime_mission_completion_confirmed(
+            failed,
+            tracking_active=False,
+            cached_completion_confirmed=cache.completion_confirmed,
+        ),
+        completion_rejected=runtime_mission_completion_rejected(failed),
+    )
+
+    assert cache.completion_confirmed is False
 
 
 def test_cache_preserves_completion_until_the_next_active_session() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -191,6 +191,16 @@ def test_starting_signal_resets_an_already_active_prior_session_once() -> None:
     assert cache.blob is current
 
 
+def test_all_area_start_notice_announces_a_new_session() -> None:
+    """The emitted base-model start notice resets coalesced prior telemetry."""
+    snapshot = SimpleNamespace(
+        task_status="mowing",
+        status_notice_name="mowing_task_started",
+    )
+
+    assert runtime_mission_new_session(snapshot) is True
+
+
 def test_active_or_incomplete_mission_keeps_measured_progress() -> None:
     """Returns, pauses, and new sessions must not be presented as complete."""
     blob = SimpleNamespace(candidate_runtime_area_progress_percent=73.3)

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -212,6 +212,97 @@ def test_stale_terminal_heartbeat_cannot_end_the_current_mission() -> None:
     assert cache.blob is current
 
 
+def test_newer_terminal_properties_supersede_stale_terminal_heartbeat() -> None:
+    """Current physical evidence can end a mission despite a retained task id."""
+    stopped = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=10.0,
+        mission_task_id=100,
+        state="idle",
+        state_event_at=30.0,
+        status_notice_name=None,
+        status_notice_event_at=None,
+    )
+    completed = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=10.0,
+        mission_task_id=100,
+        state="idle",
+        state_event_at=30.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=30.0,
+    )
+    completed_after_stale_failure = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="failed",
+        task_status_event_at=10.0,
+        mission_task_id=100,
+        state="idle",
+        state_event_at=30.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=30.0,
+    )
+    unordered_completion = SimpleNamespace(
+        mowing_session_active=False,
+        task_status="finished",
+        task_status_event_at=10.0,
+        mission_task_id=100,
+        state="idle",
+        state_event_at=30.0,
+        status_notice_name="mowing_task_completed",
+        status_notice_event_at=None,
+    )
+
+    for snapshot in (stopped, completed, completed_after_stale_failure):
+        assert (
+            runtime_mission_session_active(
+                snapshot,
+                tracking_active=False,
+                session_started_at=20.0,
+                session_identity=101,
+            )
+            is False
+        )
+    assert (
+        runtime_mission_completion_confirmed(
+            stopped,
+            tracking_active=False,
+            session_started_at=20.0,
+            session_identity=101,
+        )
+        is False
+    )
+    assert (
+        runtime_mission_completion_confirmed(
+            completed,
+            tracking_active=False,
+            session_started_at=20.0,
+            session_identity=101,
+        )
+        is True
+    )
+    assert (
+        runtime_mission_completion_confirmed(
+            unordered_completion,
+            tracking_active=False,
+            session_started_at=20.0,
+            session_identity=101,
+        )
+        is False
+    )
+    assert (
+        runtime_mission_completion_confirmed(
+            completed_after_stale_failure,
+            tracking_active=False,
+            session_started_at=20.0,
+            session_identity=101,
+        )
+        is True
+    )
+
+
 def test_current_terminal_heartbeat_can_end_the_current_mission() -> None:
     """Matching identity or newer timing accepts terminal heartbeat evidence."""
     matching = SimpleNamespace(
@@ -333,6 +424,36 @@ def test_missing_idle_heartbeat_ends_active_session_boundary() -> None:
     cache.observe_session_state(active_session=True)
 
     assert cache.blob is None
+
+
+def test_recoverable_fault_pause_preserves_active_session_boundary() -> None:
+    """A paused active task remains the same mission while faulted."""
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    assert cache.update(current, active_session=True) is True
+    generation = runtime_mission_session_generation(cache)
+
+    for state in ("error", "paused"):
+        faulted = SimpleNamespace(
+            mowing_session_active=None,
+            activity="error",
+            state=state,
+            started=True,
+            task_status="unknown",
+            task_resumable=None,
+            status_notice_name="return_to_station_failed",
+            status_notice_event_at=None,
+        )
+        mission_active = runtime_mission_session_active(
+            faulted,
+            tracking_active=False,
+        )
+        assert mission_active is None
+        cache.observe_session_state(active_session=mission_active)
+    cache.observe_session_state(active_session=True)
+
+    assert runtime_mission_session_generation(cache) == generation
+    assert cache.blob is current
 
 
 def test_stale_resume_notice_cannot_override_newer_idle_state() -> None:

--- a/tests/test_runtime_cache.py
+++ b/tests/test_runtime_cache.py
@@ -146,12 +146,26 @@ def test_active_or_incomplete_mission_keeps_measured_progress() -> None:
         task_status="mowing",
         status_notice_name="mowing_task_completed",
     )
+    manually_stopped = SimpleNamespace(
+        task_status="completed",
+        status_notice_name=None,
+    )
 
     assert (
         runtime_mission_progress_percent(
             blob,
             completion_confirmed=runtime_mission_completion_confirmed(
                 returning,
+                tracking_active=False,
+            ),
+        )
+        == 73.3
+    )
+    assert (
+        runtime_mission_progress_percent(
+            blob,
+            completion_confirmed=runtime_mission_completion_confirmed(
+                manually_stopped,
                 tracking_active=False,
             ),
         )
@@ -198,4 +212,20 @@ def test_cache_preserves_completion_until_the_next_active_session() -> None:
     assert cache.update(SimpleNamespace()) is False
     assert cache.completion_confirmed is True
     assert cache.update(SimpleNamespace(), active_session=True) is False
+    assert cache.completion_confirmed is False
+    assert cache.blob is None
+    assert cache.captured_at is None
+
+
+def test_cache_only_invalidates_once_during_an_active_session() -> None:
+    """Fresh telemetry remains cached across later polls in the same mission."""
+    previous = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+    current = SimpleNamespace(candidate_runtime_area_progress_percent=12.5)
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+
+    assert cache.update(previous, completion_confirmed=True) is True
+    assert cache.update(current, active_session=True) is True
+    cache.observe_session_state(active_session=True)
+
+    assert cache.blob is current
     assert cache.completion_confirmed is False

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -137,6 +137,54 @@ def test_heartbeat_runtime_task_identity_is_retained_when_available() -> None:
     assert reconciled.mission_task_id == 101
 
 
+def test_heartbeat_task_state_replaces_retained_property_timestamp() -> None:
+    """Heartbeat state uses only its own reception time for mission identity."""
+    property_snapshot = replace(
+        _snapshot(),
+        task_status="starting",
+        task_status_source="property",
+        task_status_event_at=10.0,
+    )
+    status_blob = SimpleNamespace(
+        task_status="starting",
+        source="realtime",
+        received_at="1970-01-01T00:00:20+00:00",
+        mowing_session_active=True,
+        task_resumable=False,
+        heartbeat_docked=False,
+        candidate_runtime_task_id=None,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(property_snapshot, status_blob)
+
+    assert reconciled.task_status_source == "heartbeat_realtime"
+    assert reconciled.task_status_event_at == 20.0
+
+
+def test_heartbeat_task_state_clears_unowned_property_timestamp() -> None:
+    """Missing heartbeat timing never borrows the retained property event."""
+    property_snapshot = replace(
+        _snapshot(),
+        task_status="starting",
+        task_status_source="property",
+        task_status_event_at=10.0,
+    )
+    status_blob = SimpleNamespace(
+        task_status="starting",
+        source="realtime",
+        received_at=None,
+        mowing_session_active=True,
+        task_resumable=False,
+        heartbeat_docked=False,
+        candidate_runtime_task_id=None,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(property_snapshot, status_blob)
+
+    assert reconciled.task_status_source == "heartbeat_realtime"
+    assert reconciled.task_status_event_at is None
+
+
 def test_idle_in_station_heartbeat_preserves_bare_active_error() -> None:
     status_blob = decode_mower_status_blob(
         [206, 0, 0, 0, 0, 0, 0, 0, 0, 0, 128, 87, 113, 255, 0, 0, 128, 206, 186, 206]

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import replace
+from types import SimpleNamespace
 
 import pytest
 
@@ -101,6 +102,7 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
     assert reconciled.task_status == "idle"
     assert reconciled.task_status_source == "heartbeat_realtime"
     assert reconciled.mowing_session_active is False
+    assert reconciled.mission_task_id == status_blob.candidate_runtime_task_id
 
 
 def test_active_paused_session_keeps_task_activity_while_recording_dock() -> None:
@@ -117,6 +119,22 @@ def test_active_paused_session_keeps_task_activity_while_recording_dock() -> Non
     assert reconciled.raw_docked is True
     assert reconciled.task_status == "paused"
     assert reconciled.mowing_session_active is True
+    assert reconciled.mission_task_id == status_blob.candidate_runtime_task_id
+
+
+def test_heartbeat_runtime_task_identity_is_retained_when_available() -> None:
+    status_blob = SimpleNamespace(
+        task_status="mowing",
+        source="realtime",
+        mowing_session_active=True,
+        task_resumable=False,
+        heartbeat_docked=False,
+        candidate_runtime_task_id=101,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(_snapshot(), status_blob)
+
+    assert reconciled.mission_task_id == 101
 
 
 def test_idle_in_station_heartbeat_preserves_bare_active_error() -> None:


### PR DESCRIPTION
## Summary

- recognize `mova.mower.g2529f` as the MOVA LiDAX Ultra 2000 across display naming, MOVA-specific device-code semantics, and confirmed cloud-video capability
- document the field-confirmed US MOVAhome, control, map, and cloud-video coverage
- report 100% only when the mower provides a success-specific completion signal, while retaining the measured area percentage in attributes
- keep one mission's telemetry across a temporary charging stop and resume, including optional telemetry failures
- invalidate prior telemetry on explicit or integration-owned fresh starts, even when realtime callbacks skip the inactive transition
- preserve the historical raw runtime-progress helper through the `sensor` compatibility facade

## Confirmation

Issue #135 identifies the LiDAX Ultra 2000 on firmware `4.3.6_0453`. The same completed-below-100 behavior was reproduced independently on a Dreame A2: measured progress remained at 99.7% while the mower reported that the mowing task completed.

## Validation

- full test suite: 1,419 passed, 1 skipped
- Ruff and diff checks pass
- independent local review plus mission-lifetime and model-registration closure audits completed
- automatic review findings were addressed: manual stop is not successful completion, new missions cannot inherit prior telemetry, charging/resume keeps the current mission cache, all-area start notices reset session identity, the LiDAX 2000 uses MOVA error semantics and stable video capability, stale realtime callbacks cannot mutate mission cache, and heartbeat-less starts preserve start-versus-resume identity, duplicate starts retain the active mission, and heartbeat-less idle snapshots close the prior mission, incomplete and unknown task state preserve unknown identity, returning starts remain resumptions, and failed or exited tasks reject stale success notices, and command acceptance cannot erase telemetry already captured by the new mission callback, and coalesced replacement missions advance identity without reusing prior telemetry, and stale foreground hydration cannot mutate the current mission cache, stale resume notices cannot override newer idle state, fallback starts lock identity through dispatch, and video safety publications apply the same mission boundary, and retained start/completion notices are ordered against the current mission boundary, including command-owned and missed-callback starts, and heartbeat task state carries only its own reception timing, and terminal heartbeat state must match the current mission identity or postdate its boundary, command boundaries are recorded after acceptance, delayed runtime reads are rejected when mission generation changes, retained start evidence must postdate command acceptance before consuming its deduplication latch, and newer inactive state or completion properties supersede independently retained active or terminal heartbeat state, recoverable fault pauses retain the mission boundary, and contradictory heartbeat starts use the device branch under its MQTT state lock, timestamp-less post-command task identities settle the command latch, superseded inactive heartbeat IDs cannot identify a newer start, and newer recoverable fault state outranks retained completion notices
- production-shaped missing-heartbeat, optional-telemetry failure, coalesced callback, non-contiguous and repeated-start, command-owned start/resume, model-code, and pre-metadata video transitions are covered

## Work-log evidence needed

Work-history entities are not included yet. The legacy vendor history endpoint returned no records for an observed mission. A useful next capture is one matched mission with the disabled-by-default `Capture Task Status Probe` run before starting, while mowing, and immediately after completion, downloading Home Assistant diagnostics after each probe. Matching MOVAhome work-log list/detail screenshots should include the same mission's local start/end times, completed/incomplete state, duration, area, and timezone. If those captures still expose no history records, implementation will require either a sanitized current-app history endpoint/response or an integration-owned journal rather than guessing another vendor API.

Addresses #135










