### PR TITLE
Improve 3D map diagnostics and cached delivery

### DIFF
--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -518,7 +518,11 @@ class DreameLawnMowerMapDataCamera(DreameLawnMowerMapCamera):
 
     async def _async_camera_image_impl(self) -> bytes | None:
         """Return a readable diagnostics card as JPEG bytes."""
-        view = await self._async_refresh_map_view()
+        view = self._map_cache.last_view
+        if view is None:
+            view = await self._async_refresh_map_view()
+        elif not self._map_cache.is_fresh():
+            self._start_map_refresh()
         summary = view.summary
         lines = [
             f"Device: {self._descriptor.name} ({self._descriptor.display_model})",

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -60,6 +60,14 @@ _POINT_CLOUD_PROBLEM_TITLE = {
 }
 
 
+def _exception_type_name(error: BaseException) -> str:
+    """Return a privacy-safe exception classifier without message or payload."""
+    exception_type = type(error)
+    if exception_type.__module__ == "builtins":
+        return exception_type.__qualname__
+    return f"{exception_type.__module__}.{exception_type.__qualname__}"
+
+
 def point_cloud_api_path(entry_id: str, map_index: int) -> str:
     """Return the local authenticated API path advertised to frontends."""
     return f"{POINT_CLOUD_API_PATH}/{entry_id}/{map_index}"
@@ -341,6 +349,7 @@ class DreameLawnMowerPointCloudAPI:
                 sample,
                 map_index=key[1],
                 allow_stored=allow_stored,
+                unexpected_error=err,
             )
             raise public_error from err
         else:
@@ -435,6 +444,7 @@ class DreameLawnMowerPointCloudAPI:
         *,
         map_index: int,
         allow_stored: bool,
+        unexpected_error: Exception | None = None,
     ) -> None:
         """Keep one privacy-safe failure event and benchmark sample."""
         context: dict[str, Any] = {
@@ -446,6 +456,14 @@ class DreameLawnMowerPointCloudAPI:
             "map_index": map_index,
             "allow_stored": allow_stored,
         }
+        exception_type = None
+        if unexpected_error is not None:
+            exception_type = _exception_type_name(unexpected_error)
+            context["exception_type"] = exception_type
+            if unexpected_error.__cause__ is not None:
+                context["cause_exception_type"] = _exception_type_name(
+                    unexpected_error.__cause__
+                )
         if sample is not None:
             context["duration_ms"] = round(sample.total_seconds * 1000, 1)
             total, phases = format_performance_sample(sample)
@@ -460,12 +478,14 @@ class DreameLawnMowerPointCloudAPI:
         )
         _LOGGER.warning(
             "Dreame mower performance: operation=point_cloud_generation "
-            "outcome=%s total=%.3fs phases=%s stage=%s retryable=%s",
+            "outcome=%s total=%.3fs phases=%s stage=%s retryable=%s "
+            "exception_type=%s",
             error.code,
             total,
             phases,
             error.stage,
             error.retryable,
+            exception_type or "none",
         )
 
     @callback
@@ -616,12 +636,14 @@ class DreameLawnMowerPointCloudView(HomeAssistantView):
                 err,
                 elapsed_seconds=time.monotonic() - started_at,
             )
-        except Exception:  # noqa: BLE001 - keep private cloud details private.
+        except Exception as err:  # noqa: BLE001 - keep private cloud details private.
             elapsed_seconds = time.monotonic() - started_at
