### PR TITLE
Fix charging-period standby and multi-map 3D loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -516,16 +516,15 @@ need source, counts, and parser evidence.
 
 The map camera also advertises a local `point_cloud_api_path` attribute. A
 Home Assistant administrator can sign that path for a short-lived download.
-When the mower has exactly one created map and that map is authoritative, the
-integration first tries its stored LiDAR object so an existing 3D map can
-display without another upload. The vendor's stored-object announcement does
-not identify which map it belongs to, so multi-map mowers always generate the
-requested map rather than risk showing a previous garden. If the stored object
-is absent, expired, or invalid, the integration asks the mower to upload the
-selected app map, immediately captures the new announcement, and validates the
-returned PCD file. Firmware without the announcement retains the older
-transient-object lookup as a fallback. Responses use `private, no-store`
-caching.
+For the active map, the integration first tries a stored LiDAR object whose map
+index is confirmed by the app inventory or mower `OBJ` response. A mower with
+exactly one created map may also reuse the vendor's `99.20` stored-object
+announcement. That announcement has no map identity, so it is never reused on
+a multi-map mower. If no safely attributed stored object is available, the
+integration asks the mower to upload the selected app map, captures the new
+announcement, and validates the returned PCD file. Firmware without the
+announcement retains the older indexed-object lookup as a fallback. Responses
+use short-lived private caching; forced refreshes use `private, no-store`.
 Vendor filenames, cloud-signed URLs, and point coordinates are never written to
 entity state or logs.
 
@@ -535,8 +534,8 @@ this attribute and offers an on-demand 3D viewer. It does not generate or
 download garden geometry during an ordinary dashboard render. Select the Hero
 layout's **3D** tab or press **Load 3D map** in another layout when you want to
 fetch it. Point-cloud access is currently restricted to Home Assistant admins.
-A stored single-map file normally avoids mower generation; otherwise the mower
-has up to 45 seconds to publish a fresh file. A failed request returns a
+A safely attributed stored file normally avoids mower generation; otherwise the
+mower has up to 45 seconds to publish a fresh file. A failed request returns a
 privacy-safe problem code and stage instead of exposing the vendor object name
 or signed download URL.
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1255,12 +1255,17 @@ class DreameLawnMowerClient(
         *,
         map_index: int = 0,
         allow_stored: bool = False,
+        allow_unscoped_stored: bool | None = None,
         timeout: float = 45.0,
         poll_interval: float = 2.0,
         download_timeout: float = 60.0,
         max_bytes: int = DEFAULT_POINT_CLOUD_MAX_BYTES,
     ) -> DreameLawnMowerPointCloudDownload:
         """Download a stored or freshly generated mower app-map point cloud."""
+        if allow_unscoped_stored is None:
+            allow_unscoped_stored = allow_stored
+        else:
+            allow_unscoped_stored = allow_stored and allow_unscoped_stored
         timeout = _validate_positive_number(timeout, "generation timeout")
         preflight_timeout = (
             _POINT_CLOUD_STORED_PREFLIGHT_BUDGET_SECONDS
@@ -1286,6 +1291,7 @@ class DreameLawnMowerClient(
                         max_bytes,
                         deadline,
                         allow_stored,
+                        allow_unscoped_stored,
                         abandoned,
                     )
                 )
@@ -1321,6 +1327,7 @@ class DreameLawnMowerClient(
         max_bytes: int,
         deadline: float,
         allow_stored: bool,
+        allow_unscoped_stored: bool,
         abandoned: _threading.Event,
     ) -> DreameLawnMowerPointCloudDownload:
         """Run one mower-wide generation while retaining ownership after cancel."""
@@ -1361,6 +1368,7 @@ class DreameLawnMowerClient(
                 max_bytes,
                 deadline,
                 allow_stored,
+                allow_unscoped_stored,
             )
         finally:
             self._point_cloud_generation_lock.release()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -778,7 +778,12 @@ class _DreameLawnMowerClientMapsMixin:
         max_bytes: int,
         deadline: float | None = None,
         allow_stored: bool = False,
+        allow_unscoped_stored: bool | None = None,
     ) -> DreameLawnMowerPointCloudDownload:
