### PR TITLE
Fix patrol point filtering and add lifetime mowing totals

### DIFF
--- a/custom_components/dreame_lawn_mower/api.py
+++ b/custom_components/dreame_lawn_mower/api.py
@@ -9,6 +9,7 @@ from .dreame_lawn_mower_client import (
     DreameLawnMowerFirmwareUpdateSupport,
     DreameLawnMowerSnapshot,
     DreameLawnMowerTwoFactorRequiredError,
+    DreameLawnMowerWorkLogTotals,
 )
 
 __all__ = [
@@ -20,4 +21,5 @@ __all__ = [
     "DreameLawnMowerFirmwareUpdateSupport",
     "DreameLawnMowerSnapshot",
     "DreameLawnMowerTwoFactorRequiredError",
+    "DreameLawnMowerWorkLogTotals",
 ]

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -18,6 +18,7 @@ from .api import (
     DreameLawnMowerDescriptor,
     DreameLawnMowerFirmwareUpdateSupport,
     DreameLawnMowerSnapshot,
+    DreameLawnMowerWorkLogTotals,
 )
 from .const import (
     CONF_ACCOUNT_TYPE,
@@ -88,6 +89,7 @@ MAINTENANCE_REFRESH_INTERVAL = timedelta(minutes=5)
 VOICE_SETTINGS_REFRESH_INTERVAL = timedelta(minutes=5)
 SCHEDULE_REFRESH_INTERVAL = timedelta(minutes=5)
 FIRMWARE_UPDATE_REFRESH_INTERVAL = timedelta(minutes=15)
+WORK_LOG_TOTALS_REFRESH_INTERVAL = timedelta(minutes=15)
 DEVICE_SNAPSHOT_GENERATION_HISTORY = 32
 PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS = 1
 BATCH_SCHEDULE_RESULT_COALESCE_SECONDS = 1.0
@@ -156,6 +158,8 @@ class DreameLawnMowerCoordinator(
         self.maintenance_status_refreshed_at: datetime | None = None
         self.voice_settings: dict[str, Any] | None = None
         self.voice_settings_refreshed_at: datetime | None = None
+        self.work_log_totals: DreameLawnMowerWorkLogTotals | None = None
+        self.work_log_totals_refreshed_at: datetime | None = None
         self.schedules: dict[str, Any] | None = None
         self.schedules_refreshed_at: datetime | None = None
         self._schedule_action_read_backoff = ScheduleActionReadBackoff()
@@ -2025,6 +2029,33 @@ class DreameLawnMowerCoordinator(
         self.maintenance_status = payload
         self.maintenance_status_refreshed_at = now
         return payload
+
+    async def async_refresh_work_log_totals(
+        self,
+        *,
+        force: bool = False,
+    ) -> DreameLawnMowerWorkLogTotals | None:
+        """Refresh cached mower-owned lifetime work-log totals."""
+        now = datetime.now(UTC)
+        if (
+            not force
+            and self.work_log_totals is not None
+            and self.work_log_totals_refreshed_at is not None
+            and now - self.work_log_totals_refreshed_at
+            < WORK_LOG_TOTALS_REFRESH_INTERVAL
+        ):
+            return self.work_log_totals
+
+        try:
+            totals = await self.client.async_get_work_log_totals()
+        except Exception as err:  # noqa: BLE001 - best-effort extra metadata
+            _LOGGER.debug("Failed to refresh work-log totals: %s", err)
+            self.work_log_totals_refreshed_at = None
+            return self.work_log_totals
+
+        self.work_log_totals = totals
+        self.work_log_totals_refreshed_at = now
+        return totals
 
     async def async_refresh_voice_settings(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -408,6 +408,10 @@ class DreameLawnMowerRefreshMixin:
                     lambda: self.async_refresh_maintenance_status(force=False),
                 ),
                 (
+                    "work_log_totals",
+                    lambda: self.async_refresh_work_log_totals(force=False),
+                ),
+                (
                     "voice",
                     lambda: self.async_refresh_voice_settings(force=False),
                 ),
@@ -617,6 +621,7 @@ class DreameLawnMowerRefreshMixin:
             "vector_map": "vector_map_details_refreshed_at",
             "weather": "weather_protection_refreshed_at",
             "maintenance": "maintenance_status_refreshed_at",
+            "work_log_totals": "work_log_totals_refreshed_at",
             "voice": "voice_settings_refreshed_at",
         }
         marker = refreshed_at_by_phase.get(phase)

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/__init__.py
@@ -184,6 +184,11 @@ from .video_runtime import (
     DreameLawnMowerXp2pRuntimeDiagnostics,
     diagnose_native_xp2p_runtime,
 )
+from .work_log import (
+    WORK_LOG_TOTALS_REQUEST,
+    DreameLawnMowerWorkLogTotals,
+    work_log_totals_from_app_data,
+)
 from .xp2p_config import (
     DreameLawnMowerXp2pConfigError,
     DreameLawnMowerXp2pDeviceConfig,
@@ -221,6 +226,7 @@ __all__ = [
     "DreameLawnMowerStatusBlob",
     "DreameLawnMowerStreamUrlProbeResult",
     "DreameLawnMowerTwoFactorRequiredError",
+    "DreameLawnMowerWorkLogTotals",
     "DreameLawnMowerXp2pExternalRunner",
     "DreameLawnMowerXp2pConfigError",
     "DreameLawnMowerXp2pDeviceConfig",
@@ -275,6 +281,7 @@ __all__ = [
     "MOWING_PREFERENCE_MODE_FIELD",
     "MOWING_PREFERENCE_PROPERTY_KEY",
     "MOWING_PREFERENCE_UPDATE_FIELDS",
+    "WORK_LOG_TOTALS_REQUEST",
     "SUPPORTED_ACCOUNT_TYPES",
     "CAPABILITY_SOURCE_ADVERTISED",
     "CAPABILITY_SOURCE_MODEL",
@@ -358,4 +365,5 @@ __all__ = [
     "run_jadx_decompile",
     "schedule_task_summary",
     "summarize_mowing_preference_info",
+    "work_log_totals_from_app_data",
 ]

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -208,6 +208,7 @@ from .vector_map import vector_map_to_summary as vector_map_to_summary
 
 if _typing.TYPE_CHECKING:
     from .map_visuals import MapRenderStyle
+    from .work_log import DreameLawnMowerWorkLogTotals
 
 _CLOUD_PRESENCE_REFRESH_INTERVAL = _client_constants.CLOUD_PRESENCE_REFRESH_INTERVAL
 
@@ -1024,6 +1025,10 @@ class DreameLawnMowerClient(
             self._sync_get_weather_protection,
             include_raw,
         )
+
+    async def async_get_work_log_totals(self) -> DreameLawnMowerWorkLogTotals:
+        """Return mower-owned lifetime area, time, and session totals."""
+        return await asyncio.to_thread(self._sync_get_work_log_totals)
 
     async def async_get_maintenance_status(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -84,6 +84,11 @@ from .schedule import (
     encode_schedule_payload_text,
     schedule_task_summary,
 )
+from .work_log import (
+    WORK_LOG_TOTALS_REQUEST,
+    DreameLawnMowerWorkLogTotals,
+    work_log_totals_from_app_data,
+)
 
 SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS = 5.0
 SCHEDULE_READ_DEADLINE_SECONDS = 10.0
@@ -91,6 +96,18 @@ SCHEDULE_READ_TIMEOUT_SECONDS = 5.0
 
 
 class _DreameLawnMowerClientSettingsMixin:
+    def _sync_get_work_log_totals(self) -> DreameLawnMowerWorkLogTotals:
+        """Fetch mower-owned lifetime totals through the MIHIS app action."""
+        response = self._sync_call_app_action(
+            WORK_LOG_TOTALS_REQUEST,
+            redact_response=True,
+        )
+        if not isinstance(response, Mapping):
+            raise DreameLawnMowerConnectionError(
+                "MIHIS returned an invalid response."
+            )
+        return work_log_totals_from_app_data(response)
+
     def _sync_get_app_schedules(
         self,
         include_raw: bool = False,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance_point_records.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/maintenance_point_records.py
@@ -10,6 +10,7 @@ from .client_shared_helpers import _operation_value_type
 
 _REQUIRED_KEYS = frozenset({"id", "param", "point", "time", "type"})
 _SUPPORTED_POINT_VECTOR_LENGTHS = frozenset({2, 3})
+_MAINTENANCE_POINT_TYPE = 1
 
 
 def app_map_maintenance_point_ids(entries: Sequence[Any]) -> list[int]:
@@ -34,7 +35,7 @@ def app_map_point_type_codes(entries: Sequence[Any]) -> list[int]:
     """Return numeric vendor type codes from recognized point records."""
     result: list[int] = []
     for entry in entries:
-        if not is_app_map_maintenance_point_record(entry):
+        if not _is_app_map_point_record(entry):
             continue
         point_type = entry.get("type")
         if (
@@ -66,7 +67,7 @@ def app_map_point_record_diagnostics(
         exact_shape_count += 1
         shape = _maintenance_point_value_shape(entry)
         grouped_shapes[shape] = grouped_shapes.get(shape, 0) + 1
-        if is_app_map_maintenance_point_record(entry):
+        if _is_app_map_point_record(entry):
             parser_accepted_count += 1
             point_id = entry.get("id")
             if (
@@ -114,7 +115,15 @@ def app_map_point_record_diagnostics(
 
 
 def is_app_map_maintenance_point_record(value: object) -> bool:
-    """Recognize exact A2-family point records without interpreting geometry."""
+    """Recognize A2-family maintenance points, excluding patrol points."""
+    return (
+        _is_app_map_point_record(value)
+        and value.get("type") == _MAINTENANCE_POINT_TYPE
+    )
+
+
+def _is_app_map_point_record(value: object) -> bool:
+    """Recognize an exact A2-family point record without assigning semantics."""
     if not isinstance(value, Mapping) or set(value) != _REQUIRED_KEYS:
         return False
     point_type = value.get("type")

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/work_log.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/work_log.py
@@ -1,0 +1,77 @@
+"""Mower-native lifetime work-log totals."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Mapping
+from dataclasses import dataclass
+from typing import Any
+
+from .exceptions import DreameLawnMowerConnectionError
+
+WORK_LOG_TOTALS_REQUEST = {"m": "g", "t": "MIHIS"}
+
+
+@dataclass(frozen=True, slots=True)
+class DreameLawnMowerWorkLogTotals:
+    """Lifetime totals reported by the mower's MIHIS action."""
+
+    total_mowed_area_sqm: float
+    total_mowing_time_minutes: int
+    total_mowing_sessions: int
+    history_start_epoch: int | None = None
+
+    def as_dict(self) -> dict[str, int | float | None]:
+        """Return the aggregate values as a plain mapping."""
+        return {
+            "total_mowed_area_sqm": self.total_mowed_area_sqm,
+            "total_mowing_time_minutes": self.total_mowing_time_minutes,
+            "total_mowing_sessions": self.total_mowing_sessions,
+            "history_start_epoch": self.history_start_epoch,
+        }
+
+
+def work_log_totals_from_app_data(
+    response: Mapping[str, Any],
+) -> DreameLawnMowerWorkLogTotals:
+    """Decode a successful MIHIS response into typed lifetime totals."""
+    if response.get("r") != 0:
+        raise DreameLawnMowerConnectionError("MIHIS returned an unsuccessful result.")
+    data = response.get("d")
+    if not isinstance(data, Mapping):
+        raise DreameLawnMowerConnectionError("MIHIS returned no totals data.")
+
+    area = _non_negative_number(data.get("area"), field="area")
+    mowing_time = _non_negative_integer(data.get("time"), field="time")
+    sessions = _non_negative_integer(data.get("count"), field="count")
+    start = data.get("start")
+    history_start = (
+        None if start is None else _non_negative_integer(start, field="start")
+    )
+    return DreameLawnMowerWorkLogTotals(
+        total_mowed_area_sqm=area,
+        total_mowing_time_minutes=mowing_time,
+        total_mowing_sessions=sessions,
+        history_start_epoch=history_start,
+    )
+
+
+def _non_negative_number(value: Any, *, field: str) -> float:
+    if (
+        not isinstance(value, int | float)
+        or isinstance(value, bool)
+        or not math.isfinite(float(value))
+        or value < 0
+    ):
+        raise DreameLawnMowerConnectionError(
+            f"MIHIS returned an invalid {field} total."
+        )
+    return float(value)
+
+
+def _non_negative_integer(value: Any, *, field: str) -> int:
+    if not isinstance(value, int) or isinstance(value, bool) or value < 0:
+        raise DreameLawnMowerConnectionError(
+            f"MIHIS returned an invalid {field} total."
+        )
+    return value

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -95,8 +95,32 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
             performance.as_dict() if hasattr(performance, "as_dict") else None
         ),
         "maintenance_points": build_maintenance_point_diagnostics(coordinator),
+        "work_log_totals": _work_log_totals_diagnostics(coordinator),
         "last_maintenance_point_probe": (
             dict(last_map_probe) if isinstance(last_map_probe, Mapping) else None
+        ),
+    }
+
+
+def _work_log_totals_diagnostics(coordinator: object) -> dict[str, Any] | None:
+    """Return aggregate work-log totals without exposing individual sessions."""
+    totals = getattr(coordinator, "work_log_totals", None)
+    if totals is None:
+        return None
+    refreshed_at = getattr(coordinator, "work_log_totals_refreshed_at", None)
+    return {
+        "source": "app_action_mihis",
+        "total_mowed_area_sqm": getattr(totals, "total_mowed_area_sqm", None),
+        "total_mowing_time_minutes": getattr(
+            totals,
+            "total_mowing_time_minutes",
+            None,
+        ),
+        "total_mowing_sessions": getattr(totals, "total_mowing_sessions", None),
+        "refreshed_at": (
+            refreshed_at.isoformat()
+            if hasattr(refreshed_at, "isoformat")
+            else None
         ),
     }
 

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -202,6 +202,11 @@ from .sensor_runtime import (  # noqa: F401
     _runtime_status_blob_summary,
     _runtime_status_blob_total_area_sqm,
 )
+from .sensor_work_log import (
+    DreameLawnMowerTotalMowedAreaSensor,
+    DreameLawnMowerTotalMowingSessionsSensor,
+    DreameLawnMowerTotalMowingTimeSensor,
+)
 from .task_status_probe import (  # noqa: F401
     task_status_probe_result_attributes,
     task_status_probe_state,
@@ -469,6 +474,9 @@ async def async_setup_entry(
         + [DreameLawnMowerRuntimeTrackLengthSensor(coordinator)]
         + [DreameLawnMowerRuntimeTrackSegmentCountSensor(coordinator)]
         + [DreameLawnMowerMowingProgressSensor(coordinator)]
+        + [DreameLawnMowerTotalMowedAreaSensor(coordinator)]
+        + [DreameLawnMowerTotalMowingTimeSensor(coordinator)]
+        + [DreameLawnMowerTotalMowingSessionsSensor(coordinator)]
         + [DreameLawnMowerAppMapObjectCountSensor(coordinator)]
         + [DreameLawnMowerFirmwareUpdateStatusSensor(coordinator)]
         + [DreameLawnMowerConfiguredScheduleCountSensor(coordinator)]

--- a/custom_components/dreame_lawn_mower/sensor_work_log.py
+++ b/custom_components/dreame_lawn_mower/sensor_work_log.py
@@ -1,0 +1,106 @@
+"""Lifetime mower work-log total sensors."""
+
+from __future__ import annotations
+
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorStateClass,
+)
+
+from .coordinator import DreameLawnMowerCoordinator
+from .entity import DreameLawnMowerEntity
+
+
+class _DreameLawnMowerWorkLogTotalSensor(
+    DreameLawnMowerEntity,
+    SensorEntity,
+):
+    """Base class for one mower-owned lifetime total."""
+
+    _attr_state_class = SensorStateClass.TOTAL_INCREASING
+
+    def __init__(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        *,
+        key: str,
+        name: str,
+        icon: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_unique_id = f"{self._descriptor.unique_id}_{key}"
+
+    @property
+    def available(self) -> bool:
+        """Return whether authoritative lifetime totals have been cached."""
+        return self.coordinator.data is not None and self.native_value is not None
+
+
+class DreameLawnMowerTotalMowedAreaSensor(
+    _DreameLawnMowerWorkLogTotalSensor,
+):
+    """Expose lifetime mowed area from MIHIS."""
+
+    _attr_device_class = SensorDeviceClass.AREA
+    _attr_native_unit_of_measurement = "m²"
+    _attr_suggested_display_precision = 1
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(
+            coordinator,
+            key="total_mowed_area",
+            name="Total Mowed Area",
+            icon="mdi:texture-box",
+        )
+
+    @property
+    def native_value(self) -> float | None:
+        """Return lifetime mowed area in square metres."""
+        totals = self.coordinator.work_log_totals
+        return totals.total_mowed_area_sqm if totals is not None else None
+
+
+class DreameLawnMowerTotalMowingTimeSensor(
+    _DreameLawnMowerWorkLogTotalSensor,
+):
+    """Expose lifetime mowing time from MIHIS."""
+
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "min"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(
+            coordinator,
+            key="total_mowing_time",
+            name="Total Mowing Time",
+            icon="mdi:timer-sand-complete",
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        """Return lifetime mowing time in minutes."""
+        totals = self.coordinator.work_log_totals
+        return totals.total_mowing_time_minutes if totals is not None else None
+
+
+class DreameLawnMowerTotalMowingSessionsSensor(
+    _DreameLawnMowerWorkLogTotalSensor,
+):
+    """Expose lifetime mowing-session count from MIHIS."""
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(
+            coordinator,
+            key="total_mowing_sessions",
+            name="Total Mowing Sessions",
+            icon="mdi:counter",
+        )
+
+    @property
+    def native_value(self) -> int | None:
+        """Return lifetime mowing-session count."""
+        totals = self.coordinator.work_log_totals
+        return totals.total_mowing_sessions if totals is not None else None

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -240,7 +240,7 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
                 "keys": ["id", "type"],
             },
         ],
-        "maintenance_point_ids": [301, 302],
+        "maintenance_point_ids": [301],
         "point_type_codes": [1, 2],
         "point_record_validation": {
             "total_count": 5,
@@ -441,21 +441,35 @@ def test_app_maps_accept_three_value_maintenance_point_vectors() -> None:
                     "param": {},
                     "point": [5910, 12400, 270],
                     "time": 1,
-                    "type": 9,
+                    "type": 1,
                 },
                 {
                     "id": 502,
                     "param": {},
                     "point": [7100, 8300, 90],
                     "time": 2,
-                    "type": 9,
+                    "type": 1,
+                },
+                {
+                    "id": 504,
+                    "param": {},
+                    "point": [9000, 9200, 180],
+                    "time": 3,
+                    "type": 2,
+                },
+                {
+                    "id": 505,
+                    "param": {},
+                    "point": [9400, 9600, 0],
+                    "time": 4,
+                    "type": 2,
                 },
                 {
                     "id": 503,
                     "param": {},
                     "point": [1, 2, 3, 4],
                     "time": 3,
-                    "type": 9,
+                    "type": 1,
                 },
             ]
         }
@@ -466,18 +480,18 @@ def test_app_maps_accept_three_value_maintenance_point_vectors() -> None:
 
     summary = result["maps"][0]["summary"]
     assert summary["maintenance_point_ids"] == [501, 502]
-    assert summary["point_type_codes"] == [9]
+    assert summary["point_type_codes"] == [1, 2]
     assert summary["point_record_validation"] == {
-        "total_count": 3,
-        "exact_shape_count": 3,
-        "parser_accepted_count": 2,
-        "identified_count": 2,
+        "total_count": 5,
+        "exact_shape_count": 5,
+        "parser_accepted_count": 4,
+        "identified_count": 4,
         "rejection_reason_counts": [
             {"reason": "point_not_coordinate_pair", "count": 1},
         ],
         "value_type_shapes": [
             {
-                "count": 2,
+                "count": 4,
                 "id_type": "number",
                 "param_type": "object",
                 "point_type": "array",

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -519,6 +519,7 @@ def test_metadata_hydration_serializes_shared_vendor_protocol_calls() -> None:
         coordinator.async_refresh_vector_map_details = complete
         coordinator.async_refresh_weather_protection = complete
         coordinator.async_refresh_maintenance_status = complete
+        coordinator.async_refresh_work_log_totals = complete
         coordinator.async_refresh_voice_settings = complete
         task = asyncio.create_task(
             coordinator._async_refresh_metadata(
@@ -584,6 +585,7 @@ def test_metadata_hydration_retries_only_missing_core_phase() -> None:
         coordinator.async_refresh_vector_map_details = complete
         coordinator.async_refresh_weather_protection = complete
         coordinator.async_refresh_maintenance_status = complete
+        coordinator.async_refresh_work_log_totals = complete
         coordinator.async_refresh_voice_settings = complete
 
         with patch(
@@ -686,6 +688,7 @@ def test_metadata_hydration_forces_incomplete_app_map_retry() -> None:
         coordinator.async_refresh_vector_map_details = complete
         coordinator.async_refresh_weather_protection = complete
         coordinator.async_refresh_maintenance_status = complete
+        coordinator.async_refresh_work_log_totals = complete
         coordinator.async_refresh_voice_settings = complete
 
         with patch(

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -122,6 +122,7 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
             "app_maps": [],
             "vector_maps": [],
         },
+        "work_log_totals": None,
         "last_maintenance_point_probe": None,
     }
 

--- a/tests/test_work_log_totals.py
+++ b/tests/test_work_log_totals.py
@@ -1,0 +1,181 @@
+"""Contracts for mower-native lifetime work-log totals."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.dreame_lawn_mower.coordinator import (
+    WORK_LOG_TOTALS_REFRESH_INTERVAL,
+    DreameLawnMowerCoordinator,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.client import (
+    DreameLawnMowerClient,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.exceptions import (
+    DreameLawnMowerConnectionError,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    DreameLawnMowerDescriptor,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.work_log import (
+    WORK_LOG_TOTALS_REQUEST,
+    DreameLawnMowerWorkLogTotals,
+    work_log_totals_from_app_data,
+)
+from custom_components.dreame_lawn_mower.reporting import (
+    build_coordinator_diagnostics,
+)
+from custom_components.dreame_lawn_mower.sensor_work_log import (
+    DreameLawnMowerTotalMowedAreaSensor,
+    DreameLawnMowerTotalMowingSessionsSensor,
+    DreameLawnMowerTotalMowingTimeSensor,
+)
+
+
+def _client() -> DreameLawnMowerClient:
+    return DreameLawnMowerClient(
+        username="user@example.invalid",
+        password="secret",
+        country="eu",
+        account_type="dreame",
+        descriptor=DreameLawnMowerDescriptor(
+            did="device-1",
+            name="Garden Mower",
+            model="dreame.mower.g2408",
+            display_model="A2",
+            account_type="dreame",
+            country="eu",
+        ),
+    )
+
+
+def _totals() -> DreameLawnMowerWorkLogTotals:
+    return DreameLawnMowerWorkLogTotals(
+        total_mowed_area_sqm=7136.0,
+        total_mowing_time_minutes=3073,
+        total_mowing_sessions=13,
+        history_start_epoch=1_704_038_400,
+    )
+
+
+def test_work_log_totals_decode_vendor_summary() -> None:
+    totals = work_log_totals_from_app_data(
+        {
+            "m": "r",
+            "r": 0,
+            "d": {
+                "area": 7136,
+                "time": 3073,
+                "count": 13,
+                "start": 1_704_038_400,
+            },
+        }
+    )
+
+    assert totals == _totals()
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"r": 1, "d": {"area": 1, "time": 1, "count": 1}},
+        {"r": 0},
+        {"r": 0, "d": {"area": -1, "time": 1, "count": 1}},
+        {"r": 0, "d": {"area": 1, "time": 1.5, "count": 1}},
+        {"r": 0, "d": {"area": 1, "time": 1, "count": True}},
+    ],
+)
+def test_work_log_totals_reject_invalid_or_partial_summaries(response: dict) -> None:
+    with pytest.raises(DreameLawnMowerConnectionError):
+        work_log_totals_from_app_data(response)
+
+
+def test_client_requests_mower_owned_mihis_summary() -> None:
+    client = _client()
+    calls: list[tuple[dict, dict]] = []
+
+    def call(payload: dict, **kwargs) -> dict:
+        calls.append((payload, kwargs))
+        return {
+            "r": 0,
+            "d": {"area": 7136, "time": 3073, "count": 13, "start": 10},
+        }
+
+    client._sync_call_app_action = call  # type: ignore[method-assign]
+
+    totals = client._sync_get_work_log_totals()
+
+    assert totals.total_mowing_sessions == 13
+    assert calls == [(WORK_LOG_TOTALS_REQUEST, {"redact_response": True})]
+
+
+@pytest.mark.asyncio
+async def test_coordinator_caches_totals_and_preserves_them_on_failure() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.work_log_totals = None
+    coordinator.work_log_totals_refreshed_at = None
+    coordinator.client = SimpleNamespace(
+        async_get_work_log_totals=AsyncMock(return_value=_totals())
+    )
+
+    first = await coordinator.async_refresh_work_log_totals()
+    second = await coordinator.async_refresh_work_log_totals()
+
+    assert first == _totals()
+    assert second is first
+    coordinator.client.async_get_work_log_totals.assert_awaited_once()
+    assert WORK_LOG_TOTALS_REFRESH_INTERVAL == timedelta(minutes=15)
+
+    coordinator.work_log_totals_refreshed_at = None
+    coordinator.client.async_get_work_log_totals = AsyncMock(
+        side_effect=DreameLawnMowerConnectionError("offline")
+    )
+
+    retained = await coordinator.async_refresh_work_log_totals()
+
+    assert retained is first
+    assert coordinator.work_log_totals_refreshed_at is None
+
+
+def test_work_log_sensors_expose_vendor_totals() -> None:
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(available=True),
+        work_log_totals=_totals(),
+    )
+    area = object.__new__(DreameLawnMowerTotalMowedAreaSensor)
+    area.coordinator = coordinator
+    mowing_time = object.__new__(DreameLawnMowerTotalMowingTimeSensor)
+    mowing_time.coordinator = coordinator
+    sessions = object.__new__(DreameLawnMowerTotalMowingSessionsSensor)
+    sessions.coordinator = coordinator
+
+    assert area.native_value == 7136.0
+    assert mowing_time.native_value == 3073
+    assert sessions.native_value == 13
+    assert area.available is True
+
+
+def test_coordinator_diagnostics_include_only_aggregate_work_log_totals() -> None:
+    refreshed_at = datetime(2026, 8, 10, 12, 30, tzinfo=UTC)
+    diagnostics = build_coordinator_diagnostics(
+        SimpleNamespace(
+            last_update_success=True,
+            last_exception=None,
+            update_interval=timedelta(seconds=30),
+            work_log_totals=_totals(),
+            work_log_totals_refreshed_at=refreshed_at,
+        )
+    )
+
+    assert diagnostics["work_log_totals"] == {
+        "source": "app_action_mihis",
+        "total_mowed_area_sqm": 7136.0,
+        "total_mowing_time_minutes": 3073,
+        "total_mowing_sessions": 13,
+        "refreshed_at": "2026-08-10T12:30:00+00:00",
+    }
+    assert "history_start" not in repr(diagnostics["work_log_totals"])

--- a/tests/test_work_log_totals.py
+++ b/tests/test_work_log_totals.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
@@ -113,32 +114,34 @@ def test_client_requests_mower_owned_mihis_summary() -> None:
     assert calls == [(WORK_LOG_TOTALS_REQUEST, {"redact_response": True})]
 
 
-@pytest.mark.asyncio
-async def test_coordinator_caches_totals_and_preserves_them_on_failure() -> None:
-    coordinator = object.__new__(DreameLawnMowerCoordinator)
-    coordinator.work_log_totals = None
-    coordinator.work_log_totals_refreshed_at = None
-    coordinator.client = SimpleNamespace(
-        async_get_work_log_totals=AsyncMock(return_value=_totals())
-    )
+def test_coordinator_caches_totals_and_preserves_them_on_failure() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.work_log_totals = None
+        coordinator.work_log_totals_refreshed_at = None
+        coordinator.client = SimpleNamespace(
+            async_get_work_log_totals=AsyncMock(return_value=_totals())
+        )
 
-    first = await coordinator.async_refresh_work_log_totals()
-    second = await coordinator.async_refresh_work_log_totals()
+        first = await coordinator.async_refresh_work_log_totals()
+        second = await coordinator.async_refresh_work_log_totals()
 
-    assert first == _totals()
-    assert second is first
-    coordinator.client.async_get_work_log_totals.assert_awaited_once()
-    assert WORK_LOG_TOTALS_REFRESH_INTERVAL == timedelta(minutes=15)
+        assert first == _totals()
+        assert second is first
+        coordinator.client.async_get_work_log_totals.assert_awaited_once()
+        assert WORK_LOG_TOTALS_REFRESH_INTERVAL == timedelta(minutes=15)
 
-    coordinator.work_log_totals_refreshed_at = None
-    coordinator.client.async_get_work_log_totals = AsyncMock(
-        side_effect=DreameLawnMowerConnectionError("offline")
-    )
+        coordinator.work_log_totals_refreshed_at = None
+        coordinator.client.async_get_work_log_totals = AsyncMock(
+            side_effect=DreameLawnMowerConnectionError("offline")
+        )
 
-    retained = await coordinator.async_refresh_work_log_totals()
+        retained = await coordinator.async_refresh_work_log_totals()
 
-    assert retained is first
-    assert coordinator.work_log_totals_refreshed_at is None
+        assert retained is first
+        assert coordinator.work_log_totals_refreshed_at is None
+
+    asyncio.run(scenario())
 
 
 def test_work_log_sensors_expose_vendor_totals() -> None:


### PR DESCRIPTION
## Summary

- keep patrol points out of the Maintenance Point selector by treating mower point type `1` as maintenance and type `2` as patrol
- preserve all structurally valid point type codes in privacy-safe diagnostics so future mower variants remain observable
- add lifetime Total Mowed Area, Total Mowing Time, and Total Mowing Sessions sensors from the mower-native `MIHIS` summary used by the Dreame app
- cache totals for 15 minutes, retain the last confirmed values during transient failures, and report aggregates without individual work-log records

## Issue linkage

- Addresses the patrol-point follow-up in #79
- Closes #138

## Validation

- verified the production totals method against an A2 3000
- full test suite and Ruff checks pass
