### PR TITLE
Add live settings refresh and anti-theft controls

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ schedules, or build automations around live mower state.
 | Maps and targeted mowing | View the active map and live cut path, switch maps, and start all-area, zone, spot, or edge runs |
 | Schedules | Read mower-native schedules through a calendar, use per-plan switches, and make guarded enable/disable changes |
 | Mowing preferences | Control supported map-wide or per-zone cutting height, mowing efficiency, edge behavior, and obstacle avoidance |
-| Monitoring | Track battery, charging, mower state, active and resumable tasks, progress, errors, maintenance, firmware, and rain protection |
+| Monitoring and protection | Track battery, charging, mower state, active and resumable tasks, progress, errors, maintenance, firmware, rain protection, and reported anti-theft settings |
 | Cameras and 3D | Use the map camera, optional live video on supported Linux hosts, and authenticated 3D point-cloud downloads where validated |
 | Home Assistant automation | Build automations from normal entities and use guarded services for map, schedule, preference, and supervised remote-control workflows |
 
@@ -135,9 +135,10 @@ operations behind clear boundaries:
   mower families still need reports.
 - Map rendering and map selection are supported, but editing no-go areas,
   virtual walls, and garden geometry is not.
-- Charging-period and rain-protection controls are field-validated on the
-  Dreame A2. Other models expose them only when their native `CFG` record
-  reports the matching setting.
+- Charging-period, rain-protection, and three-field anti-theft controls are
+  field-validated on the Dreame A2. Other models expose each group only when
+  their native `CFG` record reports the matching setting. PIN check before
+  power-off appears only on mowers that report the fourth anti-theft field.
 - Mowing-preference writes use guarded paths and have the strongest live proof
   on the A2. Other models and firmware need broader confirmation.
 - Firmware updates use the app-approved target and confirmation flow. Release
@@ -435,20 +436,28 @@ can use them when explicitly configured; automatic discovery support is tracked
 in the card project. The guarded service remains available when you need to
 inspect the complete candidate preference payload before sending it.
 
-## Charging And Rain Protection
+## Charging, Rain, And Anti-Theft Settings
 
-Models that report the mower-native `BAT` and `WRP` settings expose normal
-Home Assistant configuration entities. The charging-period switch keeps the
-configured start and end times; its two time entities can define a window that
-crosses midnight. Rain protection has a switch and a whole-hour delay select.
-The zero-hour delay means the mower stays docked until it is manually started.
+Models that report the mower-native `BAT`, `WRP`, and `ATA` records expose only
+the matching Home Assistant configuration entities. The charging-period switch
+keeps the configured start and end times; its two time entities can define a
+window that crosses midnight. Rain protection has a switch and a whole-hour
+delay select. The zero-hour delay means the mower stays docked until it is
+manually started.
+
+Anti-theft settings use ordinary switches for Lift Alarm, Off-Map Alarm, and
+Real-Time Location. PIN Check Before Power-Off is optional: Home Assistant adds
+it only when the mower reports that fourth field. Unknown future fields in the
+same record are preserved during updates.
 
 Every setting change first reads the current `CFG` record, writes only the
 setting-specific payload, and reads `CFG` again. Home Assistant updates only
 after the mower reports the requested value. Battery thresholds and rain-sensor
-sensitivity are preserved. The mower's `2:51` settings-change announcement also
-causes one coalesced refresh, so changes made in the Dreame app appear without
-waiting for the normal metadata interval.
+sensitivity and untouched anti-theft flags are preserved. The mower's `2:51`
+settings-change announcement causes one coalesced `CFG` refresh. Its separate
+`2:52` preference announcement refreshes only mowing preferences. Changes made
+in the Dreamehome or MOVAhome app therefore appear without waiting for the
+normal metadata interval.
 
 ## Maps
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -112,6 +112,13 @@ def _device_settings_read_succeeded(settings: Mapping[str, Any]) -> bool:
     )
 
 
