### PR TITLE
Cancel mower reconnect tasks during Home Assistant shutdown

### DIFF
--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -121,7 +121,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         async def _async_shutdown_on_stop(_: Event) -> None:
             """Release integration resources before Home Assistant waits for tasks."""
-            await coordinator.async_shutdown()
+            await coordinator.async_shutdown_for_home_assistant_stop()
 
         entry.async_on_unload(
             hass.bus.async_listen_once(

--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -70,6 +70,15 @@ async def async_migrate_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     """Set up Dreame lawn mower from a config entry."""
     coordinator = DreameLawnMowerCoordinator(hass, entry)
+
+    async def _async_shutdown_on_stop(_: Event) -> None:
+        """Release integration resources before Home Assistant waits for tasks."""
+        await coordinator.async_shutdown_for_home_assistant_stop()
+
+    remove_stop_listener = hass.bus.async_listen_once(
+        EVENT_HOMEASSISTANT_STOP,
+        _async_shutdown_on_stop,
+    )
     setup_cycle = coordinator.performance.start("setup")
     setup_outcome = "completed"
     lan_cache = DreameLawnMowerVideoLanCache(
@@ -119,24 +128,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
             lambda: hass.config_entries.async_forward_entry_setups(entry, platforms),
         )
 
-        async def _async_shutdown_on_stop(_: Event) -> None:
-            """Release integration resources before Home Assistant waits for tasks."""
-            await coordinator.async_shutdown_for_home_assistant_stop()
-
-        entry.async_on_unload(
-            hass.bus.async_listen_once(
-                EVENT_HOMEASSISTANT_STOP,
-                _async_shutdown_on_stop,
-            )
-        )
+        entry.async_on_unload(remove_stop_listener)
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
         return True
     except asyncio.CancelledError:
         setup_outcome = "cancelled"
+        remove_stop_listener()
         await _async_cleanup_failed_setup(hass, entry, coordinator)
         raise
     except Exception as err:  # noqa: BLE001 - retain setup failure behavior
         setup_outcome = type(err).__name__
+        remove_stop_listener()
         await _async_cleanup_failed_setup(hass, entry, coordinator)
         raise
     finally:

--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -6,8 +6,8 @@ import asyncio
 import logging
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
-from homeassistant.core import HomeAssistant
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP, Platform
+from homeassistant.core import Event, HomeAssistant
 from homeassistant.helpers import entity_registry as er
 
 from .const import (
@@ -117,6 +117,17 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         await setup_cycle.measure(
             "platforms",
             lambda: hass.config_entries.async_forward_entry_setups(entry, platforms),
+        )
+
+        async def _async_shutdown_on_stop(_: Event) -> None:
+            """Release integration resources before Home Assistant waits for tasks."""
+            await coordinator.async_shutdown()
+
+        entry.async_on_unload(
+            hass.bus.async_listen_once(
+                EVENT_HOMEASSISTANT_STOP,
+                _async_shutdown_on_stop,
+            )
         )
         entry.async_on_unload(entry.add_update_listener(_async_update_listener))
         return True

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -228,6 +228,7 @@ class DreameLawnMowerCoordinator(
         self._last_mowing_preferences_event_at: float | None = None
         self._metadata_refresh_task: asyncio.Task[None] | None = None
         self._metadata_shutdown_close_task: asyncio.Task[None] | None = None
+        self._client_close_task: asyncio.Task[None] | None = None
         self._metadata_refresh_semaphore = asyncio.Semaphore(
             METADATA_REFRESH_CONCURRENCY
         )
@@ -2211,7 +2212,45 @@ class DreameLawnMowerCoordinator(
         """Stop owned tasks without scheduling unload-oriented metadata drains."""
         self._home_assistant_stopping = True
         await self._async_cancel_metadata_shutdown_close()
+        await self._async_cancel_client_close()
         await self._async_stop_owned_tasks_serialized()
+
+    async def _async_cancel_client_close(self) -> None:
+        """Cancel the async owner of a disconnect already running for unload."""
+        close_task = getattr(self, "_client_close_task", None)
+        if close_task is None or close_task is asyncio.current_task():
+            return
+        close_task.cancel()
+        await asyncio.gather(close_task, return_exceptions=True)
+        if self._client_close_task is close_task:
+            self._client_close_task = None
+
+    async def _async_close_client_for_unload(self) -> None:
+        """Close the client through an owner the HA stop path can cancel."""
+        if getattr(self, "_home_assistant_stopping", False):
+            return
+        close_task = getattr(self, "_client_close_task", None)
+        if close_task is None or close_task.done():
+            close_task = asyncio.create_task(
+                self.client.async_close(),
+                name=f"{DOMAIN}-client-shutdown",
+            )
+            self._client_close_task = close_task
+        try:
+            await asyncio.shield(close_task)
+        except asyncio.CancelledError:
+            current = asyncio.current_task()
+            if (
+                current is not None
+                and not current.cancelling()
+                and close_task.cancelled()
+                and getattr(self, "_home_assistant_stopping", False)
+            ):
+                return
+            raise
+        finally:
+            if self._client_close_task is close_task and close_task.done():
+                self._client_close_task = None
 
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""
@@ -2223,7 +2262,7 @@ class DreameLawnMowerCoordinator(
             "_home_assistant_stopping",
             False,
         ):
-            await self.client.async_close()
+            await self._async_close_client_for_unload()
 
 
 def _app_map_index_hints(app_maps: Mapping[str, Any] | None) -> list[int]:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -2210,6 +2210,7 @@ class DreameLawnMowerCoordinator(
     async def async_shutdown_for_home_assistant_stop(self) -> None:
         """Stop owned tasks without scheduling unload-oriented metadata drains."""
         self._home_assistant_stopping = True
+        await self._async_cancel_metadata_shutdown_close()
         await self._async_stop_owned_tasks_serialized()
 
     async def async_shutdown(self) -> None:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -2184,8 +2184,8 @@ class DreameLawnMowerCoordinator(
         if pending_active_indices is not None:
             pending_active_indices.clear()
 
-    async def async_shutdown(self) -> None:
-        """Disconnect client resources."""
+    async def _async_stop_owned_tasks(self) -> None:
+        """Stop coordinator-owned work without draining vendor metadata."""
         self._shutting_down = True
         await self._async_shutdown_connectivity_recovery()
         self._client_update_pending = False
@@ -2195,6 +2195,14 @@ class DreameLawnMowerCoordinator(
             task.cancel()
             with suppress(asyncio.CancelledError):
                 await task
+
+    async def async_shutdown_for_home_assistant_stop(self) -> None:
+        """Stop owned tasks without scheduling unload-oriented metadata drains."""
+        await self._async_stop_owned_tasks()
+
+    async def async_shutdown(self) -> None:
+        """Disconnect client resources."""
+        await self._async_stop_owned_tasks()
         if await self._async_drain_metadata_for_shutdown():
             await self.client.async_close()
 

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -78,6 +78,8 @@ from .schedule_cache import (
     schedule_payload_has_usable_data,
 )
 
+CLIENT_UPDATE_SHUTDOWN_GRACE_SECONDS = 1.0
+
 _LOGGER = logging.getLogger(__name__)
 
 BATCH_DEVICE_DATA_REFRESH_INTERVAL = timedelta(minutes=15)
@@ -239,6 +241,7 @@ class DreameLawnMowerCoordinator(
         self._metadata_refresh_count = 0
         self._shutting_down = False
         self._home_assistant_stopping = False
+        self._base_shutdown_complete = False
         self._owned_tasks_shutdown_lock = asyncio.Lock()
         self._initialize_connectivity_recovery()
 
@@ -2196,8 +2199,20 @@ class DreameLawnMowerCoordinator(
         task = self._client_update_task
         if task is not None and task is not asyncio.current_task():
             task.cancel()
-            with suppress(asyncio.CancelledError):
-                await task
+            done, pending = await asyncio.wait(
+                {task},
+                timeout=CLIENT_UPDATE_SHUTDOWN_GRACE_SECONDS,
+            )
+            if done:
+                with suppress(asyncio.CancelledError):
+                    task.result()
+                if self._client_update_task is task:
+                    self._client_update_task = None
+            if pending:
+                _LOGGER.warning(
+                    "Continuing mower shutdown while a cancelled realtime "
+                    "update finishes in the background."
+                )
 
     async def _async_stop_owned_tasks_serialized(self) -> None:
         """Serialize shutdown ownership across stop and config-entry unload."""
@@ -2206,29 +2221,20 @@ class DreameLawnMowerCoordinator(
             lock = asyncio.Lock()
             self._owned_tasks_shutdown_lock = lock
         async with lock:
+            if not getattr(self, "_base_shutdown_complete", False):
+                await super().async_shutdown()
+                self._base_shutdown_complete = True
             await self._async_stop_owned_tasks()
 
     async def async_shutdown_for_home_assistant_stop(self) -> None:
-        """Stop owned tasks without scheduling unload-oriented metadata drains."""
+        """Stop owned work and close the client without draining metadata."""
         self._home_assistant_stopping = True
         await self._async_cancel_metadata_shutdown_close()
-        await self._async_cancel_client_close()
         await self._async_stop_owned_tasks_serialized()
+        await self._async_close_client()
 
-    async def _async_cancel_client_close(self) -> None:
-        """Cancel the async owner of a disconnect already running for unload."""
-        close_task = getattr(self, "_client_close_task", None)
-        if close_task is None or close_task is asyncio.current_task():
-            return
-        close_task.cancel()
-        await asyncio.gather(close_task, return_exceptions=True)
-        if self._client_close_task is close_task:
-            self._client_close_task = None
-
-    async def _async_close_client_for_unload(self) -> None:
-        """Close the client through an owner the HA stop path can cancel."""
-        if getattr(self, "_home_assistant_stopping", False):
-            return
+    async def _async_close_client(self) -> None:
+        """Close the client through one shared shutdown owner."""
         close_task = getattr(self, "_client_close_task", None)
         if close_task is None or close_task.done():
             close_task = asyncio.create_task(
@@ -2238,19 +2244,15 @@ class DreameLawnMowerCoordinator(
             self._client_close_task = close_task
         try:
             await asyncio.shield(close_task)
-        except asyncio.CancelledError:
-            current = asyncio.current_task()
-            if (
-                current is not None
-                and not current.cancelling()
-                and close_task.cancelled()
-                and getattr(self, "_home_assistant_stopping", False)
-            ):
-                return
-            raise
         finally:
             if self._client_close_task is close_task and close_task.done():
                 self._client_close_task = None
+
+    async def _async_close_client_for_unload(self) -> None:
+        """Close the client unless the Home Assistant stop path owns shutdown."""
+        if getattr(self, "_home_assistant_stopping", False):
+            return
+        await self._async_close_client()
 
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -237,6 +237,8 @@ class DreameLawnMowerCoordinator(
         self._foreground_refresh_count = 0
         self._metadata_refresh_count = 0
         self._shutting_down = False
+        self._home_assistant_stopping = False
+        self._owned_tasks_shutdown_lock = asyncio.Lock()
         self._initialize_connectivity_recovery()
 
         super().__init__(
@@ -2196,14 +2198,30 @@ class DreameLawnMowerCoordinator(
             with suppress(asyncio.CancelledError):
                 await task
 
+    async def _async_stop_owned_tasks_serialized(self) -> None:
+        """Serialize shutdown ownership across stop and config-entry unload."""
+        lock = getattr(self, "_owned_tasks_shutdown_lock", None)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._owned_tasks_shutdown_lock = lock
+        async with lock:
+            await self._async_stop_owned_tasks()
+
     async def async_shutdown_for_home_assistant_stop(self) -> None:
         """Stop owned tasks without scheduling unload-oriented metadata drains."""
-        await self._async_stop_owned_tasks()
+        self._home_assistant_stopping = True
+        await self._async_stop_owned_tasks_serialized()
 
     async def async_shutdown(self) -> None:
         """Disconnect client resources."""
-        await self._async_stop_owned_tasks()
-        if await self._async_drain_metadata_for_shutdown():
+        await self._async_stop_owned_tasks_serialized()
+        if getattr(self, "_home_assistant_stopping", False):
+            return
+        if await self._async_drain_metadata_for_shutdown() and not getattr(
+            self,
+            "_home_assistant_stopping",
+            False,
+        ):
             await self.client.async_close()
 
 

--- a/custom_components/dreame_lawn_mower/coordinator_connectivity.py
+++ b/custom_components/dreame_lawn_mower/coordinator_connectivity.py
@@ -16,6 +16,7 @@ _LOGGER = logging.getLogger(__name__)
 
 CONNECTIVITY_STALE_GRACE_SECONDS = 180.0
 CONNECTIVITY_RETRY_DELAYS_SECONDS = (1.0, 2.0, 5.0, 10.0, 30.0)
+CONNECTIVITY_SHUTDOWN_GRACE_SECONDS = 1.0
 
 
 class DreameLawnMowerConnectivityMixin:
@@ -123,7 +124,8 @@ class DreameLawnMowerConnectivityMixin:
         task = getattr(self, "_connectivity_retry_task", None)
         if task is not None and not task.done():
             return
-        self._connectivity_retry_task = self.hass.async_create_task(
+        self._connectivity_retry_task = self.entry.async_create_background_task(
+            self.hass,
             self._async_connectivity_retry(delay),
             f"{DOMAIN}-connectivity-retry",
         )
@@ -171,10 +173,24 @@ class DreameLawnMowerConnectivityMixin:
             )
             if task is not None and task is not current
         }
-        self._connectivity_retry_task = None
-        self._connectivity_retry_inflight_task = None
         for task in tasks:
             task.cancel()
-        for task in tasks:
+        if not tasks:
+            return
+        done, pending = await asyncio.wait(
+            tasks,
+            timeout=CONNECTIVITY_SHUTDOWN_GRACE_SECONDS,
+        )
+        for task in done:
             with suppress(asyncio.CancelledError):
-                await task
+                task.result()
+            if getattr(self, "_connectivity_retry_task", None) is task:
+                self._connectivity_retry_task = None
+            if getattr(self, "_connectivity_retry_inflight_task", None) is task:
+                self._connectivity_retry_inflight_task = None
+        if pending:
+            _LOGGER.warning(
+                "Continuing mower shutdown while %s cancelled connectivity "
+                "task(s) finish in the background.",
+                len(pending),
+            )

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -646,6 +646,8 @@ class DreameLawnMowerRefreshMixin:
 
     async def _async_drain_metadata_for_shutdown(self) -> bool:
         """Cancel queued metadata and bound the wait for an in-flight request."""
+        if getattr(self, "_home_assistant_stopping", False):
+            return False
         metadata_task = self._metadata_refresh_task
         if metadata_task is None or metadata_task is asyncio.current_task():
             return await self._async_drain_batch_schedule_for_shutdown()
@@ -662,6 +664,8 @@ class DreameLawnMowerRefreshMixin:
             if not metadata_task.done():
                 raise
         except TimeoutError:
+            if getattr(self, "_home_assistant_stopping", False):
+                return False
             self._metadata_shutdown_close_task = self.hass.async_create_task(
                 self._async_close_after_metadata(metadata_task),
                 f"{DOMAIN}-metadata-shutdown",
@@ -671,6 +675,8 @@ class DreameLawnMowerRefreshMixin:
 
     async def _async_drain_batch_schedule_for_shutdown(self) -> bool:
         """Wait for shared batch reads without cancelling their worker threads."""
+        if getattr(self, "_home_assistant_stopping", False):
+            return False
         tasks = set(getattr(self, "_batch_schedule_read_tasks", set()))
         latest = getattr(self, "_batch_schedule_read_task", None)
         if latest is not None:
@@ -687,6 +693,8 @@ class DreameLawnMowerRefreshMixin:
             if not drain_task.done():
                 raise
         except TimeoutError:
+            if getattr(self, "_home_assistant_stopping", False):
+                return False
             self._metadata_shutdown_close_task = self.hass.async_create_task(
                 self._async_close_after_metadata(drain_task),
                 f"{DOMAIN}-batch-schedule-shutdown",

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -758,7 +758,7 @@ class DreameLawnMowerRefreshMixin:
         await self._async_wait_batch_schedule_reads()
         if getattr(self, "_home_assistant_stopping", False):
             return
-        await self.client.async_close()
+        await self._async_close_client_for_unload()
 
     @staticmethod
     def _log_performance_sample(

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -100,6 +100,11 @@ class DreameLawnMowerRefreshMixin:
 
     async def _async_update_data(self) -> DreameLawnMowerSnapshot:
         """Fetch essential state and hydrate optional metadata in the background."""
+        if getattr(self, "_shutting_down", False):
+            current = getattr(self, "data", None)
+            if current is not None:
+                return current
+            raise UpdateFailed("The mower coordinator is shutting down.")
         if not hasattr(self, "performance"):
             self.performance = DreameLawnMowerPerformanceTracker()
         if not hasattr(self, "_device_refresh_lock"):
@@ -128,6 +133,8 @@ class DreameLawnMowerRefreshMixin:
                     )
                     if callable(record_snapshot):
                         record_snapshot(snapshot, retain=True)
+                if getattr(self, "_shutting_down", False):
+                    return snapshot
             except DreameLawnMowerConnectionError as err:
                 outcome = type(err).__name__
                 safe_error = sanitize_diagnostic_text(err)

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
-from contextlib import suppress
 from functools import partial
 from typing import Any
 
@@ -644,6 +643,16 @@ class DreameLawnMowerRefreshMixin:
         self._metadata_refresh_pending = False
         self._metadata_refresh_publish = False
 
+    async def _async_cancel_metadata_shutdown_close(self) -> None:
+        """Cancel an unload cleanup that Home Assistant would otherwise track."""
+        close_task = getattr(self, "_metadata_shutdown_close_task", None)
+        if close_task is None or close_task is asyncio.current_task():
+            return
+        close_task.cancel()
+        await asyncio.gather(close_task, return_exceptions=True)
+        if self._metadata_shutdown_close_task is close_task:
+            self._metadata_shutdown_close_task = None
+
     async def _async_drain_metadata_for_shutdown(self) -> bool:
         """Cancel queued metadata and bound the wait for an in-flight request."""
         if getattr(self, "_home_assistant_stopping", False):
@@ -737,11 +746,19 @@ class DreameLawnMowerRefreshMixin:
     ) -> None:
         """Close the shared client once a cancellation-resistant request drains."""
         try:
-            with suppress(asyncio.CancelledError, Exception):
-                await metadata_task
-        finally:
-            await self._async_wait_batch_schedule_reads()
-            await self.client.async_close()
+            await asyncio.shield(metadata_task)
+        except asyncio.CancelledError:
+            current = asyncio.current_task()
+            if current is not None and current.cancelling():
+                raise
+        except Exception:  # noqa: BLE001 - deferred cleanup is best effort
+            pass
+        if getattr(self, "_home_assistant_stopping", False):
+            return
+        await self._async_wait_batch_schedule_reads()
+        if getattr(self, "_home_assistant_stopping", False):
+            return
+        await self.client.async_close()
 
     @staticmethod
     def _log_performance_sample(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -6,6 +6,7 @@ import asyncio
 import hashlib as hashlib
 import html as html
 import json as json
+import logging as _logging
 import math as math
 import re as re
 import threading as _threading
@@ -215,6 +216,8 @@ if _typing.TYPE_CHECKING:
     from .work_log import DreameLawnMowerWorkLogTotals
 
 _CLOUD_PRESENCE_REFRESH_INTERVAL = _client_constants.CLOUD_PRESENCE_REFRESH_INTERVAL
+_DEVICE_DISCONNECT_TIMEOUT_SECONDS = 2.0
+_LOGGER = _logging.getLogger(__name__)
 
 _app_action_data = _client_helpers._app_action_data
 _app_map_area_label = _client_helpers._app_map_area_label
@@ -387,6 +390,8 @@ class DreameLawnMowerClient(
         self._account_type = account_type
         self._descriptor = descriptor
         self._device: Any | None = None
+        self._device_ownership_lock = _threading.Lock()
+        self._closing = False
         self._update_callback: _typing.Callable[[], None] | None = None
         self._latest_snapshot: DreameLawnMowerSnapshot | None = None
         self._latest_runtime_status_blob: DreameLawnMowerStatusBlob | None = None
@@ -1440,7 +1445,59 @@ class DreameLawnMowerClient(
 
     async def async_close(self) -> None:
         """Disconnect long-lived device resources."""
-        if self._device is not None:
-            self._device.listen(None)
-            await asyncio.to_thread(self._device.disconnect)
+        with self._device_ownership_lock:
+            self._closing = True
+            device = self._device
             self._device = None
+        if device is not None:
+            try:
+                device.listen(None)
+                await self._async_disconnect_device(device)
+            except asyncio.CancelledError:
+                raise
+            except Exception:
+                with self._device_ownership_lock:
+                    if self._device is None:
+                        self._device = device
+                raise
+
+    async def _async_disconnect_device(self, device: Any) -> None:
+        """Bound device disconnect without retaining HA's default executor."""
+        loop = asyncio.get_running_loop()
+        completed: asyncio.Future[None] = loop.create_future()
+
+        def settle(error: Exception | None) -> None:
+            if completed.done():
+                return
+            if error is None:
+                completed.set_result(None)
+            else:
+                completed.set_exception(error)
+
+        def disconnect() -> None:
+            error: Exception | None = None
+            try:
+                device.disconnect()
+            except Exception as err:  # noqa: BLE001 - return on the event loop
+                error = err
+            try:
+                loop.call_soon_threadsafe(settle, error)
+            except RuntimeError:
+                pass
+
+        worker = _threading.Thread(
+            target=disconnect,
+            name="dreame-device-disconnect",
+            daemon=True,
+        )
+        worker.start()
+        try:
+            async with asyncio.timeout(_DEVICE_DISCONNECT_TIMEOUT_SECONDS):
+                await completed
+        except TimeoutError:
+            completed.cancel()
+            _LOGGER.warning(
+                "Device disconnect did not finish within %.1f seconds; "
+                "continuing shutdown while its daemon worker drains.",
+                _DEVICE_DISCONNECT_TIMEOUT_SECONDS,
+            )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -922,23 +922,28 @@ class _DreameLawnMowerClientCoreMixin:
         return cloud
 
     def _ensure_device(self):
-        if self._device is not None:
+        with self._device_ownership_lock:
+            if self._closing:
+                raise DreameLawnMowerConnectionError(
+                    "The mower client is shutting down."
+                )
+            if self._device is not None:
+                return self._device
+
+            from .device import DreameMowerDevice
+
+            self._device = DreameMowerDevice(
+                self._descriptor.name,
+                self._descriptor.host,
+                self._descriptor.token or " ",
+                self._descriptor.mac,
+                self._username,
+                self._password,
+                self._country,
+                True,
+                self._account_type,
+                self._descriptor.did,
+            )
+            if self._update_callback is not None:
+                self._device.listen(self._update_callback)
             return self._device
-
-        from .device import DreameMowerDevice
-
-        self._device = DreameMowerDevice(
-            self._descriptor.name,
-            self._descriptor.host,
-            self._descriptor.token or " ",
-            self._descriptor.mac,
-            self._username,
-            self._password,
-            self._country,
-            True,
-            self._account_type,
-            self._descriptor.did,
-        )
-        if self._update_callback is not None:
-            self._device.listen(self._update_callback)
-        return self._device

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -472,9 +472,9 @@ class DreameMowerDevice(
         _LOGGER.info("Disconnect")
         self.disconnected = True
         self.schedule_update(-1)
-        self._protocol.disconnect()
         if self._map_manager:
             self._map_manager.disconnect()
+        self._protocol.disconnect()
         self._property_changed()
 
     def listen(self, callback, property: DreameMowerProperty = None) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -329,10 +329,10 @@ class DreameMowerDreameHomeCloudProtocol:
         return self._connected and self._client_connected
 
     def _reconnect_timer_cancel(self):
-        if self._reconnect_timer is not None:
-            self._reconnect_timer.cancel()
-            del self._reconnect_timer
-            self._reconnect_timer = None
+        reconnect_timer = getattr(self, "_reconnect_timer", None)
+        if reconnect_timer is not None:
+            reconnect_timer.cancel()
+        self._reconnect_timer = None
 
     def _reconnect_timer_task(self):
         self._reconnect_timer_cancel()
@@ -369,6 +369,11 @@ class DreameMowerDreameHomeCloudProtocol:
 
     @staticmethod
     def _on_client_disconnect(client, self, rc):
+        if getattr(self, "_shutdown_requested", False):
+            self._reconnect_timer_cancel()
+            self._client_connected = False
+            self._client_connecting = False
+            return
         if rc != 0 and not self._set_client_key():
             if rc == 5 and self._key_expire:
                 self.login()
@@ -1539,6 +1544,7 @@ class DreameMowerDreameHomeCloudProtocol:
 
     def disconnect(self, timeout: float = _CLOUD_DISCONNECT_TIMEOUT_SECONDS):
         self._shutdown_requested = True
+        self._reconnect_timer_cancel()
         self._disconnect_pending = True
         deadline = time.monotonic() + max(0.0, timeout)
         try:

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -2,7 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
 import ssl
+import threading
 from dataclasses import replace
 from hashlib import sha256
 from importlib import import_module
@@ -45,6 +47,109 @@ def _client() -> DreameLawnMowerClient:
             country="eu",
         ),
     )
+
+
+async def test_async_close_bounds_device_disconnect_on_daemon_thread(
+    monkeypatch,
+) -> None:
+    client = _client()
+    started = threading.Event()
+    release = threading.Event()
+    finished = threading.Event()
+    daemon_values: list[bool] = []
+
+    class _BlockingDevice:
+        def listen(self, callback) -> None:
+            assert callback is None
+
+        def disconnect(self) -> None:
+            daemon_values.append(threading.current_thread().daemon)
+            started.set()
+            release.wait()
+            finished.set()
+
+    client._device = _BlockingDevice()  # type: ignore[assignment]
+    client_module = import_module(DreameLawnMowerClient.__module__)
+    monkeypatch.setattr(
+        client_module,
+        "_DEVICE_DISCONNECT_TIMEOUT_SECONDS",
+        0.01,
+    )
+
+    await asyncio.wait_for(client.async_close(), timeout=1)
+
+    assert started.is_set()
+    assert daemon_values == [True]
+    assert not finished.is_set()
+    assert client._device is None
+
+    release.set()
+    for _ in range(100):
+        if finished.is_set():
+            break
+        await asyncio.sleep(0.001)
+    assert finished.is_set()
+
+
+async def test_async_close_blocks_replacement_device_creation(monkeypatch) -> None:
+    client = _client()
+    started = threading.Event()
+    release = threading.Event()
+
+    class _BlockingDevice:
+        def listen(self, callback) -> None:
+            assert callback is None
+
+        def disconnect(self) -> None:
+            started.set()
+            release.wait()
+
+    client._device = _BlockingDevice()  # type: ignore[assignment]
+    client_module = import_module(DreameLawnMowerClient.__module__)
+    monkeypatch.setattr(
+        client_module,
+        "_DEVICE_DISCONNECT_TIMEOUT_SECONDS",
+        1.0,
+    )
+
+    closing = asyncio.create_task(client.async_close())
+    for _ in range(100):
+        if started.is_set():
+            break
+        await asyncio.sleep(0.001)
+    assert started.is_set()
+
+    with pytest.raises(
+        DreameLawnMowerConnectionError,
+        match="shutting down",
+    ):
+        client._ensure_device()
+
+    release.set()
+    await asyncio.wait_for(closing, timeout=1)
+    assert client._device is None
+
+
+async def test_async_close_restores_device_when_listener_detach_fails() -> None:
+    client = _client()
+
+    class _FailingDevice:
+        def listen(self, callback) -> None:
+            del callback
+            raise RuntimeError("listener detach failed")
+
+    device = _FailingDevice()
+    client._device = device  # type: ignore[assignment]
+
+    with pytest.raises(RuntimeError, match="listener detach failed"):
+        await client.async_close()
+
+    assert client._device is device
+    with pytest.raises(
+        DreameLawnMowerConnectionError,
+        match="shutting down",
+    ):
+        client._ensure_device()
 
 
 def test_device_creation_without_external_listener_preserves_internal_callbacks(

--- a/tests/test_client_review_regressions.py
+++ b/tests/test_client_review_regressions.py
@@ -49,107 +49,116 @@ def _client() -> DreameLawnMowerClient:
     )
 
 
-async def test_async_close_bounds_device_disconnect_on_daemon_thread(
+def test_async_close_bounds_device_disconnect_on_daemon_thread(
     monkeypatch,
 ) -> None:
-    client = _client()
-    started = threading.Event()
-    release = threading.Event()
-    finished = threading.Event()
-    daemon_values: list[bool] = []
+    async def scenario() -> None:
+        client = _client()
+        started = threading.Event()
+        release = threading.Event()
+        finished = threading.Event()
+        daemon_values: list[bool] = []
 
-    class _BlockingDevice:
-        def listen(self, callback) -> None:
-            assert callback is None
+        class _BlockingDevice:
+            def listen(self, callback) -> None:
+                assert callback is None
 
-        def disconnect(self) -> None:
-            daemon_values.append(threading.current_thread().daemon)
-            started.set()
-            release.wait()
-            finished.set()
+            def disconnect(self) -> None:
+                daemon_values.append(threading.current_thread().daemon)
+                started.set()
+                release.wait()
+                finished.set()
 
-    client._device = _BlockingDevice()  # type: ignore[assignment]
-    client_module = import_module(DreameLawnMowerClient.__module__)
-    monkeypatch.setattr(
-        client_module,
-        "_DEVICE_DISCONNECT_TIMEOUT_SECONDS",
-        0.01,
-    )
+        client._device = _BlockingDevice()  # type: ignore[assignment]
+        client_module = import_module(DreameLawnMowerClient.__module__)
+        monkeypatch.setattr(
+            client_module,
+            "_DEVICE_DISCONNECT_TIMEOUT_SECONDS",
+            0.01,
+        )
 
-    await asyncio.wait_for(client.async_close(), timeout=1)
+        await asyncio.wait_for(client.async_close(), timeout=1)
 
-    assert started.is_set()
-    assert daemon_values == [True]
-    assert not finished.is_set()
-    assert client._device is None
+        assert started.is_set()
+        assert daemon_values == [True]
+        assert not finished.is_set()
+        assert client._device is None
 
-    release.set()
-    for _ in range(100):
-        if finished.is_set():
-            break
-        await asyncio.sleep(0.001)
-    assert finished.is_set()
+        release.set()
+        for _ in range(100):
+            if finished.is_set():
+                break
+            await asyncio.sleep(0.001)
+        assert finished.is_set()
 
-
-async def test_async_close_blocks_replacement_device_creation(monkeypatch) -> None:
-    client = _client()
-    started = threading.Event()
-    release = threading.Event()
-
-    class _BlockingDevice:
-        def listen(self, callback) -> None:
-            assert callback is None
-
-        def disconnect(self) -> None:
-            started.set()
-            release.wait()
-
-    client._device = _BlockingDevice()  # type: ignore[assignment]
-    client_module = import_module(DreameLawnMowerClient.__module__)
-    monkeypatch.setattr(
-        client_module,
-        "_DEVICE_DISCONNECT_TIMEOUT_SECONDS",
-        1.0,
-    )
-
-    closing = asyncio.create_task(client.async_close())
-    for _ in range(100):
-        if started.is_set():
-            break
-        await asyncio.sleep(0.001)
-    assert started.is_set()
-
-    with pytest.raises(
-        DreameLawnMowerConnectionError,
-        match="shutting down",
-    ):
-        client._ensure_device()
-
-    release.set()
-    await asyncio.wait_for(closing, timeout=1)
-    assert client._device is None
+    asyncio.run(scenario())
 
 
-async def test_async_close_restores_device_when_listener_detach_fails() -> None:
-    client = _client()
+def test_async_close_blocks_replacement_device_creation(monkeypatch) -> None:
+    async def scenario() -> None:
+        client = _client()
+        started = threading.Event()
+        release = threading.Event()
 
-    class _FailingDevice:
-        def listen(self, callback) -> None:
-            del callback
-            raise RuntimeError("listener detach failed")
+        class _BlockingDevice:
+            def listen(self, callback) -> None:
+                assert callback is None
 
-    device = _FailingDevice()
-    client._device = device  # type: ignore[assignment]
+            def disconnect(self) -> None:
+                started.set()
+                release.wait()
 
-    with pytest.raises(RuntimeError, match="listener detach failed"):
-        await client.async_close()
+        client._device = _BlockingDevice()  # type: ignore[assignment]
+        client_module = import_module(DreameLawnMowerClient.__module__)
+        monkeypatch.setattr(
+            client_module,
+            "_DEVICE_DISCONNECT_TIMEOUT_SECONDS",
+            1.0,
+        )
 
-    assert client._device is device
-    with pytest.raises(
-        DreameLawnMowerConnectionError,
-        match="shutting down",
-    ):
-        client._ensure_device()
+        closing = asyncio.create_task(client.async_close())
+        for _ in range(100):
+            if started.is_set():
+                break
+            await asyncio.sleep(0.001)
+        assert started.is_set()
+
+        with pytest.raises(
+            DreameLawnMowerConnectionError,
+            match="shutting down",
+        ):
+            client._ensure_device()
+
+        release.set()
+        await asyncio.wait_for(closing, timeout=1)
+        assert client._device is None
+
+    asyncio.run(scenario())
+
+
+def test_async_close_restores_device_when_listener_detach_fails() -> None:
+    async def scenario() -> None:
+        client = _client()
+
+        class _FailingDevice:
+            def listen(self, callback) -> None:
+                del callback
+                raise RuntimeError("listener detach failed")
+
+        device = _FailingDevice()
+        client._device = device  # type: ignore[assignment]
+
+        with pytest.raises(RuntimeError, match="listener detach failed"):
+            await client.async_close()
+
+        assert client._device is device
+        with pytest.raises(
+            DreameLawnMowerConnectionError,
+            match="shutting down",
+        ):
+            client._ensure_device()
+
+    asyncio.run(scenario())
 
 
 def test_device_creation_without_external_listener_preserves_internal_callbacks(

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -146,6 +146,62 @@ def test_home_assistant_stop_does_not_start_metadata_drain() -> None:
     asyncio.run(scenario())
 
 
+def test_home_assistant_stop_wins_concurrent_config_entry_unload() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        retry_cancelled = asyncio.Event()
+        retry_release = asyncio.Event()
+        metadata_release = asyncio.Event()
+
+        async def cancellation_resistant_retry() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                retry_cancelled.set()
+                await retry_release.wait()
+                raise
+
+        retry_task = asyncio.create_task(cancellation_resistant_retry())
+        metadata_task = asyncio.create_task(metadata_release.wait())
+        coordinator._shutting_down = False
+        coordinator._home_assistant_stopping = False
+        coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
+        coordinator._initialize_connectivity_recovery()
+        coordinator._connectivity_retry_task = retry_task
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._metadata_refresh_task = metadata_task
+        coordinator._metadata_shutdown_close_task = None
+        coordinator._batch_schedule_read_task = None
+        coordinator._batch_schedule_read_tasks = set()
+        coordinator.hass = SimpleNamespace(async_create_task=Mock())
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=AsyncMock(),
+        )
+
+        unload = asyncio.create_task(coordinator.async_shutdown())
+        await retry_cancelled.wait()
+        stop = asyncio.create_task(
+            coordinator.async_shutdown_for_home_assistant_stop()
+        )
+        await asyncio.sleep(0)
+        assert not stop.done()
+
+        retry_release.set()
+        await asyncio.gather(unload, stop)
+
+        assert retry_task.cancelled()
+        assert not metadata_task.done()
+        coordinator.hass.async_create_task.assert_not_called()
+        coordinator.client.async_close.assert_not_awaited()
+
+        metadata_release.set()
+        await metadata_task
+
+    asyncio.run(scenario())
+
+
 def test_short_offline_snapshot_retains_last_good_state() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     good_snapshot = SimpleNamespace(available=True, state="mowing")

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -83,6 +83,29 @@ def test_offline_snapshot_returns_normally_so_entities_remain_loaded() -> None:
     assert tracking_updates == [(None, False)]
 
 
+def test_connectivity_shutdown_cancels_delayed_retry() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator._shutting_down = False
+        coordinator.hass = SimpleNamespace(
+            async_create_task=lambda coroutine, _name: asyncio.create_task(coroutine)
+        )
+        coordinator._initialize_connectivity_recovery()
+        coordinator._schedule_connectivity_retry(60)
+        retry_task = coordinator._connectivity_retry_task
+
+        assert retry_task is not None
+        assert not retry_task.done()
+
+        await coordinator._async_shutdown_connectivity_recovery()
+
+        assert retry_task.cancelled()
+        assert coordinator._connectivity_retry_task is None
+        assert coordinator._connectivity_retry_inflight_task is None
+
+    asyncio.run(scenario())
+
+
 def test_short_offline_snapshot_retains_last_good_state() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     good_snapshot = SimpleNamespace(available=True, state="mowing")

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -106,6 +106,46 @@ def test_connectivity_shutdown_cancels_delayed_retry() -> None:
     asyncio.run(scenario())
 
 
+def test_home_assistant_stop_does_not_start_metadata_drain() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        created_tasks: list[asyncio.Task[None]] = []
+
+        def create_task(coroutine, _name):
+            task = asyncio.create_task(coroutine)
+            created_tasks.append(task)
+            return task
+
+        metadata_release = asyncio.Event()
+        metadata_task = asyncio.create_task(metadata_release.wait())
+        coordinator._shutting_down = False
+        coordinator.hass = SimpleNamespace(async_create_task=create_task)
+        coordinator._initialize_connectivity_recovery()
+        coordinator._schedule_connectivity_retry(60)
+        retry_task = coordinator._connectivity_retry_task
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._metadata_refresh_task = metadata_task
+        coordinator._metadata_shutdown_close_task = None
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=AsyncMock(),
+        )
+
+        assert retry_task is not None
+        await coordinator.async_shutdown_for_home_assistant_stop()
+
+        assert retry_task.cancelled()
+        assert not metadata_task.done()
+        assert created_tasks == [retry_task]
+        coordinator.client.async_close.assert_not_awaited()
+
+        metadata_release.set()
+        await metadata_task
+
+    asyncio.run(scenario())
+
+
 def test_short_offline_snapshot_retains_last_good_state() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     good_snapshot = SimpleNamespace(available=True, state="mowing")

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -10,6 +10,12 @@ from unittest.mock import AsyncMock, Mock, patch
 
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
+from custom_components.dreame_lawn_mower import (
+    coordinator as coordinator_module,
+)
+from custom_components.dreame_lawn_mower import (
+    coordinator_connectivity as connectivity_module,
+)
 from custom_components.dreame_lawn_mower.coordinator import (
     DreameLawnMowerCoordinator,
     _runtime_tracking_active,
@@ -87,10 +93,13 @@ def test_offline_snapshot_returns_normally_so_entities_remain_loaded() -> None:
 def test_connectivity_shutdown_cancels_delayed_retry() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
-        coordinator._shutting_down = False
-        coordinator.hass = SimpleNamespace(
-            async_create_task=lambda coroutine, _name: asyncio.create_task(coroutine)
+        coordinator.entry = SimpleNamespace(
+            async_create_background_task=lambda _hass, coroutine, _name: (
+                asyncio.create_task(coroutine)
+            )
         )
+        coordinator._shutting_down = False
+        coordinator.hass = SimpleNamespace()
         coordinator._initialize_connectivity_recovery()
         coordinator._schedule_connectivity_retry(60)
         retry_task = coordinator._connectivity_retry_task
@@ -107,20 +116,24 @@ def test_connectivity_shutdown_cancels_delayed_retry() -> None:
     asyncio.run(scenario())
 
 
-def test_home_assistant_stop_does_not_start_metadata_drain() -> None:
+def test_home_assistant_stop_skips_metadata_drain_and_closes_client() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         created_tasks: list[asyncio.Task[None]] = []
 
-        def create_task(coroutine, _name):
+        def create_task(_hass, coroutine, _name):
             task = asyncio.create_task(coroutine)
             created_tasks.append(task)
             return task
 
         metadata_release = asyncio.Event()
         metadata_task = asyncio.create_task(metadata_release.wait())
+        coordinator.entry = SimpleNamespace(
+            async_create_background_task=create_task,
+        )
         coordinator._shutting_down = False
-        coordinator.hass = SimpleNamespace(async_create_task=create_task)
+        coordinator._base_shutdown_complete = True
+        coordinator.hass = SimpleNamespace()
         coordinator._initialize_connectivity_recovery()
         coordinator._schedule_connectivity_retry(60)
         retry_task = coordinator._connectivity_retry_task
@@ -139,7 +152,7 @@ def test_home_assistant_stop_does_not_start_metadata_drain() -> None:
         assert retry_task.cancelled()
         assert not metadata_task.done()
         assert created_tasks == [retry_task]
-        coordinator.client.async_close.assert_not_awaited()
+        coordinator.client.async_close.assert_awaited_once_with()
 
         metadata_release.set()
         await metadata_task
@@ -147,58 +160,140 @@ def test_home_assistant_stop_does_not_start_metadata_drain() -> None:
     asyncio.run(scenario())
 
 
-def test_home_assistant_stop_wins_concurrent_config_entry_unload() -> None:
+def test_home_assistant_stop_bounds_concurrent_config_entry_unload() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         retry_cancelled = asyncio.Event()
         retry_release = asyncio.Event()
         metadata_release = asyncio.Event()
 
-        async def cancellation_resistant_retry() -> None:
+        async def cancellation_resistant_refresh() -> None:
             try:
                 await asyncio.Event().wait()
             except asyncio.CancelledError:
                 retry_cancelled.set()
-                await retry_release.wait()
+                while not retry_release.is_set():
+                    try:
+                        await retry_release.wait()
+                    except asyncio.CancelledError:
+                        pass
                 raise
 
-        retry_task = asyncio.create_task(cancellation_resistant_retry())
         metadata_task = asyncio.create_task(metadata_release.wait())
+        coordinator.entry = SimpleNamespace(
+            async_create_background_task=lambda _hass, coroutine, _name: (
+                asyncio.create_task(coroutine)
+            )
+        )
+        coordinator.hass = SimpleNamespace(async_create_task=Mock())
         coordinator._shutting_down = False
         coordinator._home_assistant_stopping = False
+        coordinator._base_shutdown_complete = True
         coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
         coordinator._initialize_connectivity_recovery()
-        coordinator._connectivity_retry_task = retry_task
+        coordinator.async_request_refresh = cancellation_resistant_refresh
+        coordinator._schedule_connectivity_retry(0)
+        while coordinator._connectivity_retry_inflight_task is None:
+            await asyncio.sleep(0)
+        retry_task = coordinator._connectivity_retry_inflight_task
+        assert retry_task is not None
         coordinator._client_update_pending = False
         coordinator._client_update_task = None
         coordinator._metadata_refresh_task = metadata_task
         coordinator._metadata_shutdown_close_task = None
         coordinator._batch_schedule_read_task = None
         coordinator._batch_schedule_read_tasks = set()
-        coordinator.hass = SimpleNamespace(async_create_task=Mock())
         coordinator.client = SimpleNamespace(
             set_update_callback=Mock(),
             async_close=AsyncMock(),
         )
 
-        unload = asyncio.create_task(coordinator.async_shutdown())
-        await retry_cancelled.wait()
-        stop = asyncio.create_task(
-            coordinator.async_shutdown_for_home_assistant_stop()
-        )
-        await asyncio.sleep(0)
-        assert not stop.done()
+        with patch.object(
+            connectivity_module,
+            "CONNECTIVITY_SHUTDOWN_GRACE_SECONDS",
+            0.01,
+        ):
+            unload = asyncio.create_task(coordinator.async_shutdown())
+            await retry_cancelled.wait()
+            stop = asyncio.create_task(
+                coordinator.async_shutdown_for_home_assistant_stop()
+            )
+            await asyncio.wait_for(asyncio.gather(unload, stop), timeout=0.5)
 
-        retry_release.set()
-        await asyncio.gather(unload, stop)
-
-        assert retry_task.cancelled()
+        assert not retry_task.done()
         assert not metadata_task.done()
         coordinator.hass.async_create_task.assert_not_called()
-        coordinator.client.async_close.assert_not_awaited()
+        coordinator.client.async_close.assert_awaited_once_with()
+
+        retry_release.set()
+        with suppress(asyncio.CancelledError):
+            await retry_task
+        assert coordinator._connectivity_retry_task is None
+        assert coordinator._connectivity_retry_inflight_task is None
 
         metadata_release.set()
         await metadata_task
+
+    asyncio.run(scenario())
+
+
+def test_home_assistant_stop_bounds_cancellation_resistant_realtime_update() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        update_started = asyncio.Event()
+        update_cancelled = asyncio.Event()
+        update_release = asyncio.Event()
+
+        async def cancellation_resistant_snapshot() -> None:
+            update_started.set()
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                update_cancelled.set()
+                while not update_release.is_set():
+                    try:
+                        await update_release.wait()
+                    except asyncio.CancelledError:
+                        pass
+                raise
+
+        coordinator._shutting_down = False
+        coordinator._base_shutdown_complete = True
+        coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
+        coordinator._initialize_connectivity_recovery()
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._device_refresh_lock = asyncio.Lock()
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_shutdown_close_task = None
+        coordinator.client = SimpleNamespace(
+            async_get_cached_snapshot=cancellation_resistant_snapshot,
+            set_update_callback=Mock(),
+            async_close=AsyncMock(),
+        )
+        update_task = asyncio.create_task(coordinator._async_process_client_update())
+        coordinator._client_update_task = update_task
+        await update_started.wait()
+
+        with patch.object(
+            coordinator_module,
+            "CLIENT_UPDATE_SHUTDOWN_GRACE_SECONDS",
+            0.01,
+        ):
+            await asyncio.wait_for(
+                coordinator.async_shutdown_for_home_assistant_stop(),
+                timeout=0.5,
+            )
+
+        assert update_cancelled.is_set()
+        assert not update_task.done()
+        assert coordinator._client_update_task is update_task
+        coordinator.client.async_close.assert_awaited_once_with()
+
+        update_release.set()
+        with suppress(asyncio.CancelledError):
+            await update_task
+        assert coordinator._client_update_task is None
 
     asyncio.run(scenario())
 
@@ -224,6 +319,7 @@ def test_home_assistant_stop_cancels_existing_metadata_shutdown_cleanup() -> Non
 
         coordinator._shutting_down = False
         coordinator._home_assistant_stopping = False
+        coordinator._base_shutdown_complete = True
         coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
         coordinator._initialize_connectivity_recovery()
         coordinator._client_update_pending = False
@@ -249,7 +345,7 @@ def test_home_assistant_stop_cancels_existing_metadata_shutdown_cleanup() -> Non
         assert cleanup.cancelled()
         assert coordinator._metadata_shutdown_close_task is None
         assert not metadata_task.done()
-        coordinator.client.async_close.assert_not_awaited()
+        coordinator.client.async_close.assert_awaited_once_with()
 
         metadata_release.set()
         with suppress(asyncio.CancelledError):
@@ -258,21 +354,21 @@ def test_home_assistant_stop_cancels_existing_metadata_shutdown_cleanup() -> Non
     asyncio.run(scenario())
 
 
-def test_home_assistant_stop_cancels_concurrent_unload_client_close() -> None:
+def test_home_assistant_stop_shares_concurrent_unload_client_close() -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         close_started = asyncio.Event()
-        close_cancelled = asyncio.Event()
+        close_release = asyncio.Event()
+        close_finished = asyncio.Event()
 
         async def close() -> None:
             close_started.set()
-            try:
-                await asyncio.Event().wait()
-            finally:
-                close_cancelled.set()
+            await close_release.wait()
+            close_finished.set()
 
         coordinator._shutting_down = False
         coordinator._home_assistant_stopping = False
+        coordinator._base_shutdown_complete = True
         coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
         coordinator._initialize_connectivity_recovery()
         coordinator._client_update_pending = False
@@ -284,19 +380,61 @@ def test_home_assistant_stop_cancels_concurrent_unload_client_close() -> None:
         coordinator._batch_schedule_read_tasks = set()
         coordinator.client = SimpleNamespace(
             set_update_callback=Mock(),
-            async_close=close,
+            async_close=AsyncMock(side_effect=close),
         )
 
         unload = asyncio.create_task(coordinator.async_shutdown())
         await close_started.wait()
-        await asyncio.wait_for(
-            coordinator.async_shutdown_for_home_assistant_stop(),
-            timeout=1,
+        stop = asyncio.create_task(
+            coordinator.async_shutdown_for_home_assistant_stop()
         )
+        await asyncio.sleep(0)
+
+        assert not stop.done()
+        assert not close_finished.is_set()
+
+        close_release.set()
+        await asyncio.wait_for(stop, timeout=1)
         await asyncio.wait_for(unload, timeout=1)
 
+        assert close_finished.is_set()
+        coordinator.client.async_close.assert_awaited_once_with()
         assert coordinator._client_close_task is None
-        assert close_cancelled.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_shutdown_chains_data_update_coordinator_base_once() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator._shutting_down = False
+        coordinator._home_assistant_stopping = False
+        coordinator._base_shutdown_complete = False
+        coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
+        coordinator._initialize_connectivity_recovery()
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._client_close_task = None
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_shutdown_close_task = None
+        coordinator._batch_schedule_read_task = None
+        coordinator._batch_schedule_read_tasks = set()
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=AsyncMock(),
+        )
+
+        base_shutdown = AsyncMock()
+        with patch.object(
+            DataUpdateCoordinator,
+            "async_shutdown",
+            base_shutdown,
+        ):
+            await coordinator.async_shutdown_for_home_assistant_stop()
+            await coordinator.async_shutdown()
+
+        base_shutdown.assert_awaited_once_with()
+        coordinator.client.async_close.assert_awaited_once_with()
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -258,6 +258,84 @@ def test_home_assistant_stop_cancels_existing_metadata_shutdown_cleanup() -> Non
     asyncio.run(scenario())
 
 
+def test_home_assistant_stop_cancels_concurrent_unload_client_close() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        close_started = asyncio.Event()
+        close_cancelled = asyncio.Event()
+
+        async def close() -> None:
+            close_started.set()
+            try:
+                await asyncio.Event().wait()
+            finally:
+                close_cancelled.set()
+
+        coordinator._shutting_down = False
+        coordinator._home_assistant_stopping = False
+        coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
+        coordinator._initialize_connectivity_recovery()
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._client_close_task = None
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_shutdown_close_task = None
+        coordinator._batch_schedule_read_task = None
+        coordinator._batch_schedule_read_tasks = set()
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=close,
+        )
+
+        unload = asyncio.create_task(coordinator.async_shutdown())
+        await close_started.wait()
+        await asyncio.wait_for(
+            coordinator.async_shutdown_for_home_assistant_stop(),
+            timeout=1,
+        )
+        await asyncio.wait_for(unload, timeout=1)
+
+        assert coordinator._client_close_task is None
+        assert close_cancelled.is_set()
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_unload_waiter_does_not_cancel_shared_client_close() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        close_started = asyncio.Event()
+        close_release = asyncio.Event()
+
+        async def close() -> None:
+            close_started.set()
+            await close_release.wait()
+
+        coordinator._home_assistant_stopping = False
+        coordinator._client_close_task = None
+        coordinator.client = SimpleNamespace(async_close=AsyncMock(side_effect=close))
+
+        first = asyncio.create_task(coordinator._async_close_client_for_unload())
+        second = asyncio.create_task(coordinator._async_close_client_for_unload())
+        await close_started.wait()
+
+        first.cancel()
+        with suppress(asyncio.CancelledError):
+            await first
+
+        close_task = coordinator._client_close_task
+        assert close_task is not None
+        assert not close_task.done()
+
+        close_release.set()
+        await asyncio.wait_for(second, timeout=1)
+
+        coordinator.client.async_close.assert_awaited_once_with()
+        assert coordinator._client_close_task is None
+
+    asyncio.run(scenario())
+
+
 def test_short_offline_snapshot_retains_last_good_state() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     good_snapshot = SimpleNamespace(available=True, state="mowing")

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from contextlib import suppress
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
@@ -198,6 +199,61 @@ def test_home_assistant_stop_wins_concurrent_config_entry_unload() -> None:
 
         metadata_release.set()
         await metadata_task
+
+    asyncio.run(scenario())
+
+
+def test_home_assistant_stop_cancels_existing_metadata_shutdown_cleanup() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        metadata_cancelled = asyncio.Event()
+        metadata_release = asyncio.Event()
+
+        async def cancellation_resistant_metadata() -> None:
+            try:
+                await asyncio.Event().wait()
+            except asyncio.CancelledError:
+                metadata_cancelled.set()
+                await metadata_release.wait()
+                raise
+
+        metadata_task = asyncio.create_task(cancellation_resistant_metadata())
+        await asyncio.sleep(0)
+        metadata_task.cancel()
+        await metadata_cancelled.wait()
+
+        coordinator._shutting_down = False
+        coordinator._home_assistant_stopping = False
+        coordinator._owned_tasks_shutdown_lock = asyncio.Lock()
+        coordinator._initialize_connectivity_recovery()
+        coordinator._client_update_pending = False
+        coordinator._client_update_task = None
+        coordinator._metadata_refresh_task = metadata_task
+        coordinator._batch_schedule_read_task = None
+        coordinator._batch_schedule_read_tasks = set()
+        coordinator.client = SimpleNamespace(
+            set_update_callback=Mock(),
+            async_close=AsyncMock(),
+        )
+        cleanup = asyncio.create_task(
+            coordinator._async_close_after_metadata(metadata_task)
+        )
+        coordinator._metadata_shutdown_close_task = cleanup
+        await asyncio.sleep(0)
+
+        await asyncio.wait_for(
+            coordinator.async_shutdown_for_home_assistant_stop(),
+            timeout=1,
+        )
+
+        assert cleanup.cancelled()
+        assert coordinator._metadata_shutdown_close_task is None
+        assert not metadata_task.done()
+        coordinator.client.async_close.assert_not_awaited()
+
+        metadata_release.set()
+        with suppress(asyncio.CancelledError):
+            await metadata_task
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -2956,6 +2956,7 @@ def test_shutdown_drains_metadata_before_closing_shared_client() -> None:
             close_calls.append("close")
 
         coordinator._shutting_down = False
+        coordinator._base_shutdown_complete = True
         coordinator._client_update_pending = False
         coordinator._client_update_task = None
         coordinator._metadata_refresh_task = asyncio.create_task(metadata())
@@ -3006,6 +3007,7 @@ def test_shutdown_waits_for_shielded_batch_worker_before_close() -> None:
             close_calls.append("close")
 
         coordinator._shutting_down = False
+        coordinator._base_shutdown_complete = True
         coordinator._client_update_pending = False
         coordinator._client_update_task = None
         coordinator._batch_schedule_read_task = asyncio.create_task(batch_schedule())
@@ -3060,6 +3062,7 @@ def test_shutdown_defers_close_until_batch_thread_finishes_after_grace() -> None
             close_calls.append("close")
 
         coordinator._shutting_down = False
+        coordinator._base_shutdown_complete = True
         coordinator._client_update_pending = False
         coordinator._client_update_task = None
         coordinator._batch_schedule_read_task = asyncio.create_task(batch_schedule())
@@ -3180,6 +3183,7 @@ def test_shutdown_defers_client_close_after_metadata_grace_expires() -> None:
             close_calls.append("close")
 
         coordinator._shutting_down = False
+        coordinator._base_shutdown_complete = True
         coordinator._client_update_pending = False
         coordinator._client_update_task = None
         coordinator._metadata_refresh_task = asyncio.create_task(metadata())
@@ -3225,6 +3229,7 @@ def test_failed_platform_setup_removes_coordinator_and_drains_resources() -> Non
         )
         cache = SimpleNamespace(async_load=AsyncMock())
         hass = SimpleNamespace(
+            bus=SimpleNamespace(async_listen_once=Mock(return_value=Mock())),
             data={},
             config_entries=SimpleNamespace(
                 async_forward_entry_setups=AsyncMock(
@@ -3278,16 +3283,20 @@ def test_failed_platform_setup_removes_coordinator_and_drains_resources() -> Non
 def test_successful_setup_shuts_down_coordinator_on_home_assistant_stop() -> None:
     async def scenario() -> None:
         performance = DreameLawnMowerPerformanceTracker()
+        stop_listener = None
+
+        async def first_refresh() -> None:
+            assert stop_listener is not None
+
         coordinator = SimpleNamespace(
             performance=performance,
             client=SimpleNamespace(descriptor=SimpleNamespace(did="device-1")),
-            async_config_entry_first_refresh=AsyncMock(),
+            async_config_entry_first_refresh=AsyncMock(side_effect=first_refresh),
             async_shutdown_for_home_assistant_stop=AsyncMock(),
             async_shutdown=AsyncMock(),
             _metadata_refresh_task=None,
         )
         cache = SimpleNamespace(async_load=AsyncMock())
-        stop_listener = None
         remove_stop_listener = Mock()
         unload_callbacks: list[object] = []
 
@@ -3365,6 +3374,7 @@ def test_initial_connection_failure_keeps_complete_platform_setup_pending() -> N
         )
         forward = AsyncMock()
         hass = SimpleNamespace(
+            bus=SimpleNamespace(async_listen_once=Mock(return_value=Mock())),
             data={},
             config_entries=SimpleNamespace(async_forward_entry_setups=forward),
         )

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -10,6 +10,7 @@ from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
+from homeassistant.const import EVENT_HOMEASSISTANT_STOP
 from homeassistant.exceptions import ConfigEntryNotReady
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
@@ -3270,6 +3271,74 @@ def test_failed_platform_setup_removes_coordinator_and_drains_resources() -> Non
         assert "entry-1" not in hass.data[DOMAIN]
         sample = performance.as_dict()["latest_by_operation"]["setup"]
         assert sample["outcome"] == "RuntimeError"
+
+    asyncio.run(scenario())
+
+
+def test_successful_setup_shuts_down_coordinator_on_home_assistant_stop() -> None:
+    async def scenario() -> None:
+        performance = DreameLawnMowerPerformanceTracker()
+        coordinator = SimpleNamespace(
+            performance=performance,
+            client=SimpleNamespace(descriptor=SimpleNamespace(did="device-1")),
+            async_config_entry_first_refresh=AsyncMock(),
+            async_shutdown=AsyncMock(),
+            _metadata_refresh_task=None,
+        )
+        cache = SimpleNamespace(async_load=AsyncMock())
+        stop_listener = None
+        remove_stop_listener = Mock()
+        unload_callbacks: list[object] = []
+
+        def async_listen_once(event_type, listener):
+            nonlocal stop_listener
+            assert event_type == EVENT_HOMEASSISTANT_STOP
+            stop_listener = listener
+            return remove_stop_listener
+
+        entry = SimpleNamespace(
+            entry_id="entry-1",
+            options={},
+            async_on_unload=unload_callbacks.append,
+            add_update_listener=Mock(return_value=Mock()),
+        )
+        hass = SimpleNamespace(
+            bus=SimpleNamespace(async_listen_once=async_listen_once),
+            data={},
+            config_entries=SimpleNamespace(
+                async_forward_entry_setups=AsyncMock(),
+            ),
+        )
+
+        with (
+            patch.object(
+                integration_module,
+                "DreameLawnMowerCoordinator",
+                return_value=coordinator,
+            ),
+            patch.object(
+                integration_module,
+                "DreameLawnMowerVideoLanCache",
+                return_value=cache,
+            ),
+            patch.object(
+                integration_module,
+                "DreameLawnMowerVideoProvisioningCache",
+                return_value=cache,
+            ),
+            patch.object(integration_module, "async_setup_point_cloud_api"),
+            patch.object(
+                integration_module,
+                "async_setup_services",
+                new=AsyncMock(),
+            ),
+        ):
+            assert await async_setup_entry(hass, entry) is True
+
+        assert stop_listener is not None
+        assert remove_stop_listener in unload_callbacks
+        await stop_listener(SimpleNamespace())
+        coordinator.async_shutdown.assert_awaited_once_with()
 
     asyncio.run(scenario())
 

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -3282,6 +3282,7 @@ def test_successful_setup_shuts_down_coordinator_on_home_assistant_stop() -> Non
             performance=performance,
             client=SimpleNamespace(descriptor=SimpleNamespace(did="device-1")),
             async_config_entry_first_refresh=AsyncMock(),
+            async_shutdown_for_home_assistant_stop=AsyncMock(),
             async_shutdown=AsyncMock(),
             _metadata_refresh_task=None,
         )
@@ -3338,7 +3339,8 @@ def test_successful_setup_shuts_down_coordinator_on_home_assistant_stop() -> Non
         assert stop_listener is not None
         assert remove_stop_listener in unload_callbacks
         await stop_listener(SimpleNamespace())
-        coordinator.async_shutdown.assert_awaited_once_with()
+        coordinator.async_shutdown_for_home_assistant_stop.assert_awaited_once_with()
+        coordinator.async_shutdown.assert_not_awaited()
 
     asyncio.run(scenario())
 

--- a/tests/test_device_startup.py
+++ b/tests/test_device_startup.py
@@ -80,3 +80,24 @@ def test_background_map_failure_still_schedules_next_refresh(monkeypatch) -> Non
 
     update_timer.cancel.assert_called_once_with()
     manager.schedule_update.assert_called_once_with(29.0)
+
+
+def test_disconnect_quiesces_map_before_protocol_teardown() -> None:
+    """A blocked protocol close must not leave the map timer alive."""
+    order: list[str] = []
+    mower = SimpleNamespace(
+        disconnected=False,
+        schedule_update=Mock(side_effect=lambda _wait: order.append("device")),
+        _map_manager=SimpleNamespace(
+            disconnect=Mock(side_effect=lambda: order.append("map")),
+        ),
+        _protocol=SimpleNamespace(
+            disconnect=Mock(side_effect=lambda: order.append("protocol")),
+        ),
+        _property_changed=Mock(side_effect=lambda: order.append("property")),
+    )
+
+    DreameMowerDevice.disconnect(mower)
+
+    assert mower.disconnected is True
+    assert order == ["device", "map", "protocol", "property"]

--- a/tests/test_protocol_serialization.py
+++ b/tests/test_protocol_serialization.py
@@ -142,6 +142,8 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     cloud._client = mqtt_client
     cloud._client_connected = True
     cloud._client_connecting = True
+    reconnect_timer = Mock()
+    cloud._reconnect_timer = reconnect_timer
     lock_held = Event()
     release_lock = Event()
 
@@ -172,8 +174,28 @@ def test_cloud_disconnect_does_not_wait_forever_for_deadline_worker() -> None:
     assert cloud._client is None
     assert cloud._client_connected is False
     assert cloud._client_connecting is False
+    reconnect_timer.cancel.assert_called_once_with()
+    assert cloud._reconnect_timer is None
     mqtt_client.loop_stop.assert_called_once_with()
     mqtt_client.disconnect.assert_called_once_with()
+
+
+def test_cloud_disconnect_callback_does_not_rearm_during_shutdown() -> None:
+    cloud = object.__new__(protocol_cloud.DreameMowerDreameHomeCloudProtocol)
+    cloud._shutdown_requested = True
+    cloud._reconnect_timer = None
+    cloud._client_connected = True
+    cloud._client_connecting = True
+
+    protocol_cloud.DreameMowerDreameHomeCloudProtocol._on_client_disconnect(
+        Mock(),
+        cloud,
+        1,
+    )
+
+    assert cloud._reconnect_timer is None
+    assert cloud._client_connected is False
+    assert cloud._client_connecting is False
 
 
 def test_late_deadline_worker_cannot_restore_state_after_disconnect() -> None:


### PR DESCRIPTION
## Summary

- install the Home Assistant stop hook before setup performs any awaited work
- cancel coordinator reconnect and realtime-update owners with bounded waits, then close the mower client during Home Assistant stop
- chain the base DataUpdateCoordinator shutdown exactly once and serialize overlapping stop and config-entry unload ownership
- keep normal unload metadata draining while sharing one idempotent client-close owner with the stop path
- stop map and cloud reconnect timers before potentially blocking vendor protocol teardown
- cover setup-stop timing, cancellation-resistant work, stop/unload races, deferred cleanup, base shutdown, shared close ownership, and vendor timer teardown

Closes #154