### PR TITLE
Add confirmed device settings and safer map switching

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,8 +134,9 @@ operations behind clear boundaries:
   mower families still need reports.
 - Map rendering and map selection are supported, but editing no-go areas,
   virtual walls, and garden geometry is not.
-- Rain-protection state, configured delay, and the active delay end time are
-  readable; changing rain-protection settings is not exposed yet.
+- Charging-period and rain-protection controls are field-validated on the
+  Dreame A2. Other models expose them only when their native `CFG` record
+  reports the matching setting.
 - Mowing-preference writes use guarded paths and have the strongest live proof
   on the A2. Other models and firmware need broader confirmation.
 - Firmware updates use the app-approved target and confirmation flow. Release
@@ -343,6 +344,11 @@ Common user-facing helpers include:
 - `select.<device>_edge`
 - `select.<device>_zone`
 - `select.<device>_spot`
+- `select.<device>_rain_delay`
+- `switch.<device>_charging_period`
+- `switch.<device>_rain_protection`
+- `time.<device>_charging_period_start`
+- `time.<device>_charging_period_end`
 - `binary_sensor.<device>_docked`
 - `binary_sensor.<device>_charging`
 - `binary_sensor.<device>_bluetooth_connected`
@@ -427,6 +433,21 @@ dashboards, automations, and voice assistants. The companion Lawn Mower Card
 can use them when explicitly configured; automatic discovery support is tracked
 in the card project. The guarded service remains available when you need to
 inspect the complete candidate preference payload before sending it.
+
+## Charging And Rain Protection
+
+Models that report the mower-native `BAT` and `WRP` settings expose normal
+Home Assistant configuration entities. The charging-period switch keeps the
+configured start and end times; its two time entities can define a window that
+crosses midnight. Rain protection has a switch and a whole-hour delay select.
+The zero-hour delay means the mower stays docked until it is manually started.
+
+Every setting change first reads the current `CFG` record, writes only the
+setting-specific payload, and reads `CFG` again. Home Assistant updates only
+after the mower reports the requested value. Battery thresholds and rain-sensor
+sensitivity are preserved. The mower's `2:51` settings-change announcement also
+causes one coalesced refresh, so changes made in the Dreame app appear without
+waiting for the normal metadata interval.
 
 ## Maps
 
@@ -522,6 +543,11 @@ Current map support now includes:
 - an admin-only, stored-or-fresh PCD point-cloud download for the selected app map
 - circular and rotated rectangular forbidden areas rendered from their compact
   mower map representation
+
+The mower acknowledges map-switch commands even when it ignores them during an
+active, paused, or returning task. The integration blocks those states before
+writing and does not change the selected map until `MAPL` confirms the requested
+map index.
 
 Interactive map editing is still intentionally out of scope for now:
 

--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -513,9 +513,7 @@ class DreameLawnMowerCaptureWeatherProbeButton(
         )
         payload.setdefault("captured_at", datetime.now(UTC).isoformat())
         self.coordinator.last_weather_probe_result = payload
