### PR TITLE
Restore reliable A2 3D map generation

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -80,6 +80,8 @@ from .client_core_helpers import (
 )
 from .client_device_settings import _DreameLawnMowerClientDeviceSettingsMixin
 from .client_maps import (
+    _POINT_CLOUD_CLOUD_SETUP_TIMEOUT_SECONDS,
+    _POINT_CLOUD_GENERATION_PREFLIGHT_BUDGET_SECONDS,
     _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS,
     _DreameLawnMowerClientMapsMixin,
 )
@@ -400,6 +402,7 @@ class DreameLawnMowerClient(
         self._cloud_device_info_refreshed_at = 0.0
         self._last_camera_stream_diagnostics: Mapping[str, Any] = {}
         self._app_map_object_cache_lock = _threading.Lock()
+        self._point_cloud_generation_lock = _threading.Lock()
         self._latest_app_map_inventory_identity: str | None = None
         self._latest_app_map_object_inventory_identity: str | None = None
         self._latest_app_map_object_names: tuple[str | None, ...] = ()
@@ -1254,23 +1257,41 @@ class DreameLawnMowerClient(
     ) -> DreameLawnMowerPointCloudDownload:
         """Download a stored or freshly generated mower app-map point cloud."""
         timeout = _validate_positive_number(timeout, "generation timeout")
-        operation_timeout = timeout + (
-            _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS if allow_stored else 0.0
+        preflight_timeout = (
+            _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS
+            if allow_stored
+            else _POINT_CLOUD_GENERATION_PREFLIGHT_BUDGET_SECONDS
+        )
+        operation_timeout = (
+            timeout
+            + _POINT_CLOUD_CLOUD_SETUP_TIMEOUT_SECONDS
+            + preflight_timeout
         )
         deadline = time.monotonic() + operation_timeout
+        abandoned = _threading.Event()
         try:
             async with asyncio.timeout(operation_timeout):
-                return await asyncio.to_thread(
-                    self._sync_download_app_map_point_cloud,
-                    map_index,
-                    timeout,
-                    poll_interval,
-                    download_timeout,
-                    max_bytes,
-                    deadline,
-                    allow_stored,
+                worker = asyncio.create_task(
+                    asyncio.to_thread(
+                        self._sync_download_app_map_point_cloud_singleflight,
+                        map_index,
+                        timeout,
+                        poll_interval,
+                        download_timeout,
+                        max_bytes,
+                        deadline,
+                        allow_stored,
+                        abandoned,
+                    )
                 )
+                worker.add_done_callback(
+                    lambda completed: (
+                        completed.exception() if not completed.cancelled() else None
+                    )
+                )
+                return await asyncio.shield(worker)
         except (TimeoutError, _RequestsTimeout) as err:
+            abandoned.set()
             raise DreameLawnMowerPointCloudError(
                 "Point-cloud generation timed out.",
                 code="point_cloud_timeout",
@@ -1282,6 +1303,62 @@ class DreameLawnMowerClient(
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
             ) from err
+        except asyncio.CancelledError:
+            abandoned.set()
+            raise
+
+    def _sync_download_app_map_point_cloud_singleflight(
+        self,
+        map_index: int,
+        timeout: float,
+        poll_interval: float,
+        download_timeout: float,
+        max_bytes: int,
+        deadline: float,
+        allow_stored: bool,
+        abandoned: _threading.Event,
+    ) -> DreameLawnMowerPointCloudDownload:
+        """Run one mower-wide generation while retaining ownership after cancel."""
+        if abandoned.is_set() or time.monotonic() >= deadline:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud request ended before generation started.",
+                code="point_cloud_timeout",
+                stage="queue",
+                public_message="The mower point-cloud request timed out in the queue.",
+                timeout_seconds=timeout,
+                retry_after_seconds=2,
+            )
+        if not self._point_cloud_generation_lock.acquire(blocking=False):
+            raise DreameLawnMowerPointCloudError(
+                "Another point-cloud generation is already in progress.",
+                code="point_cloud_generation_in_progress",
+                stage="queue",
+                public_message="A 3D map is already being generated for this mower.",
+                retry_after_seconds=5,
+            )
+        try:
+            if abandoned.is_set():
+                raise DreameLawnMowerPointCloudError(
+                    "Point-cloud request ended before generation started.",
+                    code="point_cloud_timeout",
+                    stage="queue",
+                    public_message=(
+                        "The mower point-cloud request timed out in the queue."
+                    ),
+                    timeout_seconds=timeout,
+                    retry_after_seconds=2,
+                )
+            return self._sync_download_app_map_point_cloud(
+                map_index,
+                timeout,
+                poll_interval,
+                download_timeout,
+                max_bytes,
+                deadline,
+                allow_stored,
+            )
+        finally:
+            self._point_cloud_generation_lock.release()
 
     async def async_get_cloud_properties(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -19,6 +19,8 @@ from datetime import datetime as datetime
 from io import BytesIO as BytesIO
 from typing import Any
 
+from requests.exceptions import Timeout as _RequestsTimeout
+
 from . import client_camera as _client_camera
 from . import client_constants as _client_constants
 from . import client_helpers as _client_helpers
@@ -1268,7 +1270,7 @@ class DreameLawnMowerClient(
                     deadline,
                     allow_stored,
                 )
-        except TimeoutError as err:
+        except (TimeoutError, _RequestsTimeout) as err:
             raise DreameLawnMowerPointCloudError(
                 "Point-cloud generation timed out.",
                 code="point_cloud_timeout",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -787,6 +787,7 @@ class _DreameLawnMowerClientMapsMixin:
             )
 
         deadline = time.monotonic() + timeout if deadline is None else deadline
+        request_deadline = deadline
         if time.monotonic() >= deadline:
             raise DreameLawnMowerPointCloudError(
                 "Point-cloud generation timed out.",
@@ -1002,6 +1003,7 @@ class _DreameLawnMowerClientMapsMixin:
                     cloud,
                     announcement_baseline[0],
                     deadline=baseline_probe_deadline,
+                    require_response=True,
                 )
             except (
                 DeviceException,
@@ -1038,6 +1040,12 @@ class _DreameLawnMowerClientMapsMixin:
                             pass
                         else:
                             stable_announcement_baseline_known = True
+
+        if allow_stored:
+            # Stored-object and stable-baseline validation are preflight work.
+            # Give the mower the caller's complete generation window after
+            # those optional reads, matching the other stored fallbacks.
+            deadline = min(request_deadline, time.monotonic() + timeout)
 
         generation_requested_at_ms: int | None = None
 
@@ -1699,18 +1707,21 @@ class _DreameLawnMowerClientMapsMixin:
         object_name: str,
         *,
         deadline: float,
+        require_response: bool = False,
     ) -> str:
         """Resolve a signed point-cloud URL within the generation deadline."""
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise DreameLawnMowerPointCloudError("Point-cloud generation timed out.")
         try:
-            raw_url = cloud.get_interim_file_url(
-                object_name,
-                retry_count=0,
-                timeout=remaining,
-                deadline=deadline,
-            )
+            signer_options: dict[str, Any] = {
+                "retry_count": 0,
+                "timeout": remaining,
+                "deadline": deadline,
+            }
+            if require_response:
+                signer_options["require_response"] = True
+            raw_url = cloud.get_interim_file_url(object_name, **signer_options)
         except RequestsTimeout as err:
             raise DreameLawnMowerPointCloudError(
                 "Point-cloud download URL request timed out.",

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -110,9 +110,14 @@ _POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS = 3
 _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS = 8.0
 _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS = 2.0
 _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
+# A stored request can sequentially try a cached object, the announced object,
+# and the live indexed OBJ result before probing the stable announcement's
+# pre-generation content identity. Reserve every bounded attempt outside the
+# advertised mower-generation window.
 _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS = (
     _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS
-    + (2 * _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS)
+    + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS
+    + (4 * _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS)
 )
 
 
@@ -918,17 +923,13 @@ class _DreameLawnMowerClientMapsMixin:
                 )
                 if stored is not None:
                     return stored
-        if allow_stored:
-            deadline = min(deadline, time.monotonic() + timeout)
         baseline_name = None
         baseline_known = use_announcement_path
         if not use_announcement_path:
-            baseline_deadline = deadline
-            if announcement_probe_pending:
-                baseline_deadline = min(
-                    deadline,
-                    time.monotonic() + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
-                )
+            baseline_deadline = min(
+                deadline,
+                time.monotonic() + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
+            )
             try:
                 baseline_result = self._sync_call_point_cloud_action(
                     {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
@@ -937,14 +938,10 @@ class _DreameLawnMowerClientMapsMixin:
                     require_data=True,
                 )
             except DreameLawnMowerPointCloudError as err:
-                if not (
-                    announcement_probe_pending
-                    and err.code
-                    in {
-                        "point_cloud_timeout",
-                        "point_cloud_mower_request_failed",
-                    }
-                ):
+                if err.code not in {
+                    "point_cloud_timeout",
+                    "point_cloud_mower_request_failed",
+                }:
                     raise
                 baseline_result = None
             else:
@@ -980,12 +977,19 @@ class _DreameLawnMowerClientMapsMixin:
             and baseline_extension.casefold() == "bin"
         )
         if fixed_object_baseline:
+            fixed_baseline_deadline = min(
+                deadline,
+                time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+            )
             try:
                 _, _, baseline_identity = self._sync_download_point_cloud_object(
                     cloud,
                     baseline_name,
-                    deadline=deadline,
-                    download_timeout=download_timeout,
+                    deadline=fixed_baseline_deadline,
+                    download_timeout=min(
+                        download_timeout,
+                        _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+                    ),
                     max_bytes=max_bytes,
                 )
             except (DeviceException, DreameLawnMowerPointCloudError):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -998,29 +998,46 @@ class _DreameLawnMowerClientMapsMixin:
                 time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
             )
             try:
-                _, _, stable_announcement_baseline_identity = (
-                    self._sync_download_point_cloud_object(
-                        cloud,
-                        announcement_baseline[0],
-                        deadline=baseline_probe_deadline,
-                        download_timeout=min(
-                            download_timeout,
-                            _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
-                        ),
-                        max_bytes=max_bytes,
-                    )
+                raw_baseline_url = self._sync_get_point_cloud_download_url(
+                    cloud,
+                    announcement_baseline[0],
+                    deadline=baseline_probe_deadline,
                 )
-            except DeviceException:
+            except (
+                DeviceException,
+                DreameLawnMowerPointCloudError,
+                json.JSONDecodeError,
+            ):
                 pass
-            except DreameLawnMowerPointCloudError as err:
-                # A prompt signer rejection proves that the stable object was
-                # unavailable before o:10. A timeout is inconclusive and must
-                # never be treated as proof of freshness later.
-                stable_announcement_baseline_known = (
-                    err.code != "point_cloud_timeout"
-                )
             else:
-                stable_announcement_baseline_known = True
+                try:
+                    baseline_url = _point_cloud_download_url(raw_baseline_url)
+                except DreameLawnMowerPointCloudError:
+                    # Only the signer's explicit empty result proves the
+                    # stable object was unavailable before o:10. Malformed or
+                    # otherwise unusable signer responses remain inconclusive.
+                    stable_announcement_baseline_known = raw_baseline_url is None
+                else:
+                    remaining = baseline_probe_deadline - time.monotonic()
+                    if remaining > 0:
+                        try:
+                            _, _, stable_announcement_baseline_identity = (
+                                _download_point_cloud_content_with_identity(
+                                    baseline_url,
+                                    timeout=min(
+                                        download_timeout,
+                                        _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+                                        remaining,
+                                    ),
+                                    max_bytes=max_bytes,
+                                )
+                            )
+                        except DreameLawnMowerPointCloudError:
+                            # HTTP, transport, size, and content failures do not
+                            # prove that a signable baseline object was absent.
+                            pass
+                        else:
+                            stable_announcement_baseline_known = True
 
         generation_requested_at_ms: int | None = None
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -885,8 +885,10 @@ class _DreameLawnMowerClientMapsMixin:
                 return stored
         if allow_stored and use_announcement_path:
             # Some A2 firmware retains an expired 99.20 announcement while
-            # OBJ still exposes a signable, indexed PCD. A supported but stale
-            # announcement must not suppress that safe stored-map fallback.
+            # OBJ still identifies the PCD for each map. Besides supporting a
+            # stored-map fallback, this bounded read disambiguates firmware
+            # that refreshes a stable 99.20 key without changing its property
+            # timestamp.
             legacy_deadline = min(
                 deadline,
                 time.monotonic() + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
@@ -988,6 +990,38 @@ class _DreameLawnMowerClientMapsMixin:
             except (DeviceException, DreameLawnMowerPointCloudError):
                 baseline_identity = None
 
+        stable_announcement_baseline_known = False
+        stable_announcement_baseline_identity: _PointCloudObjectIdentity | None = None
+        if use_announcement_path and announcement_baseline is not None:
+            baseline_probe_deadline = min(
+                deadline,
+                time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+            )
+            try:
+                _, _, stable_announcement_baseline_identity = (
+                    self._sync_download_point_cloud_object(
+                        cloud,
+                        announcement_baseline[0],
+                        deadline=baseline_probe_deadline,
+                        download_timeout=min(
+                            download_timeout,
+                            _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+                        ),
+                        max_bytes=max_bytes,
+                    )
+                )
+            except DeviceException:
+                pass
+            except DreameLawnMowerPointCloudError as err:
+                # A prompt signer rejection proves that the stable object was
+                # unavailable before o:10. A timeout is inconclusive and must
+                # never be treated as proof of freshness later.
+                stable_announcement_baseline_known = (
+                    err.code != "point_cloud_timeout"
+                )
+            else:
+                stable_announcement_baseline_known = True
+
         generation_requested_at_ms: int | None = None
 
         def mark_generation_dispatched() -> None:
@@ -1026,6 +1060,9 @@ class _DreameLawnMowerClientMapsMixin:
         object_download_attempts: dict[str, int] = {}
         announcement_download_attempts: dict[tuple[str, int], int] = {}
         announcement_reprobe_attempts = 0
+        indexed_announcement_name = None
+        stable_announcement_verification_attempts = 0
+        stable_announcement_verification_after = 0.0
         while time.monotonic() < deadline:
             announced_name = None
             announced_identity = None
@@ -1077,27 +1114,109 @@ class _DreameLawnMowerClientMapsMixin:
                     # Do not keep constraining a valid but slower legacy OBJ
                     # route when the dedicated property remains inconclusive.
                     announcement_probe_pending = False
-            if announced_name is not None:
-                attempt_key = announced_identity or (announced_name, 0)
+            stable_announced_name = None
+            stable_announcement_observed = (
+                announced_name is None
+                and announced_identity is not None
+                and announcement_baseline is not None
+                and announced_identity == announcement_baseline
+            )
+            if stable_announcement_observed and (
+                indexed_announcement_name != announced_identity[0]
+                and time.monotonic() >= stable_announcement_verification_after
+            ):
+                # Do not add an OBJ round trip to the normal fresh-property
+                # path. Query it only when the firmware actually presents an
+                # unchanged announcement after accepting generation.
+                verification_deadline = min(
+                    deadline,
+                    time.monotonic() + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
+                )
+                try:
+                    indexed_result = self._sync_call_point_cloud_action(
+                        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+                        operation="verify the requested point-cloud object identity",
+                        deadline=verification_deadline,
+                        require_data=True,
+                    )
+                except DreameLawnMowerPointCloudError:
+                    indexed_result = None
+                observed_indexed_name = _point_cloud_object_name(
+                    indexed_result,
+                    map_index,
+                )
+                stable_announcement_verification_attempts += 1
+                if observed_indexed_name == announced_identity[0]:
+                    indexed_announcement_name = observed_indexed_name
+                else:
+                    # OBJ can lag the accepted upload request or fail through
+                    # a transient routed-cloud timeout. Keep verification
+                    # retryable instead of polling only 99.20 until expiry.
+                    stable_announcement_verification_after = (
+                        time.monotonic()
+                        + min(
+                            2.0,
+                            max(poll_interval, 0.25)
+                            * (2 ** min(stable_announcement_verification_attempts, 3)),
+                        )
+                    )
+            if (
+                stable_announcement_observed
+                and indexed_announcement_name == announced_identity[0]
+            ):
+                # Firmware 4.3.6_0625 can keep both the 99.20 object name and
+                # updateDate unchanged after accepting o:10. The signer is
+                # activated for the requested indexed object instead. Only
+                # accept that stable key when a live post-dispatch OBJ read
+                # maps it to the requested map index.
+                stable_announced_name = announced_identity[0]
+            download_name = announced_name or stable_announced_name
+            if download_name is not None:
+                attempt_key = announced_identity or (download_name, 0)
                 attempts = announcement_download_attempts.get(attempt_key, 0)
                 announcement_download_attempts[attempt_key] = attempts + 1
                 try:
-                    content, content_type, _ = self._sync_download_point_cloud_object(
-                        cloud,
-                        announced_name,
-                        deadline=deadline,
-                        download_timeout=download_timeout,
-                        max_bytes=max_bytes,
+                    content, content_type, object_identity = (
+                        self._sync_download_point_cloud_object(
+                            cloud,
+                            download_name,
+                            deadline=deadline,
+                            download_timeout=download_timeout,
+                            max_bytes=max_bytes,
+                        )
                     )
+                    if stable_announced_name is not None:
+                        stable_refresh_proven = (
+                            stable_announcement_baseline_known
+                            and (
+                                stable_announcement_baseline_identity is None
+                                or object_identity.differs_from(
+                                    stable_announcement_baseline_identity
+                                )
+                            )
+                        )
+                        if not stable_refresh_proven:
+                            saw_stale_point_cloud = True
+                            raise DreameLawnMowerPointCloudError(
+                                "The stable point-cloud object has not changed "
+                                "since the generation request.",
+                                code="point_cloud_not_published",
+                            )
                     metadata = parse_pcd_metadata(
                         content,
                         max_bytes=max_bytes,
                         deadline=deadline,
                     )
-                except (DeviceException, DreameLawnMowerPointCloudError):
+                except (DeviceException, DreameLawnMowerPointCloudError) as err:
                     # The mower announces the object before upload progress
                     # reaches 100%, so the signer can briefly return no URL.
-                    saw_unusable_point_cloud = True
+                    if (
+                        isinstance(err, DreameLawnMowerPointCloudError)
+                        and err.code == "point_cloud_not_published"
+                    ):
+                        saw_stale_point_cloud = True
+                    else:
+                        saw_unusable_point_cloud = True
                     retry_delay = min(
                         _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS,
                         max(poll_interval, 0.5) * (2 ** min(attempts, 4)),

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -108,16 +108,24 @@ _POINT_CLOUD_ANNOUNCEMENT_INITIAL_BUDGET_FRACTION = 0.05
 _POINT_CLOUD_ANNOUNCEMENT_REPROBE_TIMEOUT_SECONDS = 0.5
 _POINT_CLOUD_ANNOUNCEMENT_REPROBE_ATTEMPTS = 3
 _POINT_CLOUD_ANNOUNCEMENT_RETRY_MAX_SECONDS = 8.0
+_POINT_CLOUD_CLOUD_SETUP_TIMEOUT_SECONDS = 20.0
 _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS = 2.0
+_POINT_CLOUD_LEGACY_BASELINE_TIMEOUT_SECONDS = 20.0
 _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS = 5.0
-# A stored request can sequentially try a cached object, the announced object,
-# and the live indexed OBJ result before probing the stable announcement's
-# pre-generation content identity. Reserve every bounded attempt outside the
-# advertised mower-generation window.
+# Forced generation can read a dedicated announcement or a legacy OBJ baseline,
+# then download a fixed-key baseline identity before dispatching o:10.
+_POINT_CLOUD_GENERATION_PREFLIGHT_BUDGET_SECONDS = (
+    _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS
+    + _POINT_CLOUD_LEGACY_BASELINE_TIMEOUT_SECONDS
+    + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS
+)
+# A stored request can additionally try a cached object and a stored legacy
+# baseline before downloading that baseline again for fixed-key identity.
+# This legacy path is longer than the dedicated-announcement path.
 _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS = (
     _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS
-    + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS
-    + (4 * _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS)
+    + _POINT_CLOUD_LEGACY_BASELINE_TIMEOUT_SECONDS
+    + (3 * _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS)
 )
 
 
@@ -806,7 +814,12 @@ class _DreameLawnMowerClientMapsMixin:
                 retry_after_seconds=10,
             )
         try:
-            cloud = self._sync_get_cloud_protocol(deadline=deadline)
+            cloud = self._sync_get_cloud_protocol(
+                deadline=min(
+                    deadline,
+                    time.monotonic() + _POINT_CLOUD_CLOUD_SETUP_TIMEOUT_SECONDS,
+                )
+            )
         except RequestsTimeout as err:
             raise DreameLawnMowerPointCloudError(
                 "Point-cloud cloud setup timed out.",
@@ -926,9 +939,14 @@ class _DreameLawnMowerClientMapsMixin:
         baseline_name = None
         baseline_known = use_announcement_path
         if not use_announcement_path:
+            baseline_timeout = (
+                _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS
+                if announcement_probe_pending
+                else _POINT_CLOUD_LEGACY_BASELINE_TIMEOUT_SECONDS
+            )
             baseline_deadline = min(
                 deadline,
-                time.monotonic() + _POINT_CLOUD_LEGACY_POLL_TIMEOUT_SECONDS,
+                time.monotonic() + baseline_timeout,
             )
             try:
                 baseline_result = self._sync_call_point_cloud_action(
@@ -1045,11 +1063,10 @@ class _DreameLawnMowerClientMapsMixin:
                         else:
                             stable_announcement_baseline_known = True
 
-        if allow_stored:
-            # Stored-object and stable-baseline validation are preflight work.
-            # Give the mower the caller's complete generation window after
-            # those optional reads, matching the other stored fallbacks.
-            deadline = min(request_deadline, time.monotonic() + timeout)
+        # Object baselines are preflight work for both forced and stored
+        # requests. Give o:10 the complete advertised generation window after
+        # those bounded reads finish.
+        deadline = min(request_deadline, time.monotonic() + timeout)
 
         generation_requested_at_ms: int | None = None
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -9,6 +9,8 @@ from collections.abc import Callable, Mapping, Sequence
 from dataclasses import replace
 from typing import TYPE_CHECKING, Any
 
+from requests.exceptions import Timeout as RequestsTimeout
+
 from .app_protocol import (
     MOWER_ERROR_PROPERTY_KEY,
     MOWER_PROPERTY_HINTS,
@@ -797,7 +799,20 @@ class _DreameLawnMowerClientMapsMixin:
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
             )
-        cloud = self._sync_get_cloud_protocol(deadline=deadline)
+        try:
+            cloud = self._sync_get_cloud_protocol(deadline=deadline)
+        except RequestsTimeout as err:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud cloud setup timed out.",
+                code="point_cloud_timeout",
+                stage="cloud",
+                public_message=(
+                    "The mower cloud connection timed out while preparing the "
+                    "3D map request."
+                ),
+                timeout_seconds=timeout,
+                retry_after_seconds=10,
+            ) from err
         if not hasattr(cloud, "get_interim_file_url"):
             raise DreameLawnMowerPointCloudError(
                 "The configured cloud protocol cannot download interim files.",
@@ -1359,7 +1374,7 @@ class _DreameLawnMowerClientMapsMixin:
                 timeout=probe_timeout,
                 deadline=probe_deadline,
             )
-        except (DeviceException, json.JSONDecodeError):
+        except (DeviceException, RequestsTimeout, json.JSONDecodeError):
             return None, None, None
         if payload is None:
             return None, None, None
@@ -1489,6 +1504,14 @@ class _DreameLawnMowerClientMapsMixin:
                 retry_after_seconds=10,
                 vendor_error_code=err.code,
             ) from err
+        except RequestsTimeout as err:
+            raise DreameLawnMowerPointCloudError(
+                f"The mower timed out while trying to {operation}.",
+                code="point_cloud_timeout",
+                stage="mower_request",
+                public_message="The mower did not finish the 3D map request in time.",
+                retry_after_seconds=10,
+            ) from err
         except DreameLawnMowerConnectionError as err:
             if time.monotonic() >= deadline:
                 raise DreameLawnMowerPointCloudError(
@@ -1545,12 +1568,24 @@ class _DreameLawnMowerClientMapsMixin:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
             raise DreameLawnMowerPointCloudError("Point-cloud generation timed out.")
-        raw_url = cloud.get_interim_file_url(
-            object_name,
-            retry_count=0,
-            timeout=remaining,
-            deadline=deadline,
-        )
+        try:
+            raw_url = cloud.get_interim_file_url(
+                object_name,
+                retry_count=0,
+                timeout=remaining,
+                deadline=deadline,
+            )
+        except RequestsTimeout as err:
+            raise DreameLawnMowerPointCloudError(
+                "Point-cloud download URL request timed out.",
+                code="point_cloud_timeout",
+                stage="download",
+                public_message=(
+                    "The mower cloud timed out while preparing the generated "
+                    "3D map download."
+                ),
+                retry_after_seconds=10,
+            ) from err
         if time.monotonic() >= deadline:
             raise DreameLawnMowerPointCloudError("Point-cloud generation timed out.")
         return raw_url

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -1137,13 +1137,20 @@ class DreameMowerDreameHomeCloudProtocol:
                     "The interim-file signer did not return a response."
                 )
             response_code = api_response.get("code")
-            if response_code == _INTERIM_FILE_NOT_AVAILABLE_CODE:
-                return None
             if (
                 isinstance(response_code, int)
                 and not isinstance(response_code, bool)
-                and response_code != 0
+                and response_code == _INTERIM_FILE_NOT_AVAILABLE_CODE
             ):
+                return None
+            if not isinstance(response_code, int) or isinstance(
+                response_code,
+                bool,
+            ):
+                raise DeviceException(
+                    "The interim-file signer response had an invalid code."
+                )
+            if response_code != 0:
                 raise DreameLawnMowerCloudAPIError(response_code)
             if "data" not in api_response:
                 raise DeviceException(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -560,12 +560,16 @@ class DreameMowerDreameHomeCloudProtocol:
                     pass
                 _LOGGER.error("Login failed: %s => %s -- %s -- %s", response_text,
                               self.get_api_url() + self._strings[17], headers, data)
-        except requests.exceptions.Timeout:
+        except requests.exceptions.Timeout as err:
             response = None
             _LOGGER.warning(
                 "Login Failed: Read timed out. (read timeout=%s)",
                 timeout,
             )
+            if deadline is not None:
+                raise requests.exceptions.Timeout(
+                    "The cloud login timed out."
+                ) from err
         except Exception as ex:
             response = None
             _LOGGER.error("Login failed: %s", str(ex))
@@ -1251,6 +1255,7 @@ class DreameMowerDreameHomeCloudProtocol:
         )
 
         retries = 0
+        last_timeout: requests.exceptions.Timeout | None = None
         if not retry_count or retry_count < 0:
             retry_count = 0
         response_text = None
@@ -1321,10 +1326,12 @@ class DreameMowerDreameHomeCloudProtocol:
                         response.close()
                 else:
                     response_text = response.text
+                last_timeout = None
                 break
-            except requests.exceptions.Timeout:
+            except requests.exceptions.Timeout as err:
                 retries = retries + 1
                 response = None
+                last_timeout = err
                 if self._connected:
                     _LOGGER.debug(
                         "DreameMowerDreameHomeCloudProtocol.request: Read timed out. (read timeout=%s): %s",
@@ -1339,6 +1346,7 @@ class DreameMowerDreameHomeCloudProtocol:
             except Exception as ex:
                 retries = retries + 1
                 response = None
+                last_timeout = None
                 if self._connected:
                     _LOGGER.warning(
                         "Error while executing request: %s", str(ex))
@@ -1388,6 +1396,10 @@ class DreameMowerDreameHomeCloudProtocol:
             self._connected = False
         else:
             self._fail_count = self._fail_count + 1
+        if deadline is not None and last_timeout is not None:
+            raise requests.exceptions.Timeout(
+                "The cloud operation timed out."
+            ) from last_timeout
         return None
 
     @staticmethod

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -27,6 +27,7 @@ from .deadline import DeadlineExceededError, run_with_deadline
 from .mqtt_tls import create_cloud_mqtt_ssl_context
 
 _LOGGER = logging.getLogger(__name__)
+_INTERIM_FILE_NOT_AVAILABLE_CODE = 10007
 _TX_VIDEO_API_PATH = "/dreame-third-video/tx/"
 _REDACTED_TX_VIDEO_PAYLOAD = "<redacted TX video payload>"
 _INTERIM_FILE_API_PATH = "/dreame-user-iot/iotfile/getDownloadUrl"
@@ -1116,6 +1117,7 @@ class DreameMowerDreameHomeCloudProtocol:
         timeout: float = 20,
         *,
         deadline: float | None = None,
+        require_response: bool = False,
     ) -> str:
         api_response = self._api_call(
             f"{self._strings[23]}/{self._strings[39]}/{self._strings[55]}",
@@ -1129,6 +1131,24 @@ class DreameMowerDreameHomeCloudProtocol:
             timeout=timeout,
             deadline=deadline,
         )
+        if require_response:
+            if not isinstance(api_response, Mapping):
+                raise DeviceException(
+                    "The interim-file signer did not return a response."
+                )
+            response_code = api_response.get("code")
+            if response_code == _INTERIM_FILE_NOT_AVAILABLE_CODE:
+                return None
+            if (
+                isinstance(response_code, int)
+                and not isinstance(response_code, bool)
+                and response_code != 0
+            ):
+                raise DreameLawnMowerCloudAPIError(response_code)
+            if "data" not in api_response:
+                raise DeviceException(
+                    "The interim-file signer response did not contain data."
+                )
         if api_response is None or "data" not in api_response:
             return None
 

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 import time
 from collections import OrderedDict
 from collections.abc import Mapping, Sequence
@@ -100,6 +101,15 @@ class _CacheEntry:
 
 
 @dataclass(frozen=True, slots=True)
+class _FailureEntry:
+    """Remember one retryable failure for its advertised backoff window."""
+
+    created_at: float
+    epoch: int
+    error: DreameLawnMowerPointCloudError
+
+
+@dataclass(frozen=True, slots=True)
 class _InflightGeneration:
     """Track one generation and the config-entry lifetime that started it."""
 
@@ -125,6 +135,7 @@ class DreameLawnMowerPointCloudAPI:
         self._cache_expiry_handles: dict[
             tuple[str, int], asyncio.TimerHandle
         ] = {}
+        self._failures: OrderedDict[tuple[str, int], _FailureEntry] = OrderedDict()
         self._inflight: dict[tuple[str, int], _InflightGeneration] = {}
         self._entry_epochs: dict[str, int] = {}
 
@@ -144,6 +155,10 @@ class DreameLawnMowerPointCloudAPI:
             return cached.download
 
         epoch = self._entry_epochs.get(entry_id, 0)
+        failed = self._fresh_failure_error(key, requested_at, epoch=epoch)
+        if failed is not None:
+            raise failed
+
         inflight = self._inflight.get(key)
         if inflight is not None:
             if inflight.epoch == epoch:
@@ -264,6 +279,8 @@ class DreameLawnMowerPointCloudAPI:
         """Discard private cache state for one unloaded entry."""
         for key in [key for key in self._cache if key[0] == entry_id]:
             self._remove_cache_entry(key)
+        for key in [key for key in self._failures if key[0] == entry_id]:
+            self._failures.pop(key, None)
         self._entry_epochs[entry_id] = self._entry_epochs.get(entry_id, 0) + 1
 
     async def _async_generate(
@@ -329,6 +346,7 @@ class DreameLawnMowerPointCloudAPI:
                 map_index=key[1],
                 allow_stored=allow_stored,
             )
+            self._remember_failure(key, epoch, err)
             raise
         except Exception as err:
             public_error = DreameLawnMowerPointCloudError(
@@ -351,6 +369,7 @@ class DreameLawnMowerPointCloudAPI:
                 allow_stored=allow_stored,
                 unexpected_error=err,
             )
+            self._remember_failure(key, epoch, public_error)
             raise public_error from err
         else:
             if cycle is not None:
@@ -369,6 +388,7 @@ class DreameLawnMowerPointCloudAPI:
             )
 
         created_at = time.monotonic()
+        self._failures.pop(key, None)
         self._remove_cache_entry(key)
         self._cache[key] = _CacheEntry(
             created_at=created_at,
@@ -521,6 +541,52 @@ class DreameLawnMowerPointCloudAPI:
         self._cache.move_to_end(key)
         return cached
 
+    def _fresh_failure_error(
+        self,
+        key: tuple[str, int],
+        now: float,
+        *,
+        epoch: int,
+    ) -> DreameLawnMowerPointCloudError | None:
+        """Return a failure with the remaining safe backoff when still active."""
+        failed = self._failures.get(key)
+        if failed is None:
+            return None
+        retry_after = failed.error.retry_after_seconds or 0
+        elapsed = now - failed.created_at
+        if failed.epoch != epoch or elapsed >= retry_after:
+            self._failures.pop(key, None)
+            return None
+        self._failures.move_to_end(key)
+        return _copy_point_cloud_error(
+            failed.error,
+            retry_after_seconds=max(1, math.ceil(retry_after - elapsed)),
+        )
+
+    @callback
+    def _remember_failure(
+        self,
+        key: tuple[str, int],
+        epoch: int,
+        error: DreameLawnMowerPointCloudError,
+    ) -> None:
+        """Throttle retries without retaining private exception details."""
+        retry_after = error.retry_after_seconds or 0
+        if (
+            not error.retryable
+            or retry_after <= 0
+            or self._entry_epochs.get(key[0], 0) != epoch
+        ):
+            return
+        self._failures[key] = _FailureEntry(
+            created_at=time.monotonic(),
+            epoch=epoch,
+            error=_copy_point_cloud_error(error),
+        )
+        self._failures.move_to_end(key)
+        while len(self._failures) > self._cache_max_entries:
+            self._failures.popitem(last=False)
+
     @callback
     def _expire_cache_entry(
         self,
@@ -539,6 +605,28 @@ class DreameLawnMowerPointCloudAPI:
         handle = self._cache_expiry_handles.pop(key, None)
         if handle is not None:
             handle.cancel()
+
+
+def _copy_point_cloud_error(
+    error: DreameLawnMowerPointCloudError,
+    *,
+    retry_after_seconds: int | None = None,
+) -> DreameLawnMowerPointCloudError:
+    """Copy public failure metadata without retaining private exception text."""
+    return DreameLawnMowerPointCloudError(
+        "A recent point-cloud generation attempt failed.",
+        code=error.code,
+        stage=error.stage,
+        retryable=error.retryable,
+        public_message=error.public_message,
+        timeout_seconds=error.timeout_seconds,
+        retry_after_seconds=(
+            error.retry_after_seconds
+            if retry_after_seconds is None
+            else retry_after_seconds
+        ),
+        vendor_error_code=error.vendor_error_code,
+    )
 
 
 def _stored_point_cloud_active_map_index(

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -135,7 +135,7 @@ class DreameLawnMowerPointCloudAPI:
         self._cache_expiry_handles: dict[
             tuple[str, int], asyncio.TimerHandle
         ] = {}
-        self._failures: OrderedDict[tuple[str, int], _FailureEntry] = OrderedDict()
+        self._failures: OrderedDict[str, _FailureEntry] = OrderedDict()
         self._inflight: dict[tuple[str, int], _InflightGeneration] = {}
         self._entry_epochs: dict[str, int] = {}
 
@@ -279,8 +279,7 @@ class DreameLawnMowerPointCloudAPI:
         """Discard private cache state for one unloaded entry."""
         for key in [key for key in self._cache if key[0] == entry_id]:
             self._remove_cache_entry(key)
-        for key in [key for key in self._failures if key[0] == entry_id]:
-            self._failures.pop(key, None)
+        self._failures.pop(entry_id, None)
         self._entry_epochs[entry_id] = self._entry_epochs.get(entry_id, 0) + 1
 
     async def _async_generate(
@@ -388,7 +387,7 @@ class DreameLawnMowerPointCloudAPI:
             )
 
         created_at = time.monotonic()
-        self._failures.pop(key, None)
+        self._failures.pop(key[0], None)
         self._remove_cache_entry(key)
         self._cache[key] = _CacheEntry(
             created_at=created_at,
@@ -549,15 +548,16 @@ class DreameLawnMowerPointCloudAPI:
         epoch: int,
     ) -> DreameLawnMowerPointCloudError | None:
         """Return a failure with the remaining safe backoff when still active."""
-        failed = self._failures.get(key)
+        entry_id = key[0]
+        failed = self._failures.get(entry_id)
         if failed is None:
             return None
         retry_after = failed.error.retry_after_seconds or 0
         elapsed = now - failed.created_at
         if failed.epoch != epoch or elapsed >= retry_after:
-            self._failures.pop(key, None)
+            self._failures.pop(entry_id, None)
             return None
-        self._failures.move_to_end(key)
+        self._failures.move_to_end(entry_id)
         return _copy_point_cloud_error(
             failed.error,
             retry_after_seconds=max(1, math.ceil(retry_after - elapsed)),
@@ -578,12 +578,13 @@ class DreameLawnMowerPointCloudAPI:
             or self._entry_epochs.get(key[0], 0) != epoch
         ):
             return
-        self._failures[key] = _FailureEntry(
+        entry_id = key[0]
+        self._failures[entry_id] = _FailureEntry(
             created_at=time.monotonic(),
             epoch=epoch,
             error=_copy_point_cloud_error(error),
         )
-        self._failures.move_to_end(key)
+        self._failures.move_to_end(entry_id)
         while len(self._failures) > self._cache_max_entries:
             self._failures.popitem(last=False)
 

--- a/docs/agent-handoff.md
+++ b/docs/agent-handoff.md
@@ -157,6 +157,13 @@ Last updated: 2026-04-21
   mowing. Capturing fresh property `99.20` instead of waiting on `OBJ` returned
   the same validated 2,437,272-byte PCD through the public API in 12.5 seconds,
   without pausing or docking the mower.
+- A 2026-08-12 A2 run on firmware `4.3.6_0625` exposed a second announcement
+  contract: `o:10` returned `r:0` and made the existing `99.20` object signable
+  in 0.36 seconds without changing its name, `updateDate`, or `2.54` progress.
+  The client now accepts that stable primary object only when a live indexed
+  `OBJ` read maps the same name to the requested map and pre/post object
+  evidence proves a refresh. A live run with stored fallback disabled returned
+  `source=generated` and validated 152,318 points in 1.5 seconds.
 - `examples/point_cloud_probe.py` prints coordinate-free PCD metadata and writes
   geometry only when `--out` is explicitly supplied. The older
   `app_map_probe.py --probe-object-downloads` path remains useful only for

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -382,6 +382,15 @@ The successful map path is the app action bridge described above. On
   updated. Capturing the fresh announcement directly returned the same
   2,437,272-byte PCD through the public API in 12.5 seconds without changing
   the mower's activity.
+- On 2026-08-12, firmware `4.3.6_0625` accepted `o:10` with `r:0` but kept the
+  existing `99.20` object name, its `updateDate`, and `2.54=100` unchanged. The
+  request instead made that stable object signable within 0.36 seconds. Its
+  name matched indexed `OBJ` map `0` and not map `1`. The client therefore
+  accepts an unchanged announcement only after bounded indexed-object evidence
+  proves that it belongs to the requested map and pre/post object evidence
+  proves that the generation refreshed it. With stored fallback disabled, the
+  hardened primary path downloaded and validated the 152,318-point PCD in 1.5
+  seconds.
 - `async_download_app_map_point_cloud()` now owns the generation, transient
   object capture, bounded HTTPS download, and PCD validation. It returns bytes
   plus coordinate-free metadata and deliberately omits the vendor filename and

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -139,8 +139,12 @@ announced through cloud property `99.20`. Callers should enable this only when
 the requested index is the mower's sole known map, because the announcement
 does not identify its map. If that object is absent, expired, or invalid, the
 client triggers app action `o:10`, captures the fresh LiDAR object, and resolves
-its short-lived download immediately. Firmware without that announcement
-continues through the transient `OBJ` 3D-map fallback. Every path enforces
+its short-lived download immediately. Some A2 firmware refreshes a stable
+announcement name without changing its property timestamp; the client accepts
+that object only after a live post-request indexed-object read proves it belongs
+to the requested map and pre/post object evidence proves it was refreshed.
+Firmware without the announcement continues through the transient `OBJ` 3D-map
+fallback. Every path enforces
 HTTPS, time, and size limits and validates PCD 0.7 before returning. The result
 deliberately does not expose the vendor filename or cloud-signed URL.
 

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -3251,6 +3251,50 @@ def test_failed_cached_point_cloud_preserves_full_generation_window(
     assert captured_deadlines == [112.0]
 
 
+def test_stable_announcement_preflight_preserves_full_generation_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    generation_deadlines: list[float] = []
+    cloud = SimpleNamespace(get_interim_file_url=lambda name, **options: None)
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    client._sync_try_download_stored_point_cloud = lambda *args, **kwargs: None
+
+    def probe(*args: Any, **kwargs: Any) -> tuple[bool, str, tuple[str, int]]:
+        clock[0] = 106.0
+        return True, "private/stable-map.bin", ("private/stable-map.bin", 1)
+
+    def call_action(payload: dict[str, Any], **kwargs: Any) -> Any:
+        if payload.get("m") == "g":
+            return None
+        generation_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after generation deadline capture")
+
+    def signer(*args: Any, **kwargs: Any) -> None:
+        assert kwargs["require_response"] is True
+        clock[0] = 110.0
+        return None
+
+    client._sync_get_announced_point_cloud_object = probe
+    client._sync_call_point_cloud_action = call_action
+    client._sync_get_point_cloud_download_url = signer
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+
+    with pytest.raises(RuntimeError, match="generation deadline capture"):
+        client._sync_download_app_map_point_cloud(
+            0,
+            5,
+            0.1,
+            10,
+            1024,
+            deadline=117.0,
+            allow_stored=True,
+        )
+
+    assert generation_deadlines == [115.0]
+
+
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3326,6 +3370,92 @@ def test_interim_file_protocol_forwards_absolute_deadline() -> None:
             "deadline": 101.0,
         }
     ]
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        None,
+        {},
+        {"code": 50001},
+    ],
+)
+def test_interim_file_protocol_strict_response_rejects_cloud_failures(
+    response: Any,
+) -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [""] * 56
+    strings[21] = "country"
+    strings[23] = "iot"
+    strings[35] = "model"
+    strings[39] = "file"
+    strings[40] = "filename"
+    strings[55] = "download"
+    cloud._strings = strings
+    cloud._did = "device-1"
+    cloud._model = "dreame.mower.g2408"
+    cloud._country = "eu"
+    cloud._api_call = lambda *args, **kwargs: response
+
+    with pytest.raises(_internal_exceptions_module.DeviceException):
+        cloud.get_interim_file_url(
+            "private/generated-map.pcd",
+            retry_count=0,
+            timeout=0.8,
+            deadline=101.0,
+            require_response=True,
+        )
+
+
+def test_interim_file_protocol_strict_response_preserves_explicit_absence() -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [""] * 56
+    strings[21] = "country"
+    strings[23] = "iot"
+    strings[35] = "model"
+    strings[39] = "file"
+    strings[40] = "filename"
+    strings[55] = "download"
+    cloud._strings = strings
+    cloud._did = "device-1"
+    cloud._model = "dreame.mower.g2408"
+    cloud._country = "eu"
+    cloud._api_call = lambda *args, **kwargs: {"code": 0, "data": None}
+
+    assert (
+        cloud.get_interim_file_url(
+            "private/generated-map.pcd",
+            require_response=True,
+        )
+        is None
+    )
+
+
+def test_interim_file_protocol_strict_response_classifies_unavailable_object() -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [""] * 56
+    strings[21] = "country"
+    strings[23] = "iot"
+    strings[35] = "model"
+    strings[39] = "file"
+    strings[40] = "filename"
+    strings[55] = "download"
+    cloud._strings = strings
+    cloud._did = "device-1"
+    cloud._model = "dreame.mower.g2408"
+    cloud._country = "eu"
+    cloud._api_call = lambda *args, **kwargs: {"code": 10007, "data": None}
+
+    assert (
+        cloud.get_interim_file_url(
+            "private/generated-map.pcd",
+            require_response=True,
+        )
+        is None
+    )
 
 
 def test_cloud_property_lookup_forwards_absolute_deadline() -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -94,6 +94,23 @@ def _client() -> DreameLawnMowerClient:
     )
 
 
+def _point_cloud_protocol() -> Any:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = protocol_type(
+        "user@example.invalid",
+        "secret",
+        country="eu",
+        did="device-1",
+    )
+    cloud._strings = [f"value-{index}" for index in range(57)]
+    cloud._host = "host.example.invalid"
+    cloud._model = "dreame.mower.g2408"
+    cloud._ti = "ti"
+    cloud._key = "key"
+    cloud._connected = True
+    return cloud
+
+
 def _mova_client() -> DreameLawnMowerClient:
     return DreameLawnMowerClient(
         username="user@example.invalid",
@@ -985,6 +1002,76 @@ def test_download_point_cloud_recovers_from_transient_announcement_probe(
     ]
     assert result.content == content
     assert result.metadata.points == 1
+
+
+def test_download_point_cloud_falls_back_when_announcement_probe_times_out(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/previous-map.pcd"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/generated-map.pcd"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        del kwargs
+        actions.append(payload)
+        return next(responses)
+
+    property_calls = 0
+
+    def get_properties(key: str, **options: Any) -> None:
+        nonlocal property_calls
+        del key, options
+        property_calls += 1
+        raise requests.exceptions.Timeout("private cloud timeout detail")
+
+    cloud = SimpleNamespace(
+        get_properties=get_properties,
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert property_calls >= 1
+    assert actions == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.content == content
+
+
+def test_download_point_cloud_normalizes_cloud_setup_timeout() -> None:
+    client = _client()
+    client._sync_get_cloud_protocol = lambda **kwargs: (_ for _ in ()).throw(
+        requests.exceptions.Timeout("private login timeout detail")
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert captured.value.code == "point_cloud_timeout"
+    assert captured.value.stage == "cloud"
+    assert captured.value.retry_after_seconds == 10
+    assert "private login timeout detail" not in captured.value.public_message
 
 
 def test_download_point_cloud_rejoins_after_generation_reply_is_lost(
@@ -2087,6 +2174,126 @@ def test_point_cloud_app_action_uses_and_enforces_remaining_deadline(
         ]
 
 
+def test_point_cloud_app_action_normalizes_requests_timeout() -> None:
+    client = _client()
+
+    def call_app_action(*args: Any, **kwargs: Any) -> None:
+        del args, kwargs
+        raise requests.exceptions.Timeout("private cloud timeout detail")
+
+    client._sync_call_app_action = call_app_action
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_call_point_cloud_action(
+            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+            operation="read the generated point-cloud object state",
+            deadline=time.monotonic() + 5,
+            require_data=True,
+        )
+
+    assert captured.value.code == "point_cloud_timeout"
+    assert captured.value.stage == "mower_request"
+    assert captured.value.retry_after_seconds == 10
+    assert "private cloud timeout detail" not in captured.value.public_message
+
+
+def test_point_cloud_action_normalizes_real_protocol_transport_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    cloud = _point_cloud_protocol()
+    client._sync_call_app_action = cloud.call_app_action
+    monkeypatch.setattr(
+        _internal_protocol_module,
+        "_post_cloud_response",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            requests.exceptions.Timeout("private transport timeout detail")
+        ),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_call_point_cloud_action(
+            {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+            operation="read the generated point-cloud object state",
+            deadline=time.monotonic() + 5,
+            require_data=True,
+        )
+
+    assert captured.value.code == "point_cloud_timeout"
+    assert captured.value.stage == "mower_request"
+    assert "private transport timeout detail" not in captured.value.public_message
+
+
+def test_point_cloud_signer_normalizes_requests_timeout() -> None:
+    client = _client()
+    cloud = SimpleNamespace(
+        get_interim_file_url=lambda *args, **kwargs: (_ for _ in ()).throw(
+            requests.exceptions.Timeout("private signer timeout detail")
+        )
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_get_point_cloud_download_url(
+            cloud,
+            "private/map.pcd",
+            deadline=time.monotonic() + 5,
+        )
+
+    assert captured.value.code == "point_cloud_timeout"
+    assert captured.value.stage == "download"
+    assert captured.value.retry_after_seconds == 10
+    assert "private signer timeout detail" not in captured.value.public_message
+
+
+def test_point_cloud_signer_normalizes_real_protocol_transport_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    cloud = _point_cloud_protocol()
+    monkeypatch.setattr(
+        _internal_protocol_module,
+        "_post_cloud_response",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            requests.exceptions.Timeout("private signer timeout detail")
+        ),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_get_point_cloud_download_url(
+            cloud,
+            "private/map.pcd",
+            deadline=time.monotonic() + 5,
+        )
+
+    assert captured.value.code == "point_cloud_timeout"
+    assert captured.value.stage == "download"
+    assert "private signer timeout detail" not in captured.value.public_message
+
+
+def test_deadline_aware_real_protocol_login_preserves_transport_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    cloud = _point_cloud_protocol()
+    cloud._secondary_key = "refresh-token"
+    monkeypatch.setattr(
+        _internal_protocol_module.requests,
+        "session",
+        lambda: SimpleNamespace(close=lambda: None),
+    )
+    monkeypatch.setattr(
+        _internal_protocol_module,
+        "_post_cloud_response",
+        lambda *args, **kwargs: (_ for _ in ()).throw(
+            requests.exceptions.Timeout("private login timeout detail")
+        ),
+    )
+
+    with pytest.raises(requests.exceptions.Timeout) as captured:
+        cloud.login(timeout=5, deadline=time.monotonic() + 5)
+
+    assert str(captured.value) == "The cloud login timed out."
+
+
 def test_point_cloud_action_response_enforces_overall_deadline(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -2657,6 +2864,32 @@ def test_point_cloud_generation_deadline_includes_executor_queue_time(
         assert captured.value.timeout_seconds == 0.01
         assert captured.value.retryable is True
         assert queued.is_set()
+
+    asyncio.run(run())
+
+
+def test_async_point_cloud_normalizes_requests_timeout(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+
+    async def timeout_in_executor(function: Any, *args: Any) -> Any:
+        del function, args
+        raise requests.exceptions.Timeout("private executor timeout detail")
+
+    monkeypatch.setattr(
+        _internal_client_facade_module.asyncio,
+        "to_thread",
+        timeout_in_executor,
+    )
+
+    async def run() -> None:
+        with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+            await client.async_download_app_map_point_cloud(timeout=5)
+        assert captured.value.code == "point_cloud_timeout"
+        assert captured.value.stage == "generation"
+        assert captured.value.retry_after_seconds == 10
+        assert "private executor timeout detail" not in captured.value.public_message
 
     asyncio.run(run())
 

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -3075,6 +3075,16 @@ def test_point_cloud_generation_deadline_includes_executor_queue_time(
 ) -> None:
     client = _client()
     queued = asyncio.Event()
+    monkeypatch.setattr(
+        _internal_client_facade_module,
+        "_POINT_CLOUD_GENERATION_PREFLIGHT_BUDGET_SECONDS",
+        0.0,
+    )
+    monkeypatch.setattr(
+        _internal_client_facade_module,
+        "_POINT_CLOUD_CLOUD_SETUP_TIMEOUT_SECONDS",
+        0.0,
+    )
 
     async def wait_in_executor_queue(
         function: Any,
@@ -3130,8 +3140,59 @@ def test_async_point_cloud_normalizes_requests_timeout(
     asyncio.run(run())
 
 
-def test_stored_point_cloud_preflight_has_a_separate_time_budget(
+def test_public_point_cloud_generation_remains_singleflight_after_cancel() -> None:
+    client = _client()
+    started = threading.Event()
+    release = threading.Event()
+    calls: list[int] = []
+
+    def download(
+        map_index: int,
+        *args: Any,
+        **kwargs: Any,
+    ) -> SimpleNamespace:
+        del args, kwargs
+        calls.append(map_index)
+        if len(calls) == 1:
+            started.set()
+            assert release.wait(2)
+        return SimpleNamespace(content=b"pcd")
+
+    client._sync_download_app_map_point_cloud = download
+
+    async def run() -> None:
+        first = asyncio.create_task(
+            client.async_download_app_map_point_cloud(map_index=0)
+        )
+        assert await asyncio.to_thread(started.wait, 1)
+        first.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await first
+
+        with pytest.raises(DreameLawnMowerPointCloudError) as concurrent:
+            await client.async_download_app_map_point_cloud(map_index=1)
+        assert concurrent.value.code == "point_cloud_generation_in_progress"
+        assert concurrent.value.stage == "queue"
+
+        release.set()
+        while client._point_cloud_generation_lock.locked():
+            await asyncio.sleep(0)
+        result = await client.async_download_app_map_point_cloud(map_index=1)
+        assert result.content == b"pcd"
+
+    asyncio.run(run())
+
+    assert calls == [0, 1]
+
+
+@pytest.mark.parametrize(
+    ("allow_stored", "expected_operation_timeout"),
+    [(False, 52.0), (True, 62.0)],
+)
+def test_point_cloud_preflight_has_a_separate_time_budget(
     monkeypatch: pytest.MonkeyPatch,
+    allow_stored: bool,
+    expected_operation_timeout: float,
 ) -> None:
     client = _client()
     captured: dict[str, Any] = {}
@@ -3150,19 +3211,23 @@ def test_stored_point_cloud_preflight_has_a_separate_time_budget(
     async def run() -> None:
         result = await client.async_download_app_map_point_cloud(
             timeout=5,
-            allow_stored=True,
+            allow_stored=allow_stored,
         )
         assert result.content
 
     started = time.monotonic()
     asyncio.run(run())
 
-    assert captured["function"] == client._sync_download_app_map_point_cloud
-    assert captured["args"][-1] is True
-    # 5 seconds of mower generation plus all sequential stored preflights:
-    # announcement and OBJ probes, three stored downloads, and the stable
-    # announcement's content-identity download.
-    assert captured["args"][-2] - started == pytest.approx(29, abs=0.25)
+    assert (
+        captured["function"]
+        == client._sync_download_app_map_point_cloud_singleflight
+    )
+    assert captured["args"][-2] is allow_stored
+    assert captured["args"][-3] - started == pytest.approx(
+        expected_operation_timeout,
+        abs=0.25,
+    )
+    assert isinstance(captured["args"][-1], threading.Event)
 
 
 def test_stored_point_cloud_fallback_receives_full_generation_window(
@@ -3180,7 +3245,7 @@ def test_stored_point_cloud_fallback_receives_full_generation_window(
 
     def capture_generation(payload: dict[str, Any], **kwargs: Any) -> Any:
         if payload.get("m") == "g":
-            assert kwargs["deadline"] == 108.0
+            assert kwargs["deadline"] == 126.0
             clock[0] = 108.0
             return None
         generation_deadlines.append(kwargs["deadline"])
@@ -3237,7 +3302,7 @@ def test_failed_cached_point_cloud_preserves_full_generation_window(
 
     def capture_generation(payload: dict[str, Any], **kwargs: Any) -> Any:
         if payload.get("m") == "g":
-            assert kwargs["deadline"] == 109.0
+            assert kwargs["deadline"] == 127.0
             clock[0] = 109.0
             return None
         generation_deadlines.append(kwargs["deadline"])
@@ -3306,6 +3371,93 @@ def test_stable_announcement_preflight_preserves_full_generation_window(
     assert generation_deadlines == [115.0]
 
 
+def test_forced_stable_announcement_preflight_preserves_generation_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    generation_deadlines: list[float] = []
+    cloud = SimpleNamespace(get_interim_file_url=lambda name, **options: None)
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+
+    def probe(*args: Any, **kwargs: Any) -> tuple[bool, str, tuple[str, int]]:
+        clock[0] = 102.0
+        return True, "private/stable-map.bin", ("private/stable-map.bin", 1)
+
+    def call_action(payload: dict[str, Any], **kwargs: Any) -> Any:
+        generation_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after generation deadline capture")
+
+    def signer(*args: Any, **kwargs: Any) -> None:
+        assert kwargs["require_response"] is True
+        clock[0] = 107.0
+        return None
+
+    client._sync_get_announced_point_cloud_object = probe
+    client._sync_call_point_cloud_action = call_action
+    client._sync_get_point_cloud_download_url = signer
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+
+    with pytest.raises(RuntimeError, match="generation deadline capture"):
+        client._sync_download_app_map_point_cloud(
+            0,
+            5,
+            0.1,
+            10,
+            1024,
+            deadline=132.0,
+            allow_stored=False,
+        )
+
+    assert generation_deadlines == [112.0]
+
+
+def test_cold_cloud_setup_preserves_forced_generation_window(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    generation_deadlines: list[float] = []
+    cloud = SimpleNamespace(get_interim_file_url=lambda name, **options: None)
+
+    def cloud_setup(**kwargs: Any) -> Any:
+        assert kwargs["deadline"] == 120.0
+        clock[0] = 120.0
+        return cloud
+
+    def probe(*args: Any, **kwargs: Any) -> tuple[bool, str, tuple[str, int]]:
+        clock[0] = 122.0
+        return True, "private/stable-map.bin", ("private/stable-map.bin", 1)
+
+    def call_action(payload: dict[str, Any], **kwargs: Any) -> Any:
+        generation_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after generation deadline capture")
+
+    def signer(*args: Any, **kwargs: Any) -> None:
+        assert kwargs["require_response"] is True
+        clock[0] = 127.0
+        return None
+
+    client._sync_get_cloud_protocol = cloud_setup
+    client._sync_get_announced_point_cloud_object = probe
+    client._sync_call_point_cloud_action = call_action
+    client._sync_get_point_cloud_download_url = signer
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+
+    with pytest.raises(RuntimeError, match="generation deadline capture"):
+        client._sync_download_app_map_point_cloud(
+            0,
+            5,
+            0.1,
+            10,
+            1024,
+            deadline=152.0,
+            allow_stored=False,
+        )
+
+    assert generation_deadlines == [132.0]
+
+
 def test_legacy_baseline_preflight_is_bounded_before_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3322,8 +3474,8 @@ def test_legacy_baseline_preflight_is_bounded_before_generation(
 
     def call_action(payload: dict[str, Any], **kwargs: Any) -> Any:
         if payload.get("m") == "g":
-            assert kwargs["deadline"] == 104.0
-            clock[0] = 104.0
+            assert kwargs["deadline"] == 122.0
+            clock[0] = 110.0
             return {"name": ["private/stable-map.bin"]}
         generation_deadlines.append(kwargs["deadline"])
         raise RuntimeError("stop after generation deadline capture")
@@ -3347,12 +3499,12 @@ def test_legacy_baseline_preflight_is_bounded_before_generation(
             0.1,
             10,
             1024,
-            deadline=129.0,
+            deadline=142.0,
             allow_stored=True,
         )
 
-    assert object_deadlines == [(109.0, 5.0), (114.0, 5.0)]
-    assert generation_deadlines == [119.0]
+    assert object_deadlines == [(115.0, 5.0), (120.0, 5.0)]
+    assert generation_deadlines == [125.0]
 
 
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1022,6 +1022,57 @@ def test_download_point_cloud_rejects_unchanged_signable_stable_announcement(
     assert captured.value.code == "point_cloud_not_published"
 
 
+def test_download_point_cloud_keeps_failed_signable_baseline_inconclusive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    responses = iter(
+        [
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/stable-map.bin"]}},
+        ]
+    )
+    client._sync_call_app_action = lambda payload, **kwargs: next(responses)
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stable-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    download_attempts = 0
+
+    def open_response(
+        request: Any,
+        *,
+        timeout: float,
+        deadline: float,
+    ) -> _FakeResponse:
+        nonlocal download_attempts
+        download_attempts += 1
+        if download_attempts == 1:
+            raise urllib.error.URLError("transient baseline failure")
+        return _FakeResponse(content, request.full_url)
+
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        open_response,
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(0, 0.05, 0.001, 10, 1024)
+
+    assert captured.value.code == "point_cloud_not_published"
+    assert download_attempts >= 2
+
+
 def test_download_point_cloud_retries_stable_announcement_index_verification(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -3159,7 +3159,10 @@ def test_stored_point_cloud_preflight_has_a_separate_time_budget(
 
     assert captured["function"] == client._sync_download_app_map_point_cloud
     assert captured["args"][-1] is True
-    assert captured["args"][-2] - started == pytest.approx(17, abs=0.25)
+    # 5 seconds of mower generation plus all sequential stored preflights:
+    # announcement and OBJ probes, three stored downloads, and the stable
+    # announcement's content-identity download.
+    assert captured["args"][-2] - started == pytest.approx(29, abs=0.25)
 
 
 def test_stored_point_cloud_fallback_receives_full_generation_window(
@@ -3167,7 +3170,7 @@ def test_stored_point_cloud_fallback_receives_full_generation_window(
 ) -> None:
     client = _client()
     clock = [100.0]
-    captured_deadlines: list[float] = []
+    generation_deadlines: list[float] = []
     cloud = SimpleNamespace(get_interim_file_url=lambda name: None)
     client._sync_get_cloud_protocol = lambda **kwargs: cloud
 
@@ -3175,26 +3178,30 @@ def test_stored_point_cloud_fallback_receives_full_generation_window(
         clock[0] = 106.0
         return False, None, None
 
-    def stop_at_baseline(payload: dict[str, Any], **kwargs: Any) -> Any:
-        captured_deadlines.append(kwargs["deadline"])
-        raise RuntimeError("stop after deadline capture")
+    def capture_generation(payload: dict[str, Any], **kwargs: Any) -> Any:
+        if payload.get("m") == "g":
+            assert kwargs["deadline"] == 108.0
+            clock[0] = 108.0
+            return None
+        generation_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after generation deadline capture")
 
     client._sync_get_announced_point_cloud_object = probe
-    client._sync_call_point_cloud_action = stop_at_baseline
+    client._sync_call_point_cloud_action = capture_generation
     monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
 
-    with pytest.raises(RuntimeError, match="deadline capture"):
+    with pytest.raises(RuntimeError, match="generation deadline capture"):
         client._sync_download_app_map_point_cloud(
             0,
             5,
             0.1,
             10,
             1024,
-            deadline=112.0,
+            deadline=129.0,
             allow_stored=True,
         )
 
-    assert captured_deadlines == [111.0]
+    assert generation_deadlines == [113.0]
 
 
 def test_failed_cached_point_cloud_preserves_full_generation_window(
@@ -3202,7 +3209,7 @@ def test_failed_cached_point_cloud_preserves_full_generation_window(
 ) -> None:
     client = _client()
     clock = [100.0]
-    captured_deadlines: list[float] = []
+    generation_deadlines: list[float] = []
     cloud = SimpleNamespace(get_interim_file_url=lambda name: None)
     client._sync_get_cloud_protocol = lambda **kwargs: cloud
     client._sync_update_app_map_inventory_identity(
@@ -3228,27 +3235,31 @@ def test_failed_cached_point_cloud_preserves_full_generation_window(
         clock[0] = 107.0
         return False, None, None
 
-    def stop_at_baseline(payload: dict[str, Any], **kwargs: Any) -> Any:
-        captured_deadlines.append(kwargs["deadline"])
-        raise RuntimeError("stop after deadline capture")
+    def capture_generation(payload: dict[str, Any], **kwargs: Any) -> Any:
+        if payload.get("m") == "g":
+            assert kwargs["deadline"] == 109.0
+            clock[0] = 109.0
+            return None
+        generation_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after generation deadline capture")
 
     client._sync_try_download_stored_point_cloud = fail_cached_download
     client._sync_get_announced_point_cloud_object = probe
-    client._sync_call_point_cloud_action = stop_at_baseline
+    client._sync_call_point_cloud_action = capture_generation
     monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
 
-    with pytest.raises(RuntimeError, match="deadline capture"):
+    with pytest.raises(RuntimeError, match="generation deadline capture"):
         client._sync_download_app_map_point_cloud(
             0,
             5,
             0.1,
             10,
             1024,
-            deadline=117.0,
+            deadline=129.0,
             allow_stored=True,
         )
 
-    assert captured_deadlines == [112.0]
+    assert generation_deadlines == [114.0]
 
 
 def test_stable_announcement_preflight_preserves_full_generation_window(
@@ -3293,6 +3304,55 @@ def test_stable_announcement_preflight_preserves_full_generation_window(
         )
 
     assert generation_deadlines == [115.0]
+
+
+def test_legacy_baseline_preflight_is_bounded_before_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    clock = [100.0]
+    object_deadlines: list[tuple[float, float]] = []
+    generation_deadlines: list[float] = []
+    cloud = SimpleNamespace(get_interim_file_url=lambda name, **options: None)
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+
+    def probe(*args: Any, **kwargs: Any) -> tuple[bool, None, None]:
+        clock[0] = 102.0
+        return False, None, None
+
+    def call_action(payload: dict[str, Any], **kwargs: Any) -> Any:
+        if payload.get("m") == "g":
+            assert kwargs["deadline"] == 104.0
+            clock[0] = 104.0
+            return {"name": ["private/stable-map.bin"]}
+        generation_deadlines.append(kwargs["deadline"])
+        raise RuntimeError("stop after generation deadline capture")
+
+    def fail_object_download(*args: Any, **kwargs: Any) -> None:
+        object_deadlines.append(
+            (kwargs["deadline"], kwargs["download_timeout"])
+        )
+        clock[0] += 5.0
+        raise DreameLawnMowerPointCloudError("not ready")
+
+    client._sync_get_announced_point_cloud_object = probe
+    client._sync_call_point_cloud_action = call_action
+    client._sync_download_point_cloud_object = fail_object_download
+    monkeypatch.setattr(client_module.time, "monotonic", lambda: clock[0])
+
+    with pytest.raises(RuntimeError, match="generation deadline capture"):
+        client._sync_download_app_map_point_cloud(
+            0,
+            5,
+            0.1,
+            10,
+            1024,
+            deadline=129.0,
+            allow_stored=True,
+        )
+
+    assert object_deadlines == [(109.0, 5.0), (114.0, 5.0)]
+    assert generation_deadlines == [119.0]
 
 
 def test_point_cloud_url_lookup_uses_and_enforces_remaining_deadline(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -435,7 +435,10 @@ def test_download_point_cloud_uses_action_dispatch_as_freshness_boundary(
     result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
 
     assert actions == [{"m": "a", "p": 0, "o": 10, "d": {"idx": 0}}]
-    assert signed_names == ["private/generated-map.bin"]
+    assert signed_names == [
+        "private/baseline-map.bin",
+        "private/generated-map.bin",
+    ]
     assert result.source == "generated"
 
 
@@ -711,7 +714,7 @@ def test_download_point_cloud_regenerates_when_stored_object_is_invalid(
         return next(responses)
 
     now_ms = int(time.time() * 1000)
-    update_dates = iter([now_ms - 1_000, now_ms - 1_000, now_ms + 1_000])
+    update_dates = iter([now_ms - 1_000, now_ms + 1_000])
 
     def get_properties(key: str, **options: Any) -> list[dict[str, Any]]:
         updated_at = next(update_dates)
@@ -736,7 +739,14 @@ def test_download_point_cloud_regenerates_when_stored_object_is_invalid(
     client._sync_call_app_action = call_app_action
     client._sync_get_cloud_protocol = lambda **kwargs: cloud
     fresh_content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
-    downloads = iter([b"not a pcd", b"still not a pcd", fresh_content])
+    downloads = iter(
+        [
+            b"not a pcd",
+            b"still not a pcd",
+            b"pre-generation object",
+            fresh_content,
+        ]
+    )
     monkeypatch.setattr(
         _internal_client_module,
         "_open_point_cloud_response",
@@ -859,8 +869,27 @@ def test_download_point_cloud_does_not_fallback_from_stale_announcement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _client()
+    client._sync_update_app_map_inventory_identity(
+        [
+            {
+                "idx": 0,
+                "current": True,
+                "created": True,
+                "info": {"hash": "map-hash-1", "size": 123},
+            }
+        ]
+    )
+    client._latest_app_map_object_names = ("private/stale-map.bin",)
+    client._latest_app_map_object_inventory_identity = (
+        client._latest_app_map_inventory_identity
+    )
     calls: list[dict[str, Any]] = []
-    responses = iter([{"r": 0}])
+    responses = iter(
+        [
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/other-map.bin"]}},
+        ]
+    )
 
     def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         calls.append(payload)
@@ -880,6 +909,15 @@ def test_download_point_cloud_does_not_fallback_from_stale_announcement(
     )
     client._sync_call_app_action = call_app_action
     client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
     with pytest.raises(DreameLawnMowerPointCloudError):
         client._sync_download_app_map_point_cloud(
             0,
@@ -891,7 +929,154 @@ def test_download_point_cloud_does_not_fallback_from_stale_announcement(
 
     assert calls == [
         {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
     ]
+
+
+def test_download_point_cloud_accepts_indexed_stable_announcement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/stable-map.bin"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    signed_urls = iter([None, "https://downloads.example.invalid/object"])
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stable-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: next(signed_urls),
+    )
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.source == "generated"
+    assert result.content == content
+
+
+def test_download_point_cloud_rejects_unchanged_signable_stable_announcement(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    responses = iter(
+        [
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/stable-map.bin"]}},
+        ]
+    )
+    client._sync_call_app_action = lambda payload, **kwargs: next(responses)
+    cloud = SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stable-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    client._sync_get_cloud_protocol = lambda **kwargs: cloud
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(0, 0.05, 0.001, 10, 1024)
+
+    assert captured.value.code == "point_cloud_not_published"
+
+
+def test_download_point_cloud_retries_stable_announcement_index_verification(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    calls: list[dict[str, Any]] = []
+    verification_attempts = 0
+
+    def call_point_cloud_action(
+        payload: dict[str, Any],
+        *,
+        operation: str,
+        deadline: float,
+        require_data: bool,
+        on_dispatch: Any = None,
+    ) -> Any:
+        nonlocal verification_attempts
+        calls.append(payload)
+        if payload.get("m") == "a":
+            on_dispatch()
+            return None
+        verification_attempts += 1
+        if verification_attempts == 1:
+            raise DreameLawnMowerPointCloudError(
+                "transient routed timeout",
+                code="point_cloud_timeout",
+            )
+        return {"name": ["private/stable-map.bin"]}
+
+    signed_urls = iter([None, "https://downloads.example.invalid/object"])
+    client._sync_call_point_cloud_action = call_point_cloud_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stable-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: next(signed_urls),
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 2, 0.01, 10, 1024)
+
+    assert verification_attempts == 2
+    assert calls.count({"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}) == 2
+    assert result.source == "generated"
 
 
 def test_download_point_cloud_caps_optional_announcement_probe(
@@ -1713,7 +1898,7 @@ def test_download_point_cloud_bounds_invalid_announced_object_downloads(
         )
 
     assert captured.value.code == "point_cloud_download_invalid"
-    assert download_count == 1
+    assert download_count == 2
 
 
 def test_download_point_cloud_waits_for_changed_mova_fixed_object(

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -3589,6 +3589,11 @@ def test_interim_file_protocol_forwards_absolute_deadline() -> None:
     [
         None,
         {},
+        {"data": None},
+        {"code": None, "data": None},
+        {"code": "0", "data": None},
+        {"code": 0.0, "data": None},
+        {"code": False, "data": None},
         {"code": 50001},
     ],
 )
@@ -3643,6 +3648,31 @@ def test_interim_file_protocol_strict_response_preserves_explicit_absence() -> N
         )
         is None
     )
+
+
+def test_interim_file_protocol_strict_response_preserves_success() -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    strings = [""] * 56
+    strings[21] = "country"
+    strings[23] = "iot"
+    strings[35] = "model"
+    strings[39] = "file"
+    strings[40] = "filename"
+    strings[55] = "download"
+    cloud._strings = strings
+    cloud._did = "device-1"
+    cloud._model = "dreame.mower.g2408"
+    cloud._country = "eu"
+    cloud._api_call = lambda *args, **kwargs: {
+        "code": 0,
+        "data": "https://downloads.example.invalid/object",
+    }
+
+    assert cloud.get_interim_file_url(
+        "private/generated-map.pcd",
+        require_response=True,
+    ) == "https://downloads.example.invalid/object"
 
 
 def test_interim_file_protocol_strict_response_classifies_unavailable_object() -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -11,6 +11,9 @@ from typing import Any
 import pytest
 from homeassistant.exceptions import Unauthorized
 
+from custom_components.dreame_lawn_mower import (
+    point_cloud_api as point_cloud_api_module,
+)
 from custom_components.dreame_lawn_mower.const import DOMAIN
 from custom_components.dreame_lawn_mower.diagnostic_events import (
     DreameLawnMowerDiagnosticEventStore,
@@ -687,6 +690,100 @@ def test_point_cloud_api_purges_unloaded_entry() -> None:
         await api.async_get("entry-1", 0)
         api.purge_entry("entry-1")
         await api.async_get("entry-1", 0)
+
+    asyncio.run(run())
+
+    assert calls == 2
+
+
+def test_point_cloud_api_throttles_retryable_failures_until_retry_after(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    calls = 0
+    clock = [100.0]
+    monkeypatch.setattr(
+        point_cloud_api_module.time,
+        "monotonic",
+        lambda: clock[0],
+    )
+
+    async def download(**kwargs: Any) -> None:
+        nonlocal calls
+        del kwargs
+        calls += 1
+        raise DreameLawnMowerPointCloudError(
+            "private cloud timeout detail",
+            code="point_cloud_timeout",
+            stage="mower_request",
+            public_message="The mower did not finish the 3D map request in time.",
+            timeout_seconds=45,
+            retry_after_seconds=10,
+        )
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        with pytest.raises(DreameLawnMowerPointCloudError):
+            await api.async_get("entry-1", 0, refresh=True)
+        clock[0] = 109.2
+        with pytest.raises(DreameLawnMowerPointCloudError) as cached:
+            await api.async_get("entry-1", 0, refresh=True)
+        assert cached.value.code == "point_cloud_timeout"
+        assert cached.value.stage == "mower_request"
+        assert cached.value.retry_after_seconds == 1
+        assert "private cloud timeout detail" not in str(cached.value)
+        clock[0] = 110.0
+        with pytest.raises(DreameLawnMowerPointCloudError):
+            await api.async_get("entry-1", 0, refresh=True)
+
+    asyncio.run(run())
+
+    assert calls == 2
+
+
+def test_point_cloud_api_purge_clears_retryable_failure_backoff() -> None:
+    calls = 0
+
+    async def download(**kwargs: Any) -> None:
+        nonlocal calls
+        del kwargs
+        calls += 1
+        raise DreameLawnMowerPointCloudError(
+            "timeout",
+            code="point_cloud_timeout",
+            retry_after_seconds=10,
+        )
+
+    hass = SimpleNamespace(
+        data={
+            DOMAIN: {
+                "entry-1": SimpleNamespace(
+                    client=SimpleNamespace(
+                        async_download_app_map_point_cloud=download,
+                    )
+                )
+            }
+        }
+    )
+    api = DreameLawnMowerPointCloudAPI(hass)
+
+    async def run() -> None:
+        with pytest.raises(DreameLawnMowerPointCloudError):
+            await api.async_get("entry-1", 0)
+        api.purge_entry("entry-1")
+        with pytest.raises(DreameLawnMowerPointCloudError):
+            await api.async_get("entry-1", 0)
 
     asyncio.run(run())
 

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -699,7 +699,7 @@ def test_point_cloud_api_purges_unloaded_entry() -> None:
 def test_point_cloud_api_throttles_retryable_failures_until_retry_after(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    calls = 0
+    calls: list[int] = []
     clock = [100.0]
     monkeypatch.setattr(
         point_cloud_api_module.time,
@@ -708,9 +708,7 @@ def test_point_cloud_api_throttles_retryable_failures_until_retry_after(
     )
 
     async def download(**kwargs: Any) -> None:
-        nonlocal calls
-        del kwargs
-        calls += 1
+        calls.append(kwargs["map_index"])
         raise DreameLawnMowerPointCloudError(
             "private cloud timeout detail",
             code="point_cloud_timeout",
@@ -738,18 +736,18 @@ def test_point_cloud_api_throttles_retryable_failures_until_retry_after(
             await api.async_get("entry-1", 0, refresh=True)
         clock[0] = 109.2
         with pytest.raises(DreameLawnMowerPointCloudError) as cached:
-            await api.async_get("entry-1", 0, refresh=True)
+            await api.async_get("entry-1", 1, refresh=True)
         assert cached.value.code == "point_cloud_timeout"
         assert cached.value.stage == "mower_request"
         assert cached.value.retry_after_seconds == 1
         assert "private cloud timeout detail" not in str(cached.value)
         clock[0] = 110.0
         with pytest.raises(DreameLawnMowerPointCloudError):
-            await api.async_get("entry-1", 0, refresh=True)
+            await api.async_get("entry-1", 1, refresh=True)
 
     asyncio.run(run())
 
-    assert calls == 2
+    assert calls == [0, 1]
 
 
 def test_point_cloud_api_purge_clears_retryable_failure_backoff() -> None:


### PR DESCRIPTION
## Summary

- recover the primary A2 LiDAR path when current firmware refreshes a stable `99.20` object without changing its name or timestamp
- distinguish the A2 signer's explicit object-unavailable response (`10007`) from generic cloud failures before accepting a stable-key refresh
- prove stable-object freshness with pre/post object identity and require a live indexed map match before returning it
- retry transient indexed-object verification instead of polling the unchanged announcement until timeout
- preserve the complete generation window after bounded cloud setup and forced/stored preflight work
- serialize mower-wide generation in the reusable client, including after caller cancellation, so overlapping map requests cannot misattribute a global announcement
- enforce retry cooldown per mower entry rather than per map index
- normalize cloud transport timeouts into structured retryable HTTP 504 responses and retain bounded failure cooldowns
- keep the older `OBJ` generation route only for firmware that does not expose the dedicated announcement property

## Why

A live A2 request on firmware `4.3.6_0625` accepted `o:10` with `r:0`, but `99.20` and upload progress retained their previous values. The firmware made the existing indexed map object signable instead. The client required a new name or timestamp, ignored that successful primary refresh, and eventually returned repeated 502/timeout responses.

## Live proof

With stored and legacy fallback disabled, the final reusable-client flow returned `source=generated`, validated a binary PCD containing 152,318 points and 2,437,272 bytes, and completed in 1.524 seconds while the mower remained docked. No mower movement or setting change was performed.

## Validation

- complete repository CI test command passes locally (existing config-flow exclusion retained)
- focused point-cloud and HTTP API suites pass, including signer-failure classification, stable-key freshness, forced/stored/cold-login budget, mower-wide single-flight and cooldown, multi-map attribution, and transient verification retry contracts
- Ruff and diff checks pass across the repository
- fresh local review, targeted confirmation, and a broader owner-level completion audit found all reported freshness, attribution, cancellation, cooldown, and timeout-budget defect classes resolved