### PR TITLE
Add MOVA LiDAX Ultra 2000 AWD support

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ brand name:
 | Dreame A3 AWD 1000 | `dreame.mower.q2501a` | **Validated** | Core entities, mower state, maps, and cloud live video on firmware `4.3.6_0418` with an EU account |
 | MOVA LiDAX Ultra 1000 | `mova.mower.g2529c` | **Field-reported** | MOVAhome EU login, commands, battery, and model-specific cloud property handling |
 | MOVA LiDAX Ultra 2000 | `mova.mower.g2529f` | **Field-reported** | MOVAhome US login, core state and commands, maps, and cloud live video on firmware `4.3.6_0453` |
+| MOVA LiDAX Ultra 2000 AWD | `mova.mower.g2584a` | **Field-reported** | MOVAhome US login, realtime state, zone mowing, docking, maps, and cloud live video on firmware `4.3.6_0439` |
 | Dreame A3 AWD Pro 3500 | `dreame.mower.g2541e` | **Recognized** | Model mapping and diagnostics report; broader live confirmation is still needed |
 | Dreame A1 | `dreame.mower.p2255` | **Recognized** | Model mapping and mower-specific state semantics; live video is explicitly unsupported |
 | Dreame A1 Pro | `dreame.mower.g2422` | **Recognized** | Model mapping and mower-specific state semantics; needs fixtures and live validation |

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_code_semantics.py
@@ -222,8 +222,10 @@ _MOVA_MODELS: Final[frozenset[str]] = frozenset(
     {
         "mova.mower.g2529c",
         "mova.mower.g2529f",
+        "mova.mower.g2584a",
         "g2529c",
         "g2529f",
+        "g2584a",
     }
 )
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/feature_capabilities.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/feature_capabilities.py
@@ -34,6 +34,9 @@ MODEL_FEATURE_CAPABILITIES: Final[dict[str, dict[str, str]]] = {
     "mova.mower.g2529f": {
         FEATURE_LIVE_VIDEO: CAPABILITY_SUPPORTED,
     },
+    "mova.mower.g2584a": {
+        FEATURE_LIVE_VIDEO: CAPABILITY_SUPPORTED,
+    },
 }
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -36,6 +36,7 @@ MODEL_NAME_MAP = {
     "dreame.mower.q2501a": "A3 AWD 1000",
     "mova.mower.g2529c": "LiDAX Ultra 1000",
     "mova.mower.g2529f": "LiDAX Ultra 2000",
+    "mova.mower.g2584a": "LiDAX Ultra 2000 AWD",
 }
 
 DISPLAY_NAME_ALIASES = {
@@ -49,6 +50,7 @@ DISPLAY_NAME_ALIASES = {
     "lidax ultra 1000": "LiDAX Ultra 1000",
     "lidax ultra 1200": "LiDAX Ultra 1200",
     "lidax ultra 2000": "LiDAX Ultra 2000",
+    "lidax ultra 2000 awd": "LiDAX Ultra 2000 AWD",
     "viax 300": "Viax 300",
     "vivax 250": "Vivax 250",
 }

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -54,6 +54,50 @@ def runtime_blob_has_nonzero_session_metrics(blob: Any) -> bool:
     )
 
 