-        self.coordinator.weather_protection = dict(payload)
-        self.coordinator.weather_protection_refreshed_at = datetime.now(UTC)
-        self.coordinator.async_update_listeners()
+        self.coordinator._cache_device_settings(payload, source="weather_probe")
         _LOGGER.info(
             "Captured Dreame lawn mower weather probe for %s: %s",
             self.coordinator.client.descriptor.title,

--- a/custom_components/dreame_lawn_mower/button.py
+++ b/custom_components/dreame_lawn_mower/button.py
@@ -508,12 +508,7 @@ class DreameLawnMowerCaptureWeatherProbeButton(
 
     async def async_press(self) -> None:
         """Probe read-only weather/rain protection settings and log the result."""
-        payload = await self.coordinator.client.async_get_weather_protection(
-            include_raw=False,
-        )
-        payload.setdefault("captured_at", datetime.now(UTC).isoformat())
-        self.coordinator.last_weather_probe_result = payload
-        self.coordinator._cache_device_settings(payload, source="weather_probe")
+        payload = await self.coordinator.async_capture_weather_protection()
         _LOGGER.info(
             "Captured Dreame lawn mower weather probe for %s: %s",
             self.coordinator.client.descriptor.title,

--- a/custom_components/dreame_lawn_mower/const.py
+++ b/custom_components/dreame_lawn_mower/const.py
@@ -100,6 +100,7 @@ PLATFORMS: list[Platform] = [
     Platform.SELECT,
     Platform.SENSOR,
     Platform.SWITCH,
+    Platform.TIME,
     Platform.UPDATE,
 ]
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -96,6 +96,20 @@ BATCH_SCHEDULE_RESULT_COALESCE_SECONDS = 1.0
 _runtime_tracking_active = runtime_tracking_active
 
 
+def _device_settings_read_succeeded(settings: Mapping[str, Any]) -> bool:
+    """Return whether a settings payload contains a successful CFG read."""
+    if "present_config_keys" not in settings:
+        return False
+    errors = settings.get("errors")
+    return not (
+        isinstance(errors, Sequence)
+        and any(
+            isinstance(error, Mapping) and error.get("stage") == "config"
+            for error in errors
+        )
+    )
+
+
 class DreameLawnMowerCoordinator(
     DreameLawnMowerConnectivityMixin,
     DreameLawnMowerRefreshMixin,
@@ -591,16 +605,16 @@ class DreameLawnMowerCoordinator(
                 settings_event_at is not None
                 and settings_event_at != self._last_device_settings_event_at
             ):
-                self._last_device_settings_event_at = settings_event_at
                 # Property 2:51 identifies that some CFG value changed but not
                 # which one. Let the mower finish applying it, then read CFG once.
                 await asyncio.sleep(1)
-                async with self._device_settings_write_lock:
-                    await self.async_refresh_device_settings(
-                        force=True,
-                        source="device_settings_realtime",
-                    )
-                self.async_update_listeners()
+                refreshed = await self.async_refresh_device_settings(
+                    force=True,
+                    source="device_settings_realtime",
+                )
+                if refreshed is not None:
+                    self._last_device_settings_event_at = settings_event_at
+                    self.async_update_listeners()
         except Exception as err:  # noqa: BLE001 - callback must not escape HA task
             _LOGGER.debug("Failed to process cached mower update: %s", err)
         finally:
@@ -1845,6 +1859,23 @@ class DreameLawnMowerCoordinator(
         source: str = "weather_protection_auto",
     ) -> dict[str, Any] | None:
         """Refresh the mower-native settings record and rain-delay state."""
+        async with self._device_settings_write_lock:
+            return await self._async_refresh_device_settings_unlocked(
+                force=force,
+                source=source,
+                use_weather_alias=True,
+                return_stale_on_failure=True,
+            )
+
+    async def _async_refresh_device_settings_unlocked(
+        self,
+        *,
+        force: bool,
+        source: str,
+        use_weather_alias: bool,
+        return_stale_on_failure: bool,
+    ) -> dict[str, Any] | None:
+        """Refresh CFG while the caller owns the settings lock."""
         now = datetime.now(UTC)
         if (
             not force
@@ -1856,13 +1887,21 @@ class DreameLawnMowerCoordinator(
             return self.weather_protection
 
         try:
-            device_settings = await self.client.async_get_device_settings(
-                include_raw=False,
+            read_settings = (
+                self.client.async_get_weather_protection
+                if use_weather_alias
+                else self.client.async_get_device_settings
             )
+            device_settings = await read_settings(include_raw=False)
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh device settings: %s", err)
             self.weather_protection_refreshed_at = None
-            return self.weather_protection
+            return self.weather_protection if return_stale_on_failure else None
+
+        if not _device_settings_read_succeeded(device_settings):
+            _LOGGER.debug("Device settings refresh returned no successful CFG read")
+            self.weather_protection_refreshed_at = None
+            return self.weather_protection if return_stale_on_failure else None
 
         payload = dict(device_settings)
         payload.setdefault("captured_at", now.isoformat())
@@ -1879,10 +1918,27 @@ class DreameLawnMowerCoordinator(
         source: str = "device_settings_auto",
     ) -> dict[str, Any] | None:
         """Expose the canonical name for the shared CFG settings refresh."""
-        return await self.async_refresh_weather_protection(
-            force=force,
-            source=source,
-        )
+        async with self._device_settings_write_lock:
+            return await self._async_refresh_device_settings_unlocked(
+                force=force,
+                source=source,
+                use_weather_alias=False,
+                return_stale_on_failure=False,
+            )
+
+    async def async_capture_weather_protection(self) -> dict[str, Any]:
+        """Capture the historical weather probe under the settings lock."""
+        async with self._device_settings_write_lock:
+            payload = await self.client.async_get_weather_protection(
+                include_raw=False,
+            )
+            payload.setdefault("captured_at", datetime.now(UTC).isoformat())
+            self.last_weather_probe_result = payload
+            if _device_settings_read_succeeded(payload):
+                self._cache_device_settings(payload, source="weather_probe")
+            else:
+                self.async_update_listeners()
+            return payload
 
     def _cache_device_settings(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -136,6 +136,7 @@ class DreameLawnMowerCoordinator(
         self.vector_map_details: dict[str, Any] | None = None
         self.vector_map_details_refreshed_at: datetime | None = None
         self.weather_protection: dict[str, Any] | None = None
+        self.device_settings: dict[str, Any] | None = None
         self.weather_protection_refreshed_at: datetime | None = None
         self.maintenance_status: dict[str, Any] | None = None
         self.maintenance_status_refreshed_at: datetime | None = None
@@ -164,6 +165,7 @@ class DreameLawnMowerCoordinator(
         self._batch_schedule_read_completed_at: float | None = None
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
+        self._device_settings_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
         self._device_snapshot_generation = 0
         self._published_device_snapshot_generation = 0
@@ -196,6 +198,7 @@ class DreameLawnMowerCoordinator(
         self.last_maintenance_reset_result: dict[str, Any] | None = None
         self._client_update_task: asyncio.Task[None] | None = None
         self._client_update_pending = False
+        self._last_device_settings_event_at: float | None = None
         self._metadata_refresh_task: asyncio.Task[None] | None = None
         self._metadata_shutdown_close_task: asyncio.Task[None] | None = None
         self._metadata_refresh_semaphore = asyncio.Semaphore(
@@ -583,6 +586,21 @@ class DreameLawnMowerCoordinator(
                     bluetooth_error,
                 )
             self.async_set_updated_data(snapshot)
+            settings_event_at = getattr(snapshot, "device_settings_event_at", None)
+            if (
+                settings_event_at is not None
+                and settings_event_at != self._last_device_settings_event_at
+            ):
+                self._last_device_settings_event_at = settings_event_at
+                # Property 2:51 identifies that some CFG value changed but not
+                # which one. Let the mower finish applying it, then read CFG once.
+                await asyncio.sleep(1)
+                async with self._device_settings_write_lock:
+                    await self.async_refresh_device_settings(
+                        force=True,
+                        source="device_settings_realtime",
+                    )
+                self.async_update_listeners()
         except Exception as err:  # noqa: BLE001 - callback must not escape HA task
             _LOGGER.debug("Failed to process cached mower update: %s", err)
         finally:
@@ -1826,7 +1844,7 @@ class DreameLawnMowerCoordinator(
         force: bool = False,
         source: str = "weather_protection_auto",
     ) -> dict[str, Any] | None:
-        """Refresh cached read-only weather and rain-protection state."""
+        """Refresh the mower-native settings record and rain-delay state."""
         now = datetime.now(UTC)
         if (
             not force
@@ -1838,20 +1856,86 @@ class DreameLawnMowerCoordinator(
             return self.weather_protection
 
         try:
-            weather_protection = await self.client.async_get_weather_protection(
+            device_settings = await self.client.async_get_device_settings(
                 include_raw=False,
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
-            _LOGGER.debug("Failed to refresh weather protection: %s", err)
+            _LOGGER.debug("Failed to refresh device settings: %s", err)
             self.weather_protection_refreshed_at = None
             return self.weather_protection
 
-        payload = dict(weather_protection)
+        payload = dict(device_settings)
         payload.setdefault("captured_at", now.isoformat())
         payload["source"] = source
+        self.device_settings = payload
         self.weather_protection = payload
         self.weather_protection_refreshed_at = now
         return payload
+
+    async def async_refresh_device_settings(
+        self,
+        *,
+        force: bool = False,
+        source: str = "device_settings_auto",
+    ) -> dict[str, Any] | None:
+        """Expose the canonical name for the shared CFG settings refresh."""
+        return await self.async_refresh_weather_protection(
+            force=force,
+            source=source,
+        )
+
+    def _cache_device_settings(
+        self,
+        settings: Mapping[str, Any],
+        *,
+        source: str,
+    ) -> dict[str, Any]:
+        """Publish one confirmed settings readback to every settings entity."""
+        now = datetime.now(UTC)
+        payload = dict(settings)
+        payload["captured_at"] = now.isoformat()
+        payload["source"] = source
+        self.device_settings = payload
+        self.weather_protection = payload
+        self.weather_protection_refreshed_at = now
+        self.async_update_listeners()
+        return payload
+
+    async def async_set_charging_period(
+        self,
+        *,
+        enabled: bool | None = None,
+        start_minutes: int | None = None,
+        end_minutes: int | None = None,
+    ) -> dict[str, Any]:
+        """Persist and publish one confirmed charging-period update."""
+        async with self._device_settings_write_lock:
+            settings = await self.client.async_set_charging_period(
+                enabled=enabled,
+                start_minutes=start_minutes,
+                end_minutes=end_minutes,
+            )
+            return self._cache_device_settings(
+                settings,
+                source="charging_period_write",
+            )
+
+    async def async_set_rain_protection(
+        self,
+        *,
+        enabled: bool | None = None,
+        delay_hours: int | None = None,
+    ) -> dict[str, Any]:
+        """Persist and publish one confirmed rain-protection update."""
+        async with self._device_settings_write_lock:
+            settings = await self.client.async_set_rain_protection(
+                enabled=enabled,
+                delay_hours=delay_hours,
+            )
+            return self._cache_device_settings(
+                settings,
+                source="rain_protection_write",
+            )
 
     async def async_refresh_maintenance_status(
         self,

--- a/custom_components/dreame_lawn_mower/device_settings_control.py
+++ b/custom_components/dreame_lawn_mower/device_settings_control.py
@@ -1,0 +1,33 @@
+"""Thin Home Assistant adapters for mower-native device settings."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from datetime import time
+from typing import Any
+
+
+def device_settings_section(value: Any) -> Mapping[str, Any] | None:
+    """Return a usable cached CFG settings record."""
+    if not isinstance(value, Mapping) or not value.get("available"):
+        return None
+    return value
+
+
+def minutes_to_time(minutes: int | None) -> time | None:
+    """Convert minutes since midnight to a Home Assistant time value."""
+    if minutes is None:
+        return None
+    return time(hour=int(minutes) // 60, minute=int(minutes) % 60)
+
+
+def time_to_minutes(value: time) -> int:
+    """Convert a Home Assistant time value to minutes since midnight."""
+    return value.hour * 60 + value.minute
+
+
+def rain_delay_label(hours: int) -> str:
+    """Return a stable, human-friendly rain-delay option."""
+    if hours == 0:
+        return "Until manually started"
+    return f"{hours} hour" if hours == 1 else f"{hours} hours"

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -54,6 +54,7 @@ from .debug_ota_catalog import (
     build_debug_ota_catalog_url,
     normalize_debug_ota_catalog_payload,
 )
+from .exceptions import DreameLawnMowerCommandRejectedError
 from .feature_capabilities import (
     CAPABILITY_SOURCE_ADVERTISED,
     CAPABILITY_SOURCE_MODEL,
@@ -201,6 +202,7 @@ __all__ = [
     "DreameLawnMowerCameraStreamRuntimeInputs",
     "DreameLawnMowerClient",
     "DreameLawnMowerConnectionError",
+    "DreameLawnMowerCommandRejectedError",
     "DreameLawnMowerDescriptor",
     "DreameLawnMowerError",
     "DreameLawnMowerFirmwareUpdateSupport",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -76,6 +76,7 @@ from .client_core_helpers import (
 from .client_core_helpers import (
     _FIRMWARE_DESCRIPTION_PREFERRED_KEYS as _FIRMWARE_DESCRIPTION_PREFERRED_KEYS,
 )
+from .client_device_settings import _DreameLawnMowerClientDeviceSettingsMixin
 from .client_maps import (
     _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS,
     _DreameLawnMowerClientMapsMixin,
@@ -357,6 +358,7 @@ def _targeted_task_confirmed(
 class DreameLawnMowerClient(
     _DreameLawnMowerCameraMixin,
     _DreameLawnMowerClientCoreMixin,
+    _DreameLawnMowerClientDeviceSettingsMixin,
     _DreameLawnMowerClientSettingsMixin,
     _DreameLawnMowerClientMapsMixin,
 ):
@@ -688,29 +690,57 @@ class DreameLawnMowerClient(
         )
 
     async def async_switch_current_map(self, map_index: int) -> Any:
-        """Switch the active mower map through the app task path."""
+        """Switch the active map only while idle and require map-list readback."""
         map_index = int(map_index)
+        snapshot = await self.async_refresh_authoritative_snapshot()
+        session_unknown_outside_safe_state = (
+            snapshot.mowing_session_active is None
+            and snapshot.activity not in {"docked", "idle"}
+        )
+        if (
+            snapshot.mowing_session_active is True
+            or session_unknown_outside_safe_state
+            or snapshot.mowing
+            or snapshot.paused
+            or snapshot.returning
+        ):
+            raise _DreameLawnMowerCommandRejectedError(
+                "The active map cannot be changed while a mowing task is active, "
+                "paused, or returning to the dock. Finish or cancel the task first."
+            )
         try:
-            return await asyncio.to_thread(self._sync_switch_current_map, map_index)
+            response = await asyncio.to_thread(self._sync_switch_current_map, map_index)
         except _DreameLawnMowerCommandRejectedError:
             raise
-        except DreameLawnMowerConnectionError as err:
-            for delay in (0.5, 1.5, 3.0):
+        except DreameLawnMowerConnectionError:
+            # A timed-out setter can still have reached the mower. The same
+            # mandatory readback below decides whether it took effect.
+            response = None
+
+        readable = False
+        for delay in (0.0, 0.75, 1.5, 3.0):
+            if delay:
                 await asyncio.sleep(delay)
-                try:
-                    maps = await self.async_get_app_maps(
-                        include_payload=False,
-                        include_objects=False,
-                    )
-                except DreameLawnMowerConnectionError:
-                    continue
-                if maps.get("current_map_index") == map_index:
-                    return None
-            raise DreameLawnMowerConnectionError(
-                "The mower may have received the map switch request, but the "
-                "active map could not be confirmed after the connection was "
-                "interrupted. Refresh the map state before trying again."
-            ) from err
+            try:
+                maps = await self.async_get_app_maps(
+                    include_payload=False,
+                    include_objects=False,
+                )
+            except DreameLawnMowerConnectionError:
+                continue
+            readable = True
+            if maps.get("current_map_index") == map_index:
+                return response
+
+        if readable:
+            raise _DreameLawnMowerCommandRejectedError(
+                "The mower acknowledged the map switch but stayed on its previous "
+                "map. Map switching is only supported while no task is active."
+            )
+        raise DreameLawnMowerConnectionError(
+            "The active map could not be confirmed because every map-list "
+            "readback failed. Refresh the mower before trying again."
+        )
 
     async def async_get_vector_map_details(self) -> dict[str, Any]:
         """Return JSON-safe parsed batch vector-map details."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -722,14 +722,11 @@ class DreameLawnMowerClient(
             if delay:
                 await asyncio.sleep(delay)
             try:
-                maps = await self.async_get_app_maps(
-                    include_payload=False,
-                    include_objects=False,
-                )
+                current_map_index = await self.async_get_current_app_map_index()
             except DreameLawnMowerConnectionError:
                 continue
             readable = True
-            if maps.get("current_map_index") == map_index:
+            if current_map_index == map_index:
                 return response
 
         if readable:
@@ -1163,6 +1160,12 @@ class DreameLawnMowerClient(
             include_payload,
             include_objects,
             include_object_urls,
+        )
+
+    async def async_get_current_app_map_index(self) -> int | None:
+        """Read the active map index without downloading map payloads."""
+        return await asyncio.to_thread(
+            self._sync_get_current_app_map_index_readback,
         )
 
     async def async_get_batch_schedules(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_device_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_device_settings.py
@@ -1,0 +1,255 @@
+"""Confirmed mower-native device-setting reads and writes."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Mapping
+from typing import Any
+
+from .client_settings_helpers import _weather_protection_active_summary
+from .client_shared_helpers import _app_action_data, _ensure_app_write_succeeded
+from .device_settings import (
+    build_charging_period_request,
+    build_rain_protection_request,
+    decode_device_settings,
+    validate_rain_delay,
+    validate_time_of_day,
+)
+from .exceptions import (
+    DreameLawnMowerCommandRejectedError,
+    DreameLawnMowerConnectionError,
+)
+from .payload_utils import _json_safe
+
+
+class _DreameLawnMowerClientDeviceSettingsMixin:
+    def _sync_get_device_settings(
+        self,
+        include_raw: bool = False,
+        include_rain_end_time: bool = True,
+    ) -> dict[str, Any]:
+        """Read CFG once and decode all settings owned by this integration."""
+        result: dict[str, Any] = {
+            "source": "app_action_device_settings",
+            "available": False,
+            "config_keys": ["BAT", "WRF", "WRP"],
+            "fault_hint": "INFO_BAD_WEATHER_PROTECTING",
+            "rain_end_time_command": "RPET",
+            "errors": [],
+            "warnings": [],
+        }
+        try:
+            config_result = self._sync_call_app_action({"m": "g", "t": "CFG"})
+            if include_raw:
+                result["raw_config"] = _json_safe(config_result, max_depth=4)
+            config = _app_action_data(config_result)
+            if not isinstance(config, Mapping):
+                raise DreameLawnMowerConnectionError(
+                    "CFG returned no device-settings record."
+                )
+            result["present_config_keys"] = [
+                key for key in result["config_keys"] if key in config
+            ]
+            result.update(decode_device_settings(config))
+            rain_end_time = config.get("rainProtectEndTime")
+            if rain_end_time is None:
+                rain_end_time = config.get("rain_protect_end_time")
+            if rain_end_time is not None:
+                result["rain_protect_end_time"] = rain_end_time
+                result["rain_protect_end_time_present"] = True
+            result["available"] = True
+        except Exception as err:  # noqa: BLE001 - return partial diagnostic evidence
+            result["errors"].append({"stage": "config", "error": str(err)})
+
+        if include_rain_end_time:
+            try:
+                rain_end_result = self._sync_call_app_action({"m": "g", "t": "RPET"})
+                if include_raw:
+                    result["raw_rain_end_time"] = _json_safe(
+                        rain_end_result,
+                        max_depth=4,
+                    )
+                rain_end_data = _app_action_data(rain_end_result)
+                if isinstance(rain_end_data, Mapping):
+                    end_time = rain_end_data.get("endTime")
+                    if end_time is None:
+                        end_time = rain_end_data.get("end_time")
+                    result["rain_protect_end_time_present"] = end_time is not None
+                    if end_time is not None:
+                        result["rain_protect_end_time"] = end_time
+                        result["available"] = True
+                elif rain_end_data is None:
+                    result["rain_protect_end_time_present"] = False
+                else:
+                    result["warnings"].append(
+                        {
+                            "stage": "rain_end_time",
+                            "warning": "RPET returned unexpected data.",
+                        }
+                    )
+            except Exception as err:  # noqa: BLE001 - RPET may be conditionally available
+                result["warnings"].append(
+                    {"stage": "rain_end_time", "warning": str(err)}
+                )
+
+        result.update(_weather_protection_active_summary(result))
+        return result
+
+    def _sync_get_weather_protection(
+        self,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Keep the historical weather read contract over the settings owner."""
+        result = self._sync_get_device_settings(include_raw=include_raw)
+        result["source"] = "app_action_weather_protection"
+        return result
+
+    def _sync_set_charging_period(
+        self,
+        *,
+        enabled: bool | None = None,
+        start_minutes: int | None = None,
+        end_minutes: int | None = None,
+    ) -> dict[str, Any]:
+        """Update only the BAT charging window and require CFG readback."""
+        current = self._sync_get_device_settings(include_rain_end_time=False)
+        if not current.get("charging_settings_available"):
+            raise DreameLawnMowerConnectionError(
+                "The mower did not report charging-period settings."
+            )
+        next_enabled = (
+            bool(current["charging_period_enabled"])
+            if enabled is None
+            else bool(enabled)
+        )
+        next_start = (
+            int(current["charging_period_start_minutes"])
+            if start_minutes is None
+            else validate_time_of_day(start_minutes, "start")
+        )
+        next_end = (
+            int(current["charging_period_end_minutes"])
+            if end_minutes is None
+            else validate_time_of_day(end_minutes, "end")
+        )
+        request = build_charging_period_request(
+            enabled=next_enabled,
+            start_minutes=next_start,
+            end_minutes=next_end,
+        )
+        response = self._sync_call_app_action(request)
+        _ensure_app_write_succeeded(response, operation="Charging period update")
+        refreshed = self._sync_get_device_settings(include_rain_end_time=False)
+        expected = (
+            next_enabled,
+            next_start,
+            next_end,
+            current.get("recharge_battery_level"),
+            current.get("resume_battery_level"),
+            current.get("resume_after_charging"),
+        )
+        actual = (
+            refreshed.get("charging_period_enabled"),
+            refreshed.get("charging_period_start_minutes"),
+            refreshed.get("charging_period_end_minutes"),
+            refreshed.get("recharge_battery_level"),
+            refreshed.get("resume_battery_level"),
+            refreshed.get("resume_after_charging"),
+        )
+        if actual != expected:
+            raise DreameLawnMowerCommandRejectedError(
+                "The mower acknowledged the charging-period update but CFG did "
+                "not confirm the requested values and preserved BAT thresholds."
+            )
+        return refreshed
+
+    def _sync_set_rain_protection(
+        self,
+        *,
+        enabled: bool | None = None,
+        delay_hours: int | None = None,
+    ) -> dict[str, Any]:
+        """Update WRP while preserving sensitivity and require CFG readback."""
+        current = self._sync_get_device_settings(include_rain_end_time=False)
+        if not current.get("rain_settings_available"):
+            raise DreameLawnMowerConnectionError(
+                "The mower did not report rain-protection settings."
+            )
+        next_enabled = (
+            bool(current["rain_protection_enabled"])
+            if enabled is None
+            else bool(enabled)
+        )
+        next_delay = (
+            int(current["rain_protection_duration_hours"])
+            if delay_hours is None
+            else validate_rain_delay(delay_hours)
+        )
+        request = build_rain_protection_request(
+            enabled=next_enabled,
+            delay_hours=next_delay,
+            sensitivity=int(current["rain_sensor_sensitivity"]),
+        )
+        response = self._sync_call_app_action(request)
+        _ensure_app_write_succeeded(response, operation="Rain protection update")
+        refreshed = self._sync_get_device_settings(include_rain_end_time=True)
+        expected = (
+            next_enabled,
+            next_delay,
+            current.get("rain_sensor_sensitivity"),
+        )
+        actual = (
+            refreshed.get("rain_protection_enabled"),
+            refreshed.get("rain_protection_duration_hours"),
+            refreshed.get("rain_sensor_sensitivity"),
+        )
+        if actual != expected:
+            raise DreameLawnMowerCommandRejectedError(
+                "The mower acknowledged the rain-protection update but CFG did "
+                "not confirm the requested values and preserved sensitivity."
+            )
+        return refreshed
+
+    async def async_get_device_settings(
+        self,
+        *,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Return decoded mower-native device settings."""
+        return await asyncio.to_thread(self._sync_get_device_settings, include_raw)
+
+    async def async_get_weather_protection(
+        self,
+        *,
+        include_raw: bool = False,
+    ) -> dict[str, Any]:
+        """Keep the historical weather read API over the CFG settings owner."""
+        return await asyncio.to_thread(self._sync_get_weather_protection, include_raw)
+
+    async def async_set_charging_period(
+        self,
+        *,
+        enabled: bool | None = None,
+        start_minutes: int | None = None,
+        end_minutes: int | None = None,
+    ) -> dict[str, Any]:
+        """Set and confirm the mower-native charging period."""
+        return await asyncio.to_thread(
+            self._sync_set_charging_period,
+            enabled=enabled,
+            start_minutes=start_minutes,
+            end_minutes=end_minutes,
+        )
+
+    async def async_set_rain_protection(
+        self,
+        *,
+        enabled: bool | None = None,
+        delay_hours: int | None = None,
+    ) -> dict[str, Any]:
+        """Set and confirm the mower-native rain protection settings."""
+        return await asyncio.to_thread(
+            self._sync_set_rain_protection,
+            enabled=enabled,
+            delay_hours=delay_hours,
+        )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -152,6 +152,22 @@ def _app_map_inventory_identity(
 
 
 class _DreameLawnMowerClientMapsMixin:
+    def _sync_get_current_app_map_index_readback(self) -> int | None:
+        """Read only MAPL and return its unambiguous current map index."""
+        try:
+            map_list_result = self._sync_call_app_action({"m": "g", "t": "MAPL"})
+        except DeviceException as err:
+            raise DreameLawnMowerConnectionError(str(err)) from err
+        entries = _normalize_app_map_entries(map_list_result)
+        if not _app_map_entries_are_valid(map_list_result, entries):
+            raise DreameLawnMowerConnectionError(
+                "MAPL returned an incomplete or ambiguous map list."
+            )
+        for entry in entries:
+            if entry.get("created") is not False and entry.get("current") is True:
+                return int(entry["idx"])
+        return None
+
     def _sync_switch_current_map(self, map_index: int) -> Any:
         """Switch the active mower map by app map index."""
         if map_index < 0:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -38,8 +38,6 @@ from .client_settings_helpers import (
     _schedule_plan_overview,
     _schedule_upload_overview,
     _voice_settings_summary,
-    _weather_protection_active_summary,
-    _weather_protection_summary,
 )
 from .client_shared_helpers import (
     _app_action_data,
@@ -1013,71 +1011,6 @@ class _DreameLawnMowerClientSettingsMixin:
             result["refreshed_item"] = maintenance_item_status(refreshed, item)
         except Exception as err:  # noqa: BLE001 - write result is still useful
             result["refresh_error"] = str(err)
-        return result
-
-    def _sync_get_weather_protection(
-        self,
-        include_raw: bool = False,
-    ) -> dict[str, Any]:
-        """Fetch read-only weather and rain-protection settings."""
-        result: dict[str, Any] = {
-            "source": "app_action_weather_protection",
-            "available": False,
-            "fault_hint": "INFO_BAD_WEATHER_PROTECTING",
-            "config_keys": ["WRF", "WRP"],
-            "rain_end_time_command": "RPET",
-            "errors": [],
-            "warnings": [],
-        }
-
-        try:
-            config_result = self._sync_call_app_action({"m": "g", "t": "CFG"})
-            if include_raw:
-                result["raw_config"] = _json_safe(config_result, max_depth=4)
-            config = _app_action_data(config_result)
-            if not isinstance(config, Mapping):
-                raise DreameLawnMowerConnectionError(
-                    f"CFG returned invalid weather config: {config_result}"
-                )
-            result["present_config_keys"] = [
-                key for key in result["config_keys"] if key in config
-            ]
-            result.update(_weather_protection_summary(config))
-            result["available"] = True
-        except Exception as err:  # noqa: BLE001 - diagnostic probe should return evidence
-            result["errors"].append({"stage": "config", "error": str(err)})
-
-        try:
-            rain_end_result = self._sync_call_app_action({"m": "g", "t": "RPET"})
-            if include_raw:
-                result["raw_rain_end_time"] = _json_safe(
-                    rain_end_result,
-                    max_depth=4,
-                )
-            rain_end_data = _app_action_data(rain_end_result)
-            if isinstance(rain_end_data, Mapping):
-                end_time = rain_end_data.get("endTime")
-                if end_time is None:
-                    end_time = rain_end_data.get("end_time")
-                if end_time is not None:
-                    result["rain_protect_end_time"] = end_time
-                    result["rain_protect_end_time_present"] = True
-                    result["available"] = True
-                else:
-                    result["rain_protect_end_time_present"] = False
-            elif rain_end_data is None:
-                result["rain_protect_end_time_present"] = False
-            elif rain_end_data is not None:
-                result["warnings"].append(
-                    {
-                        "stage": "rain_end_time",
-                        "warning": f"RPET returned unexpected data: {rain_end_data}",
-                    }
-                )
-        except Exception as err:  # noqa: BLE001 - RPET may only answer while protection is active
-            result["warnings"].append({"stage": "rain_end_time", "warning": str(err)})
-
-        result.update(_weather_protection_active_summary(result))
         return result
 
     def _sync_get_voice_settings(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_settings.py
@@ -1,0 +1,180 @@
+"""Mower-native CFG device-setting codecs and write payloads."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from typing import Any
+
+MINUTES_PER_DAY = 24 * 60
+RAIN_DELAY_MIN_HOURS = 0
+RAIN_DELAY_MAX_HOURS = 24
+
+BATTERY_SETTING_LENGTH = 6
+BATTERY_RECHARGE_LEVEL_INDEX = 0
+BATTERY_RESUME_LEVEL_INDEX = 1
+BATTERY_RESUME_AFTER_CHARGING_INDEX = 2
+CHARGING_PERIOD_ENABLED_INDEX = 3
+CHARGING_PERIOD_START_INDEX = 4
+CHARGING_PERIOD_END_INDEX = 5
+
+RAIN_SETTING_MINIMUM_LENGTH = 2
+RAIN_SETTING_LENGTH = 3
+RAIN_SETTING_ENABLED_INDEX = 0
+RAIN_SETTING_DELAY_INDEX = 1
+RAIN_SETTING_SENSITIVITY_INDEX = 2
+RAIN_SETTING_DEFAULT_SENSITIVITY = 0
+
+
+def _integer_record(
+    value: Any,
+    *,
+    minimum_length: int,
+    fill_to_length: int | None = None,
+    fill_value: int = 0,
+) -> list[int] | None:
+    """Return a validated integer setting record."""
+    if isinstance(value, Mapping):
+        value = value.get("value")
+    if not isinstance(value, Sequence) or isinstance(
+        value,
+        str | bytes | bytearray,
+    ):
+        return None
+    values = list(value)
+    if len(values) < minimum_length:
+        return None
+    try:
+        record = [int(item) for item in values]
+    except (TypeError, ValueError):
+        return None
+    if fill_to_length is not None:
+        record.extend([fill_value] * max(0, fill_to_length - len(record)))
+    return record
+
+
+def decode_charging_settings(config: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Decode the six-slot BAT record without changing its threshold fields."""
+    record = _integer_record(
+        config.get("BAT"),
+        minimum_length=BATTERY_SETTING_LENGTH,
+    )
+    if record is None:
+        return None
+    return {
+        "charging_settings_available": True,
+        "recharge_battery_level": record[BATTERY_RECHARGE_LEVEL_INDEX],
+        "resume_battery_level": record[BATTERY_RESUME_LEVEL_INDEX],
+        "resume_after_charging": bool(
+            record[BATTERY_RESUME_AFTER_CHARGING_INDEX]
+        ),
+        "charging_period_enabled": bool(record[CHARGING_PERIOD_ENABLED_INDEX]),
+        "charging_period_start_minutes": record[CHARGING_PERIOD_START_INDEX],
+        "charging_period_end_minutes": record[CHARGING_PERIOD_END_INDEX],
+        "battery_settings_raw": record,
+    }
+
+
+def decode_rain_settings(config: Mapping[str, Any]) -> dict[str, Any] | None:
+    """Decode WRP, filling only the sensitivity omitted by older firmware."""
+    record = _integer_record(
+        config.get("WRP"),
+        minimum_length=RAIN_SETTING_MINIMUM_LENGTH,
+        fill_to_length=RAIN_SETTING_LENGTH,
+        fill_value=RAIN_SETTING_DEFAULT_SENSITIVITY,
+    )
+    if record is None:
+        return None
+    return {
+        "rain_settings_available": True,
+        "rain_protection_enabled": bool(record[RAIN_SETTING_ENABLED_INDEX]),
+        "rain_protection_duration_hours": record[RAIN_SETTING_DELAY_INDEX],
+        "rain_sensor_sensitivity": record[RAIN_SETTING_SENSITIVITY_INDEX],
+        "rain_protection_raw": record,
+    }
+
+
+def decode_device_settings(config: Mapping[str, Any]) -> dict[str, Any]:
+    """Decode the CFG settings this integration owns."""
+    result: dict[str, Any] = {}
+    charging = decode_charging_settings(config)
+    if charging is not None:
+        result.update(charging)
+    rain = decode_rain_settings(config)
+    if rain is not None:
+        result.update(rain)
+    if "WRF" in config:
+        try:
+            result["weather_switch_enabled"] = bool(int(config["WRF"]))
+        except (TypeError, ValueError):
+            pass
+    return result
+
+
+def validate_time_of_day(minutes: int, label: str) -> int:
+    """Return minutes since midnight after validating the device range."""
+    try:
+        normalized = int(minutes)
+    except (TypeError, ValueError) as err:
+        raise ValueError(
+            f"Charging period {label} must be a number of minutes."
+        ) from err
+    if not 0 <= normalized < MINUTES_PER_DAY:
+        raise ValueError(
+            f"Charging period {label} must be between 0 and "
+            f"{MINUTES_PER_DAY - 1} minutes."
+        )
+    return normalized
+
+
+def validate_rain_delay(delay_hours: int) -> int:
+    """Return a whole-hour after-rain delay supported by the mower."""
+    try:
+        normalized = int(delay_hours)
+    except (TypeError, ValueError) as err:
+        raise ValueError("After-rain delay must be a number of hours.") from err
+    if not RAIN_DELAY_MIN_HOURS <= normalized <= RAIN_DELAY_MAX_HOURS:
+        raise ValueError(
+            f"After-rain delay must be between {RAIN_DELAY_MIN_HOURS} and "
+            f"{RAIN_DELAY_MAX_HOURS} hours."
+        )
+    return normalized
+
+
+def build_charging_period_request(
+    *,
+    enabled: bool,
+    start_minutes: int,
+    end_minutes: int,
+) -> dict[str, Any]:
+    """Build the narrow BAT charging-period setter used by the app."""
+    start = validate_time_of_day(start_minutes, "start")
+    end = validate_time_of_day(end_minutes, "end")
+    if start == end:
+        raise ValueError("Charging period start and end times must differ.")
+    return {
+        "m": "s",
+        "t": "BAT",
+        "d": {
+            "type": "charging",
+            "value": [int(bool(enabled)), start, end],
+        },
+    }
+
+
+def build_rain_protection_request(
+    *,
+    enabled: bool,
+    delay_hours: int,
+    sensitivity: int,
+) -> dict[str, Any]:
+    """Build WRP while preserving the mower's existing sensitivity."""
+    delay = validate_rain_delay(delay_hours)
+    return {
+        "m": "s",
+        "t": "WRP",
+        "d": {
+            "value": int(bool(enabled)),
+            "time": delay,
+            "sen": int(sensitivity),
+        },
+    }

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
@@ -17,6 +17,7 @@ from typing import Any, Optional
 from .app_protocol import (
     MOWER_BLUETOOTH_PROPERTY_KEY,
     MOWER_RUNTIME_STATUS_PROPERTY_KEY,
+    MOWER_TIME_PROPERTY_KEY,
     mower_realtime_property_name,
 )
 from .device_code_semantics import (
@@ -154,6 +155,7 @@ _EXTERNAL_REALTIME_UPDATE_KEYS = frozenset(
     {
         MOWER_RUNTIME_STATUS_PROPERTY_KEY,
         MOWER_BLUETOOTH_PROPERTY_KEY,
+        MOWER_TIME_PROPERTY_KEY,
     }
 )
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -22,6 +22,7 @@ REMOTE_CONTROL_STATES = {"remote_control"}
 REALTIME_STATE_PROPERTY_KEY = "2.1"
 REALTIME_ERROR_PROPERTY_KEY = "2.2"
 REALTIME_TASK_STATUS_PROPERTY_KEY = "4.7"
+REALTIME_SETTINGS_PROPERTY_KEY = "2.51"
 OPERATIONAL_HUMAN_DETECTION_NOTICE_MODELS = frozenset(
     {"dreame.mower.q2501a", "q2501a"}
 )
@@ -360,6 +361,11 @@ class DreameLawnMowerSnapshot:
     task_status_name: str | None = None
     task_status_source: str | None = None
     task_status_event_at: float | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
+    device_settings_event_at: float | None = field(
         default=None,
         repr=False,
         compare=False,
@@ -1351,6 +1357,10 @@ def snapshot_from_device(
         task_status_event_at=_realtime_property_last_seen(
             device,
             REALTIME_TASK_STATUS_PROPERTY_KEY,
+        ),
+        device_settings_event_at=_realtime_property_last_seen(
+            device,
+            REALTIME_SETTINGS_PROPERTY_KEY,
         ),
         error_code=error_code,
         error_name=error_name,

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -35,10 +35,15 @@ from .control_options import (
     zone_label,
 )
 from .coordinator import DreameLawnMowerCoordinator
+from .device_settings_control import device_settings_section, rain_delay_label
 from .dreame_lawn_mower_client.client import (
     VOICE_LANGUAGE_INDEX_TO_LABEL,
     VOICE_LANGUAGE_LABEL_TO_INDEX,
     VOICE_LANGUAGE_LABELS,
+)
+from .dreame_lawn_mower_client.device_settings import (
+    RAIN_DELAY_MAX_HOURS,
+    RAIN_DELAY_MIN_HOURS,
 )
 from .entity import DreameLawnMowerEntity
 from .mowing_preference_control import (
@@ -62,6 +67,7 @@ async def async_setup_entry(
     async_add_entities(
         [
             DreameLawnMowerVoiceLanguageSelect(coordinator),
+            DreameLawnMowerRainDelaySelect(coordinator),
             DreameLawnMowerMapSelect(coordinator),
             DreameLawnMowerSelectedMapRotationSelect(coordinator),
             DreameLawnMowerMowingActionSelect(coordinator),
@@ -80,6 +86,49 @@ async def async_setup_entry(
 
 class DreameLawnMowerSelectEntity(DreameLawnMowerEntity, SelectEntity):
     """Shared base class for current-map selector entities."""
+
+
+class DreameLawnMowerRainDelaySelect(DreameLawnMowerSelectEntity):
+    """Choose how long the mower waits after rain before resuming."""
+
+    _attr_name = "After-Rain Delay"
+    _attr_icon = "mdi:weather-rainy"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_rain_delay"
+        self._hours_by_label = {
+            rain_delay_label(hours): hours
+            for hours in range(RAIN_DELAY_MIN_HOURS, RAIN_DELAY_MAX_HOURS + 1)
+        }
+
+    @property
+    def available(self) -> bool:
+        settings = device_settings_section(self.coordinator.device_settings)
+        return bool(
+            self.coordinator.data is not None
+            and settings
+            and settings.get("rain_settings_available")
+        )
+
+    @property
+    def options(self) -> list[str]:
+        return list(self._hours_by_label)
+
+    @property
+    def current_option(self) -> str | None:
+        settings = device_settings_section(self.coordinator.device_settings)
+        if settings is None:
+            return None
+        delay = settings.get("rain_protection_duration_hours")
+        return rain_delay_label(int(delay)) if delay is not None else None
+
+    async def async_select_option(self, option: str) -> None:
+        delay = self._hours_by_label.get(option)
+        if delay is None:
+            raise ValueError(f"Unknown after-rain delay option: {option}")
+        await self.coordinator.async_set_rain_protection(delay_hours=delay)
 
 
 class DreameLawnMowerVoiceLanguageSelect(DreameLawnMowerSelectEntity):

--- a/custom_components/dreame_lawn_mower/switch.py
+++ b/custom_components/dreame_lawn_mower/switch.py
@@ -13,6 +13,7 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
 from .coordinator import DreameLawnMowerCoordinator
+from .device_settings_control import device_settings_section
 from .entity import DreameLawnMowerEntity
 from .preference_switch import (
     AI_CLASS_SWITCHES,
@@ -76,6 +77,8 @@ async def async_setup_entry(
                 )
                 for key, name, index, icon in VOICE_PROMPT_SWITCHES
             ),
+            DreameLawnMowerChargingPeriodSwitch(coordinator),
+            DreameLawnMowerRainProtectionSwitch(coordinator),
         ]
     )
     known_schedule_plans: set[tuple[int, int]] = set()
@@ -159,6 +162,74 @@ class DreameLawnMowerVoicePromptSwitch(DreameLawnMowerEntity, SwitchEntity):
         await self.coordinator.client.async_set_voice_prompts(updated)
         await self.coordinator.async_refresh_voice_settings(force=True)
         self.coordinator.async_update_listeners()
+
+
+class DreameLawnMowerChargingPeriodSwitch(DreameLawnMowerEntity, SwitchEntity):
+    """Enable the mower-native custom charging window."""
+
+    _attr_name = "Charging Period"
+    _attr_icon = "mdi:battery-clock"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_charging_period"
+
+    @property
+    def available(self) -> bool:
+        settings = device_settings_section(self.coordinator.device_settings)
+        return bool(
+            self.coordinator.data is not None
+            and settings
+            and settings.get("charging_settings_available")
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        settings = device_settings_section(self.coordinator.device_settings)
+        if settings is None or not settings.get("charging_settings_available"):
+            return None
+        return bool(settings.get("charging_period_enabled"))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.async_set_charging_period(enabled=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.async_set_charging_period(enabled=False)
+
+
+class DreameLawnMowerRainProtectionSwitch(DreameLawnMowerEntity, SwitchEntity):
+    """Enable mower-native rain detection and return-to-dock protection."""
+
+    _attr_name = "Rain Protection"
+    _attr_icon = "mdi:weather-rainy"
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_rain_protection"
+
+    @property
+    def available(self) -> bool:
+        settings = device_settings_section(self.coordinator.device_settings)
+        return bool(
+            self.coordinator.data is not None
+            and settings
+            and settings.get("rain_settings_available")
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        settings = device_settings_section(self.coordinator.device_settings)
+        if settings is None or not settings.get("rain_settings_available"):
+            return None
+        return bool(settings.get("rain_protection_enabled"))
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        await self.coordinator.async_set_rain_protection(enabled=True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        await self.coordinator.async_set_rain_protection(enabled=False)
 
 
 class DreameLawnMowerSchedulePlanSwitch(DreameLawnMowerEntity, SwitchEntity):

--- a/custom_components/dreame_lawn_mower/time.py
+++ b/custom_components/dreame_lawn_mower/time.py
@@ -1,0 +1,106 @@
+"""Time entities for mower-native charging-period settings."""
+
+from __future__ import annotations
+
+from datetime import time
+
+from homeassistant.components.time import TimeEntity
+from homeassistant.config_entries import ConfigEntry
+from homeassistant.core import HomeAssistant
+from homeassistant.helpers.entity import EntityCategory
+from homeassistant.helpers.entity_platform import AddEntitiesCallback
+
+from .const import DOMAIN
+from .coordinator import DreameLawnMowerCoordinator
+from .device_settings_control import (
+    device_settings_section,
+    minutes_to_time,
+    time_to_minutes,
+)
+from .entity import DreameLawnMowerEntity
+
+
+async def async_setup_entry(
+    hass: HomeAssistant,
+    entry: ConfigEntry,
+    async_add_entities: AddEntitiesCallback,
+) -> None:
+    """Set up charging-period time entities."""
+    coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
+    async_add_entities(
+        [
+            DreameLawnMowerChargingPeriodStartTime(coordinator),
+            DreameLawnMowerChargingPeriodEndTime(coordinator),
+        ]
+    )
+
+
+class DreameLawnMowerChargingPeriodTime(DreameLawnMowerEntity, TimeEntity):
+    """Base for one end of the mower-native charging window."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    @property
+    def available(self) -> bool:
+        settings = device_settings_section(self.coordinator.device_settings)
+        return bool(
+            self.coordinator.data is not None
+            and settings
+            and settings.get("charging_settings_available")
+        )
+
+    @property
+    def native_value(self) -> time | None:
+        return minutes_to_time(self._minutes)
+
+    @property
+    def _minutes(self) -> int | None:
+        raise NotImplementedError
+
+
+class DreameLawnMowerChargingPeriodStartTime(DreameLawnMowerChargingPeriodTime):
+    """Start of the mower-native charging period."""
+
+    _attr_name = "Charging Period Start"
+    _attr_icon = "mdi:clock-start"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_charging_period_start"
+
+    @property
+    def _minutes(self) -> int | None:
+        settings = device_settings_section(self.coordinator.device_settings)
+        if settings is None:
+            return None
+        value = settings.get("charging_period_start_minutes")
+        return int(value) if value is not None else None
+
+    async def async_set_value(self, value: time) -> None:
+        await self.coordinator.async_set_charging_period(
+            start_minutes=time_to_minutes(value)
+        )
+
+
+class DreameLawnMowerChargingPeriodEndTime(DreameLawnMowerChargingPeriodTime):
+    """End of the mower-native charging period."""
+
+    _attr_name = "Charging Period End"
+    _attr_icon = "mdi:clock-end"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_charging_period_end"
+
+    @property
+    def _minutes(self) -> int | None:
+        settings = device_settings_section(self.coordinator.device_settings)
+        if settings is None:
+            return None
+        value = settings.get("charging_period_end_minutes")
+        return int(value) if value is not None else None
+
+    async def async_set_value(self, value: time) -> None:
+        await self.coordinator.async_set_charging_period(
+            end_minutes=time_to_minutes(value)
+        )

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -294,17 +294,19 @@ Last updated: 2026-04-21
   already-current `mowing_height_cm=6.0` value. The mower returned top-level
   `r: 0` and the client recorded `executed=true` with `request_verified=true`
   in ignored `preference-write-live-noop.json`.
-- The downloaded A2 plugin bundle identifies weather/rain protection settings
-  in read-only `CFG`: `WRF` is the weather switch and `WRP` is the rain
-  protection tuple. `RPET` returns `endTime` while
+- The downloaded A2 plugin bundle identifies charging and rain settings in
+  `CFG`: `BAT[3:6]` is charging-period enable/start/end, `WRF` is the weather
+  switch, and `WRP` is the rain-protection tuple. `RPET` returns `endTime` while
   `INFO_BAD_WEATHER_PROTECTING` is active. The reusable client now has
   `async_get_weather_protection()` plus `examples/weather_probe.py`, and Home
   Assistant has disabled-by-default Capture/Last Weather Probe diagnostics.
   The probe distinguishes configured rain protection from an observed active
   rain-delay window with `rain_protection_active`; when an end time is present,
   it also exposes `rain_protect_end_time_iso`.
-  Keep writes (`setWRF`/`setWRP`) unexposed until runtime locks and safety are
-  validated live.
+  The client now owns confirmed `BAT` charging-period and `WRP` rain-protection
+  writes. Home Assistant exposes switches, charging start/end times, and a rain
+  delay select. Every write preserves unrelated values and requires `CFG`
+  readback; `2:51` notifications coalesce into a settings refresh.
 - A live read-only weather probe on 2026-04-19 while rain was expected returned
   `WRP=[1,8,0]`, decoded as rain protection enabled for 8 hours with sensitivity
   `0`. `CFG` did not include `WRF`, and `RPET` returned no active end time at

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -236,28 +236,37 @@ path using map `0`, area `1`, and the already-current
 recorded `executed=true` and `request_verified=true` without changing the
 effective mower settings.
 
-## Observed weather and rain protection settings
+## Observed charging and rain-protection settings
 
 The A2 plugin bundle identifies the weather/rain-protection read path as the
 general settings app action `CFG`. Relevant fields observed in the bundle:
 
 - `WRF`: boolean weather switch used by the app as `weatherSwitch`.
+- `BAT`: six-value battery record. Slots `0-2` are recharge/resume settings;
+  slots `3-5` are charging-period enabled, start minutes, and end minutes.
 - `WRP`: rain-protection tuple. The app default is `[1, 8, 0]`, and older
   two-value payloads are padded with a third `0` before use.
 - `RPET`: read-only app action returning `endTime` while
   `INFO_BAD_WEATHER_PROTECTING` is active.
 
-The Python client now exposes `async_get_weather_protection()` and
-`examples/weather_probe.py`. Home Assistant mirrors this as disabled-by-default
-diagnostic entities: `Capture Weather Probe` and `Last Weather Probe`. These are
-read-only; write actions such as `setWRF` and `setWRP` remain intentionally
-unexposed until their runtime constraints and mower-state safety are validated
-live.
+The Python client exposes `async_get_device_settings()` (with the historical
+`async_get_weather_protection()` read alias), confirmed charging/rain setters,
+and `examples/weather_probe.py`. Home Assistant exposes a charging-period
+switch with start/end time entities plus a rain-protection switch and delay
+select. Writes preserve unrelated BAT thresholds and WRP sensitivity, then
+require a full `CFG` readback before publishing state.
 
 A live read-only A2 run of `examples/weather_probe.py` on 2026-04-19 while rain
 was expected returned `WRP=[1,8,0]`, decoded as rain protection enabled for 8
 hours with sensitivity `0`. `CFG` did not include `WRF` on that device, and
 `RPET` returned no active `endTime` at capture time.
+
+On 2026-08-10, the live A2 on firmware `4.3.6_0625` reported
+`BAT=[15,95,1,0,1080,480]`, `WRF=1`, and `WRP=[1,8,1]` while docked and idle.
+Supervised charging-period and rain-protection writes were followed by `CFG`
+readback and restoration of the original values. Property `2:51` remains a
+generic settings-change announcement: it says that a setting changed without
+naming the CFG key, so the integration coalesces it into one settings refresh.
 
 ## First live probe result
 

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -104,7 +104,8 @@ upgrade does not create duplicate entities.
   app payloads, with explicit confirmation required before execution
 - read-only app-map retrieval, all-map summaries, and simple map rendering
 - on-demand app-map point-cloud generation, bounded download, and PCD validation
-- weather/rain-protection and mowing-preference diagnostics
+- decoded mower-native charging/rain settings, confirmed setting writes, and
+  mowing-preference diagnostics
 - firmware/update evidence gathering without claiming unverified OTA support
 - guarded remote-control support helpers for supervised short movement pulses
 - reusable payload decoders for app realtime/status keys

--- a/dreame_lawn_mower_client/exceptions.py
+++ b/dreame_lawn_mower_client/exceptions.py
@@ -2,15 +2,19 @@
 
 from ._loader import load_internal_module
 
-_internal = load_internal_module("client")
+_internal = load_internal_module()
 DreameLawnMowerError = _internal.DreameLawnMowerError
 DreameLawnMowerAuthError = _internal.DreameLawnMowerAuthError
 DreameLawnMowerConnectionError = _internal.DreameLawnMowerConnectionError
+DreameLawnMowerCommandRejectedError = (
+    _internal.DreameLawnMowerCommandRejectedError
+)
 DreameLawnMowerTwoFactorRequiredError = _internal.DreameLawnMowerTwoFactorRequiredError
 
 __all__ = [
     "DreameLawnMowerError",
     "DreameLawnMowerAuthError",
     "DreameLawnMowerConnectionError",
+    "DreameLawnMowerCommandRejectedError",
     "DreameLawnMowerTwoFactorRequiredError",
 ]

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -324,6 +324,48 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
     assert coordinator._client_update_task is None
 
 
+def test_cached_settings_event_refreshes_cfg_once_per_event() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    snapshot = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        device_settings_event_at=123.0,
+    )
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator._last_device_settings_event_at = None
+    coordinator._device_settings_write_lock = asyncio.Lock()
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.selected_map_index = 0
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+        async_get_runtime_status_blob=AsyncMock(return_value=None),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+    coordinator.async_refresh_device_settings = AsyncMock()
+    coordinator.async_update_listeners = Mock()
+
+    with patch(
+        "custom_components.dreame_lawn_mower.coordinator.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        asyncio.run(coordinator._async_process_client_update())
+        asyncio.run(coordinator._async_process_client_update())
+
+    coordinator.async_refresh_device_settings.assert_awaited_once_with(
+        force=True,
+        source="device_settings_realtime",
+    )
+    coordinator.async_update_listeners.assert_called_once_with()
+    assert coordinator._last_device_settings_event_at == 123.0
+
+
 def test_cached_completion_survives_runtime_failure_and_later_idle_refresh() -> None:
     """A transient completion event is cached before optional telemetry reads."""
     completed = SimpleNamespace(

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -348,7 +348,9 @@ def test_cached_settings_event_refreshes_cfg_once_per_event() -> None:
         update_runtime_live_tracking=Mock(),
     )
     coordinator.async_set_updated_data = Mock()
-    coordinator.async_refresh_device_settings = AsyncMock()
+    coordinator.async_refresh_device_settings = AsyncMock(
+        return_value={"present_config_keys": ["BAT", "WRP"], "errors": []}
+    )
     coordinator.async_update_listeners = Mock()
 
     with patch(
@@ -362,6 +364,50 @@ def test_cached_settings_event_refreshes_cfg_once_per_event() -> None:
         force=True,
         source="device_settings_realtime",
     )
+    coordinator.async_update_listeners.assert_called_once_with()
+    assert coordinator._last_device_settings_event_at == 123.0
+
+
+def test_cached_settings_event_retries_after_failed_cfg_refresh() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    snapshot = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        device_settings_event_at=123.0,
+    )
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator._last_device_settings_event_at = None
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.selected_map_index = 0
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+        async_get_runtime_status_blob=AsyncMock(return_value=None),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+    coordinator.async_refresh_device_settings = AsyncMock(
+        side_effect=(
+            None,
+            {"present_config_keys": ["BAT", "WRP"], "errors": []},
+        )
+    )
+    coordinator.async_update_listeners = Mock()
+
+    with patch(
+        "custom_components.dreame_lawn_mower.coordinator.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        asyncio.run(coordinator._async_process_client_update())
+        assert coordinator._last_device_settings_event_at is None
+        asyncio.run(coordinator._async_process_client_update())
+
+    assert coordinator.async_refresh_device_settings.await_count == 2
     coordinator.async_update_listeners.assert_called_once_with()
     assert coordinator._last_device_settings_event_at == 123.0
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -755,6 +755,8 @@ def test_failed_metadata_refresh_expires_old_cache_marker(
     cached = {"cached": True}
     setattr(coordinator, cache_attr, cached)
     setattr(coordinator, refreshed_at_attr, datetime.now(UTC))
+    if refresh_method == "async_refresh_weather_protection":
+        coordinator._device_settings_write_lock = asyncio.Lock()
     coordinator.client = SimpleNamespace(
         **{client_method: AsyncMock(side_effect=TimeoutError)}
     )

--- a/tests/test_device_settings.py
+++ b/tests/test_device_settings.py
@@ -1,0 +1,293 @@
+"""Contracts for mower-native charging and rain settings."""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import time
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from custom_components.dreame_lawn_mower.button import (
+    DreameLawnMowerCaptureWeatherProbeButton,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    device_settings,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
+    DreameLawnMowerClient,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.exceptions import (
+    DreameLawnMowerCommandRejectedError,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    DreameLawnMowerDescriptor,
+)
+from custom_components.dreame_lawn_mower.select import (
+    DreameLawnMowerRainDelaySelect,
+)
+from custom_components.dreame_lawn_mower.switch import (
+    DreameLawnMowerChargingPeriodSwitch,
+    DreameLawnMowerRainProtectionSwitch,
+)
+from custom_components.dreame_lawn_mower.time import (
+    DreameLawnMowerChargingPeriodEndTime,
+    DreameLawnMowerChargingPeriodStartTime,
+)
+
+
+def _client() -> DreameLawnMowerClient:
+    return DreameLawnMowerClient(
+        username="user@example.invalid",
+        password="secret",
+        country="eu",
+        account_type="dreame",
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-1",
+            name="Garden Mower",
+            model="dreame.mower.g2408",
+            display_model="A2",
+            account_type="dreame",
+            country="eu",
+        ),
+    )
+
+
+def _cfg(*, charging_enabled: int = 0, rain_enabled: int = 1) -> dict:
+    return {
+        "m": "r",
+        "r": 0,
+        "d": {
+            "BAT": [15, 95, 1, charging_enabled, 1080, 480],
+            "WRF": 1,
+            "WRP": [rain_enabled, 8, 1],
+        },
+    }
+
+
+def test_decode_device_settings_keeps_battery_thresholds_separate() -> None:
+    assert device_settings.BATTERY_SETTING_LENGTH == 6
+    settings = device_settings.decode_device_settings(_cfg()["d"])
+
+    assert settings == {
+        "charging_settings_available": True,
+        "recharge_battery_level": 15,
+        "resume_battery_level": 95,
+        "resume_after_charging": True,
+        "charging_period_enabled": False,
+        "charging_period_start_minutes": 1080,
+        "charging_period_end_minutes": 480,
+        "battery_settings_raw": [15, 95, 1, 0, 1080, 480],
+        "rain_settings_available": True,
+        "rain_protection_enabled": True,
+        "rain_protection_duration_hours": 8,
+        "rain_sensor_sensitivity": 1,
+        "rain_protection_raw": [1, 8, 1],
+        "weather_switch_enabled": True,
+    }
+
+
+def test_setting_payloads_are_narrow_and_preserve_rain_sensitivity() -> None:
+    assert device_settings.build_charging_period_request(
+        enabled=True,
+        start_minutes=1320,
+        end_minutes=360,
+    ) == {
+        "m": "s",
+        "t": "BAT",
+        "d": {"type": "charging", "value": [1, 1320, 360]},
+    }
+    assert device_settings.build_rain_protection_request(
+        enabled=False,
+        delay_hours=3,
+        sensitivity=1,
+    ) == {
+        "m": "s",
+        "t": "WRP",
+        "d": {"value": 0, "time": 3, "sen": 1},
+    }
+
+
+def test_charging_write_preserves_times_and_requires_cfg_readback() -> None:
+    client = _client()
+    responses = iter(
+        [
+            _cfg(charging_enabled=0),
+            {"m": "r", "r": 0, "d": {}},
+            _cfg(charging_enabled=1),
+        ]
+    )
+    requests: list[dict] = []
+
+    def call(request: dict, **kwargs) -> dict:  # noqa: ARG001
+        requests.append(request)
+        return next(responses)
+
+    client._sync_call_app_action = call  # type: ignore[method-assign]
+    settings = client._sync_set_charging_period(enabled=True)
+
+    assert settings["charging_period_enabled"] is True
+    assert requests[1] == {
+        "m": "s",
+        "t": "BAT",
+        "d": {"type": "charging", "value": [1, 1080, 480]},
+    }
+
+
+def test_charging_write_rejects_acknowledged_but_ignored_update() -> None:
+    client = _client()
+    responses = iter(
+        [
+            _cfg(charging_enabled=0),
+            {"m": "r", "r": 0, "d": {}},
+            _cfg(charging_enabled=0),
+        ]
+    )
+    client._sync_call_app_action = lambda request, **kwargs: next(responses)  # type: ignore[method-assign]  # noqa: ARG005
+
+    with pytest.raises(DreameLawnMowerCommandRejectedError, match="did not confirm"):
+        client._sync_set_charging_period(enabled=True)
+
+
+def test_charging_write_rejects_changed_battery_threshold() -> None:
+    client = _client()
+    changed = _cfg(charging_enabled=1)
+    changed["d"]["BAT"][0] = 20
+    responses = iter(
+        [
+            _cfg(charging_enabled=0),
+            {"m": "r", "r": 0, "d": {}},
+            changed,
+        ]
+    )
+    client._sync_call_app_action = lambda request, **kwargs: next(responses)  # type: ignore[method-assign]  # noqa: ARG005
+
+    with pytest.raises(DreameLawnMowerCommandRejectedError, match="thresholds"):
+        client._sync_set_charging_period(enabled=True)
+
+
+def test_rain_write_preserves_sensitivity_and_confirms_delay() -> None:
+    client = _client()
+    responses = iter(
+        [
+            _cfg(rain_enabled=1),
+            {"m": "r", "r": 0, "d": {}},
+            _cfg(rain_enabled=0),
+            {"m": "r", "r": 0, "d": {"endTime": 0}},
+        ]
+    )
+    requests: list[dict] = []
+
+    def call(request: dict, **kwargs) -> dict:  # noqa: ARG001
+        requests.append(request)
+        return next(responses)
+
+    client._sync_call_app_action = call  # type: ignore[method-assign]
+    settings = client._sync_set_rain_protection(enabled=False)
+
+    assert settings["rain_protection_enabled"] is False
+    assert requests[1] == {
+        "m": "s",
+        "t": "WRP",
+        "d": {"value": 0, "time": 8, "sen": 1},
+    }
+
+
+def test_rain_write_rejects_changed_sensitivity() -> None:
+    client = _client()
+    changed = _cfg(rain_enabled=0)
+    changed["d"]["WRP"][2] = 0
+    responses = iter(
+        [
+            _cfg(rain_enabled=1),
+            {"m": "r", "r": 0, "d": {}},
+            changed,
+            {"m": "r", "r": 0, "d": {"endTime": 0}},
+        ]
+    )
+    client._sync_call_app_action = lambda request, **kwargs: next(responses)  # type: ignore[method-assign]  # noqa: ARG005
+
+    with pytest.raises(DreameLawnMowerCommandRejectedError, match="sensitivity"):
+        client._sync_set_rain_protection(enabled=False)
+
+
+def test_weather_probe_updates_canonical_device_settings_cache() -> None:
+    payload = {
+        "source": "app_action_weather_protection",
+        "available": True,
+        "charging_settings_available": True,
+        "rain_settings_available": True,
+    }
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(
+            async_get_weather_protection=AsyncMock(return_value=payload),
+            descriptor=SimpleNamespace(title="Test mower"),
+        ),
+        last_weather_probe_result=None,
+        _cache_device_settings=Mock(),
+        hass=SimpleNamespace(),
+        entry=SimpleNamespace(entry_id="entry-1"),
+    )
+    button = object.__new__(DreameLawnMowerCaptureWeatherProbeButton)
+    button.coordinator = coordinator
+
+    with patch(
+        "custom_components.dreame_lawn_mower.button.persistent_notification.async_create"
+    ):
+        asyncio.run(button.async_press())
+
+    coordinator._cache_device_settings.assert_called_once_with(
+        payload,
+        source="weather_probe",
+    )
+    assert coordinator.last_weather_probe_result is payload
+
+
+def test_settings_entities_are_thin_over_confirmed_coordinator_writes() -> None:
+    settings = {
+        "available": True,
+        "charging_settings_available": True,
+        "charging_period_enabled": False,
+        "charging_period_start_minutes": 1080,
+        "charging_period_end_minutes": 480,
+        "rain_settings_available": True,
+        "rain_protection_enabled": True,
+        "rain_protection_duration_hours": 8,
+    }
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(),
+        device_settings=settings,
+        async_set_charging_period=AsyncMock(),
+        async_set_rain_protection=AsyncMock(),
+    )
+
+    charging = object.__new__(DreameLawnMowerChargingPeriodSwitch)
+    charging.coordinator = coordinator
+    rain = object.__new__(DreameLawnMowerRainProtectionSwitch)
+    rain.coordinator = coordinator
+    start = object.__new__(DreameLawnMowerChargingPeriodStartTime)
+    start.coordinator = coordinator
+    end = object.__new__(DreameLawnMowerChargingPeriodEndTime)
+    end.coordinator = coordinator
+    delay = object.__new__(DreameLawnMowerRainDelaySelect)
+    delay.coordinator = coordinator
+    delay._hours_by_label = {"3 hours": 3}
+
+    assert charging.available is True
+    assert charging.is_on is False
+    assert rain.is_on is True
+    assert start.native_value == time(18, 0)
+    assert end.native_value == time(8, 0)
+
+    asyncio.run(charging.async_turn_on())
+    asyncio.run(rain.async_turn_off())
+    asyncio.run(start.async_set_value(time(22, 30)))
+    asyncio.run(end.async_set_value(time(6, 15)))
+    asyncio.run(delay.async_select_option("3 hours"))
+
+    coordinator.async_set_charging_period.assert_any_await(enabled=True)
+    coordinator.async_set_charging_period.assert_any_await(start_minutes=1350)
+    coordinator.async_set_charging_period.assert_any_await(end_minutes=375)
+    coordinator.async_set_rain_protection.assert_any_await(enabled=False)
+    coordinator.async_set_rain_protection.assert_any_await(delay_hours=3)

--- a/tests/test_device_settings.py
+++ b/tests/test_device_settings.py
@@ -12,6 +12,9 @@ import pytest
 from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerCaptureWeatherProbeButton,
 )
+from custom_components.dreame_lawn_mower.coordinator import (
+    DreameLawnMowerCoordinator,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     device_settings,
 )
@@ -216,16 +219,16 @@ def test_weather_probe_updates_canonical_device_settings_cache() -> None:
     payload = {
         "source": "app_action_weather_protection",
         "available": True,
+        "present_config_keys": ["BAT", "WRP"],
+        "errors": [],
         "charging_settings_available": True,
         "rain_settings_available": True,
     }
     coordinator = SimpleNamespace(
         client=SimpleNamespace(
-            async_get_weather_protection=AsyncMock(return_value=payload),
             descriptor=SimpleNamespace(title="Test mower"),
         ),
-        last_weather_probe_result=None,
-        _cache_device_settings=Mock(),
+        async_capture_weather_protection=AsyncMock(return_value=payload),
         hass=SimpleNamespace(),
         entry=SimpleNamespace(entry_id="entry-1"),
     )
@@ -237,11 +240,89 @@ def test_weather_probe_updates_canonical_device_settings_cache() -> None:
     ):
         asyncio.run(button.async_press())
 
-    coordinator._cache_device_settings.assert_called_once_with(
-        payload,
-        source="weather_probe",
+    coordinator.async_capture_weather_protection.assert_awaited_once_with()
+
+
+def test_weather_probe_serializes_and_updates_canonical_cache() -> None:
+    payload = {
+        "available": True,
+        "present_config_keys": ["BAT", "WRP"],
+        "errors": [],
+    }
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._device_settings_write_lock = asyncio.Lock()
+    coordinator.client = SimpleNamespace(
+        async_get_weather_protection=AsyncMock(return_value=payload)
     )
+    coordinator.last_weather_probe_result = None
+    coordinator.device_settings = None
+    coordinator.weather_protection = None
+    coordinator.weather_protection_refreshed_at = None
+    coordinator.async_update_listeners = Mock()
+
+    result = asyncio.run(coordinator.async_capture_weather_protection())
+
+    assert result is payload
     assert coordinator.last_weather_probe_result is payload
+    assert coordinator.device_settings["source"] == "weather_probe"
+    assert coordinator.weather_protection == coordinator.device_settings
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
+def test_device_settings_refresh_and_write_cache_are_serialized() -> None:
+    old_payload = {
+        "available": True,
+        "present_config_keys": ["BAT", "WRP"],
+        "errors": [],
+        "charging_period_enabled": False,
+    }
+    new_payload = {
+        **old_payload,
+        "charging_period_enabled": True,
+    }
+
+    async def scenario() -> None:
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+
+        async def read_settings(*, include_raw: bool) -> dict:
+            assert include_raw is False
+            read_started.set()
+            await release_read.wait()
+            return old_payload
+
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator._device_settings_write_lock = asyncio.Lock()
+        coordinator.client = SimpleNamespace(
+            async_get_device_settings=read_settings,
+            async_set_charging_period=AsyncMock(return_value=new_payload),
+        )
+        coordinator.device_settings = None
+        coordinator.weather_protection = None
+        coordinator.weather_protection_refreshed_at = None
+        coordinator.async_update_listeners = Mock()
+
+        refresh_task = asyncio.create_task(
+            coordinator.async_refresh_device_settings(force=True)
+        )
+        await read_started.wait()
+        write_task = asyncio.create_task(
+            coordinator.async_set_charging_period(enabled=True)
+        )
+        await asyncio.sleep(0)
+        assert write_task.done() is False
+
+        release_read.set()
+        await asyncio.gather(refresh_task, write_task)
+
+        assert coordinator.device_settings["charging_period_enabled"] is True
+        coordinator.client.async_set_charging_period.assert_awaited_once_with(
+            enabled=True,
+            start_minutes=None,
+            end_minutes=None,
+        )
+
+    asyncio.run(scenario())
 
 
 def test_settings_entities_are_thin_over_confirmed_coordinator_writes() -> None:

--- a/tests/test_legacy_module_ownership.py
+++ b/tests/test_legacy_module_ownership.py
@@ -150,12 +150,14 @@ def test_client_facade_composes_canonical_domain_owners() -> None:
     facade = load_internal_module("client")
     camera = load_internal_module("client_camera")
     core = load_internal_module("client_core")
+    device_settings = load_internal_module("client_device_settings")
     maps = load_internal_module("client_maps")
     settings = load_internal_module("client_settings")
 
     assert facade.DreameLawnMowerClient.__bases__ == (
         camera._DreameLawnMowerCameraMixin,
         core._DreameLawnMowerClientCoreMixin,
+        device_settings._DreameLawnMowerClientDeviceSettingsMixin,
         settings._DreameLawnMowerClientSettingsMixin,
         maps._DreameLawnMowerClientMapsMixin,
     )

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -2,9 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 import json
 from io import BytesIO
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 from PIL import Image
@@ -21,6 +23,7 @@ from dreame_lawn_mower_client import (
     DreameLawnMowerClient,
     DreameLawnMowerConnectionError,
 )
+from dreame_lawn_mower_client.exceptions import DreameLawnMowerCommandRejectedError
 from dreame_lawn_mower_client.models import (
     DreameLawnMowerDescriptor,
     DreameLawnMowerMapSummary,
@@ -477,6 +480,81 @@ def test_client_map_switch_rejects_missing_or_failed_reply(response: object) -> 
 
     with pytest.raises(DreameLawnMowerConnectionError, match="map switch"):
         client._sync_switch_current_map(1)
+
+
+def test_async_map_switch_requires_idle_state_and_confirmed_readback() -> None:
+    client = _client()
+    client.async_refresh_authoritative_snapshot = AsyncMock(
+        return_value=SimpleNamespace(
+            mowing_session_active=False,
+            mowing=False,
+            paused=False,
+            returning=False,
+        )
+    )
+    client._sync_switch_current_map = lambda map_index: {"map_index": map_index}  # type: ignore[method-assign]
+    client.async_get_app_maps = AsyncMock(return_value={"current_map_index": 1})
+
+    result = asyncio.run(client.async_switch_current_map(1))
+
+    assert result == {"map_index": 1}
+    client.async_get_app_maps.assert_awaited_once_with(
+        include_payload=False,
+        include_objects=False,
+    )
+
+
+def test_async_map_switch_rejects_active_task_before_write() -> None:
+    client = _client()
+    client.async_refresh_authoritative_snapshot = AsyncMock(
+        return_value=SimpleNamespace(
+            mowing_session_active=True,
+            mowing=False,
+            paused=True,
+            returning=False,
+        )
+    )
+    client._sync_switch_current_map = Mock()  # type: ignore[method-assign]
+
+    with pytest.raises(DreameLawnMowerCommandRejectedError, match="Finish or cancel"):
+        asyncio.run(client.async_switch_current_map(1))
+
+    client._sync_switch_current_map.assert_not_called()
+
+
+def test_async_map_switch_allows_docked_snapshot_with_unknown_session_flag() -> None:
+    client = _client()
+    client.async_refresh_authoritative_snapshot = AsyncMock(
+        return_value=SimpleNamespace(
+            activity="docked",
+            mowing_session_active=None,
+            mowing=False,
+            paused=False,
+            returning=False,
+        )
+    )
+    client._sync_switch_current_map = lambda map_index: {"map_index": map_index}  # type: ignore[method-assign]
+    client.async_get_app_maps = AsyncMock(return_value={"current_map_index": 1})
+
+    assert asyncio.run(client.async_switch_current_map(1)) == {"map_index": 1}
+
+
+def test_async_map_switch_rejects_acknowledged_but_ignored_switch() -> None:
+    client = _client()
+    client.async_refresh_authoritative_snapshot = AsyncMock(
+        return_value=SimpleNamespace(
+            mowing_session_active=False,
+            mowing=False,
+            paused=False,
+            returning=False,
+        )
+    )
+    client._sync_switch_current_map = lambda map_index: {"map_index": map_index}  # type: ignore[method-assign]
+    client.async_get_app_maps = AsyncMock(return_value={"current_map_index": 0})
+
+    with patch("asyncio.sleep", new=AsyncMock()):
+        with pytest.raises(DreameLawnMowerCommandRejectedError, match="stayed"):
+            asyncio.run(client.async_switch_current_map(1))
 
 
 def test_map_view_uses_batch_vector_map_when_app_map_fails() -> None:

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -482,6 +482,16 @@ def test_client_map_switch_rejects_missing_or_failed_reply(response: object) -> 
         client._sync_switch_current_map(1)
 
 
+def test_current_map_readback_uses_only_map_list() -> None:
+    client = _client()
+    client._sync_call_app_action = Mock(
+        return_value={"r": 0, "d": [[0, 0, 1, 1, 0], [1, 1, 1, 1, 0]]}
+    )
+
+    assert client._sync_get_current_app_map_index_readback() == 1
+    client._sync_call_app_action.assert_called_once_with({"m": "g", "t": "MAPL"})
+
+
 def test_async_map_switch_requires_idle_state_and_confirmed_readback() -> None:
     client = _client()
     client.async_refresh_authoritative_snapshot = AsyncMock(
@@ -493,15 +503,12 @@ def test_async_map_switch_requires_idle_state_and_confirmed_readback() -> None:
         )
     )
     client._sync_switch_current_map = lambda map_index: {"map_index": map_index}  # type: ignore[method-assign]
-    client.async_get_app_maps = AsyncMock(return_value={"current_map_index": 1})
+    client.async_get_current_app_map_index = AsyncMock(return_value=1)
 
     result = asyncio.run(client.async_switch_current_map(1))
 
     assert result == {"map_index": 1}
-    client.async_get_app_maps.assert_awaited_once_with(
-        include_payload=False,
-        include_objects=False,
-    )
+    client.async_get_current_app_map_index.assert_awaited_once_with()
 
 
 def test_async_map_switch_rejects_active_task_before_write() -> None:
@@ -534,7 +541,7 @@ def test_async_map_switch_allows_docked_snapshot_with_unknown_session_flag() -> 
         )
     )
     client._sync_switch_current_map = lambda map_index: {"map_index": map_index}  # type: ignore[method-assign]
-    client.async_get_app_maps = AsyncMock(return_value={"current_map_index": 1})
+    client.async_get_current_app_map_index = AsyncMock(return_value=1)
 
     assert asyncio.run(client.async_switch_current_map(1)) == {"map_index": 1}
 
@@ -550,7 +557,7 @@ def test_async_map_switch_rejects_acknowledged_but_ignored_switch() -> None:
         )
     )
     client._sync_switch_current_map = lambda map_index: {"map_index": map_index}  # type: ignore[method-assign]
-    client.async_get_app_maps = AsyncMock(return_value={"current_map_index": 0})
+    client.async_get_current_app_map_index = AsyncMock(return_value=0)
 
     with patch("asyncio.sleep", new=AsyncMock()):
         with pytest.raises(DreameLawnMowerCommandRejectedError, match="stayed"):


### PR DESCRIPTION
## Summary

- add charging-period, charging start/end time, rain-protection, and after-rain delay configuration entities when the mower reports those native settings
- keep Home Assistant synchronized with setting changes announced by the mower while preserving the existing weather diagnostics API
- prevent misleading map selection by blocking unsafe task states and requiring the mower to confirm the active map

## Safety and compatibility

Setting updates first read the current mower configuration, write only the requested setting, and read the configuration again before publishing state. Charging updates preserve the existing battery thresholds, while rain updates preserve sensor sensitivity. Acknowledged commands that do not produce the requested state are reported as rejected.

Map changes require an authoritative idle or docked snapshot and a successful map-list readback. Historical Python client exports and weather-protection reads remain compatible.

## Validation

- full test suite passed under WSL, with one existing skip
- Ruff, Python 3.13 compilation, and diff checks passed
- charging, rain, and reversible map changes were confirmed against a docked A2 and restored to their original values
