### PR TITLE
Verify data-less mower preference writes

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -49,6 +49,7 @@ from .debug_ota_catalog import (
     normalize_debug_ota_catalog_payload,
 )
 from .exceptions import (
+    DreameLawnMowerCommandRejectedError,
     DreameLawnMowerConnectionError,
 )
 from .exceptions import (
@@ -658,14 +659,37 @@ class _DreameLawnMowerClientSettingsMixin:
         if execute:
             responses: list[Any] = []
             response_payloads: list[Any] = []
+            preference_readback_required = False
             for request in request_sequence:
                 response = self._sync_call_app_action(request)
+                is_preference_settings_write = request.get("t") == "PRE"
+                missing_response_data = (
+                    is_preference_settings_write
+                    and isinstance(response, Mapping)
+                    and "d" not in response
+                )
                 response_data = _ensure_app_write_succeeded(
                     response,
                     operation="Preference write",
+                    allow_missing_data=is_preference_settings_write,
                 )
+                preference_readback_required |= missing_response_data
                 responses.append(_json_safe(response, max_depth=4))
                 response_payloads.append(_json_safe(response_data, max_depth=4))
+            if preference_readback_required:
+                result["readback"] = self._sync_verify_mowing_preference_readback(
+                    map_index=map_index,
+                    area_id=area_id,
+                    setting_changes=setting_changes,
+                    requested_mode=requested_mode,
+                )
+                result["verification_source"] = "preference_readback"
+                result["notes"].append(
+                    "The PRE response omitted data; the requested values were "
+                    "confirmed through mower preference readback."
+                )
+            else:
+                result["verification_source"] = "response_data"
             result["executed"] = True
             result["request_verified"] = True
             if len(responses) == 1:
@@ -675,6 +699,85 @@ class _DreameLawnMowerClientSettingsMixin:
                 result["responses"] = responses
                 result["response_data"] = response_payloads
         return result
+
+    def _sync_verify_mowing_preference_readback(
+        self,
+        *,
+        map_index: int,
+        area_id: int | None,
+        setting_changes: Mapping[str, Any],
+        requested_mode: int | None,
+    ) -> dict[str, Any]:
+        """Require exact PRE/PREI readback after a data-less success response."""
+        preferences = self._sync_get_mowing_preferences(map_indices=[map_index])
+        maps = preferences.get("maps")
+        preference_map = (
+            next(
+                (
+                    item
+                    for item in maps
+                    if isinstance(item, Mapping) and item.get("idx") == map_index
+                ),
+                None,
+            )
+            if isinstance(maps, list)
+            else None
+        )
+        if not isinstance(preference_map, Mapping):
+            raise DreameLawnMowerConnectionError(
+                "Preference write returned success without response data, but the "
+                "mower did not return the target map for readback. Refresh the mower "
+                "before trying again."
+            )
+
+        unconfirmed_fields: list[str] = []
+        if (
+            requested_mode is not None
+            and _positive_int(preference_map.get("mode")) != requested_mode
+        ):
+            unconfirmed_fields.append(MOWING_PREFERENCE_MODE_FIELD)
+
+        readback_preference: Mapping[str, Any] | None = None
+        if setting_changes:
+            raw_preferences = preference_map.get("preferences")
+            if isinstance(raw_preferences, list):
+                readback_preference = next(
+                    (
+                        item
+                        for item in raw_preferences
+                        if isinstance(item, Mapping)
+                        and _positive_int(item.get("area_id")) == area_id
+                    ),
+                    None,
+                )
+            if readback_preference is None:
+                raise DreameLawnMowerConnectionError(
+                    "Preference write returned success without response data, but the "
+                    "mower did not return the target area for readback. Refresh the "
+                    "mower before trying again."
+                )
+            _, remaining_changes = apply_mowing_preference_changes(
+                readback_preference,
+                setting_changes,
+            )
+            unconfirmed_fields.extend(remaining_changes)
+
+        if unconfirmed_fields:
+            fields = ", ".join(dict.fromkeys(unconfirmed_fields))
+            raise DreameLawnMowerCommandRejectedError(
+                "The mower returned success without response data, but preference "
+                f"readback did not confirm the requested fields: {fields}."
+            )
+
+        return {
+            "source": "app_action_mowing_preference_readback",
+            "map": _mowing_preference_map_overview(preference_map),
+            "preference": (
+                _mowing_preference_overview(readback_preference)
+                if readback_preference is not None
+                else None
+            ),
+        }
 
     def _sync_get_batch_schedules(
         self,
@@ -803,7 +906,17 @@ class _DreameLawnMowerClientSettingsMixin:
                             f"area {area_id}."
                         )
                     preference = decode_mowing_preference_payload(preference_data)
-                    preference["area_id"] = area_id
+                    reported_map_index = _positive_int(preference.get("map_index"))
+                    reported_area_id = _positive_int(preference.get("area_id"))
+                    if (
+                        reported_map_index != map_index
+                        or reported_area_id != area_id
+                    ):
+                        raise DreameLawnMowerConnectionError(
+                            "PRE returned mismatched preference identity for requested "
+                            f"map {map_index} area {area_id}: payload map "
+                            f"{reported_map_index} area {reported_area_id}."
+                        )
                     preference["reported_version"] = area.get("version")
                     if include_raw:
                         preference["raw_response"] = _json_safe(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_shared_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_shared_helpers.py
@@ -65,9 +65,18 @@ def _app_action_data(value: Any) -> Any:
     return value.get("d")
 
 
-def _ensure_app_write_succeeded(value: Any, *, operation: str) -> Any:
+def _ensure_app_write_succeeded(
+    value: Any,
+    *,
+    operation: str,
+    allow_missing_data: bool = False,
+) -> Any:
     """Require an explicit mower acknowledgement for a state-changing request."""
-    if not isinstance(value, Mapping) or value.get("r") != 0 or "d" not in value:
+    if not isinstance(value, Mapping) or value.get("r") != 0:
+        raise DreameLawnMowerConnectionError(
+            f"{operation} failed: the mower did not acknowledge the request."
+        )
+    if "d" not in value and not allow_missing_data:
         raise DreameLawnMowerConnectionError(
             f"{operation} failed: the mower did not acknowledge the request."
         )

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -6,6 +6,8 @@ import pytest
 
 from dreame_lawn_mower_client import (
     DreameLawnMowerClient,
+    DreameLawnMowerCommandRejectedError,
+    DreameLawnMowerConnectionError,
     apply_mowing_preference_changes,
     decode_mowing_preference_payload,
     encode_mowing_preference_payload,
@@ -97,6 +99,23 @@ def _client() -> DreameLawnMowerClient:
             country="eu",
         ),
     )
+
+
+def _preference_result(preference: dict[str, object]) -> dict[str, object]:
+    return {
+        "available": True,
+        "maps": [
+            {
+                "idx": 0,
+                "label": "map_0",
+                "available": True,
+                "mode": 0,
+                "mode_name": "global",
+                "area_count": 1,
+                "preferences": [preference],
+            }
+        ],
+    }
 
 
 def test_decode_mowing_preference_payload_names_known_fields() -> None:
@@ -211,6 +230,41 @@ def test_get_mowing_preferences_can_limit_maps_and_include_raw() -> None:
     assert "raw_info" in result["maps"][0]
     assert "raw_response" in result["maps"][0]["preferences"][0]
     assert [call["t"] for call in cloud.calls] == ["PREI", "PRE", "PRE"]
+
+
+@pytest.mark.parametrize(
+    ("payload_map_index", "payload_area_id"),
+    [(1, 11), (0, 12)],
+)
+def test_get_mowing_preferences_rejects_mismatched_payload_identity(
+    payload_map_index: int,
+    payload_area_id: int,
+) -> None:
+    client = _client()
+    cloud = _FakePreferenceCloud()
+    call_app_action = cloud.call_app_action
+
+    def mismatched_call(
+        payload: dict[str, object],
+        *,
+        siid: int = 2,
+        aiid: int = 50,
+    ) -> dict[str, object]:
+        result = call_app_action(payload, siid=siid, aiid=aiid)
+        if payload.get("t") == "PRE" and payload.get("m") == "g":
+            preference = result["out"][0]["d"]
+            preference[1] = payload_map_index
+            preference[2] = payload_area_id
+        return result
+
+    cloud.call_app_action = mismatched_call  # type: ignore[method-assign]
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    result = client._sync_get_mowing_preferences(map_indices=[0])
+
+    assert result["available"] is False
+    assert result["maps"][0]["preferences"] == []
+    assert "mismatched preference identity" in result["maps"][0]["error"]
 
 
 def test_encode_mowing_preference_payload_round_trips_decoded_values() -> None:
@@ -404,6 +458,101 @@ def test_plan_app_mowing_preference_update_can_execute_confirmed_request() -> No
     assert result["request_verified"] is True
     assert result["response_data"] == {"r": 0, "ok": True}
     assert [call["t"] for call in cloud.calls] == ["PREI", "PRE", "PRE", "PRE"]
+
+
+def test_preference_write_accepts_data_less_success_after_exact_readback() -> None:
+    client = _client()
+    before = decode_mowing_preference_payload(
+        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1, 2, 0, 1]
+    )
+    after = decode_mowing_preference_payload(
+        [221, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 3, 1, 2, 0, 1]
+    )
+    reads = iter(
+        [
+            _preference_result(before),
+            _preference_result(after),
+        ]
+    )
+    requests: list[dict[str, object]] = []
+    client._sync_get_mowing_preferences = lambda **kwargs: next(reads)  # type: ignore[method-assign]  # noqa: ARG005
+    client._sync_call_app_action = lambda request: (  # type: ignore[method-assign]
+        requests.append(request) or {"m": "r", "q": 42, "r": 0}
+    )
+
+    result = client._sync_plan_app_mowing_preference_update(
+        map_index=0,
+        area_id=0,
+        changes={"obstacle_avoidance_ai_classes": ["people", "animals"]},
+        execute=True,
+        confirm_write=True,
+    )
+
+    assert result["executed"] is True
+    assert result["request_verified"] is True
+    assert result["verification_source"] == "preference_readback"
+    assert result["response_data"] is None
+    assert result["readback"]["preference"]["version"] == 221
+    assert result["readback"]["preference"]["obstacle_avoidance_ai_classes"] == [
+        "people",
+        "animals",
+    ]
+    assert requests == [
+        {
+            "m": "s",
+            "t": "PRE",
+            "d": [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 3, 1, 2, 0, 1],
+        }
+    ]
+
+
+def test_preference_write_rejects_data_less_success_without_matching_readback() -> None:
+    client = _client()
+    unchanged = decode_mowing_preference_payload(
+        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: _preference_result(  # type: ignore[method-assign]  # noqa: ARG005
+        unchanged
+    )
+    client._sync_call_app_action = lambda request: {  # type: ignore[method-assign]  # noqa: ARG005
+        "m": "r",
+        "r": 0,
+    }
+
+    with pytest.raises(
+        DreameLawnMowerCommandRejectedError,
+        match="did not confirm.*obstacle_avoidance_ai_classes",
+    ):
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=0,
+            changes={"obstacle_avoidance_ai_classes": ["people", "animals"]},
+            execute=True,
+            confirm_write=True,
+        )
+
+
+def test_preference_write_still_rejects_failed_outer_response() -> None:
+    client = _client()
+    current = decode_mowing_preference_payload(
+        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: _preference_result(  # type: ignore[method-assign]  # noqa: ARG005
+        current
+    )
+    client._sync_call_app_action = lambda request: {  # type: ignore[method-assign]  # noqa: ARG005
+        "m": "r",
+        "r": 5,
+    }
+
+    with pytest.raises(DreameLawnMowerConnectionError, match="did not acknowledge"):
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=0,
+            changes={"obstacle_avoidance_ai_classes": ["people", "animals"]},
+            execute=True,
+            confirm_write=True,
+        )
 
 
 def test_plan_app_mowing_preference_update_can_build_mode_only_request() -> None:


### PR DESCRIPTION
## Summary

- accept successful PRE responses without response data only after an exact mower readback
- keep other writes and explicit outer or nested failures fail-closed
- reject preference payloads whose map or area identity does not match the requested target

Fixes #149