### PR TITLE
Prevent camera attributes from flooding Recorder

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,11 +246,13 @@ lets Tencent negotiate the available network route. The explicit cloud policy
 always refreshes Dreame/Tencent inputs first. `Auto` also probes Tencent's
 separate same-LAN service when mower firmware advertises one.
 The tested A2 production firmware does not advertise that service, so the
-integration does not offer a LAN-only policy. The camera's
-`last_stream_session` attribute reports `stream_route` as `direct` only when
-the separate LAN service was selected; otherwise it stays `unknown`. Tencent's
-misleadingly named `getStreamLinkMode` API returns a network/NAT-type bitmask,
-exposed as `sdk_stream_network_type`, rather than a direct-versus-relay result.
+integration does not offer a LAN-only policy. Downloaded integration
+diagnostics report `coordinator.video_runtime.last_stream_session.stream_route`
+as `direct` only when the separate LAN service was selected; otherwise it stays
+`unknown`. This runtime detail is excluded from camera state and Recorder
+history. Tencent's misleadingly named `getStreamLinkMode` API returns a
+network/NAT-type bitmask, exposed as `sdk_stream_network_type`, rather than a
+direct-versus-relay result.
 
 After valid FLV media reaches the relay, `Auto` privately caches the minimum
 XP2P identity, P2P material, QCloud/app credentials, and resolved device

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -12,6 +12,7 @@ from typing import Any
 
 from homeassistant.components.camera import Camera
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import MATCH_ALL
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity import EntityCategory
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
@@ -118,20 +119,9 @@ class DreameLawnMowerMapCamera(
     _requires_map_capability = True
     _prewarm_map_image = True
     _refresh_cached_view_on_coordinator_update = True
-    _unrecorded_attributes = frozenset(
-        {
-            "runtime_pose_x",
-            "runtime_pose_y",
-            "runtime_heading_deg",
-            "runtime_region_id",
-            "runtime_position_updated_at",
-            "position_x",
-            "position_y",
-            "position_heading",
-            "position_segment",
-            "position_updated_at",
-        }
-    )
+    # Camera attributes describe the current rendered/diagnostic view. Persisting
+    # their large map payloads on every refresh creates unbounded recorder churn.
+    _unrecorded_attributes = frozenset({MATCH_ALL})
 
     def __init__(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Callable, Mapping, Sequence
 from contextlib import suppress
 from copy import deepcopy
 from datetime import UTC, datetime, timedelta
@@ -211,6 +211,7 @@ class DreameLawnMowerCoordinator(
         self._advertised_feature_capabilities: set[str] = set()
         self._observed_feature_capabilities: set[str] = set()
         self.diagnostic_events = DreameLawnMowerDiagnosticEventStore()
+        self.video_diagnostics_provider: Callable[[], Mapping[str, Any]] | None = None
         self.performance = DreameLawnMowerPerformanceTracker()
         self.last_batch_device_data_probe_result: dict[str, Any] | None = None
         self.last_map_probe_result: dict[str, Any] | None = None

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -25,7 +25,7 @@ from .dreame_lawn_mower_client.models import (
     remote_control_state_safe,
 )
 
-DIAGNOSTIC_SCHEMA_VERSION = 8
+DIAGNOSTIC_SCHEMA_VERSION = 9
 UNKNOWN_REALTIME_PREFIX = "UNKNOWN_REALTIME_"
 
 REDACT_KEYS = {

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -76,6 +76,19 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
     last_exception = getattr(coordinator, "last_exception", None)
     performance = getattr(coordinator, "performance", None)
     last_map_probe = getattr(coordinator, "last_map_probe_result", None)
+    video_diagnostics_provider = getattr(
+        coordinator,
+        "video_diagnostics_provider",
+        None,
+    )
+    video_diagnostics = None
+    if callable(video_diagnostics_provider):
+        try:
+            video_diagnostics = video_diagnostics_provider()
+        except Exception as err:  # noqa: BLE001 - diagnostics must remain downloadable.
+            video_diagnostics = {
+                "collection_error": sanitize_diagnostic_text(err),
+            }
     return {
         "last_update_success": getattr(coordinator, "last_update_success", None),
         "last_exception_type": (
@@ -96,6 +109,7 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
         ),
         "maintenance_points": build_maintenance_point_diagnostics(coordinator),
         "work_log_totals": _work_log_totals_diagnostics(coordinator),
+        "video_runtime": sanitize_debug_data(video_diagnostics),
         "last_maintenance_point_probe": (
             dict(last_map_probe) if isinstance(last_map_probe, Mapping) else None
         ),

--- a/custom_components/dreame_lawn_mower/video_camera.py
+++ b/custom_components/dreame_lawn_mower/video_camera.py
@@ -22,6 +22,7 @@ from homeassistant.components.stream.const import (
     DOMAIN as STREAM_DOMAIN,
 )
 from homeassistant.config_entries import ConfigEntry
+from homeassistant.const import MATCH_ALL
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from . import video_stream_helpers as video_helpers
@@ -121,6 +122,9 @@ class DreameLawnMowerVideoCamera(
     _attr_icon = "mdi:video-wireless-outline"
     _attr_entity_registry_enabled_default = True
     _attr_supported_features = CameraEntityFeature.STREAM | CameraEntityFeature.ON_OFF
+    # Runtime diagnostics can change for every media packet. They remain visible
+    # in downloaded diagnostics but must never be persisted by the recorder.
+    _unrecorded_attributes = frozenset({MATCH_ALL})
 
     # Preserve the historical method surface while focused mixins own the
     # implementations. Reading from ``__dict__`` retains property and
@@ -135,6 +139,9 @@ class DreameLawnMowerVideoCamera(
     device_info = DreameLawnMowerVideoStateMixin.__dict__["device_info"]
     extra_state_attributes = DreameLawnMowerVideoStateMixin.__dict__[
         "extra_state_attributes"
+    ]
+    video_runtime_diagnostics = DreameLawnMowerVideoStateMixin.__dict__[
+        "video_runtime_diagnostics"
     ]
     _async_start_stream = DreameLawnMowerVideoStartupMixin.__dict__[
         "_async_start_stream"
@@ -292,6 +299,7 @@ class DreameLawnMowerVideoCamera(
     async def async_added_to_hass(self) -> None:
         """Schedule managed runtime preparation without blocking entity setup."""
         await super().async_added_to_hass()
+        self.coordinator.video_diagnostics_provider = self.video_runtime_diagnostics
         if not self._lan_cache.loaded:
             try:
                 await self._lan_cache.async_load()
@@ -938,6 +946,9 @@ class DreameLawnMowerVideoCamera(
 
     async def async_will_remove_from_hass(self) -> None:
         """Stop XP2P video when Home Assistant unloads the camera."""
+        provider = getattr(self.coordinator, "video_diagnostics_provider", None)
+        if provider == self.video_runtime_diagnostics:
+            self.coordinator.video_diagnostics_provider = None
         prepare_task = self._runtime_prepare_task
         self._runtime_prepare_task = None
         if prepare_task is not None and not prepare_task.done():

--- a/custom_components/dreame_lawn_mower/video_camera_state.py
+++ b/custom_components/dreame_lawn_mower/video_camera_state.py
@@ -150,22 +150,29 @@ class DreameLawnMowerVideoStateMixin:
 
     @property
     def extra_state_attributes(self) -> dict[str, Any]:
-        """Expose stream readiness without leaking runtime credentials."""
+        """Expose compact stream readiness without recorder-heavy telemetry."""
         capability = self._resolved_video_capability()
         return {
             "video_runtime_configured": self._runtime_configured,
             "video_runtime_mode": self._runtime_mode,
             "video_transport_policy": self._video_transport,
             "video_retention_mode": self._video_retention_mode,
-            "video_live_view_seen": self._video_live_view_seen,
             "video_block_reason": camera_stream_block_reason(self.coordinator.data),
+            "video_capability": capability.state,
+            "video_capability_source": capability.source,
+            "last_video_transport": self._last_video_transport,
+            "stream_session_active": self._session is not None,
+        }
+
+    def video_runtime_diagnostics(self) -> dict[str, Any]:
+        """Return detailed runtime telemetry for downloaded diagnostics only."""
+        return {
+            **self.extra_state_attributes,
+            "video_live_view_seen": self._video_live_view_seen,
             "video_capability_advertised": snapshot_advertises_video(
                 self.coordinator.data
             ),
             "video_capability_observed": self._video_capability_observed,
-            "video_capability": capability.state,
-            "video_capability_source": capability.source,
-            "last_video_transport": self._last_video_transport,
             "last_video_transport_attempted": self._last_video_transport_attempted,
             "lan_video_identity_cached": self._lan_cache.inputs is not None,
             "lan_video_endpoint_cached": self._lan_cache.endpoint is not None,
@@ -184,7 +191,6 @@ class DreameLawnMowerVideoStateMixin:
                 video_helpers.managed_runtime_environment()
             ),
             "video_runtime_preparation_error": self._runtime_preparation_error,
-            "stream_session_active": self._session is not None,
             "video_recovery_pending": self._video_recovery_pending,
             "video_recovery_failure_count": self._video_recovery_failure_count,
             "video_recovery_success_count": self._video_recovery_success_count,

--- a/examples/home_assistant_video_playback_probe.py
+++ b/examples/home_assistant_video_playback_probe.py
@@ -24,6 +24,7 @@ import shutil
 import socket
 import sys
 import tempfile
+from collections.abc import Mapping
 from pathlib import Path
 from typing import Any
 from urllib.parse import urljoin
@@ -293,6 +294,17 @@ def _find_video_camera(hass: HomeAssistant) -> Any:
     return entities[0]
 
 
+def _video_runtime_diagnostics(camera: Any) -> dict[str, Any]:
+    """Read volatile video telemetry from its diagnostics-only owner."""
+    provider = getattr(camera, "video_runtime_diagnostics", None)
+    if not callable(provider):
+        raise RuntimeError("Dreame live-video diagnostics provider is unavailable.")
+    diagnostics = provider()
+    if not isinstance(diagnostics, Mapping):
+        raise RuntimeError("Dreame live-video diagnostics returned an invalid value.")
+    return dict(diagnostics)
+
+
 def _find_mower_entity(hass: HomeAssistant) -> Any:
     component = hass.data[lawn_mower_component.DATA_COMPONENT]
     entities = [
@@ -463,7 +475,7 @@ async def _verify_cached_xp2p_after_reload(
         ha_stream = await camera.async_create_stream()
         if ha_stream is None:
             raise RuntimeError(
-                camera.extra_state_attributes.get("last_stream_error")
+                _video_runtime_diagnostics(camera).get("last_stream_error")
                 or "Cached XP2P restart returned no stream."
             )
         hls_output = ha_stream.add_provider("hls")
@@ -477,7 +489,7 @@ async def _verify_cached_xp2p_after_reload(
             None,
         )
         status, playlist = await _fetch_hls_playlist(port, endpoint)
-        attributes = camera.extra_state_attributes
+        diagnostics = _video_runtime_diagnostics(camera)
     finally:
         if client_type is not None:
             client_type.async_get_camera_stream_runtime_inputs = original_inputs
@@ -485,8 +497,8 @@ async def _verify_cached_xp2p_after_reload(
 
     result = {
         "blocked_dreame_video_calls": blocked_calls,
-        "stream_session": attributes["last_stream_session"],
-        "last_video_transport": attributes["last_video_transport"],
+        "stream_session": diagnostics["last_stream_session"],
+        "last_video_transport": diagnostics["last_video_transport"],
         "hls_endpoint_status": status,
         "hls_playlist_present": "#EXTM3U" in playlist,
         "decoded_frame_count": frame["decoded_frame_count"],
@@ -494,7 +506,7 @@ async def _verify_cached_xp2p_after_reload(
         "height": frame["height"],
         "verified": bool(
             blocked_calls == []
-            and attributes["last_video_transport"] == "cached_xp2p"
+            and diagnostics["last_video_transport"] == "cached_xp2p"
             and status == 200
             and "#EXTM3U" in playlist
             and frame["decoded_frame_count"] > 1
@@ -538,27 +550,25 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             camera = _find_video_camera(hass)
             mower = _find_mower_entity(hass)
             snapshot = await client.async_refresh()
+            camera_attributes = camera.extra_state_attributes
+            camera_diagnostics = _video_runtime_diagnostics(camera)
             output["before"] = _snapshot_summary(snapshot)
             output["camera_entity"] = {
                 "entity_id": camera.entity_id,
                 "available": camera.available,
-                "runtime_mode": camera.extra_state_attributes[
-                    "video_runtime_mode"
-                ],
-                "transport_policy": camera.extra_state_attributes[
-                    "video_transport_policy"
-                ],
-                "block_reason": camera.extra_state_attributes["video_block_reason"],
-                "lan_identity_cached": camera.extra_state_attributes[
+                "runtime_mode": camera_attributes["video_runtime_mode"],
+                "transport_policy": camera_attributes["video_transport_policy"],
+                "block_reason": camera_attributes["video_block_reason"],
+                "lan_identity_cached": camera_diagnostics[
                     "lan_video_identity_cached"
                 ],
-                "lan_endpoint_cached": camera.extra_state_attributes[
+                "lan_endpoint_cached": camera_diagnostics[
                     "lan_video_endpoint_cached"
                 ],
-                "xp2p_provisioning_cached": camera.extra_state_attributes[
+                "xp2p_provisioning_cached": camera_diagnostics[
                     "xp2p_provisioning_cached"
                 ],
-                "runtime_preparation_error": camera.extra_state_attributes[
+                "runtime_preparation_error": camera_diagnostics[
                     "video_runtime_preparation_error"
                 ],
             }
@@ -586,16 +596,17 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                 )
                 output["coordinator_after_start"] = _snapshot_summary(coordinator.data)
                 camera_attributes = camera.extra_state_attributes
+                camera_diagnostics = _video_runtime_diagnostics(camera)
                 output["camera_entity"].update(
                     available_after_start=camera_available,
                     block_reason_after_start=camera_attributes["video_block_reason"],
-                    lan_identity_cached_after_start=camera_attributes[
+                    lan_identity_cached_after_start=camera_diagnostics[
                         "lan_video_identity_cached"
                     ],
-                    lan_endpoint_cached_after_start=camera_attributes[
+                    lan_endpoint_cached_after_start=camera_diagnostics[
                         "lan_video_endpoint_cached"
                     ],
-                    xp2p_provisioning_cached_after_start=camera_attributes[
+                    xp2p_provisioning_cached_after_start=camera_diagnostics[
                         "xp2p_provisioning_cached"
                     ],
                 )
@@ -611,7 +622,7 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
             ha_stream = await camera.async_create_stream()
             if ha_stream is None:
                 raise RuntimeError(
-                    camera.extra_state_attributes.get("last_stream_error")
+                    _video_runtime_diagnostics(camera).get("last_stream_error")
                     or "Home Assistant camera returned no stream."
                 )
             hls_output = ha_stream.add_provider("hls")
@@ -650,9 +661,9 @@ async def _run(args: argparse.Namespace) -> dict[str, Any]:
                 "camera_image": camera_image,
                 "decoded_frame": frame,
             }
-            camera_attributes = camera.extra_state_attributes
-            output["stream_session"] = camera_attributes["last_stream_session"]
-            output["last_video_transport"] = camera_attributes[
+            camera_diagnostics = _video_runtime_diagnostics(camera)
+            output["stream_session"] = camera_diagnostics["last_stream_session"]
+            output["last_video_transport"] = camera_diagnostics[
                 "last_video_transport"
             ]
             output["visual_frame_verified"] = bool(

--- a/tests/test_camera_stream_probe_example.py
+++ b/tests/test_camera_stream_probe_example.py
@@ -104,6 +104,37 @@ def test_ha_playback_probe_starts_snapshot_consumer_with_hls() -> None:
     assert image == b"jpeg"
 
 
+def test_ha_playback_probe_reads_volatile_state_from_diagnostics() -> None:
+    module = _load_ha_playback_probe_module()
+    camera = SimpleNamespace(
+        extra_state_attributes={
+            "video_runtime_mode": "managed",
+            "video_transport_policy": "auto",
+            "video_block_reason": None,
+        },
+        video_runtime_diagnostics=lambda: {
+            "lan_video_identity_cached": True,
+            "lan_video_endpoint_cached": True,
+            "xp2p_provisioning_cached": True,
+            "video_runtime_preparation_error": None,
+            "last_stream_session": {"transport": "lan"},
+            "last_stream_error": None,
+        },
+    )
+
+    diagnostics = module._video_runtime_diagnostics(camera)
+
+    assert diagnostics == {
+        "lan_video_identity_cached": True,
+        "lan_video_endpoint_cached": True,
+        "xp2p_provisioning_cached": True,
+        "video_runtime_preparation_error": None,
+        "last_stream_session": {"transport": "lan"},
+        "last_stream_error": None,
+    }
+    assert "lan_video_identity_cached" not in camera.extra_state_attributes
+
+
 def test_probe_help_uses_standalone_client_package(tmp_path) -> None:
     (tmp_path / "sitecustomize.py").write_text(
         "\n".join(

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -164,7 +164,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
         device=device,
     )
 
-    assert payload["diagnostic_schema_version"] == 8
+    assert payload["diagnostic_schema_version"] == 9
     assert payload["entry"]["username"] == "**REDACTED**"
     assert payload["entry"]["password"] == "**REDACTED**"
     assert payload["entry"]["token"] == "**REDACTED**"
@@ -272,7 +272,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
     }
     assert payload["state_reconciliation"]["warnings"] == []
     assert payload["triage"] == {
-        "schema_version": 8,
+        "schema_version": 9,
         "known_model": True,
         "model": "dreame.mower.g2408",
         "display_model": "A2",
@@ -512,7 +512,7 @@ def test_build_debug_payload_highlights_state_disagreements() -> None:
         "raw_mower_state_looks_docked_but_raw_docked_false",
         "raw_mower_state_differs_from_state_name",
     ]
-    assert payload["triage"]["schema_version"] == 8
+    assert payload["triage"]["schema_version"] == 9
     assert payload["triage"]["error"] == {
         "active": True,
         "code": 73,

--- a/tests/test_diagnostics_download.py
+++ b/tests/test_diagnostics_download.py
@@ -74,13 +74,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         last_exception=None,
         update_interval=timedelta(seconds=30),
         async_request_refresh=_refresh,
-    )
-    state = SimpleNamespace(
-        state="idle",
-        attributes={
-            "anonymous_feature": _AnonymousFeature(0),
-            "last_stream_error_code": "video_cloud_start_failed",
-            "last_stream_error": "accessToken=secret failed",
+        video_diagnostics_provider=lambda: {
             "last_runtime_input_diagnostics": {
                 "operation": "camera_stream_inputs",
                 "stages": [
@@ -110,6 +104,14 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
                     }
                 ],
             },
+        },
+    )
+    state = SimpleNamespace(
+        state="idle",
+        attributes={
+            "anonymous_feature": _AnonymousFeature(0),
+            "last_stream_error_code": "video_cloud_start_failed",
+            "last_stream_error": "accessToken=secret failed",
         },
     )
     hass = SimpleNamespace(
@@ -166,7 +168,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
     )
 
-    assert payload["diagnostic_schema_version"] == 8
+    assert payload["diagnostic_schema_version"] == 9
     assert payload["report_context"]["integration_version"] == "0.3.0"
     assert payload["report_context"]["home_assistant"]["arch"] == "aarch64"
     assert "user" not in payload["report_context"]["home_assistant"]
@@ -177,7 +179,10 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         "accessToken=**REDACTED** failed"
     )
     assert payload["entities"][0]["attributes"]["anonymous_feature"] == 0
-    operation = payload["entities"][0]["attributes"][
+    assert "last_runtime_input_diagnostics" not in payload["entities"][0][
+        "attributes"
+    ]
+    operation = payload["coordinator"]["video_runtime"][
         "last_runtime_input_diagnostics"
     ]
     assert operation["stages"][0]["stage"] == "cloud_device_identity"

--- a/tests/test_map_camera.py
+++ b/tests/test_map_camera.py
@@ -7,6 +7,7 @@ from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 
 import pytest
+from homeassistant.const import MATCH_ALL
 
 from custom_components.dreame_lawn_mower import camera as camera_module
 from custom_components.dreame_lawn_mower.camera import (
@@ -44,6 +45,21 @@ def test_optional_map_cameras_refresh_only_when_requested() -> None:
     assert DreameLawnMowerLivePathMapCamera.__dict__[refresh_policy] is False
     assert DreameLawnMowerAllMapsCamera.__dict__[refresh_policy] is False
     assert DreameLawnMowerMapDataCamera.__dict__[refresh_policy] is False
+
+
+def test_map_camera_attributes_are_excluded_from_recorder() -> None:
+    """Large current-map payloads belong in live state, not recorder history."""
+    assert DreameLawnMowerMapCamera._unrecorded_attributes == frozenset({MATCH_ALL})
+    assert (
+        DreameLawnMowerLivePathMapCamera._unrecorded_attributes
+        == frozenset({MATCH_ALL})
+    )
+    assert DreameLawnMowerAllMapsCamera._unrecorded_attributes == frozenset(
+        {MATCH_ALL}
+    )
+    assert DreameLawnMowerMapDataCamera._unrecorded_attributes == frozenset(
+        {MATCH_ALL}
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -123,7 +123,33 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
             "vector_maps": [],
         },
         "work_log_totals": None,
+        "video_runtime": None,
         "last_maintenance_point_probe": None,
+    }
+
+
+def test_coordinator_diagnostics_collect_video_runtime_privately() -> None:
+    diagnostics = build_coordinator_diagnostics(
+        SimpleNamespace(
+            last_update_success=True,
+            last_exception=None,
+            update_interval=timedelta(seconds=30),
+            video_diagnostics_provider=lambda: {
+                "video_delivery": {"relay_packet_count": 42},
+                "last_runtime_input_diagnostics": {
+                    "access_token": "secret",
+                    "operation": "camera_stream_inputs",
+                },
+            },
+        )
+    )
+
+    assert diagnostics["video_runtime"] == {
+        "video_delivery": {"relay_packet_count": 42},
+        "last_runtime_input_diagnostics": {
+            "access_token": "**REDACTED**",
+            "operation": "camera_stream_inputs",
+        },
     }
 
 

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -11,6 +11,7 @@ from unittest.mock import patch
 
 import pytest
 from homeassistant.components.camera import CameraEntityFeature
+from homeassistant.const import MATCH_ALL
 
 import custom_components.dreame_lawn_mower.video_camera as video_camera_module
 import custom_components.dreame_lawn_mower.video_stream_helpers as video_helpers_module
@@ -314,6 +315,7 @@ def test_video_camera_facade_preserves_split_method_surface() -> None:
             "available",
             "device_info",
             "extra_state_attributes",
+            "video_runtime_diagnostics",
         ),
         video_camera_startup_module.DreameLawnMowerVideoStartupMixin: (
             "_async_start_stream",
@@ -643,6 +645,53 @@ def test_known_a1_video_camera_reports_unsupported_after_registry_restore() -> N
     assert entity.extra_state_attributes["video_capability_source"] == "model"
 
 
+def test_live_video_attributes_are_small_stable_and_unrecorded() -> None:
+    """Media counters and diagnostic blobs must not churn recorder state."""
+    entity = _uninitialized_entity()
+    entity._last_runtime_input_diagnostics = {"payload": "x" * 4096}
+    entity._last_native_runtime_diagnostics = {"ready": True}
+    entity._last_managed_runtime_diagnostics = {"ready": True}
+    entity._flv_relay = SimpleNamespace(
+        diagnostics={"relay_packet_count": 1},
+        direct_subscriber_count=0,
+    )
+
+    with patch.object(video_camera_state_module, "monotonic", return_value=10.0):
+        first = entity.extra_state_attributes
+    entity._video_retry_not_before = 60.0
+    entity._flv_relay.diagnostics["relay_packet_count"] = 2
+    with patch.object(video_camera_state_module, "monotonic", return_value=20.0):
+        second = entity.extra_state_attributes
+
+    assert first == second
+    assert set(first) == {
+        "last_video_transport",
+        "stream_session_active",
+        "video_block_reason",
+        "video_capability",
+        "video_capability_source",
+        "video_retention_mode",
+        "video_runtime_configured",
+        "video_runtime_mode",
+        "video_transport_policy",
+    }
+    assert len(json.dumps(first, separators=(",", ":"))) < 512
+    assert "video_recovery_retry_after_seconds" not in first
+    assert "video_delivery" not in first
+    assert "last_runtime_input_diagnostics" not in first
+    assert DreameLawnMowerVideoCamera._unrecorded_attributes == frozenset(
+        {MATCH_ALL}
+    )
+
+    with patch.object(video_camera_state_module, "monotonic", return_value=20.0):
+        diagnostics = entity.video_runtime_diagnostics()
+    assert diagnostics["video_recovery_retry_after_seconds"] == 40.0
+    assert diagnostics["video_delivery"]["relay_packet_count"] == 2
+    assert diagnostics["last_runtime_input_diagnostics"] == {
+        "payload": "x" * 4096
+    }
+
+
 def test_video_camera_unavailable_without_video_metadata() -> None:
     snapshot = SimpleNamespace(
         capabilities=("map", "lidar_navigation"),
@@ -756,8 +805,9 @@ def test_video_camera_remembers_support_when_metadata_disappears() -> None:
         entity._handle_coordinator_update()
 
     assert entity.available is True
-    assert entity.extra_state_attributes["video_capability_advertised"] is False
-    assert entity.extra_state_attributes["video_capability_observed"] is False
+    diagnostics = entity.video_runtime_diagnostics()
+    assert diagnostics["video_capability_advertised"] is False
+    assert diagnostics["video_capability_observed"] is False
     assert entity.extra_state_attributes["video_capability"] == "supported"
     assert entity.extra_state_attributes["video_capability_source"] == "advertised"
 


### PR DESCRIPTION
Closes #147

## What changed

- Keep the live-video camera state small and stable by exposing only runtime mode, transport policy, capability, block reason, and session status.
- Move relay counters, retry timing, health details, and runtime diagnostics to the downloaded integration diagnostics under coordinator.video_runtime.
- Exclude all Dreame camera and map attributes from Recorder history while keeping their current values available in Home Assistant.
- Update the Home Assistant playback probe for the diagnostics-only runtime fields and advance the diagnostics schema to version 9.

## Compatibility

Volatile live-video troubleshooting fields are no longer available as camera state attributes. Download the integration diagnostics to access the same detailed runtime evidence.