### PR TITLE
Use GitHub-generated release notes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,7 +27,7 @@ jobs:
       checks: read
       contents: write
       pull-requests: read
-    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@457a36d5e3692245c466b19a9cf4092d9d4f5399 # PowerForge v1.0.4
+    uses: EvotecIT/PSPublishModule/.github/workflows/powerforge-homeassistant-release.yml@3ef66f138c163b6fd1acc04329bcd4bab57f4953 # PowerForge.Build 1.0.9
     with:
       pr_number: ${{ format('{0}', github.event.pull_request.number || inputs.pr_number) }}
       merge_commit_sha: ${{ github.event.pull_request.merge_commit_sha || inputs.merge_commit_sha }}


### PR DESCRIPTION
## Summary

- repin the shared Home Assistant release workflow to merged PSPublishModule commit 3ef66f138c163b6fd1acc04329bcd4bab57f4953
- use PowerForge.Build 1.0.9 so future releases include GitHub's native change list, contributors, and full changelog
- retain hidden PowerForge provenance metadata for safe retry and recovery

## Release behavior

This workflow-only change does not publish a product release. It changes the presentation of the next release triggered by a product or dependency pull request.