+        if allow_unscoped_stored is None:
+            allow_unscoped_stored = allow_stored
+        else:
+            allow_unscoped_stored = allow_stored and allow_unscoped_stored
         map_index = _validate_point_cloud_map_index(map_index)
         timeout = _validate_positive_number(timeout, "generation timeout")
         poll_interval = _validate_positive_number(poll_interval, "poll interval")
@@ -888,7 +893,7 @@ class _DreameLawnMowerClientMapsMixin:
         use_announcement_path = announcement_capability is True
         announcement_probe_pending = announcement_capability is None
         if (
-            allow_stored
+            allow_unscoped_stored
             and stored_name is not None
             and stored_name != cached_name
         ):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
@@ -765,10 +765,12 @@ class DreameMowerDeviceStatus:
         Used for preventing updates on settings that relates to currently performing task.
         """
         status = self.status
+        task_status = self.task_status
         return bool(
             (
-                self.task_status is not DreameMowerTaskStatus.COMPLETED
-                and self.task_status is not DreameMowerTaskStatus.DOCKING_PAUSED
+                task_status is not DreameMowerTaskStatus.UNKNOWN
+                and task_status is not DreameMowerTaskStatus.COMPLETED
+                and task_status is not DreameMowerTaskStatus.DOCKING_PAUSED
             )
             or self.cleaning_paused
             or status is DreameMowerStatus.CLEANING

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
@@ -167,6 +167,10 @@ _RUNNING_STATUSES = frozenset(
 _ACTIVE_TASK_STATUSES = (_RUNNING_STATUSES - {DreameMowerStatus.BACK_HOME}) | {
     DreameMowerStatus.PAUSED
 }
+_UNKNOWN_TASK_INACTIVE_STATUSES = {
+    DreameMowerStatus.IDLE,
+    DreameMowerStatus.STANDBY,
+}
 
 
 
@@ -790,9 +794,12 @@ class DreameMowerDeviceStatus:
         task_status = self.task_status
         return bool(
             (
-                task_status is not DreameMowerTaskStatus.UNKNOWN
-                and task_status is not DreameMowerTaskStatus.COMPLETED
+                task_status is not DreameMowerTaskStatus.COMPLETED
                 and task_status is not DreameMowerTaskStatus.DOCKING_PAUSED
+                and (
+                    task_status is not DreameMowerTaskStatus.UNKNOWN
+                    or status not in _UNKNOWN_TASK_INACTIVE_STATUSES
+                )
             )
             or self.cleaning_paused
             or status in _ACTIVE_TASK_STATUSES

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
@@ -773,6 +773,7 @@ class DreameMowerDeviceStatus:
                 and task_status is not DreameMowerTaskStatus.DOCKING_PAUSED
             )
             or self.cleaning_paused
+            or status is DreameMowerStatus.PAUSED
             or status is DreameMowerStatus.CLEANING
             or status is DreameMowerStatus.SEGMENT_CLEANING
             or status is DreameMowerStatus.ZONE_CLEANING

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_status.py
@@ -146,6 +146,28 @@ from .map_decoder import DreameMowerMapDecoder
 
 _LOGGER = logging.getLogger(__name__)
 
+_RUNNING_STATUSES = frozenset(
+    {
+        DreameMowerStatus.CLEANING,
+        DreameMowerStatus.BACK_HOME,
+        DreameMowerStatus.PART_CLEANING,
+        DreameMowerStatus.FOLLOW_WALL,
+        DreameMowerStatus.REMOTE_CONTROL,
+        DreameMowerStatus.SEGMENT_CLEANING,
+        DreameMowerStatus.ZONE_CLEANING,
+        DreameMowerStatus.SPOT_CLEANING,
+        DreameMowerStatus.FAST_MAPPING,
+        DreameMowerStatus.CRUISING_PATH,
+        DreameMowerStatus.CRUISING_POINT,
+        DreameMowerStatus.SUMMON_CLEAN,
+        DreameMowerStatus.SHORTCUT,
+        DreameMowerStatus.PERSON_FOLLOW,
+    }
+)
+_ACTIVE_TASK_STATUSES = (_RUNNING_STATUSES - {DreameMowerStatus.BACK_HOME}) | {
+    DreameMowerStatus.PAUSED
+}
+
 
 
 class DreameMowerDeviceStatus:
@@ -773,16 +795,7 @@ class DreameMowerDeviceStatus:
                 and task_status is not DreameMowerTaskStatus.DOCKING_PAUSED
             )
             or self.cleaning_paused
-            or status is DreameMowerStatus.PAUSED
-            or status is DreameMowerStatus.CLEANING
-            or status is DreameMowerStatus.SEGMENT_CLEANING
-            or status is DreameMowerStatus.ZONE_CLEANING
-            or status is DreameMowerStatus.SPOT_CLEANING
-            or status is DreameMowerStatus.PART_CLEANING
-            or status is DreameMowerStatus.FAST_MAPPING
-            or status is DreameMowerStatus.CRUISING_PATH
-            or status is DreameMowerStatus.CRUISING_POINT
-            or status is DreameMowerStatus.SHORTCUT
+            or status in _ACTIVE_TASK_STATUSES
         )
 
     @property
@@ -817,23 +830,7 @@ class DreameMowerDeviceStatus:
                 self.charging
                 or self.charging_status is DreameMowerChargingStatus.CHARGING_COMPLETED
             )
-            and (
-                status is DreameMowerStatus.CLEANING
-                or status is DreameMowerStatus.BACK_HOME
-                or status is DreameMowerStatus.PART_CLEANING
-                or status is DreameMowerStatus.FOLLOW_WALL
-                or status is DreameMowerStatus.REMOTE_CONTROL
-                or status is DreameMowerStatus.SEGMENT_CLEANING
-                or status is DreameMowerStatus.ZONE_CLEANING
-                or status is DreameMowerStatus.SPOT_CLEANING
-                or status is DreameMowerStatus.PART_CLEANING
-                or status is DreameMowerStatus.FAST_MAPPING
-                or status is DreameMowerStatus.CRUISING_PATH
-                or status is DreameMowerStatus.CRUISING_POINT
-                or status is DreameMowerStatus.SUMMON_CLEAN
-                or status is DreameMowerStatus.SHORTCUT
-                or status is DreameMowerStatus.PERSON_FOLLOW
-            )
+            and status in _RUNNING_STATUSES
         )
 
     @property

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -118,6 +118,14 @@ class _InflightGeneration:
     task: asyncio.Task[DreameLawnMowerPointCloudDownload]
 
 
+@dataclass(frozen=True, slots=True)
+class _StoredPointCloudPolicy:
+    """Describe which stored object-discovery routes are safe for one map."""
+
+    allow_indexed: bool = False
+    allow_unscoped: bool = False
+
+
 class DreameLawnMowerPointCloudAPI:
     """Coordinate bounded, de-duplicated point-cloud downloads."""
 
@@ -205,15 +213,15 @@ class DreameLawnMowerPointCloudAPI:
                 ),
             )
 
-        allow_stored = (
-            not refresh
-            and _stored_point_cloud_active_map_index(coordinator) == map_index
-        )
+        stored_policy = _stored_point_cloud_policy(coordinator, map_index)
+        allow_stored = not refresh and stored_policy.allow_indexed
+        allow_unscoped_stored = not refresh and stored_policy.allow_unscoped
         generation = self._async_generate(
             key,
             coordinator,
             epoch=epoch,
             allow_stored=allow_stored,
+            allow_unscoped_stored=allow_unscoped_stored,
         )
         create_task = getattr(self._hass, "async_create_task", None)
         if callable(create_task):
@@ -289,6 +297,7 @@ class DreameLawnMowerPointCloudAPI:
         *,
         epoch: int,
         allow_stored: bool,
+        allow_unscoped_stored: bool,
     ) -> DreameLawnMowerPointCloudDownload:
         """Run and cache one generation independently of HTTP waiters."""
         performance = getattr(coordinator, "performance", None)
@@ -297,6 +306,12 @@ class DreameLawnMowerPointCloudAPI:
             if hasattr(performance, "start")
             else None
         )
+        download_options = {
+            "map_index": key[1],
+            "allow_stored": allow_stored,
+        }
+        if allow_unscoped_stored != allow_stored:
+            download_options["allow_unscoped_stored"] = allow_unscoped_stored
         sample = None
         try:
             if self._entry_epochs.get(key[0], 0) != epoch:
@@ -314,15 +329,13 @@ class DreameLawnMowerPointCloudAPI:
                 download = await cycle.measure(
                     "generate_download_validate",
                     lambda: coordinator.client.async_download_app_map_point_cloud(
-                        map_index=key[1],
-                        allow_stored=allow_stored,
+                        **download_options,
                     ),
                 )
             else:
                 download = (
                     await coordinator.client.async_download_app_map_point_cloud(
-                        map_index=key[1],
-                        allow_stored=allow_stored,
+                        **download_options,
                     )
                 )
             if self._entry_epochs.get(key[0], 0) != epoch:
@@ -344,6 +357,7 @@ class DreameLawnMowerPointCloudAPI:
                 sample,
                 map_index=key[1],
                 allow_stored=allow_stored,
+                allow_unscoped_stored=allow_unscoped_stored,
             )
             self._remember_failure(key, epoch, err)
             raise
@@ -366,6 +380,7 @@ class DreameLawnMowerPointCloudAPI:
                 sample,
                 map_index=key[1],
                 allow_stored=allow_stored,
+                allow_unscoped_stored=allow_unscoped_stored,
                 unexpected_error=err,
             )
             self._remember_failure(key, epoch, public_error)
@@ -463,6 +478,7 @@ class DreameLawnMowerPointCloudAPI:
         *,
         map_index: int,
         allow_stored: bool,
+        allow_unscoped_stored: bool,
         unexpected_error: Exception | None = None,
     ) -> None:
         """Keep one privacy-safe failure event and benchmark sample."""
@@ -474,6 +490,7 @@ class DreameLawnMowerPointCloudAPI:
             "vendor_error_code": error.vendor_error_code,
             "map_index": map_index,
             "allow_stored": allow_stored,
+            "allow_unscoped_stored": allow_unscoped_stored,
         }
         exception_type = None
         if unexpected_error is not None:
@@ -630,19 +647,20 @@ def _copy_point_cloud_error(
     )
 
 
-def _stored_point_cloud_active_map_index(
+def _stored_point_cloud_policy(
     coordinator: DreameLawnMowerCoordinator,
-) -> int | None:
-    """Return the authoritative active map eligible for stored-object reuse."""
+    map_index: int,
+) -> _StoredPointCloudPolicy:
+    """Return safe stored-object routes for the requested active map."""
     app_maps = getattr(coordinator, "app_maps", None)
     if not isinstance(app_maps, Mapping):
-        return None
+        return _StoredPointCloudPolicy()
     maps = app_maps.get("maps")
     if not isinstance(maps, Sequence) or isinstance(
         maps,
         str | bytes | bytearray,
     ):
-        return None
+        return _StoredPointCloudPolicy()
     indices = {
         entry.get("idx")
         for entry in maps
@@ -652,10 +670,6 @@ def _stored_point_cloud_active_map_index(
         and entry["idx"] >= 0
         and entry.get("created") is not False
     }
-    # The 99.20 stored-object announcement has no map identity. Reusing it is
-    # safe only when exactly one created map can own that object.
-    if len(indices) != 1:
-        return None
     active_index = active_map_index(
         app_maps,
         selected_map_index=getattr(
@@ -664,7 +678,16 @@ def _stored_point_cloud_active_map_index(
             None,
         ),
     )
-    return active_index if active_index in indices else None
+    if active_index != map_index or active_index not in indices:
+        return _StoredPointCloudPolicy()
+
+    # Cached app-object inventories and OBJ responses are indexed by map, so
+    # they remain safe with multiple maps. The 99.20 announcement has no map
+    # identity and may be reused only when one created map can own it.
+    return _StoredPointCloudPolicy(
+        allow_indexed=True,
+        allow_unscoped=len(indices) == 1,
+    )
 
 
 class DreameLawnMowerPointCloudView(HomeAssistantView):

--- a/docs/dreamehome-research.md
+++ b/docs/dreamehome-research.md
@@ -369,9 +369,11 @@ The successful map path is the app action bridge described above. On
 - Property `99.20` can keep the last generated object signable after the upload.
   A read-only A2 check on 2026-07-25 resolved that stored object in 0.03 seconds
   and downloaded and validated the 2,437,272-byte PCD in another 0.38 seconds.
-  Home Assistant uses this stored path only when the mower has exactly one
-  verified map because the property does not carry a map index; absent, expired,
-  invalid, and multi-map requests retain fresh generation.
+  Home Assistant uses this unscoped stored path only when the mower has exactly
+  one verified map because the property does not carry a map index. Multi-map
+  mowers can still reuse stored objects attributed to the active map by the app
+  inventory or mower `OBJ` response; absent, expired, or invalid objects retain
+  fresh generation.
 - The generated file was a standard PCD 0.7 binary with fields `x y z rgb`,
   152,318 finite points, 991 observed colors, and 2,437,272 total bytes.
   Repeating the flow through the new public client returned the same validated

--- a/docs/python-library.md
+++ b/docs/python-library.md
@@ -126,7 +126,8 @@ from pathlib import Path
 
 download = await client.async_download_app_map_point_cloud(
     map_index=0,
-    allow_stored=True,  # Only when map 0 is the mower's sole known map.
+    allow_stored=True,  # Reuse only objects attributed to map 0.
+    allow_unscoped_stored=False,  # Keep the unindexed 99.20 object out.
 )
 print(download.metadata.as_dict())
 
@@ -134,15 +135,18 @@ print(download.metadata.as_dict())
 Path("garden-map.pcd").write_bytes(download.content)
 ```
 
-With `allow_stored=True`, the method first validates the object currently
-announced through cloud property `99.20`. Callers should enable this only when
-the requested index is the mower's sole known map, because the announcement
-does not identify its map. If that object is absent, expired, or invalid, the
-client triggers app action `o:10`, captures the fresh LiDAR object, and resolves
-its short-lived download immediately. Some A2 firmware refreshes a stable
-announcement name without changing its property timestamp; the client accepts
-that object only after a live post-request indexed-object read proves it belongs
-to the requested map and pre/post object evidence proves it was refreshed.
+With `allow_stored=True`, the method first tries stored objects whose map index
+is confirmed by the app inventory or the mower's `OBJ` response. The separate
+`allow_unscoped_stored` option controls the object announced through cloud
+property `99.20`; keep it false when more than one map exists because that
+announcement has no map identity. Its default is `None`, which follows
+`allow_stored` for compatibility with single-map callers. If no safely
+attributed object is available, the client triggers app action `o:10`, captures
+the fresh LiDAR object, and resolves its short-lived download immediately. Some
+A2 firmware refreshes a stable announcement name without changing its property
+timestamp; the client accepts that object only after a live post-request
+indexed-object read proves it belongs to the requested map and pre/post object
+evidence proves it was refreshed.
 Firmware without the announcement continues through the transient `OBJ` 3D-map
 fallback. Every path enforces
 HTTPS, time, and size limits and validates PCD 0.7 before returning. The result

--- a/tests/test_device_status_state.py
+++ b/tests/test_device_status_state.py
@@ -77,6 +77,18 @@ def test_unknown_task_keeps_explicit_mowing_state_active() -> None:
     assert status.state is DreameMowerState.MOWING
 
 
+def test_unknown_task_keeps_explicit_paused_state_active() -> None:
+    status = _status(
+        status=DreameMowerStatus.PAUSED,
+        state=DreameMowerState.PAUSED,
+        task_status=None,
+    )
+
+    assert status.started is True
+    assert status.paused is True
+    assert status.state is DreameMowerState.PAUSED
+
+
 def test_explicit_paused_task_remains_active_and_paused() -> None:
     status = _status(
         status=DreameMowerStatus.IDLE,

--- a/tests/test_device_status_state.py
+++ b/tests/test_device_status_state.py
@@ -16,7 +16,7 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device_types i
     DreameMowerTaskStatus,
 )
 
-_UNKNOWN_TASK_ACTIVE_STATUSES = frozenset(
+_EXPLICIT_ACTIVE_TASK_STATUSES = frozenset(
     {
         DreameMowerStatus.PAUSED,
         DreameMowerStatus.CLEANING,
@@ -34,6 +34,10 @@ _UNKNOWN_TASK_ACTIVE_STATUSES = frozenset(
         DreameMowerStatus.PERSON_FOLLOW,
     }
 )
+_UNKNOWN_TASK_INACTIVE_STATUSES = {
+    DreameMowerStatus.IDLE,
+    DreameMowerStatus.STANDBY,
+}
 
 
 def _status(
@@ -94,12 +98,14 @@ def test_unknown_task_requires_definitive_active_status(
         task_status=None,
     )
 
-    assert status.started is (reported_status in _UNKNOWN_TASK_ACTIVE_STATUSES)
+    assert status.started is (
+        status.status not in _UNKNOWN_TASK_INACTIVE_STATUSES
+    )
 
 
 @pytest.mark.parametrize(
     "reported_status",
-    sorted(_UNKNOWN_TASK_ACTIVE_STATUSES - {DreameMowerStatus.PAUSED}),
+    sorted(_EXPLICIT_ACTIVE_TASK_STATUSES - {DreameMowerStatus.PAUSED}),
 )
 def test_unknown_task_keeps_explicit_running_status_active(
     reported_status: DreameMowerStatus,
@@ -116,14 +122,14 @@ def test_unknown_task_keeps_explicit_running_status_active(
     assert status.state is DreameMowerState.MOWING
 
 
-def test_unknown_task_keeps_returning_separate_from_started_task() -> None:
+def test_unknown_task_keeps_returning_active_and_separately_identified() -> None:
     status = _status(
         status=DreameMowerStatus.BACK_HOME,
         state=DreameMowerState.RETURNING,
         task_status=None,
     )
 
-    assert status.started is False
+    assert status.started is True
     assert status.returning is True
     assert status.running is True
 
@@ -138,6 +144,18 @@ def test_unknown_task_keeps_explicit_paused_state_active() -> None:
     assert status.started is True
     assert status.paused is True
     assert status.state is DreameMowerState.PAUSED
+
+
+def test_unknown_task_keeps_sleeping_interruption_active_and_paused() -> None:
+    status = _status(
+        status=DreameMowerStatus.SLEEPING,
+        state=DreameMowerState.IDLE,
+        task_status=None,
+    )
+
+    assert status.started is True
+    assert status.running is False
+    assert status.paused is True
 
 
 def test_explicit_paused_task_remains_active_and_paused() -> None:

--- a/tests/test_device_status_state.py
+++ b/tests/test_device_status_state.py
@@ -1,0 +1,89 @@
+"""Regression tests for mower task and physical-state interpretation."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device_status import (
+    DreameMowerDeviceStatus,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device_types import (
+    DreameMowerProperty,
+    DreameMowerState,
+    DreameMowerStatus,
+    DreameMowerTaskStatus,
+)
+
+
+def _status(
+    *,
+    status: DreameMowerStatus,
+    state: DreameMowerState,
+    task_status: DreameMowerTaskStatus | None,
+) -> DreameMowerDeviceStatus:
+    properties = {
+        DreameMowerProperty.STATUS: status.value,
+        DreameMowerProperty.STATE: state.value,
+        DreameMowerProperty.TASK_STATUS: (
+            None if task_status is None else task_status.value
+        ),
+        DreameMowerProperty.CLEANING_PAUSED: 0,
+        # A3 firmware can report an unsupported zero while the charging period
+        # is active, so station state cannot be inferred from this property.
+        DreameMowerProperty.CHARGING_STATUS: 0,
+    }
+    device = SimpleNamespace(
+        capability=SimpleNamespace(
+            auto_charging=False,
+            cruising=False,
+            new_state=True,
+        ),
+        device_connected=True,
+        get_property=lambda prop: properties.get(prop),
+    )
+    return DreameMowerDeviceStatus(device)
+
+
+@pytest.mark.parametrize(
+    "reported_status",
+    [DreameMowerStatus.IDLE, DreameMowerStatus.STANDBY],
+)
+def test_unknown_task_does_not_turn_charging_period_standby_into_pause(
+    reported_status: DreameMowerStatus,
+) -> None:
+    status = _status(
+        status=reported_status,
+        state=DreameMowerState.IDLE,
+        task_status=None,
+    )
+
+    assert status.task_status is DreameMowerTaskStatus.UNKNOWN
+    assert status.started is False
+    assert status.paused is False
+    assert status.state is DreameMowerState.IDLE
+
+
+def test_unknown_task_keeps_explicit_mowing_state_active() -> None:
+    status = _status(
+        status=DreameMowerStatus.CLEANING,
+        state=DreameMowerState.MOWING,
+        task_status=None,
+    )
+
+    assert status.started is True
+    assert status.paused is False
+    assert status.state is DreameMowerState.MOWING
+
+
+def test_explicit_paused_task_remains_active_and_paused() -> None:
+    status = _status(
+        status=DreameMowerStatus.IDLE,
+        state=DreameMowerState.IDLE,
+        task_status=DreameMowerTaskStatus.AUTO_CLEANING_PAUSED,
+    )
+
+    assert status.started is True
+    assert status.paused is True
+    assert status.state is DreameMowerState.PAUSED