+            exception_type = _exception_type_name(err)
             _LOGGER.warning(
                 "Dreame point-cloud request failed: code=point_cloud_failed "
-                "stage=delivery elapsed=%.3fs retryable=True",
+                "stage=delivery elapsed=%.3fs retryable=True exception_type=%s",
                 elapsed_seconds,
+                exception_type,
             )
             return _point_cloud_problem_response(
                 DreameLawnMowerPointCloudError(

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -295,6 +295,76 @@ def test_all_maps_camera_returns_loading_image_while_refresh_starts() -> None:
     assert cache.last_image is None
 
 
+def test_map_diagnostics_serves_stale_shared_view_during_background_refresh(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Diagnostics must not wait for a slow provider when shared map data exists."""
+    cache = DreameLawnMowerMapCameraCache(ttl=timedelta(seconds=60))
+    cache.store_view(
+        DreameLawnMowerMapView(source="batch_vector_map"),
+        now=datetime(2026, 4, 19, 8, 0, tzinfo=UTC),
+    )
+    entity = object.__new__(DreameLawnMowerMapDataCamera)
+    entity._map_cache = cache
+    entity._descriptor = SimpleNamespace(name="Garden", display_model="A2")
+    refresh_calls = 0
+    rendered_lines: list[str] = []
+
+    async def async_add_executor_job(target: object) -> bytes:
+        return target()  # type: ignore[operator]
+
+    def start_refresh() -> None:
+        nonlocal refresh_calls
+        refresh_calls += 1
+
+    def render(*, lines: list[str]) -> bytes:
+        rendered_lines.extend(lines)
+        return b"diagnostics-jpeg"
+
+    entity.hass = SimpleNamespace(async_add_executor_job=async_add_executor_job)
+    entity._start_map_refresh = start_refresh  # type: ignore[method-assign]
+    monkeypatch.setattr(camera_module, "map_diagnostics_jpeg", render)
+
+    image = asyncio.run(entity._async_camera_image_impl())
+
+    assert image == b"diagnostics-jpeg"
+    assert refresh_calls == 1
+    assert "Source: batch_vector_map" in rendered_lines
+
+
+def test_map_diagnostics_refreshes_in_foreground_without_shared_view(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The first diagnostics request still hydrates an otherwise empty cache."""
+    cache = DreameLawnMowerMapCameraCache(ttl=timedelta(seconds=60))
+    entity = object.__new__(DreameLawnMowerMapDataCamera)
+    entity._map_cache = cache
+    entity._descriptor = SimpleNamespace(name="Garden", display_model="A2")
+    refresh_calls = 0
+    view = DreameLawnMowerMapView(source="app_action_map")
+
+    async def async_add_executor_job(target: object) -> bytes:
+        return target()  # type: ignore[operator]
+
+    async def refresh_view() -> DreameLawnMowerMapView:
+        nonlocal refresh_calls
+        refresh_calls += 1
+        return view
+
+    entity.hass = SimpleNamespace(async_add_executor_job=async_add_executor_job)
+    entity._async_refresh_map_view = refresh_view  # type: ignore[method-assign]
+    monkeypatch.setattr(
+        camera_module,
+        "map_diagnostics_jpeg",
+        lambda *, lines: b"diagnostics-jpeg",
+    )
+
+    image = asyncio.run(entity._async_camera_image_impl())
+
+    assert image == b"diagnostics-jpeg"
+    assert refresh_calls == 1
+
+
 def test_all_maps_camera_serves_stale_image_during_background_refresh() -> None:
     """A slow refresh must not blank or delay the last good contact sheet."""
     cache = DreameLawnMowerMapCameraCache(ttl=timedelta(seconds=60))

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -940,6 +940,41 @@ def test_point_cloud_view_does_not_log_private_exception_details(
     assert response.status == 502
     assert json.loads(response.text)["code"] == "point_cloud_failed"
     assert "code=point_cloud_failed" in caplog.text
+    assert "exception_type=RuntimeError" in caplog.text
     assert private_detail not in caplog.text
     assert "do-not-log" not in caplog.text
     assert private_detail not in response.text
+
+
+def test_point_cloud_api_records_safe_unexpected_exception_type(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Unexpected generation failures retain a useful, payload-free classifier."""
+    private_detail = (
+        "https://downloads.example.invalid/private-map.pcd?secret=do-not-log"
+    )
+
+    async def download(**kwargs: Any) -> None:
+        del kwargs
+        raise RuntimeError(private_detail)
+
+    coordinator = SimpleNamespace(
+        app_maps={"current_map_index": 0, "maps": [{"idx": 0}]},
+        selected_map_index=0,
+        client=SimpleNamespace(async_download_app_map_point_cloud=download),
+        diagnostic_events=DreameLawnMowerDiagnosticEventStore(),
+        performance=DreameLawnMowerPerformanceTracker(),
+    )
+    hass = SimpleNamespace(data={DOMAIN: {"entry-1": coordinator}})
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    with caplog.at_level(logging.WARNING):
+        with pytest.raises(DreameLawnMowerPointCloudError) as raised:
+            asyncio.run(api.async_get("entry-1", 0))
+
+    assert raised.value.code == "point_cloud_failed"
+    event = coordinator.diagnostic_events.as_list()[0]
+    assert event["context"]["exception_type"] == "RuntimeError"
+    assert "exception_type=RuntimeError" in caplog.text
+    assert private_detail not in repr(event)
+    assert private_detail not in caplog.text


### PR DESCRIPTION
## Summary

- serve Map Diagnostics from the existing shared map view instead of blocking on a stale provider refresh
- refresh stale map data in the background while preserving foreground hydration when no shared view exists
- retain privacy-safe exception class names for unexpected 3D map generation and delivery failures without exposing exception messages, cloud URLs, payloads, or coordinates

## Validation

- focused map-camera and point-cloud API regression coverage
- full Linux CI-equivalent test suite
- whole-repository Ruff and diff checks