+def _batch_mowing_preferences_read_succeeded(
+    settings: Mapping[str, Any],
+) -> bool:
+    """Return whether a batch preference payload decoded successfully."""
+    return bool(settings.get("available")) and not settings.get("errors")
+
+
 class DreameLawnMowerCoordinator(
     DreameLawnMowerConnectivityMixin,
     DreameLawnMowerRefreshMixin,
@@ -217,6 +224,7 @@ class DreameLawnMowerCoordinator(
         self._client_update_task: asyncio.Task[None] | None = None
         self._client_update_pending = False
         self._last_device_settings_event_at: float | None = None
+        self._last_mowing_preferences_event_at: float | None = None
         self._metadata_refresh_task: asyncio.Task[None] | None = None
         self._metadata_shutdown_close_task: asyncio.Task[None] | None = None
         self._metadata_refresh_semaphore = asyncio.Semaphore(
@@ -254,9 +262,7 @@ class DreameLawnMowerCoordinator(
         for _attempt in range(2):
             async with self._device_refresh_lock:
                 try:
-                    snapshot = (
-                        await self.client.async_refresh_authoritative_snapshot()
-                    )
+                    snapshot = await self.client.async_refresh_authoritative_snapshot()
                 except Exception as err:
                     self._record_connectivity_failure(err)
                     raise
@@ -293,8 +299,7 @@ class DreameLawnMowerCoordinator(
         if retain:
             self._retained_device_snapshot_ids.add(snapshot_id)
         while (
-            len(self._device_snapshot_generations)
-            > DEVICE_SNAPSHOT_GENERATION_HISTORY
+            len(self._device_snapshot_generations) > DEVICE_SNAPSHOT_GENERATION_HISTORY
         ):
             evictable = (
                 snapshot_id
@@ -303,9 +308,9 @@ class DreameLawnMowerCoordinator(
             )
             oldest = min(
                 evictable,
-                key=lambda snapshot_id: self._device_snapshot_generations[
-                    snapshot_id
-                ][1],
+                key=lambda snapshot_id: self._device_snapshot_generations[snapshot_id][
+                    1
+                ],
                 default=None,
             )
             if oldest is None:
@@ -326,9 +331,7 @@ class DreameLawnMowerCoordinator(
         generations = getattr(self, "_device_snapshot_generations", None)
         recorded = generations.get(id(data)) if generations else None
         generation = (
-            recorded[1]
-            if recorded is not None and recorded[0] is data
-            else None
+            recorded[1] if recorded is not None and recorded[0] is data else None
         )
         if generation is not None:
             self._published_device_snapshot_generation = generation
@@ -537,9 +540,7 @@ class DreameLawnMowerCoordinator(
             # cached snapshot is still current after every await.
             if self._device_snapshot_is_stale(snapshot) or (
                 observed_mission_generation is not None
-                and runtime_mission_session_generation(
-                    self.runtime_telemetry_cache
-                )
+                and runtime_mission_session_generation(self.runtime_telemetry_cache)
                 != observed_mission_generation
             ):
                 return
@@ -605,13 +606,25 @@ class DreameLawnMowerCoordinator(
                 )
             self.async_set_updated_data(snapshot)
             settings_event_at = getattr(snapshot, "device_settings_event_at", None)
-            if (
+            preferences_event_at = getattr(
+                snapshot,
+                "mowing_preferences_event_at",
+                None,
+            )
+            settings_changed = (
                 settings_event_at is not None
                 and settings_event_at != self._last_device_settings_event_at
-            ):
-                # Property 2:51 identifies that some CFG value changed but not
-                # which one. Let the mower finish applying it, then read CFG once.
+            )
+            preferences_changed = (
+                preferences_event_at is not None
+                and preferences_event_at
+                != getattr(self, "_last_mowing_preferences_event_at", None)
+            )
+            if settings_changed or preferences_changed:
+                # These announcements identify the changed record, but the
+                # mower may publish them just before its read model catches up.
                 await asyncio.sleep(1)
+            if settings_changed:
                 refreshed = await self.async_refresh_device_settings(
                     force=True,
                     source="device_settings_realtime",
@@ -619,15 +632,21 @@ class DreameLawnMowerCoordinator(
                 if refreshed is not None:
                     self._last_device_settings_event_at = settings_event_at
                     self.async_update_listeners()
+            if preferences_changed:
+                refreshed = await self.async_refresh_mowing_preferences(
+                    source="mowing_preferences_realtime",
+                )
+                if refreshed is not None:
+                    self._last_mowing_preferences_event_at = preferences_event_at
+                    self.async_update_listeners()
         except Exception as err:  # noqa: BLE001 - callback must not escape HA task
             _LOGGER.debug("Failed to process cached mower update: %s", err)
         finally:
             if snapshot is not None:
                 self._release_device_snapshot(snapshot)
             self._client_update_task = None
-            if (
-                getattr(self, "_client_update_pending", False)
-                and not getattr(self, "_shutting_down", False)
+            if getattr(self, "_client_update_pending", False) and not getattr(
+                self, "_shutting_down", False
             ):
                 self._client_update_pending = False
                 self._schedule_client_update()
@@ -705,9 +724,8 @@ class DreameLawnMowerCoordinator(
                     succeeded=action_read_succeeded,
                     generation=action_read_generation,
                 )
-                if (
-                    action_read_succeeded
-                    and not self._schedule_read_can_publish(action_read_generation)
+                if action_read_succeeded and not self._schedule_read_can_publish(
+                    action_read_generation
                 ):
                     return self.schedules
         app_maps = getattr(self, "app_maps", None)
@@ -873,12 +891,9 @@ class DreameLawnMowerCoordinator(
         ):
             return False
         known_map_indices = _app_map_index_hints(getattr(self, "app_maps", None))
-        if (
-            not isinstance(self.schedules, Mapping)
-            or (
-                not allow_incomplete
-                and not self._has_complete_schedule_cache(known_map_indices)
-            )
+        if not isinstance(self.schedules, Mapping) or (
+            not allow_incomplete
+            and not self._has_complete_schedule_cache(known_map_indices)
         ):
             return False
         normalized = merge_batch_schedule_payload(
@@ -1071,9 +1086,7 @@ class DreameLawnMowerCoordinator(
         )
         if pending_contradictions is None:
             pending_contradictions = {}
-            self._pending_schedule_plan_state_contradictions = (
-                pending_contradictions
-            )
+            self._pending_schedule_plan_state_contradictions = pending_contradictions
         for key, (version, enabled) in tuple(pending_states.items()):
             map_index, plan_id = key
             schedule = next(
@@ -1106,10 +1119,7 @@ class DreameLawnMowerCoordinator(
                 pending_contradictions.pop(key, None)
                 continue
             contradictory_reads = pending_contradictions.get(key, 0) + 1
-            if (
-                contradictory_reads
-                > PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS
-            ):
+            if contradictory_reads > PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS:
                 pending_states.pop(key, None)
                 pending_contradictions.pop(key, None)
             else:
@@ -1135,8 +1145,7 @@ class DreameLawnMowerCoordinator(
                 and not isinstance(schedule.get("idx"), bool)
             }
             unknown_slot_is_unambiguous = (
-                not matching_numeric_indices
-                or matching_numeric_indices == {map_index}
+                not matching_numeric_indices or matching_numeric_indices == {map_index}
             )
             for schedule in schedules:
                 if not isinstance(schedule, dict) or not (
@@ -1240,8 +1249,7 @@ class DreameLawnMowerCoordinator(
             (
                 schedule
                 for schedule in schedules or []
-                if isinstance(schedule, Mapping)
-                and schedule.get("idx") == map_index
+                if isinstance(schedule, Mapping) and schedule.get("idx") == map_index
             ),
             None,
         )
@@ -1348,9 +1356,8 @@ class DreameLawnMowerCoordinator(
                 pending_active_indices.discard(map_index)
                 continue
             if schedule.get("plans") == pending_schedule.get("plans"):
-                if (
-                    map_index in pending_active_indices
-                    and isinstance(self.schedules, dict)
+                if map_index in pending_active_indices and isinstance(
+                    self.schedules, dict
                 ):
                     self.schedules["active_schedule_version"] = pending_version
                     self.schedules["active_schedule_index"] = map_index
@@ -1360,10 +1367,7 @@ class DreameLawnMowerCoordinator(
                 pending_active_indices.discard(map_index)
                 continue
             contradictory_reads = pending_contradictions.get(map_index, 0) + 1
-            if (
-                contradictory_reads
-                > PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS
-            ):
+            if contradictory_reads > PENDING_SCHEDULE_PLAN_MAX_CONTRADICTORY_READS:
                 pending_uploads.pop(map_index, None)
                 pending_contradictions.pop(map_index, None)
                 pending_active_indices.discard(map_index)
@@ -1512,9 +1516,8 @@ class DreameLawnMowerCoordinator(
         }
         self.batch_device_data = payload
         self.batch_device_data_refreshed_at = now
-        if (
-            batch_schedule is not self.schedules
-            and self._schedule_refresh_is_current(schedule_generation)
+        if batch_schedule is not self.schedules and self._schedule_refresh_is_current(
+            schedule_generation
         ):
             self._cache_batch_schedules(
                 batch_schedule,
@@ -1555,6 +1558,32 @@ class DreameLawnMowerCoordinator(
             else:
                 self.async_update_listeners()
             return result
+
+    async def async_refresh_mowing_preferences(
+        self,
+        *,
+        source: str,
+    ) -> dict[str, Any] | None:
+        """Refresh only SETTINGS.* after the mower announces a change."""
+        async with self._preference_write_lock:
+            try:
+                preferences = await self.client.async_get_batch_mowing_preferences(
+                    include_raw=False,
+                    map_index_hints=_app_map_index_hints(self.app_maps),
+                )
+            except Exception as err:  # noqa: BLE001 - retry on the next event pass
+                _LOGGER.debug("Failed to refresh mowing preferences: %s", err)
+                return None
+            if not _batch_mowing_preferences_read_succeeded(preferences):
+                _LOGGER.debug("Mowing preference refresh returned no usable maps")
+                return None
+
+            payload = dict(self.batch_device_data or {})
+            payload["captured_at"] = datetime.now(UTC).isoformat()
+            payload["source"] = source
+            payload["batch_mowing_preferences"] = preferences
+            self.batch_device_data = payload
+            return preferences
 
     async def _async_fetch_batch_device_data(
         self,
@@ -1638,9 +1667,7 @@ class DreameLawnMowerCoordinator(
                 # App-map discovery already ran in this metadata cycle. Batch
                 # decoding can safely retain an explicit unknown slot.
                 options["discover_map_index"] = False
-            task = asyncio.create_task(
-                self.client.async_get_batch_schedules(**options)
-            )
+            task = asyncio.create_task(self.client.async_get_batch_schedules(**options))
             self._batch_schedule_read_task = task
             batch_tasks = getattr(self, "_batch_schedule_read_tasks", None)
             if batch_tasks is None:
@@ -1823,12 +1850,9 @@ class DreameLawnMowerCoordinator(
             payload,
             refresh_succeeded=True,
         )
-        if (
-            map_hints_authoritative
-            and (
-                not previous_map_hints_authoritative
-                or known_map_indices != previous_map_indices
-            )
+        if map_hints_authoritative and (
+            not previous_map_hints_authoritative
+            or known_map_indices != previous_map_indices
         ):
             self._invalidate_schedule_map_hint()
         if current_idx is not None:
@@ -1995,6 +2019,27 @@ class DreameLawnMowerCoordinator(
             return self._cache_device_settings(
                 settings,
                 source="rain_protection_write",
+            )
+
+    async def async_set_anti_theft_settings(
+        self,
+        *,
+        lift_alarm_enabled: bool | None = None,
+        off_map_alarm_enabled: bool | None = None,
+        real_time_location_enabled: bool | None = None,
+        pin_check_before_power_off_enabled: bool | None = None,
+    ) -> dict[str, Any]:
+        """Persist and publish one confirmed anti-theft update."""
+        async with self._device_settings_write_lock:
+            settings = await self.client.async_set_anti_theft_settings(
+                lift_alarm_enabled=lift_alarm_enabled,
+                off_map_alarm_enabled=off_map_alarm_enabled,
+                real_time_location_enabled=real_time_location_enabled,
+                pin_check_before_power_off_enabled=pin_check_before_power_off_enabled,
+            )
+            return self._cache_device_settings(
+                settings,
+                source="anti_theft_settings_write",
             )
 
     async def async_refresh_maintenance_status(
@@ -2279,7 +2324,5 @@ def _schedule_write_version(result: Mapping[str, Any]) -> int | None:
     """Return the writable version confirmed by a schedule write."""
     version = result.get("version")
     return (
-        version
-        if isinstance(version, int) and not isinstance(version, bool)
-        else None
+        version if isinstance(version, int) and not isinstance(version, bool) else None
     )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -8,6 +8,7 @@ from typing import Final
 
 from .device_code_semantics import mower_device_code_name
 from .models import DreameLawnMowerStatusBlob
+from .mowing_preferences import MOWING_PREFERENCE_PROPERTY_KEY
 
 MOWER_RAW_STATUS_PROPERTY_KEY: Final[str] = "1.1"
 MOWER_RUNTIME_STATUS_PROPERTY_KEY: Final[str] = "1.4"
@@ -25,6 +26,7 @@ MOWER_PROPERTY_HINTS: Final[dict[str, str]] = {
     MOWER_ERROR_PROPERTY_KEY: "mower_error",
     MOWER_TASK_PROPERTY_KEY: "task_status",
     MOWER_TIME_PROPERTY_KEY: "device_time",
+    MOWING_PREFERENCE_PROPERTY_KEY: "mowing_preferences",
     MOWER_BATTERY_PROPERTY_KEY: "battery_level",
 }
 MOWER_STATE_LABELS: Final[dict[str, dict[str, str]]] = {
@@ -277,9 +279,7 @@ def decode_mower_status_blob(
         candidate_runtime_area_progress_percent=runtime_telemetry.get(
             "area_progress_percent"
         ),
-        candidate_runtime_current_area_sqm=runtime_telemetry.get(
-            "current_area_sqm"
-        ),
+        candidate_runtime_current_area_sqm=runtime_telemetry.get("current_area_sqm"),
         candidate_runtime_total_area_sqm=runtime_telemetry.get("total_area_sqm"),
         candidate_runtime_pose_x=runtime_telemetry.get("pose_x"),
         candidate_runtime_pose_y=runtime_telemetry.get("pose_y"),
@@ -309,9 +309,7 @@ _HEARTBEAT_TASK_STATUSES = {
     6: "exit",
     7: "returning_to_dock",
 }
-_INACTIVE_HEARTBEAT_TASK_STATUSES = frozenset(
-    {"idle", "finished", "failed", "exit"}
-)
+_INACTIVE_HEARTBEAT_TASK_STATUSES = frozenset({"idle", "finished", "failed", "exit"})
 
 
 def _decode_heartbeat_task_state(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_device_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_device_settings.py
@@ -9,6 +9,7 @@ from typing import Any
 from .client_settings_helpers import _weather_protection_active_summary
 from .client_shared_helpers import _app_action_data, _ensure_app_write_succeeded
 from .device_settings import (
+    build_anti_theft_settings_request,
     build_charging_period_request,
     build_rain_protection_request,
     decode_device_settings,
@@ -32,7 +33,7 @@ class _DreameLawnMowerClientDeviceSettingsMixin:
         result: dict[str, Any] = {
             "source": "app_action_device_settings",
             "available": False,
-            "config_keys": ["BAT", "WRF", "WRP"],
+            "config_keys": ["ATA", "BAT", "WRF", "WRP"],
             "fault_hint": "INFO_BAD_WEATHER_PROTECTING",
             "rain_end_time_command": "RPET",
             "errors": [],
@@ -210,6 +211,37 @@ class _DreameLawnMowerClientDeviceSettingsMixin:
             )
         return refreshed
 
+    def _sync_set_anti_theft_settings(
+        self,
+        *,
+        lift_alarm_enabled: bool | None = None,
+        off_map_alarm_enabled: bool | None = None,
+        real_time_location_enabled: bool | None = None,
+        pin_check_before_power_off_enabled: bool | None = None,
+    ) -> dict[str, Any]:
+        """Update ATA flags and require an exact CFG readback."""
+        current = self._sync_get_device_settings(include_rain_end_time=False)
+        if not current.get("anti_theft_settings_available"):
+            raise DreameLawnMowerConnectionError(
+                "The mower did not report anti-theft settings."
+            )
+        request = build_anti_theft_settings_request(
+            current["anti_theft_settings_raw"],
+            lift_alarm_enabled=lift_alarm_enabled,
+            off_map_alarm_enabled=off_map_alarm_enabled,
+            real_time_location_enabled=real_time_location_enabled,
+            pin_check_before_power_off_enabled=pin_check_before_power_off_enabled,
+        )
+        response = self._sync_call_app_action(request)
+        _ensure_app_write_succeeded(response, operation="Anti-theft settings update")
+        refreshed = self._sync_get_device_settings(include_rain_end_time=False)
+        if refreshed.get("anti_theft_settings_raw") != request["d"]["value"]:
+            raise DreameLawnMowerCommandRejectedError(
+                "The mower acknowledged the anti-theft update but CFG did not "
+                "confirm the requested values."
+            )
+        return refreshed
+
     async def async_get_device_settings(
         self,
         *,
@@ -252,4 +284,21 @@ class _DreameLawnMowerClientDeviceSettingsMixin:
             self._sync_set_rain_protection,
             enabled=enabled,
             delay_hours=delay_hours,
+        )
+
+    async def async_set_anti_theft_settings(
+        self,
+        *,
+        lift_alarm_enabled: bool | None = None,
+        off_map_alarm_enabled: bool | None = None,
+        real_time_location_enabled: bool | None = None,
+        pin_check_before_power_off_enabled: bool | None = None,
+    ) -> dict[str, Any]:
+        """Set and confirm the mower-native anti-theft flags."""
+        return await asyncio.to_thread(
+            self._sync_set_anti_theft_settings,
+            lift_alarm_enabled=lift_alarm_enabled,
+            off_map_alarm_enabled=off_map_alarm_enabled,
+            real_time_location_enabled=real_time_location_enabled,
+            pin_check_before_power_off_enabled=pin_check_before_power_off_enabled,
         )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_settings.py
@@ -24,6 +24,12 @@ RAIN_SETTING_DELAY_INDEX = 1
 RAIN_SETTING_SENSITIVITY_INDEX = 2
 RAIN_SETTING_DEFAULT_SENSITIVITY = 0
 
+ANTI_THEFT_SETTING_MINIMUM_LENGTH = 3
+ANTI_THEFT_LIFT_ALARM_INDEX = 0
+ANTI_THEFT_OFF_MAP_ALARM_INDEX = 1
+ANTI_THEFT_REAL_TIME_LOCATION_INDEX = 2
+ANTI_THEFT_PIN_CHECK_INDEX = 3
+
 
 def _integer_record(
     value: Any,
@@ -64,9 +70,7 @@ def decode_charging_settings(config: Mapping[str, Any]) -> dict[str, Any] | None
         "charging_settings_available": True,
         "recharge_battery_level": record[BATTERY_RECHARGE_LEVEL_INDEX],
         "resume_battery_level": record[BATTERY_RESUME_LEVEL_INDEX],
-        "resume_after_charging": bool(
-            record[BATTERY_RESUME_AFTER_CHARGING_INDEX]
-        ),
+        "resume_after_charging": bool(record[BATTERY_RESUME_AFTER_CHARGING_INDEX]),
         "charging_period_enabled": bool(record[CHARGING_PERIOD_ENABLED_INDEX]),
         "charging_period_start_minutes": record[CHARGING_PERIOD_START_INDEX],
         "charging_period_end_minutes": record[CHARGING_PERIOD_END_INDEX],
@@ -93,6 +97,37 @@ def decode_rain_settings(config: Mapping[str, Any]) -> dict[str, Any] | None:
     }
 
 
+def decode_anti_theft_settings(
+    config: Mapping[str, Any],
+) -> dict[str, Any] | None:
+    """Decode the ATA flags reported by the mower without inventing fields."""
+    record = _integer_record(
+        config.get("ATA"),
+        minimum_length=ANTI_THEFT_SETTING_MINIMUM_LENGTH,
+    )
+    if record is None:
+        return None
+    supported_settings = [
+        "lift_alarm_enabled",
+        "off_map_alarm_enabled",
+        "real_time_location_enabled",
+    ]
+    result: dict[str, Any] = {
+        "anti_theft_settings_available": True,
+        "anti_theft_supported_settings": supported_settings,
+        "lift_alarm_enabled": bool(record[ANTI_THEFT_LIFT_ALARM_INDEX]),
+        "off_map_alarm_enabled": bool(record[ANTI_THEFT_OFF_MAP_ALARM_INDEX]),
+        "real_time_location_enabled": bool(record[ANTI_THEFT_REAL_TIME_LOCATION_INDEX]),
+        "anti_theft_settings_raw": record,
+    }
+    if len(record) > ANTI_THEFT_PIN_CHECK_INDEX:
+        supported_settings.append("pin_check_before_power_off_enabled")
+        result["pin_check_before_power_off_enabled"] = bool(
+            record[ANTI_THEFT_PIN_CHECK_INDEX]
+        )
+    return result
+
+
 def decode_device_settings(config: Mapping[str, Any]) -> dict[str, Any]:
     """Decode the CFG settings this integration owns."""
     result: dict[str, Any] = {}
@@ -102,6 +137,9 @@ def decode_device_settings(config: Mapping[str, Any]) -> dict[str, Any]:
     rain = decode_rain_settings(config)
     if rain is not None:
         result.update(rain)
+    anti_theft = decode_anti_theft_settings(config)
+    if anti_theft is not None:
+        result.update(anti_theft)
     if "WRF" in config:
         try:
             result["weather_switch_enabled"] = bool(int(config["WRF"]))
@@ -178,3 +216,35 @@ def build_rain_protection_request(
             "sen": int(sensitivity),
         },
     }
+
+
+def build_anti_theft_settings_request(
+    current_record: Sequence[int],
+    *,
+    lift_alarm_enabled: bool | None = None,
+    off_map_alarm_enabled: bool | None = None,
+    real_time_location_enabled: bool | None = None,
+    pin_check_before_power_off_enabled: bool | None = None,
+) -> dict[str, Any]:
+    """Build one full ATA record while preserving unsupported future slots."""
+    record = _integer_record(
+        current_record,
+        minimum_length=ANTI_THEFT_SETTING_MINIMUM_LENGTH,
+    )
+    if record is None:
+        raise ValueError("Anti-theft settings require at least three values.")
+    changes = (
+        (ANTI_THEFT_LIFT_ALARM_INDEX, lift_alarm_enabled),
+        (ANTI_THEFT_OFF_MAP_ALARM_INDEX, off_map_alarm_enabled),
+        (ANTI_THEFT_REAL_TIME_LOCATION_INDEX, real_time_location_enabled),
+        (ANTI_THEFT_PIN_CHECK_INDEX, pin_check_before_power_off_enabled),
+    )
+    for index, value in changes:
+        if value is None:
+            continue
+        if index >= len(record):
+            raise ValueError(
+                "PIN check before power-off is not reported by this mower."
+            )
+        record[index] = int(bool(value))
+    return {"m": "s", "t": "ATA", "d": {"value": record}}

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
@@ -148,6 +148,7 @@ from .exceptions import (
 from .protocol import DreameMowerProtocol
 from .map_manager import DreameMapMowerMapManager
 from .map_decoder import DreameMowerMapDecoder
+from .mowing_preferences import MOWING_PREFERENCE_PROPERTY_KEY
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -156,6 +157,12 @@ _EXTERNAL_REALTIME_UPDATE_KEYS = frozenset(
         MOWER_RUNTIME_STATUS_PROPERTY_KEY,
         MOWER_BLUETOOTH_PROPERTY_KEY,
         MOWER_TIME_PROPERTY_KEY,
+    }
+)
+_EXTERNAL_REALTIME_ANNOUNCEMENT_KEYS = frozenset(
+    {
+        MOWER_TIME_PROPERTY_KEY,
+        MOWING_PREFERENCE_PROPERTY_KEY,
     }
 )
 
@@ -448,7 +455,9 @@ class _DreameMowerDeviceStateMixin:
                 else time.time()
             ),
         }
-        return key in _EXTERNAL_REALTIME_UPDATE_KEYS and previous_value != value
+        return key in _EXTERNAL_REALTIME_ANNOUNCEMENT_KEYS or (
+            key in _EXTERNAL_REALTIME_UPDATE_KEYS and previous_value != value
+        )
 
     def _request_properties(self, properties: list[DreameMowerProperty] = None) -> bool:
         """Request properties from the device."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -13,6 +13,7 @@ from .device_code_semantics import (
     mower_fault_code,
     mower_status_notice_code,
 )
+from .mowing_preferences import MOWING_PREFERENCE_PROPERTY_KEY
 from .video_provisioning_status import classify_xp2p_provisioning_issue
 
 SUPPORTED_ACCOUNT_TYPES = ("dreame", "mova")
@@ -23,9 +24,7 @@ REALTIME_STATE_PROPERTY_KEY = "2.1"
 REALTIME_ERROR_PROPERTY_KEY = "2.2"
 REALTIME_TASK_STATUS_PROPERTY_KEY = "4.7"
 REALTIME_SETTINGS_PROPERTY_KEY = "2.51"
-OPERATIONAL_HUMAN_DETECTION_NOTICE_MODELS = frozenset(
-    {"dreame.mower.q2501a", "q2501a"}
-)
+OPERATIONAL_HUMAN_DETECTION_NOTICE_MODELS = frozenset({"dreame.mower.q2501a", "q2501a"})
 
 MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
@@ -372,6 +371,11 @@ class DreameLawnMowerSnapshot:
         repr=False,
         compare=False,
     )
+    mowing_preferences_event_at: float | None = field(
+        default=None,
+        repr=False,
+        compare=False,
+    )
     mowing_session_active: bool | None = None
     task_resumable: bool | None = None
     error_code: int | None = None
@@ -509,9 +513,7 @@ def camera_metadata_advertises_video(
 ) -> bool:
     """Return whether normalized device metadata advertises camera/video support."""
     permit_tokens = {
-        item.strip().casefold()
-        for item in str(permit or "").split(",")
-        if item.strip()
+        item.strip().casefold() for item in str(permit or "").split(",") if item.strip()
     }
     return bool(
         camera_streaming
@@ -594,9 +596,7 @@ class DreameLawnMowerStatusBlob:
 
     def as_dict(self) -> dict[str, Any]:
         """Return a JSON-safe status blob payload."""
-        return {
-            key: value for key, value in asdict(self).items() if value is not None
-        }
+        return {key: value for key, value in asdict(self).items() if value is not None}
 
 
 @dataclass(slots=True, frozen=True)
@@ -1002,10 +1002,7 @@ def camera_stream_block_reason(snapshot: Any) -> str | None:
         bool(getattr(snapshot, "returning", False))
         or state == "returning"
         or activity == "returning"
-        or (
-            bool(raw_attributes.get("returning"))
-            and not known_video_activity
-        )
+        or (bool(raw_attributes.get("returning")) and not known_video_activity)
     ):
         return "Camera stream handshake probe is blocked while returning to dock."
 
@@ -1085,10 +1082,13 @@ def snapshot_from_device(
     task_obj = getattr(device.status, "task_status", None)
     error_obj = getattr(device.status, "error", None)
     state = state_obj.name.lower() if state_obj is not None else "unknown"
-    state_name = getattr(device.status, "state_name", None) or state.replace(
-        "_",
-        " ",
-    ).title()
+    state_name = (
+        getattr(device.status, "state_name", None)
+        or state.replace(
+            "_",
+            " ",
+        ).title()
+    )
     status_attributes = dict(getattr(device.status, "attributes", {}) or {})
     if "fast_mapping" not in status_attributes:
         fast_mapping = getattr(device.status, "fast_mapping", None)
@@ -1134,10 +1134,7 @@ def snapshot_from_device(
         # Unknown numeric overlap with a vacuum code is not a hard fault.
         error_name = None
         error_text = None
-        has_error = bool(
-            raw_code_definition is None
-            and state == "error"
-        )
+        has_error = bool(raw_code_definition is None and state == "error")
         if has_error:
             error_code = raw_error_code
             error_name = mower_device_code_name(
@@ -1154,11 +1151,7 @@ def snapshot_from_device(
         # code exists. An explicit mower state of ERROR is stronger evidence.
         has_error = bool(
             state == "error"
-            or (
-                status_has_error
-                and error_name is None
-                and error_text is None
-            )
+            or (status_has_error and error_name is None and error_text is None)
         )
 
     error_source: str | None = "status" if has_error else None
@@ -1228,9 +1221,7 @@ def snapshot_from_device(
         "charging",
         getattr(device.status, "charging", None),
     )
-    raw_charging = (
-        None if raw_charging_source is None else bool(raw_charging_source)
-    )
+    raw_charging = None if raw_charging_source is None else bool(raw_charging_source)
     confirmed_at_station = bool(raw_docked or raw_charging)
 
     suppressed_error_code: int | None = None
@@ -1364,6 +1355,10 @@ def snapshot_from_device(
             device,
             REALTIME_SETTINGS_PROPERTY_KEY,
         ),
+        mowing_preferences_event_at=_realtime_property_last_seen(
+            device,
+            MOWING_PREFERENCE_PROPERTY_KEY,
+        ),
         error_code=error_code,
         error_name=error_name,
         error_text=error_text,
@@ -1417,9 +1412,7 @@ def snapshot_from_device(
         realtime_error_code=realtime_error_code,
         _error_suppression_active=error_suppression_active,
         _suppressed_error_code=suppressed_error_code,
-        _suppressed_realtime_error_last_seen=(
-            suppressed_realtime_error_last_seen
-        ),
+        _suppressed_realtime_error_last_seen=(suppressed_realtime_error_last_seen),
         firmware_version=getattr(
             getattr(device, "info", None),
             "firmware_version",
@@ -1724,9 +1717,7 @@ def firmware_update_support_from_device(
         plugin_force_update=plugin_force_update,
         plugin_force_update_sources=plugin_force_update_sources,
         plugin_status=_as_optional_str(device_info.get("status")),
-        firmware_develop_type=_as_optional_str(
-            device_info.get("firmwareDevelopType")
-        ),
+        firmware_develop_type=_as_optional_str(device_info.get("firmwareDevelopType")),
         device_info_release_at=_as_optional_str(device_info.get("releaseAt")),
         device_info_updated_at=_as_optional_str(device_info.get("updatedAt")),
         cloud_check_available=cloud_check_available,

--- a/custom_components/dreame_lawn_mower/select.py
+++ b/custom_components/dreame_lawn_mower/select.py
@@ -6,7 +6,7 @@ from typing import Any
 
 from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -67,7 +67,6 @@ async def async_setup_entry(
     async_add_entities(
         [
             DreameLawnMowerVoiceLanguageSelect(coordinator),
-            DreameLawnMowerRainDelaySelect(coordinator),
             DreameLawnMowerMapSelect(coordinator),
             DreameLawnMowerSelectedMapRotationSelect(coordinator),
             DreameLawnMowerMowingActionSelect(coordinator),
@@ -82,6 +81,23 @@ async def async_setup_entry(
             DreameLawnMowerSpotSelect(coordinator),
         ]
     )
+    rain_delay_added = False
+
+    @callback
+    def async_add_rain_delay() -> None:
+        nonlocal rain_delay_added
+        settings = device_settings_section(coordinator.device_settings)
+        if (
+            rain_delay_added
+            or settings is None
+            or not settings.get("rain_settings_available")
+        ):
+            return
+        rain_delay_added = True
+        async_add_entities([DreameLawnMowerRainDelaySelect(coordinator)])
+
+    async_add_rain_delay()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_rain_delay))
 
 
 class DreameLawnMowerSelectEntity(DreameLawnMowerEntity, SelectEntity):

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -13,7 +13,7 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -497,7 +497,6 @@ async def async_setup_entry(
         + [DreameLawnMowerPreferenceMapCountSensor(coordinator)]
         + [DreameLawnMowerWeatherProtectionStatusSensor(coordinator)]
         + [DreameLawnMowerRainProtectionDurationSensor(coordinator)]
-        + [DreameLawnMowerRainDelayEndTimeSensor(coordinator)]
         + [
             DreameLawnMowerMaintenanceRemainingSensor(coordinator, item)
             for item in MAINTENANCE_ITEMS
@@ -511,6 +510,23 @@ async def async_setup_entry(
         + [DreameLawnMowerLastPreferenceProbeSensor(coordinator)]
         + [DreameLawnMowerLastWeatherProbeSensor(coordinator)]
     )
+    rain_delay_end_added = False
+
+    @callback
+    def async_add_rain_delay_end() -> None:
+        nonlocal rain_delay_end_added
+        settings = coordinator.device_settings
+        if (
+            rain_delay_end_added
+            or not isinstance(settings, dict)
+            or not settings.get("rain_settings_available")
+        ):
+            return
+        rain_delay_end_added = True
+        async_add_entities([DreameLawnMowerRainDelayEndTimeSensor(coordinator)])
+
+    async_add_rain_delay_end()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_rain_delay_end))
 
 
 class DreameLawnMowerSensor(DreameLawnMowerEntity, SensorEntity):

--- a/custom_components/dreame_lawn_mower/switch.py
+++ b/custom_components/dreame_lawn_mower/switch.py
@@ -49,6 +49,29 @@ VOICE_PROMPT_SWITCHES = (
     ),
 )
 
+ANTI_THEFT_SWITCHES = (
+    (
+        "lift_alarm_enabled",
+        "Lift Alarm",
+        "mdi:alarm-light-outline",
+    ),
+    (
+        "off_map_alarm_enabled",
+        "Off-Map Alarm",
+        "mdi:map-marker-alert-outline",
+    ),
+    (
+        "real_time_location_enabled",
+        "Real-Time Location",
+        "mdi:crosshairs-gps",
+    ),
+    (
+        "pin_check_before_power_off_enabled",
+        "PIN Check Before Power-Off",
+        "mdi:shield-key-outline",
+    ),
+)
+
 
 async def async_setup_entry(
     hass: HomeAssistant,
@@ -60,14 +83,6 @@ async def async_setup_entry(
     async_add_entities(
         [
             *(
-                DreameLawnMowerPreferenceSwitch(coordinator, description)
-                for description in PREFERENCE_SWITCHES
-            ),
-            *(
-                DreameLawnMowerPreferenceAiClassSwitch(coordinator, description)
-                for description in AI_CLASS_SWITCHES
-            ),
-            *(
                 DreameLawnMowerVoicePromptSwitch(
                     coordinator,
                     key=key,
@@ -77,11 +92,11 @@ async def async_setup_entry(
                 )
                 for key, name, index, icon in VOICE_PROMPT_SWITCHES
             ),
-            DreameLawnMowerChargingPeriodSwitch(coordinator),
-            DreameLawnMowerRainProtectionSwitch(coordinator),
         ]
     )
     known_schedule_plans: set[tuple[int, int]] = set()
+    known_setting_switches: set[str] = set()
+    known_preference_switches: set[str] = set()
 
     @callback
     def async_add_schedule_switches() -> None:
@@ -101,8 +116,76 @@ async def async_setup_entry(
         if new_entities:
             async_add_entities(new_entities)
 
+    @callback
+    def async_add_setting_switches() -> None:
+        settings = device_settings_section(coordinator.device_settings)
+        if settings is None:
+            return
+        new_entities: list[SwitchEntity] = []
+        if (
+            settings.get("charging_settings_available")
+            and "charging_period" not in known_setting_switches
+        ):
+            known_setting_switches.add("charging_period")
+            new_entities.append(DreameLawnMowerChargingPeriodSwitch(coordinator))
+        if (
+            settings.get("rain_settings_available")
+            and "rain_protection" not in known_setting_switches
+        ):
+            known_setting_switches.add("rain_protection")
+            new_entities.append(DreameLawnMowerRainProtectionSwitch(coordinator))
+        supported = settings.get("anti_theft_supported_settings")
+        supported_keys = set(supported) if isinstance(supported, list) else set()
+        for key, name, icon in ANTI_THEFT_SWITCHES:
+            if key not in supported_keys or key in known_setting_switches:
+                continue
+            known_setting_switches.add(key)
+            new_entities.append(
+                DreameLawnMowerAntiTheftSwitch(
+                    coordinator,
+                    key=key,
+                    name=name,
+                    icon=icon,
+                )
+            )
+        if new_entities:
+            async_add_entities(new_entities)
+
+    @callback
+    def async_add_preference_switches() -> None:
+        supported_keys = reported_preference_switch_keys(coordinator.batch_device_data)
+        new_entities: list[SwitchEntity] = []
+        for description in PREFERENCE_SWITCHES:
+            if (
+                description.key not in supported_keys
+                or description.key in known_preference_switches
+            ):
+                continue
+            known_preference_switches.add(description.key)
+            new_entities.append(
+                DreameLawnMowerPreferenceSwitch(coordinator, description)
+            )
+        if "obstacle_avoidance_ai" in supported_keys:
+            for description in AI_CLASS_SWITCHES:
+                unique_key = f"obstacle_avoidance_ai:{description.key}"
+                if unique_key in known_preference_switches:
+                    continue
+                known_preference_switches.add(unique_key)
+                new_entities.append(
+                    DreameLawnMowerPreferenceAiClassSwitch(
+                        coordinator,
+                        description,
+                    )
+                )
+        if new_entities:
+            async_add_entities(new_entities)
+
     async_add_schedule_switches()
+    async_add_setting_switches()
+    async_add_preference_switches()
     entry.async_on_unload(coordinator.async_add_listener(async_add_schedule_switches))
+    entry.async_on_unload(coordinator.async_add_listener(async_add_setting_switches))
+    entry.async_on_unload(coordinator.async_add_listener(async_add_preference_switches))
 
 
 class DreameLawnMowerVoicePromptSwitch(DreameLawnMowerEntity, SwitchEntity):
@@ -230,6 +313,57 @@ class DreameLawnMowerRainProtectionSwitch(DreameLawnMowerEntity, SwitchEntity):
 
     async def async_turn_off(self, **kwargs: Any) -> None:
         await self.coordinator.async_set_rain_protection(enabled=False)
+
+
+class DreameLawnMowerAntiTheftSwitch(DreameLawnMowerEntity, SwitchEntity):
+    """Expose one anti-theft flag explicitly reported by the mower."""
+
+    _attr_entity_category = EntityCategory.CONFIG
+
+    def __init__(
+        self,
+        coordinator: DreameLawnMowerCoordinator,
+        *,
+        key: str,
+        name: str,
+        icon: str,
+    ) -> None:
+        super().__init__(coordinator)
+        self._setting_key = key
+        self._attr_name = name
+        self._attr_icon = icon
+        self._attr_unique_id = f"{self._descriptor.unique_id}_{key}"
+
+    @property
+    def available(self) -> bool:
+        """Return whether this exact ATA field remains reported."""
+        settings = device_settings_section(self.coordinator.device_settings)
+        supported = settings.get("anti_theft_supported_settings") if settings else None
+        return bool(
+            self.coordinator.data is not None
+            and isinstance(supported, list)
+            and self._setting_key in supported
+        )
+
+    @property
+    def is_on(self) -> bool | None:
+        """Return the confirmed cached ATA value."""
+        settings = device_settings_section(self.coordinator.device_settings)
+        value = settings.get(self._setting_key) if settings else None
+        return value if isinstance(value, bool) else None
+
+    async def async_turn_on(self, **kwargs: Any) -> None:
+        """Enable this anti-theft setting."""
+        await self._async_set_state(True)
+
+    async def async_turn_off(self, **kwargs: Any) -> None:
+        """Disable this anti-theft setting."""
+        await self._async_set_state(False)
+
+    async def _async_set_state(self, enabled: bool) -> None:
+        await self.coordinator.async_set_anti_theft_settings(
+            **{self._setting_key: enabled}
+        )
 
 
 class DreameLawnMowerSchedulePlanSwitch(DreameLawnMowerEntity, SwitchEntity):
@@ -360,6 +494,35 @@ def schedule_plan_entries(value: Mapping[str, Any] | None) -> list[dict[str, Any
                     "task_count": task_count,
                 }
             )
+    return result
+
+
+def reported_preference_switch_keys(
+    value: Mapping[str, Any] | None,
+) -> set[str]:
+    """Return boolean preference fields actually reported by at least one map."""
+    preferences = (
+        value.get("batch_mowing_preferences") if isinstance(value, Mapping) else None
+    )
+    maps = preferences.get("maps") if isinstance(preferences, Mapping) else None
+    result: set[str] = set()
+    if not isinstance(maps, list):
+        return result
+    switch_keys = {description.key for description in PREFERENCE_SWITCHES}
+    for map_entry in maps:
+        entries = (
+            map_entry.get("preferences") if isinstance(map_entry, Mapping) else None
+        )
+        if not isinstance(entries, list):
+            continue
+        for entry in entries:
+            if not isinstance(entry, Mapping):
+                continue
+            result.update(
+                key for key in switch_keys if isinstance(entry.get(key), bool)
+            )
+            if isinstance(entry.get("obstacle_avoidance_ai"), int):
+                result.add("obstacle_avoidance_ai")
     return result
 
 

--- a/custom_components/dreame_lawn_mower/time.py
+++ b/custom_components/dreame_lawn_mower/time.py
@@ -6,7 +6,7 @@ from datetime import time
 
 from homeassistant.components.time import TimeEntity
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.core import HomeAssistant
+from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
@@ -27,12 +27,28 @@ async def async_setup_entry(
 ) -> None:
     """Set up charging-period time entities."""
     coordinator: DreameLawnMowerCoordinator = hass.data[DOMAIN][entry.entry_id]
-    async_add_entities(
-        [
-            DreameLawnMowerChargingPeriodStartTime(coordinator),
-            DreameLawnMowerChargingPeriodEndTime(coordinator),
-        ]
-    )
+    entities_added = False
+
+    @callback
+    def async_add_supported_entities() -> None:
+        nonlocal entities_added
+        settings = device_settings_section(coordinator.device_settings)
+        if (
+            entities_added
+            or settings is None
+            or not settings.get("charging_settings_available")
+        ):
+            return
+        entities_added = True
+        async_add_entities(
+            [
+                DreameLawnMowerChargingPeriodStartTime(coordinator),
+                DreameLawnMowerChargingPeriodEndTime(coordinator),
+            ]
+        )
+
+    async_add_supported_entities()
+    entry.async_on_unload(coordinator.async_add_listener(async_add_supported_entities))
 
 
 class DreameLawnMowerChargingPeriodTime(DreameLawnMowerEntity, TimeEntity):

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -412,6 +412,108 @@ def test_cached_settings_event_retries_after_failed_cfg_refresh() -> None:
     assert coordinator._last_device_settings_event_at == 123.0
 
 
+def test_cached_preference_event_refreshes_only_preferences_once() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    snapshot = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        device_settings_event_at=None,
+        mowing_preferences_event_at=456.0,
+    )
+    preferences = {
+        "available": True,
+        "maps": [{"idx": 0, "preferences": []}],
+        "errors": [],
+    }
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator._last_device_settings_event_at = None
+    coordinator._last_mowing_preferences_event_at = None
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator.app_maps = {"current_map_index": 0, "maps": [{"idx": 0}]}
+    coordinator.batch_device_data = {
+        "batch_schedule": {"available": True},
+        "batch_ota_info": {"available": True},
+    }
+    coordinator.selected_map_index = 0
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+        async_get_runtime_status_blob=AsyncMock(return_value=None),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        async_get_batch_mowing_preferences=AsyncMock(return_value=preferences),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+    coordinator.async_update_listeners = Mock()
+
+    with patch(
+        "custom_components.dreame_lawn_mower.coordinator.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        asyncio.run(coordinator._async_process_client_update())
+        asyncio.run(coordinator._async_process_client_update())
+
+    coordinator.client.async_get_batch_mowing_preferences.assert_awaited_once_with(
+        include_raw=False,
+        map_index_hints=[0],
+    )
+    assert coordinator.batch_device_data["batch_schedule"] == {"available": True}
+    assert coordinator.batch_device_data["batch_ota_info"] == {"available": True}
+    assert coordinator.batch_device_data["batch_mowing_preferences"] is preferences
+    assert coordinator._last_mowing_preferences_event_at == 456.0
+
+
+def test_cached_preference_event_retries_after_failed_decode() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    snapshot = SimpleNamespace(
+        available=True,
+        mowing_session_active=False,
+        activity="docked",
+        device_settings_event_at=None,
+        mowing_preferences_event_at=456.0,
+    )
+    coordinator._client_update_task = Mock()
+    coordinator._runtime_map_identity_verified = True
+    coordinator._last_device_settings_event_at = None
+    coordinator._last_mowing_preferences_event_at = None
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.batch_device_data = None
+    coordinator.selected_map_index = 0
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+    coordinator.bluetooth_connected = None
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+        async_get_runtime_status_blob=AsyncMock(return_value=None),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        async_get_batch_mowing_preferences=AsyncMock(
+            side_effect=(
+                {"available": False, "maps": [], "errors": ["not ready"]},
+                {"available": True, "maps": [{"idx": 0}], "errors": []},
+            )
+        ),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+    coordinator.async_update_listeners = Mock()
+
+    with patch(
+        "custom_components.dreame_lawn_mower.coordinator.asyncio.sleep",
+        new=AsyncMock(),
+    ):
+        asyncio.run(coordinator._async_process_client_update())
+        assert coordinator._last_mowing_preferences_event_at is None
+        asyncio.run(coordinator._async_process_client_update())
+
+    assert coordinator.client.async_get_batch_mowing_preferences.await_count == 2
+    assert coordinator._last_mowing_preferences_event_at == 456.0
+
+
 def test_cached_completion_survives_runtime_failure_and_later_idle_refresh() -> None:
     """A transient completion event is cached before optional telemetry reads."""
     completed = SimpleNamespace(
@@ -630,6 +732,7 @@ def test_foreground_charging_snapshot_preserves_current_session_cache() -> None:
         active=False,
     )
 
+
 def test_cached_device_update_does_not_confirm_connectivity() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     confirmed = SimpleNamespace(
@@ -706,23 +809,20 @@ def test_newer_video_safety_state_wins_over_delayed_cached_mqtt_update() -> None
         coordinator.app_maps = {"current_map_index": 2}
         coordinator.selected_map_index = 2
         coordinator.runtime_status_blob = None
-        completed_blob = SimpleNamespace(
-            candidate_runtime_area_progress_percent=99.7
+        completed_blob = SimpleNamespace(candidate_runtime_area_progress_percent=99.7)
+        coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+        assert (
+            coordinator.runtime_telemetry_cache.update(
+                completed_blob,
+                completion_confirmed=True,
+            )
+            is True
         )
-        coordinator.runtime_telemetry_cache = (
-            DreameLawnMowerRuntimeTelemetryCache()
-        )
-        assert coordinator.runtime_telemetry_cache.update(
-            completed_blob,
-            completion_confirmed=True,
-        ) is True
         coordinator.bluetooth_connected = None
         coordinator.client = SimpleNamespace(
             async_get_cached_snapshot=AsyncMock(return_value=cached_snapshot),
             async_refresh=AsyncMock(return_value=video_snapshot),
-            async_refresh_authoritative_snapshot=AsyncMock(
-                return_value=video_snapshot
-            ),
+            async_refresh_authoritative_snapshot=AsyncMock(return_value=video_snapshot),
             async_get_runtime_status_blob=runtime_status,
             async_get_bluetooth_connected=bluetooth_status,
             update_runtime_live_tracking=Mock(),
@@ -761,9 +861,7 @@ def test_command_boundary_blocks_delayed_cached_mqtt_runtime_side_effects() -> N
         )
         runtime_started = asyncio.Event()
         release_runtime = asyncio.Event()
-        stale_runtime = SimpleNamespace(
-            candidate_runtime_area_progress_percent=100.0
-        )
+        stale_runtime = SimpleNamespace(candidate_runtime_area_progress_percent=100.0)
         cache = DreameLawnMowerRuntimeTelemetryCache()
         assert cache.update(stale_runtime, completion_confirmed=True) is True
 
@@ -930,9 +1028,7 @@ def test_runtime_map_identity_does_not_fall_back_after_fresh_unknown_map() -> No
 def test_app_map_refresh_synchronizes_selected_map_identity() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator.client = SimpleNamespace(
-        async_get_app_maps=AsyncMock(
-            return_value={"current_map_index": 2, "maps": []}
-        )
+        async_get_app_maps=AsyncMock(return_value={"current_map_index": 2, "maps": []})
     )
     coordinator.app_maps = {"current_map_index": 0}
     coordinator.app_maps_refreshed_at = None

--- a/tests/test_device_settings.py
+++ b/tests/test_device_settings.py
@@ -12,6 +12,7 @@ import pytest
 from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerCaptureWeatherProbeButton,
 )
+from custom_components.dreame_lawn_mower.const import DOMAIN
 from custom_components.dreame_lawn_mower.coordinator import (
     DreameLawnMowerCoordinator,
 )
@@ -30,13 +31,24 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import 
 from custom_components.dreame_lawn_mower.select import (
     DreameLawnMowerRainDelaySelect,
 )
+from custom_components.dreame_lawn_mower.select import (
+    async_setup_entry as async_setup_select_entry,
+)
 from custom_components.dreame_lawn_mower.switch import (
+    DreameLawnMowerAntiTheftSwitch,
     DreameLawnMowerChargingPeriodSwitch,
     DreameLawnMowerRainProtectionSwitch,
+    reported_preference_switch_keys,
+)
+from custom_components.dreame_lawn_mower.switch import (
+    async_setup_entry as async_setup_switch_entry,
 )
 from custom_components.dreame_lawn_mower.time import (
     DreameLawnMowerChargingPeriodEndTime,
     DreameLawnMowerChargingPeriodStartTime,
+)
+from custom_components.dreame_lawn_mower.time import (
+    async_setup_entry as async_setup_time_entry,
 )
 
 
@@ -57,8 +69,13 @@ def _client() -> DreameLawnMowerClient:
     )
 
 
-def _cfg(*, charging_enabled: int = 0, rain_enabled: int = 1) -> dict:
-    return {
+def _cfg(
+    *,
+    charging_enabled: int = 0,
+    rain_enabled: int = 1,
+    anti_theft: list[int] | None = None,
+) -> dict:
+    payload = {
         "m": "r",
         "r": 0,
         "d": {
@@ -67,6 +84,9 @@ def _cfg(*, charging_enabled: int = 0, rain_enabled: int = 1) -> dict:
             "WRP": [rain_enabled, 8, 1],
         },
     }
+    if anti_theft is not None:
+        payload["d"]["ATA"] = anti_theft
+    return payload
 
 
 def test_decode_device_settings_keeps_battery_thresholds_separate() -> None:
@@ -110,6 +130,43 @@ def test_setting_payloads_are_narrow_and_preserve_rain_sensitivity() -> None:
         "t": "WRP",
         "d": {"value": 0, "time": 3, "sen": 1},
     }
+
+
+def test_anti_theft_codec_reports_only_fields_present_on_the_mower() -> None:
+    three_field = device_settings.decode_device_settings(
+        _cfg(anti_theft=[0, 1, 0])["d"]
+    )
+    assert three_field["anti_theft_supported_settings"] == [
+        "lift_alarm_enabled",
+        "off_map_alarm_enabled",
+        "real_time_location_enabled",
+    ]
+    assert three_field["off_map_alarm_enabled"] is True
+    assert "pin_check_before_power_off_enabled" not in three_field
+
+    four_field = device_settings.decode_device_settings(
+        _cfg(anti_theft=[1, 0, 1, 1, 7])["d"]
+    )
+    assert four_field["pin_check_before_power_off_enabled"] is True
+    assert four_field["anti_theft_settings_raw"] == [1, 0, 1, 1, 7]
+
+
+def test_anti_theft_request_preserves_unmodified_and_future_fields() -> None:
+    assert device_settings.build_anti_theft_settings_request(
+        [0, 1, 0, 1, 7],
+        lift_alarm_enabled=True,
+        pin_check_before_power_off_enabled=False,
+    ) == {
+        "m": "s",
+        "t": "ATA",
+        "d": {"value": [1, 1, 0, 0, 7]},
+    }
+
+    with pytest.raises(ValueError, match="not reported"):
+        device_settings.build_anti_theft_settings_request(
+            [0, 0, 0],
+            pin_check_before_power_off_enabled=True,
+        )
 
 
 def test_charging_write_preserves_times_and_requires_cfg_readback() -> None:
@@ -213,6 +270,47 @@ def test_rain_write_rejects_changed_sensitivity() -> None:
 
     with pytest.raises(DreameLawnMowerCommandRejectedError, match="sensitivity"):
         client._sync_set_rain_protection(enabled=False)
+
+
+def test_anti_theft_write_preserves_other_flags_and_requires_readback() -> None:
+    client = _client()
+    responses = iter(
+        [
+            _cfg(anti_theft=[0, 1, 0]),
+            {"m": "r", "r": 0, "d": {}},
+            _cfg(anti_theft=[1, 1, 0]),
+        ]
+    )
+    requests: list[dict] = []
+
+    def call(request: dict, **kwargs) -> dict:  # noqa: ARG001
+        requests.append(request)
+        return next(responses)
+
+    client._sync_call_app_action = call  # type: ignore[method-assign]
+    settings = client._sync_set_anti_theft_settings(lift_alarm_enabled=True)
+
+    assert settings["lift_alarm_enabled"] is True
+    assert requests[1] == {
+        "m": "s",
+        "t": "ATA",
+        "d": {"value": [1, 1, 0]},
+    }
+
+
+def test_anti_theft_write_rejects_acknowledged_but_ignored_update() -> None:
+    client = _client()
+    responses = iter(
+        [
+            _cfg(anti_theft=[0, 0, 0]),
+            {"m": "r", "r": 0, "d": {}},
+            _cfg(anti_theft=[0, 0, 0]),
+        ]
+    )
+    client._sync_call_app_action = lambda request, **kwargs: next(responses)  # type: ignore[method-assign]  # noqa: ARG005
+
+    with pytest.raises(DreameLawnMowerCommandRejectedError, match="did not confirm"):
+        client._sync_set_anti_theft_settings(lift_alarm_enabled=True)
 
 
 def test_weather_probe_updates_canonical_device_settings_cache() -> None:
@@ -335,12 +433,16 @@ def test_settings_entities_are_thin_over_confirmed_coordinator_writes() -> None:
         "rain_settings_available": True,
         "rain_protection_enabled": True,
         "rain_protection_duration_hours": 8,
+        "anti_theft_settings_available": True,
+        "anti_theft_supported_settings": ["lift_alarm_enabled"],
+        "lift_alarm_enabled": False,
     }
     coordinator = SimpleNamespace(
         data=SimpleNamespace(),
         device_settings=settings,
         async_set_charging_period=AsyncMock(),
         async_set_rain_protection=AsyncMock(),
+        async_set_anti_theft_settings=AsyncMock(),
     )
 
     charging = object.__new__(DreameLawnMowerChargingPeriodSwitch)
@@ -354,21 +456,150 @@ def test_settings_entities_are_thin_over_confirmed_coordinator_writes() -> None:
     delay = object.__new__(DreameLawnMowerRainDelaySelect)
     delay.coordinator = coordinator
     delay._hours_by_label = {"3 hours": 3}
+    lift_alarm = object.__new__(DreameLawnMowerAntiTheftSwitch)
+    lift_alarm.coordinator = coordinator
+    lift_alarm._setting_key = "lift_alarm_enabled"
 
     assert charging.available is True
     assert charging.is_on is False
     assert rain.is_on is True
     assert start.native_value == time(18, 0)
     assert end.native_value == time(8, 0)
+    assert lift_alarm.available is True
+    assert lift_alarm.is_on is False
 
     asyncio.run(charging.async_turn_on())
     asyncio.run(rain.async_turn_off())
     asyncio.run(start.async_set_value(time(22, 30)))
     asyncio.run(end.async_set_value(time(6, 15)))
     asyncio.run(delay.async_select_option("3 hours"))
+    asyncio.run(lift_alarm.async_turn_on())
 
     coordinator.async_set_charging_period.assert_any_await(enabled=True)
     coordinator.async_set_charging_period.assert_any_await(start_minutes=1350)
     coordinator.async_set_charging_period.assert_any_await(end_minutes=375)
     coordinator.async_set_rain_protection.assert_any_await(enabled=False)
     coordinator.async_set_rain_protection.assert_any_await(delay_hours=3)
+    coordinator.async_set_anti_theft_settings.assert_awaited_once_with(
+        lift_alarm_enabled=True
+    )
+
+
+def test_reported_preference_switch_keys_omit_missing_optional_fields() -> None:
+    result = reported_preference_switch_keys(
+        {
+            "batch_mowing_preferences": {
+                "maps": [
+                    {
+                        "preferences": [
+                            {
+                                "edge_mowing_auto": True,
+                                "edge_mowing_safe": False,
+                                "edge_cutting_attachment": None,
+                                "obstacle_avoidance_ai": 3,
+                            }
+                        ]
+                    }
+                ]
+            }
+        }
+    )
+
+    assert result == {
+        "edge_mowing_auto",
+        "edge_mowing_safe",
+        "obstacle_avoidance_ai",
+    }
+
+
+def test_setting_platforms_add_only_reported_entities_and_follow_late_discovery() -> (
+    None
+):
+    descriptor = _client().descriptor
+    listeners: list = []
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(descriptor=descriptor),
+        data=SimpleNamespace(),
+        device_settings=None,
+        batch_device_data=None,
+        schedules=None,
+        async_add_listener=lambda listener: listeners.append(listener) or Mock(),
+    )
+    hass = SimpleNamespace(data={DOMAIN: {"entry-1": coordinator}})
+    entry = SimpleNamespace(entry_id="entry-1", async_on_unload=Mock())
+    added: list[object] = []
+
+    async def setup() -> None:
+        await async_setup_switch_entry(hass, entry, added.extend)
+        await async_setup_select_entry(hass, entry, added.extend)
+        await async_setup_time_entry(hass, entry, added.extend)
+
+    asyncio.run(setup())
+
+    assert not any(
+        isinstance(
+            entity,
+            (
+                DreameLawnMowerAntiTheftSwitch,
+                DreameLawnMowerChargingPeriodSwitch,
+                DreameLawnMowerRainProtectionSwitch,
+                DreameLawnMowerRainDelaySelect,
+                DreameLawnMowerChargingPeriodStartTime,
+                DreameLawnMowerChargingPeriodEndTime,
+            ),
+        )
+        for entity in added
+    )
+
+    coordinator.device_settings = {
+        "available": True,
+        "charging_settings_available": True,
+        "rain_settings_available": True,
+        "anti_theft_settings_available": True,
+        "anti_theft_supported_settings": [
+            "lift_alarm_enabled",
+            "off_map_alarm_enabled",
+            "real_time_location_enabled",
+        ],
+    }
+    for listener in listeners:
+        listener()
+
+    assert (
+        sum(isinstance(entity, DreameLawnMowerAntiTheftSwitch) for entity in added) == 3
+    )
+    assert not any(
+        isinstance(entity, DreameLawnMowerAntiTheftSwitch)
+        and entity._setting_key == "pin_check_before_power_off_enabled"
+        for entity in added
+    )
+    assert (
+        sum(isinstance(entity, DreameLawnMowerChargingPeriodSwitch) for entity in added)
+        == 1
+    )
+    assert (
+        sum(isinstance(entity, DreameLawnMowerRainProtectionSwitch) for entity in added)
+        == 1
+    )
+    assert (
+        sum(isinstance(entity, DreameLawnMowerRainDelaySelect) for entity in added) == 1
+    )
+    assert (
+        sum(
+            isinstance(entity, DreameLawnMowerChargingPeriodStartTime)
+            for entity in added
+        )
+        == 1
+    )
+    assert (
+        sum(
+            isinstance(entity, DreameLawnMowerChargingPeriodEndTime) for entity in added
+        )
+        == 1
+    )
+
+    for listener in listeners:
+        listener()
+    assert (
+        sum(isinstance(entity, DreameLawnMowerAntiTheftSwitch) for entity in added) == 3
+    )

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -82,6 +82,28 @@ class _FakeDevice:
         return None
 
 
+def test_snapshot_tracks_mowing_preference_announcement_timestamp() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-1",
+            "customName": "Garden mower",
+            "model": "dreame.mower.g2408",
+        },
+        account_type="dreame",
+        country="eu",
+    )
+    assert descriptor is not None
+    device = _FakeDevice()
+    device.realtime_properties["2.52"] = {
+        "value": {},
+        "last_seen": 456.0,
+    }
+
+    snapshot = snapshot_from_device(descriptor, device)
+
+    assert snapshot.mowing_preferences_event_at == 456.0
+
+
 class _FakeErrorStatus(_FakeStatus):
     def __init__(self) -> None:
         super().__init__()
@@ -887,9 +909,7 @@ def test_snapshot_keeps_bare_has_error_when_no_error_details_exist() -> None:
     device.status.error_name = None
     device.status.has_error = True
     device.status.attributes = {
-        key: value
-        for key, value in device.status.attributes.items()
-        if key != "error"
+        key: value for key, value in device.status.attributes.items() if key != "error"
     }
 
     snapshot = snapshot_from_device(descriptor, device)
@@ -967,19 +987,26 @@ def test_firmware_update_support_preserves_evidence_without_guessing_ota() -> No
     assert support.latest_status == 13
     assert support.update_available is None
     assert support.candidate_update_fields["info.ver"] == "4.3.6_0320"
-    assert support.candidate_update_fields["info.updateTime"] == (
-        "2025-04-22 10:03:44"
-    )
+    assert support.candidate_update_fields["info.updateTime"] == ("2025-04-22 10:03:44")
     assert support.candidate_update_fields["deviceInfo.pluginForceUpdate"] is True
-    assert support.candidate_update_fields[
-        "cloud_device_info.deviceInfo.pluginForceUpdate"
-    ] is False
-    assert support.candidate_update_fields[
-        "cloud_device_list_page.page.records[0].latestStatus"
-    ] == 13
-    assert support.candidate_update_fields[
-        "cloud_device_list_page.page.records[0].deviceInfo.firmwareDevelopType"
-    ] == "SINGLE_PLATFORM"
+    assert (
+        support.candidate_update_fields[
+            "cloud_device_info.deviceInfo.pluginForceUpdate"
+        ]
+        is False
+    )
+    assert (
+        support.candidate_update_fields[
+            "cloud_device_list_page.page.records[0].latestStatus"
+        ]
+        == 13
+    )
+    assert (
+        support.candidate_update_fields[
+            "cloud_device_list_page.page.records[0].deviceInfo.firmwareDevelopType"
+        ]
+        == "SINGLE_PLATFORM"
+    )
     assert support.warnings == ("plugin_force_update_conflict",)
     assert "differs across cloud metadata sources" in support.reason
     assert support.evidence["info"]["latestStatus"] == 13
@@ -1028,12 +1055,18 @@ def test_firmware_update_support_tracks_live_like_plugin_sources() -> None:
     }
     assert support.warnings == ("plugin_force_update_conflict",)
     assert support.update_available is None
-    assert support.candidate_update_fields[
-        "cloud_device_list_page.records[0].deviceInfo.pluginForceUpdate"
-    ] is True
-    assert support.candidate_update_fields[
-        "cloud_device_list_page.records[0].deviceInfo.firmwareDevelopType"
-    ] == "SINGLE_PLATFORM"
+    assert (
+        support.candidate_update_fields[
+            "cloud_device_list_page.records[0].deviceInfo.pluginForceUpdate"
+        ]
+        is True
+    )
+    assert (
+        support.candidate_update_fields[
+            "cloud_device_list_page.records[0].deviceInfo.firmwareDevelopType"
+        ]
+        == "SINGLE_PLATFORM"
+    )
 
 
 def test_firmware_update_support_marks_update_state() -> None:
@@ -1099,8 +1132,7 @@ def test_firmware_update_support_uses_verified_batch_ota_signal() -> None:
     )
     assert support.candidate_update_fields["batch_ota_info.update_available"] is True
     assert (
-        support.candidate_update_fields["batch_ota_info.auto_upgrade_enabled"]
-        is False
+        support.candidate_update_fields["batch_ota_info.auto_upgrade_enabled"] is False
     )
     assert support.candidate_update_fields["batch_ota_info.ota_status"] == 0
     assert support.evidence["batch_ota_info"] == {
@@ -1271,6 +1303,9 @@ def test_firmware_update_support_summarizes_root_records() -> None:
         "records": [{"latestStatus": 13}],
     }
     assert "cloud_device_list_page.total" not in support.candidate_update_fields
-    assert support.candidate_update_fields[
-        "cloud_device_list_page.records[0].latestStatus"
-    ] == 13
+    assert (
+        support.candidate_update_fields[
+            "cloud_device_list_page.records[0].latestStatus"
+        ]
+        == 13
+    )

--- a/tests/test_python_package.py
+++ b/tests/test_python_package.py
@@ -129,12 +129,8 @@ def test_client_module_preserves_camera_exports() -> None:
 def test_public_package_exports_map_helpers() -> None:
     assert DreameLawnMowerMapSummary is MapSummaryFromModule
     assert DreameLawnMowerMapView is MapViewFromModule
-    assert DreameLawnMowerCameraFeatureSupport.__name__.endswith(
-        "CameraFeatureSupport"
-    )
-    assert DreameLawnMowerRemoteControlSupport.__name__.endswith(
-        "RemoteControlSupport"
-    )
+    assert DreameLawnMowerCameraFeatureSupport.__name__.endswith("CameraFeatureSupport")
+    assert DreameLawnMowerRemoteControlSupport.__name__.endswith("RemoteControlSupport")
     assert DreameLawnMowerFirmwareUpdateSupport.__name__.endswith(
         "FirmwareUpdateSupport"
     )
@@ -165,10 +161,7 @@ def test_public_package_exports_map_helpers() -> None:
     assert callable(remote_control_block_reason)
     assert callable(remote_control_state_safe)
     assert callable(classify_xp2p_provisioning_issue)
-    assert (
-        XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING
-        == "device_triple_missing"
-    )
+    assert XP2P_PROVISIONING_DEVICE_TRIPLE_MISSING == "device_triple_missing"
     assert callable(key_definition_label)
     assert callable(analyze_decompiled_sources)
     assert callable(analyze_dreamehome_assets)
@@ -286,8 +279,10 @@ def test_public_package_exports_app_protocol_helpers() -> None:
     assert MOWER_PROPERTY_HINTS["1.53"] == "bluetooth_connected"
     assert MOWER_PROPERTY_HINTS["2.50"] == "task_status"
     assert MOWER_PROPERTY_HINTS["2.51"] == "device_time"
+    assert MOWER_PROPERTY_HINTS["2.52"] == "mowing_preferences"
     assert MOWER_PROPERTY_HINTS["3.1"] == "battery_level"
     assert mower_property_hint("2.51") == "device_time"
+    assert mower_property_hint("2.52") == "mowing_preferences"
     assert mower_property_hint("9.4") is None
     assert mower_realtime_property_name("2.51", "UNKNOWN_REALTIME_2.51") == (
         "device_time"

--- a/tests/test_unknown_properties.py
+++ b/tests/test_unknown_properties.py
@@ -170,12 +170,9 @@ def test_message_callback_tracks_realtime_properties_and_unmapped_pairs() -> Non
     assert device.realtime_properties["9.4"]["value"] == {"blob": 123}
     assert device.last_realtime_message is not None
     assert device.last_realtime_message["message"]["method"] == "properties_changed"
-    assert len(
-        {
-            entry["last_seen"]
-            for entry in device.realtime_properties.values()
-        }
-    ) == 1
+    assert (
+        len({entry["last_seen"] for entry in device.realtime_properties.values()}) == 1
+    )
 
 
 @pytest.mark.parametrize("piid", [4, 53])
@@ -207,6 +204,21 @@ def test_message_callback_publishes_external_realtime_property_changes(
     )
 
     assert updates == ["changed", "changed"]
+
+
+@pytest.mark.parametrize("piid", [51, 52])
+def test_message_callback_publishes_each_settings_announcement(piid: int) -> None:
+    device, updates = _device_stub()
+    message = {
+        "method": "properties_changed",
+        "params": [{"siid": 2, "piid": piid, "value": {}}],
+    }
+
+    DreameMowerDevice._message_callback(device, message)
+    DreameMowerDevice._message_callback(device, message)
+
+    assert updates == ["changed", "changed"]
+    assert device.realtime_properties[f"2.{piid}"]["value"] == {}
 
 
 def test_message_callback_does_not_publish_raw_heartbeat_as_pose() -> None:


### PR DESCRIPTION
## Summary

- Add capability-gated Lift Alarm, Off-Map Alarm, Real-Time Location, and optional PIN Check Before Power-Off switches.
- Preserve untouched and future anti-theft fields, serialize settings writes, and publish values only after exact mower readback.
- Refresh CFG settings and mowing preferences from their distinct realtime announcements, including repeated event sentinels.
- Create charging, rain, anti-theft, and preference entities only after the mower reports the matching fields.

## User impact

Supported Dreamehome and MOVAhome mowers now expose only the settings they actually implement. Changes made in either mobile app are reflected without waiting for the normal metadata interval, while existing schedules and OTA metadata remain intact.

## Validation

- Full Python test suite passed with one expected skip.
- Home Assistant config-flow suite passed under Linux/WSL.
- Static checks and package compilation passed.
- A docked Dreame A2 confirmed the three-field anti-theft capability and exact no-op write/readback path without movement or an effective settings change.
- Independent local review completed; its realtime-delivery finding was fixed and target-confirmed.