+def runtime_blob_matches_active_session(cache: Any, blob: Any) -> bool:
+    """Return whether live telemetry is safe to expose for the active mission.
+
+    The mower can retain property ``1.4`` from the preceding mission while a
+    replacement mission is already active.  Prefer ordered reception evidence,
+    with the task id as a safe fallback when the vendor omitted a timestamp.
+    Test doubles and older coordinator shapes without the integration-owned
+    cache retain the previous active-state behavior.
+    """
+    if not isinstance(cache, DreameLawnMowerRuntimeTelemetryCache):
+        return True
+    if blob is None or not cache._session_active or cache.blob is not blob:
+        return False
+
+    session_identity = cache._session_identity
+    blob_identity = getattr(blob, "candidate_runtime_task_id", None)
+    if (
+        session_identity is not None
+        and blob_identity is not None
+        and blob_identity != session_identity
+    ):
+        return False
+
+    session_started_at = cache._session_started_at
+    if session_started_at is None:
+        return True
+
+    received_at = getattr(blob, "received_at", None)
+    if isinstance(received_at, str):
+        try:
+            parsed = datetime.fromisoformat(received_at.replace("Z", "+00:00"))
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return parsed.timestamp() >= session_started_at
+        except ValueError:
+            pass
+
+    return bool(
+        session_identity is not None
+        and blob_identity is not None
+        and blob_identity == session_identity
+    )
+
+
 def runtime_mission_completion_confirmed(
     snapshot: Any,
     *,

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -117,6 +117,7 @@ from .sensor_map_data import (  # noqa: F401
     _current_vector_map_runtime_track_point_count,
     _current_vector_map_runtime_track_segment_count,
     _current_vector_map_summary,
+    _current_vector_map_zone_count,
     _selected_contour_id,
     _selected_map_index,
     _selected_map_label,
@@ -179,6 +180,8 @@ from .sensor_operations import (  # noqa: F401
     schedule_write_result_attributes,
 )
 from .sensor_runtime import (  # noqa: F401
+    DreameLawnMowerCurrentMowedAreaSensor,
+    DreameLawnMowerCurrentZoneSensor,
     DreameLawnMowerMowingProgressSensor,
     DreameLawnMowerRuntimeCurrentAreaSensor,
     DreameLawnMowerRuntimeHeadingSensor,
@@ -189,7 +192,10 @@ from .sensor_runtime import (  # noqa: F401
     DreameLawnMowerRuntimeTrackLengthSensor,
     DreameLawnMowerRuntimeTrackPointCountSensor,
     DreameLawnMowerRuntimeTrackSegmentCountSensor,
+    _current_mowed_area,
     _current_zone_label,
+    _current_zone_label_for_coordinator,
+    _live_runtime_status_blob,
     _runtime_progress_available_for_snapshot,
     _runtime_session_attributes,
     _runtime_session_blob,
@@ -427,6 +433,8 @@ SENSORS = [
     ),
 ]
 
+_SPECIALIZED_SENSOR_KEYS = frozenset({"current_cleaned_area", "current_zone"})
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -436,7 +444,11 @@ async def async_setup_entry(
     """Set up mower sensors."""
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities(
-        [DreameLawnMowerSensor(coordinator, description) for description in SENSORS]
+        [
+            DreameLawnMowerSensor(coordinator, description)
+            for description in SENSORS
+            if description.key not in _SPECIALIZED_SENSOR_KEYS
+        ]
         + [DreameLawnMowerAppMapCountSensor(coordinator)]
         + [DreameLawnMowerAvailableVectorMapCountSensor(coordinator)]
         + [DreameLawnMowerSelectedMowingActionSensor(coordinator)]
@@ -473,6 +485,8 @@ async def async_setup_entry(
         + [DreameLawnMowerRuntimeTrackPointCountSensor(coordinator)]
         + [DreameLawnMowerRuntimeTrackLengthSensor(coordinator)]
         + [DreameLawnMowerRuntimeTrackSegmentCountSensor(coordinator)]
+        + [DreameLawnMowerCurrentMowedAreaSensor(coordinator)]
+        + [DreameLawnMowerCurrentZoneSensor(coordinator)]
         + [DreameLawnMowerMowingProgressSensor(coordinator)]
         + [DreameLawnMowerTotalMowedAreaSensor(coordinator)]
         + [DreameLawnMowerTotalMowingTimeSensor(coordinator)]

--- a/custom_components/dreame_lawn_mower/sensor_map_data.py
+++ b/custom_components/dreame_lawn_mower/sensor_map_data.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import math
+from collections.abc import Sequence
 from typing import Any
 
 from .control_options import (
@@ -566,6 +567,24 @@ def _current_app_map_zone_count(
         return None
     value = summary.get("map_area_count")
     return value if isinstance(value, int) else None
+
+
+def _current_vector_map_zone_count(
+    result: dict[str, Any] | None,
+    app_maps: dict[str, Any] | None = None,
+    batch_device_data: dict[str, Any] | None = None,
+) -> int | None:
+    """Return the parsed zone count instead of the app map's mixed area count."""
+    summary = _current_vector_map_summary(result, app_maps, batch_device_data)
+    if not isinstance(summary, dict):
+        return None
+    zone_ids = summary.get("zone_ids")
+    if not isinstance(zone_ids, Sequence) or isinstance(
+        zone_ids,
+        str | bytes | bytearray,
+    ):
+        return None
+    return len(zone_ids)
 
 
 def _current_app_map_spot_count(

--- a/custom_components/dreame_lawn_mower/sensor_map_entities.py
+++ b/custom_components/dreame_lawn_mower/sensor_map_entities.py
@@ -25,6 +25,7 @@ from .sensor_map_data import (
     _current_vector_map_mow_path_length_m,
     _current_vector_map_mow_path_point_count,
     _current_vector_map_name,
+    _current_vector_map_zone_count,
     _selected_map_label,
     _selected_map_preference_summary,
     _selected_map_preference_value,
@@ -738,6 +739,13 @@ class DreameLawnMowerCurrentAppMapZoneCountSensor(
     @property
     def native_value(self) -> int | None:
         """Return the zone count of the current app map."""
+        vector_count = _current_vector_map_zone_count(
+            getattr(self.coordinator, "vector_map_details", None),
+            self.coordinator.app_maps,
+            self.coordinator.batch_device_data,
+        )
+        if vector_count is not None:
+            return vector_count
         return _current_app_map_zone_count(
             self.coordinator.app_maps,
             self.coordinator.batch_device_data,
@@ -751,10 +759,29 @@ class DreameLawnMowerCurrentAppMapZoneCountSensor(
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
         """Return safe cached current-map attributes."""
-        return current_app_map_attributes(
+        attributes = current_app_map_attributes(
             self.coordinator.app_maps,
             self.coordinator.batch_device_data,
         )
+        if (
+            _current_vector_map_zone_count(
+                getattr(self.coordinator, "vector_map_details", None),
+                self.coordinator.app_maps,
+                self.coordinator.batch_device_data,
+            )
+            is not None
+        ):
+            vector_attributes = current_vector_map_attributes(
+                self.coordinator.vector_map_details,
+                self.coordinator.app_maps,
+                self.coordinator.batch_device_data,
+            )
+            attributes["zone_count_source"] = "vector_map"
+            if "current_vector_map" in vector_attributes:
+                attributes["current_vector_map"] = vector_attributes[
+                    "current_vector_map"
+                ]
+        return attributes
 
 
 class DreameLawnMowerCurrentAppMapSpotCountSensor(

--- a/custom_components/dreame_lawn_mower/sensor_runtime.py
+++ b/custom_components/dreame_lawn_mower/sensor_runtime.py
@@ -7,10 +7,12 @@ from typing import Any
 from homeassistant.components.sensor import SensorEntity
 from homeassistant.helpers.entity import EntityCategory
 
+from .control_options import current_zone_entries
 from .coordinator import DreameLawnMowerCoordinator, runtime_tracking_active
 from .entity import DreameLawnMowerEntity
 from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
+    runtime_blob_matches_active_session,
     runtime_mission_cached_session_identity,
     runtime_mission_completion_confirmed,
     runtime_mission_progress_percent,
@@ -40,6 +42,104 @@ def _current_zone_label(snapshot: Any) -> str | None:
     return None
 
 
+def _live_runtime_status_blob(coordinator: Any) -> Any:
+    """Return runtime telemetry only while it belongs to the active mission."""
+    snapshot = getattr(coordinator, "data", None)
+    if snapshot is None or not runtime_tracking_active(snapshot):
+        return None
+    blob = getattr(coordinator, "runtime_status_blob", None)
+    if not runtime_blob_matches_active_session(
+        getattr(coordinator, "runtime_telemetry_cache", None),
+        blob,
+    ):
+        return None
+    return blob
+
+
+def _current_mowed_area(coordinator: Any) -> float | int | None:
+    """Return the legacy session area with live runtime telemetry as fallback."""
+    snapshot = getattr(coordinator, "data", None)
+    value = getattr(snapshot, "mowed_area", None)
+    if isinstance(value, int | float) and not isinstance(value, bool):
+        return value
+    return _runtime_status_blob_current_area_sqm(_live_runtime_status_blob(coordinator))
+
+
+def _current_zone_label_for_coordinator(coordinator: Any) -> str | None:
+    """Return the snapshot zone or resolve the live runtime region id."""
+    snapshot = getattr(coordinator, "data", None)
+    label = _current_zone_label(snapshot)
+    if label is not None:
+        return label
+
+    region_id = getattr(
+        _live_runtime_status_blob(coordinator),
+        "candidate_runtime_region_id",
+        None,
+    )
+    if not isinstance(region_id, int) or isinstance(region_id, bool) or region_id <= 0:
+        return None
+    for entry in current_zone_entries(
+        getattr(coordinator, "batch_device_data", None),
+        getattr(coordinator, "app_maps", None),
+        getattr(coordinator, "vector_map_details", None),
+    ):
+        if entry.get("area_id") == region_id:
+            entry_label = entry.get("label")
+            if isinstance(entry_label, str) and entry_label:
+                return entry_label
+    return f"Zone {region_id}"
+
+
+class DreameLawnMowerCurrentMowedAreaSensor(
+    DreameLawnMowerEntity,
+    SensorEntity,
+):
+    """Expose current task area across legacy and runtime mower protocols."""
+
+    _attr_name = "Current Mowed Area"
+    _attr_icon = "mdi:texture-box"
+    _attr_native_unit_of_measurement = "m²"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_current_cleaned_area"
+
+    @property
+    def native_value(self) -> float | int | None:
+        """Return the current task area from the best live source."""
+        return _current_mowed_area(self.coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Return whether a current task area is available."""
+        return self.coordinator.data is not None and self.native_value is not None
+
+
+class DreameLawnMowerCurrentZoneSensor(
+    DreameLawnMowerEntity,
+    SensorEntity,
+):
+    """Expose the current zone across legacy and runtime mower protocols."""
+
+    _attr_name = "Current Zone"
+    _attr_icon = "mdi:map-marker-outline"
+
+    def __init__(self, coordinator: DreameLawnMowerCoordinator) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_current_zone"
+
+    @property
+    def native_value(self) -> str | None:
+        """Return the current zone from the best live source."""
+        return _current_zone_label_for_coordinator(self.coordinator)
+
+    @property
+    def available(self) -> bool:
+        """Return whether current-zone telemetry is available."""
+        return self.coordinator.data is not None and self.native_value is not None
+
+
 class DreameLawnMowerMowingProgressSensor(
     DreameLawnMowerEntity,
     SensorEntity,
@@ -63,10 +163,13 @@ class DreameLawnMowerMowingProgressSensor(
             self.coordinator.app_maps,
             self.coordinator.batch_device_data,
         )
-        if mowed_area is None or current_map_area in (None, 0):
-            return None
-        progress = (float(mowed_area) / float(current_map_area)) * 100
-        return round(max(0.0, min(progress, 100.0)), 1)
+        if mowed_area is not None and current_map_area not in (None, 0):
+            progress = (float(mowed_area) / float(current_map_area)) * 100
+            return round(max(0.0, min(progress, 100.0)), 1)
+        return runtime_mission_progress_percent(
+            _live_runtime_status_blob(self.coordinator),
+            completion_confirmed=False,
+        )
 
     @property
     def available(self) -> bool:
@@ -79,13 +182,14 @@ class DreameLawnMowerMowingProgressSensor(
         snapshot = self.coordinator.data
         if snapshot is None:
             return {}
+        mowed_area = _current_mowed_area(self.coordinator)
         attributes: dict[str, Any] = {
-            "mowed_area": snapshot.mowed_area,
+            "mowed_area": mowed_area,
             "mowing_time": snapshot.mowing_time,
             # Compatibility aliases for existing dashboards and automations.
-            "cleaned_area": snapshot.cleaned_area,
+            "cleaned_area": mowed_area,
             "cleaning_time": snapshot.cleaning_time,
-            "current_zone": _current_zone_label(snapshot),
+            "current_zone": _current_zone_label_for_coordinator(self.coordinator),
             "active_segment_count": getattr(snapshot, "active_segment_count", None),
         }
         current_map = _current_app_map_summary(

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -225,6 +225,23 @@ def test_descriptor_maps_lidax_ultra_2000_model_name() -> None:
     assert descriptor.title == "Back Lawn (LiDAX Ultra 2000)"
 
 
+def test_descriptor_maps_lidax_ultra_2000_awd_model_name() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-6-awd",
+            "model": "mova.mower.g2584a",
+            "customName": "Side Lawn",
+            "deviceInfo": {"displayName": "Lidax Ultra 2000 AWD"},
+        },
+        account_type="mova",
+        country="us",
+    )
+
+    assert descriptor is not None
+    assert descriptor.display_model == "LiDAX Ultra 2000 AWD"
+    assert descriptor.title == "Side Lawn (LiDAX Ultra 2000 AWD)"
+
+
 def test_descriptor_maps_a3_awd_pro_3500_model_name() -> None:
     descriptor = descriptor_from_cloud_record(
         {

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -47,8 +47,10 @@ from custom_components.dreame_lawn_mower.sensor import (
     DreameLawnMowerCurrentAppMapTrajectoryLengthSensor,
     DreameLawnMowerCurrentAppMapTrajectoryPointCountSensor,
     DreameLawnMowerCurrentAppMapZoneCountSensor,
+    DreameLawnMowerCurrentMowedAreaSensor,
     DreameLawnMowerCurrentVectorMapIdSensor,
     DreameLawnMowerCurrentVectorMapNameSensor,
+    DreameLawnMowerCurrentZoneSensor,
     DreameLawnMowerLastMaintenanceResetSensor,
     DreameLawnMowerLastPreferenceProbeSensor,
     DreameLawnMowerLastScheduleProbeSensor,
@@ -131,21 +133,21 @@ def test_activity_sensor_exposes_normalized_client_activity() -> None:
 
 
 def test_current_mowed_area_sensor_can_become_available_after_startup() -> None:
-    entity = object.__new__(DreameLawnMowerSensor)
+    entity = object.__new__(DreameLawnMowerCurrentMowedAreaSensor)
     entity.coordinator = SimpleNamespace(
         data=SimpleNamespace(
+            activity="docked",
             mowed_area=None,
-            raw_attributes={},
-        )
+        ),
+        runtime_status_blob=None,
     )
-    entity.entity_description = _sensor_description("current_cleaned_area")
 
     assert entity.available is False
     assert entity.native_value is None
 
     entity.coordinator.data = SimpleNamespace(
+        activity="mowing",
         mowed_area=42,
-        raw_attributes={},
     )
 
     assert entity.available is True
@@ -175,18 +177,63 @@ def test_current_mowing_time_sensor_can_become_available_after_startup() -> None
 
 
 def test_current_zone_sensor_prefers_zone_name() -> None:
-    entity = object.__new__(DreameLawnMowerSensor)
+    entity = object.__new__(DreameLawnMowerCurrentZoneSensor)
     entity.coordinator = SimpleNamespace(
         data=SimpleNamespace(
+            activity="mowing",
             current_zone_id=7,
             current_zone_name="Front Lawn",
-            raw_attributes={},
-        )
+        ),
+        runtime_status_blob=None,
     )
-    entity.entity_description = _sensor_description("current_zone")
 
     assert entity.available is True
     assert entity.native_value == "Front Lawn"
+
+
+def test_session_entities_use_live_runtime_fallbacks_for_sparse_models() -> None:
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            activity="mowing",
+            mowed_area=None,
+            current_zone_id=None,
+            current_zone_name=None,
+        ),
+        runtime_status_blob=SimpleNamespace(
+            candidate_runtime_current_area_sqm=72.95,
+            candidate_runtime_region_id=1,
+        ),
+        batch_device_data=None,
+        app_maps={"current_map_index": 0, "maps": [{"idx": 0, "current": True}]},
+        vector_map_details={
+            "maps": [
+                {
+                    "map_index": 0,
+                    "zone_ids": [1, 2, 3],
+                    "zone_names": ["Front Lawn", "Side Lawn", "Back Lawn"],
+                }
+            ]
+        },
+    )
+    current_area = object.__new__(DreameLawnMowerCurrentMowedAreaSensor)
+    current_area.coordinator = coordinator
+    current_zone = object.__new__(DreameLawnMowerCurrentZoneSensor)
+    current_zone.coordinator = coordinator
+
+    assert current_area.available is True
+    assert current_area.native_value == 72.95
+    assert current_zone.available is True
+    assert current_zone.native_value == "Front Lawn (#1)"
+
+    coordinator.data = SimpleNamespace(
+        activity="docked",
+        mowed_area=None,
+        current_zone_id=None,
+        current_zone_name=None,
+    )
+
+    assert current_area.available is False
+    assert current_zone.available is False
 
 
 def test_active_segment_count_sensor_uses_snapshot_count() -> None:
@@ -1408,6 +1455,126 @@ def test_current_app_map_sensors_use_cached_current_map_state() -> None:
     }
 
 
+def test_current_app_map_zone_count_prefers_parsed_zones_over_mixed_areas() -> None:
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(),
+        batch_device_data=None,
+        app_maps={
+            "source": "app_maps_auto",
+            "available": True,
+            "current_map_index": 0,
+            "maps": [
+                {
+                    "idx": 0,
+                    "current": True,
+                    "available": True,
+                    "created": True,
+                    "summary": {"map_area_count": 6},
+                }
+            ],
+        },
+        vector_map_details={
+            "source": "vector_map_auto",
+            "maps": [
+                {
+                    "map_id": 1,
+                    "map_index": 0,
+                    "zone_ids": [1, 2, 3],
+                    "zone_names": ["Zone1", "Zone2", "Zone3"],
+                    "contour_ids": [[1, 0], [2, 0], [3, 0]],
+                    "contour_count": 3,
+                }
+            ],
+        },
+    )
+    entity = object.__new__(DreameLawnMowerCurrentAppMapZoneCountSensor)
+    entity.coordinator = coordinator
+
+    assert entity.native_value == 3
+    assert entity.extra_state_attributes["source"] == "app_maps_auto"
+    assert entity.extra_state_attributes["current_app_map"]["map_area_count"] == 6
+    assert entity.extra_state_attributes["zone_count_source"] == "vector_map"
+    assert entity.extra_state_attributes["current_vector_map"]["zone_ids"] == [
+        1,
+        2,
+        3,
+    ]
+
+
+def test_session_fallback_rejects_runtime_blob_from_previous_mission() -> None:
+    """A retained property 1.4 frame must not populate a replacement session."""
+    stale_blob = SimpleNamespace(
+        received_at="2026-08-12T10:00:00+00:00",
+        candidate_runtime_task_id=100,
+        candidate_runtime_area_progress_percent=88.0,
+        candidate_runtime_current_area_sqm=440.0,
+        candidate_runtime_region_id=3,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session(session_started_at=1_786_528_900.0)
+    assert cache.update(stale_blob, active_session=True) is True
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            activity="mowing",
+            mowed_area=None,
+            mowing_time=None,
+            cleaned_area=None,
+            cleaning_time=None,
+            current_zone_id=None,
+            current_zone_name=None,
+            active_segment_count=None,
+        ),
+        runtime_status_blob=stale_blob,
+        runtime_telemetry_cache=cache,
+        batch_device_data=None,
+        app_maps=None,
+        vector_map_details=None,
+    )
+    current_area = object.__new__(DreameLawnMowerCurrentMowedAreaSensor)
+    current_area.coordinator = coordinator
+    progress = object.__new__(DreameLawnMowerMowingProgressSensor)
+    progress.coordinator = coordinator
+    current_zone = object.__new__(DreameLawnMowerCurrentZoneSensor)
+    current_zone.coordinator = coordinator
+
+    assert current_area.native_value is None
+    assert progress.native_value is None
+    assert current_zone.native_value is None
+
+
+def test_session_fallback_accepts_runtime_blob_received_after_mission_start() -> None:
+    fresh_blob = SimpleNamespace(
+        received_at="2026-08-12T10:02:00+00:00",
+        candidate_runtime_task_id=101,
+        candidate_runtime_area_progress_percent=2.0,
+        candidate_runtime_current_area_sqm=10.0,
+        candidate_runtime_region_id=1,
+    )
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session(session_started_at=1_786_528_900.0)
+    assert cache.update(fresh_blob, active_session=True) is True
+    coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            activity="mowing",
+            mowed_area=None,
+            current_zone_id=None,
+            current_zone_name=None,
+        ),
+        runtime_status_blob=fresh_blob,
+        runtime_telemetry_cache=cache,
+        batch_device_data=None,
+        app_maps=None,
+        vector_map_details=None,
+    )
+    current_area = object.__new__(DreameLawnMowerCurrentMowedAreaSensor)
+    current_area.coordinator = coordinator
+    current_zone = object.__new__(DreameLawnMowerCurrentZoneSensor)
+    current_zone.coordinator = coordinator
+
+    assert current_area.native_value == 10.0
+    assert current_zone.native_value == "Zone 1"
+
+
 def test_current_vector_map_sensors_follow_active_map() -> None:
     coordinator = SimpleNamespace(
         data=SimpleNamespace(),
@@ -1700,6 +1867,50 @@ def test_runtime_mission_progress_sensor_uses_runtime_blob_area_ratio() -> None:
         "track_length_m": 52.64,
         "notes": ["unexpected_length", "unexpected_runtime_progress_value"],
     }
+
+
+def test_mowing_progress_uses_runtime_when_legacy_area_is_absent() -> None:
+    entity = object.__new__(DreameLawnMowerMowingProgressSensor)
+    entity.coordinator = SimpleNamespace(
+        data=SimpleNamespace(
+            activity="mowing",
+            mowed_area=None,
+            mowing_time=None,
+            cleaned_area=None,
+            cleaning_time=None,
+            current_zone_id=None,
+            current_zone_name=None,
+            active_segment_count=None,
+        ),
+        batch_device_data=None,
+        app_maps={
+            "current_map_index": 0,
+            "maps": [
+                {
+                    "idx": 0,
+                    "current": True,
+                    "summary": {"total_area": 827.85},
+                }
+            ],
+        },
+        vector_map_details=None,
+        runtime_status_blob=SimpleNamespace(
+            source="realtime",
+            candidate_runtime_area_progress_percent=13.7,
+            candidate_runtime_progress_percent=None,
+            candidate_runtime_current_area_sqm=72.95,
+            candidate_runtime_total_area_sqm=531.0,
+            candidate_runtime_region_id=1,
+            candidate_runtime_track_segments=(),
+            notes=(),
+        ),
+    )
+
+    assert entity.available is True
+    assert entity.native_value == 13.7
+    assert entity.extra_state_attributes["mowed_area"] == 72.95
+    assert entity.extra_state_attributes["cleaned_area"] == 72.95
+    assert entity.extra_state_attributes["current_zone"] == "Zone 1"
 
 
 def test_runtime_mission_sensors_preserve_last_session_after_docking() -> None:

--- a/tests/test_feature_capabilities.py
+++ b/tests/test_feature_capabilities.py
@@ -71,6 +71,16 @@ def test_field_confirmed_lidax_2000_video_is_available_before_metadata() -> None
     assert capability.source == CAPABILITY_SOURCE_MODEL
 
 
+def test_field_confirmed_lidax_2000_awd_video_is_available_before_metadata() -> None:
+    capability = resolve_feature_capability(
+        FEATURE_LIVE_VIDEO,
+        snapshot=_snapshot("mova.mower.g2584a"),
+    )
+
+    assert capability.state == CAPABILITY_SUPPORTED
+    assert capability.source == CAPABILITY_SOURCE_MODEL
+
+
 def test_unknown_model_without_evidence_remains_unknown() -> None:
     capability = resolve_feature_capability(
         FEATURE_LIVE_VIDEO,

--- a/tests/test_mower_error_semantics.py
+++ b/tests/test_mower_error_semantics.py
@@ -576,7 +576,12 @@ def test_model_overrides_prevent_cross_model_code_guesses() -> None:
         == "robot_lifted"
     )
     assert mower_fault_active(0, model="mova.mower.g2529c") is True
-    for model in ("mova.mower.g2529f", "g2529f"):
+    for model in (
+        "mova.mower.g2529f",
+        "g2529f",
+        "mova.mower.g2584a",
+        "g2584a",
+    ):
         assert mower_device_code_name(0, model=model) == "robot_lifted"
         assert mower_fault_active(0, model=model) is True
         assert mower_device_code_name(55, model=model) == "cannot_start_low_battery"


### PR DESCRIPTION
## Summary

- recognize `mova.mower.g2584a` as the MOVA LiDAX Ultra 2000 AWD and apply the confirmed MOVA error and cloud-video capabilities
- keep the existing current-area, current-zone, and mowing-progress entity IDs while filling sparse legacy values from active runtime telemetry
- reject retained runtime frames from a previous mowing session before exposing fallback values
- count parsed vector-map zones instead of combining zones and contours, while preserving the existing app-map diagnostics contract
- document the field-reported MOVAhome US support boundary

Unknown realtime properties `5.106` and `5.107` remain diagnostic-only until their meaning is supported by state-transition or vendor evidence.

Closes #143