--- a/tests/test_device_status_state.py
+++ b/tests/test_device_status_state.py
@@ -16,6 +16,25 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device_types i
     DreameMowerTaskStatus,
 )
 
+_UNKNOWN_TASK_ACTIVE_STATUSES = frozenset(
+    {
+        DreameMowerStatus.PAUSED,
+        DreameMowerStatus.CLEANING,
+        DreameMowerStatus.PART_CLEANING,
+        DreameMowerStatus.FOLLOW_WALL,
+        DreameMowerStatus.REMOTE_CONTROL,
+        DreameMowerStatus.SEGMENT_CLEANING,
+        DreameMowerStatus.ZONE_CLEANING,
+        DreameMowerStatus.SPOT_CLEANING,
+        DreameMowerStatus.FAST_MAPPING,
+        DreameMowerStatus.CRUISING_PATH,
+        DreameMowerStatus.CRUISING_POINT,
+        DreameMowerStatus.SUMMON_CLEAN,
+        DreameMowerStatus.SHORTCUT,
+        DreameMowerStatus.PERSON_FOLLOW,
+    }
+)
+
 
 def _status(
     *,
@@ -65,16 +84,48 @@ def test_unknown_task_does_not_turn_charging_period_standby_into_pause(
     assert status.state is DreameMowerState.IDLE
 
 
-def test_unknown_task_keeps_explicit_mowing_state_active() -> None:
+@pytest.mark.parametrize("reported_status", list(DreameMowerStatus))
+def test_unknown_task_requires_definitive_active_status(
+    reported_status: DreameMowerStatus,
+) -> None:
     status = _status(
-        status=DreameMowerStatus.CLEANING,
+        status=reported_status,
+        state=DreameMowerState.IDLE,
+        task_status=None,
+    )
+
+    assert status.started is (reported_status in _UNKNOWN_TASK_ACTIVE_STATUSES)
+
+
+@pytest.mark.parametrize(
+    "reported_status",
+    sorted(_UNKNOWN_TASK_ACTIVE_STATUSES - {DreameMowerStatus.PAUSED}),
+)
+def test_unknown_task_keeps_explicit_running_status_active(
+    reported_status: DreameMowerStatus,
+) -> None:
+    status = _status(
+        status=reported_status,
         state=DreameMowerState.MOWING,
         task_status=None,
     )
 
     assert status.started is True
+    assert status.running is True
     assert status.paused is False
     assert status.state is DreameMowerState.MOWING
+
+
+def test_unknown_task_keeps_returning_separate_from_started_task() -> None:
+    status = _status(
+        status=DreameMowerStatus.BACK_HOME,
+        state=DreameMowerState.RETURNING,
+        task_status=None,
+    )
+
+    assert status.started is False
+    assert status.returning is True
+    assert status.running is True
 
 
 def test_unknown_task_keeps_explicit_paused_state_active() -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -531,6 +531,65 @@ def test_download_point_cloud_uses_legacy_stored_bin_after_property_timeout(
     assert result.source == "stored"
 
 
+def test_download_point_cloud_uses_indexed_object_for_multi_map_stored_request(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _client()
+    actions: list[dict[str, Any]] = []
+    client._sync_call_app_action = lambda payload, **kwargs: (
+        actions.append(payload)
+        or {
+            "r": 0,
+            "d": {
+                "name": [
+                    "private/front-map.bin",
+                    "private/back-map.bin",
+                ]
+            },
+        }
+    )
+    signed_names: list[str] = []
+
+    def get_interim_file_url(name: str, **options: Any) -> str:
+        signed_names.append(name)
+        return "https://downloads.example.invalid/stored"
+
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/ambiguous-map.bin",
+                "updateDate": 1_000,
+            }
+        ],
+        get_interim_file_url=get_interim_file_url,
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(
+        0,
+        45,
+        1,
+        10,
+        1024,
+        allow_stored=True,
+        allow_unscoped_stored=False,
+    )
+
+    assert actions == [{"m": "g", "t": "OBJ", "d": {"type": "3dmap"}}]
+    assert signed_names == ["private/front-map.bin"]
+    assert result.content == content
+    assert result.source == "stored"
+
+
 def test_download_point_cloud_uses_legacy_stored_bin_after_stale_announcement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3222,8 +3281,9 @@ def test_point_cloud_preflight_has_a_separate_time_budget(
         captured["function"]
         == client._sync_download_app_map_point_cloud_singleflight
     )
+    assert captured["args"][-3] is allow_stored
     assert captured["args"][-2] is allow_stored
-    assert captured["args"][-3] - started == pytest.approx(
+    assert captured["args"][-4] - started == pytest.approx(
         expected_operation_timeout,
         abs=0.25,
     )

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -147,7 +147,7 @@ def test_point_cloud_api_does_not_use_stored_object_for_inactive_map() -> None:
     assert options == [{"map_index": 1, "allow_stored": False}]
 
 
-def test_point_cloud_api_does_not_reuse_ambiguous_stored_multi_map_object() -> None:
+def test_point_cloud_api_reuses_only_indexed_stored_multi_map_object() -> None:
     options: list[dict[str, Any]] = []
 
     async def download(**kwargs: Any) -> DreameLawnMowerPointCloudDownload:
@@ -174,7 +174,13 @@ def test_point_cloud_api_does_not_reuse_ambiguous_stored_multi_map_object() -> N
 
     asyncio.run(api.async_get("entry-1", 0))
 
-    assert options == [{"map_index": 0, "allow_stored": False}]
+    assert options == [
+        {
+            "map_index": 0,
+            "allow_stored": True,
+            "allow_unscoped_stored": False,
+        }
+    ]
 
 
 def test_point_cloud_api_does_not_use_stored_object_for_selected_inactive_map() -> None:


### PR DESCRIPTION
## Summary

- treat an unknown mower task status as inactive only when the effective physical status is idle or standby, so charging-period standby is no longer exposed as a paused mowing session
- fail closed for sleeping, paused, returning, unknown, and every explicit running mode, keeping task-sensitive controls guarded when the vendor task field is unavailable
- reuse stored 3D point clouds on multi-map mowers only when the app inventory or mower `OBJ` response attributes the object to the requested map
- keep the unindexed `99.20` stored object limited to single-map mowers and document the two trust levels

## User impact

Charging-period standby no longer blocks idle-only controls such as selecting a map or going to a maintenance point. Multi-map A3 mowers can load an already published, correctly indexed 3D map instead of repeatedly requesting a new upload that the mower may not publish.

## Validation

- exhaustive mower-status decision table for unavailable task status
- full pure-Python test suite
- Home Assistant config-flow and translation tests on Linux
- focused status, control, map-switching, point-cloud client, and point-cloud API regressions
- Python compilation, Ruff, and diff checks

Fixes #157