### PR TITLE
Match mower maps to Dreame app orientation

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -34,6 +34,7 @@ from .map_visuals import (
     map_font,
     map_render_style,
     marker_radius,
+    project_dreame_app_point,
 )
 from .models import (
     DreameLawnMowerMapSummary,
@@ -777,9 +778,17 @@ def _render_app_map_payload_png(
 
     def project(point: tuple[float, float]) -> tuple[int, int]:
         x, y = point
+        px, py = project_dreame_app_point(
+            x,
+            y,
+            max_x=max_x,
+            min_y=min_y,
+            scale=scale,
+            padding=padding,
+        )
         return (
-            int(round((x - min_x) * scale + padding)),
-            int(round((max_y - y) * scale + padding)),
+            int(round(px)),
+            int(round(py)),
         )
 
     from PIL import Image, ImageDraw

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map_visuals.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map_visuals.py
@@ -168,6 +168,22 @@ def marker_radius(style: MapRenderStyle, base: int) -> int:
     return max(2, int(round(base * style.marker_scale)))
 
 
+def project_dreame_app_point(
+    x: float,
+    y: float,
+    *,
+    max_x: float,
+    min_y: float,
+    scale: float,
+    padding: int,
+) -> tuple[float, float]:
+    """Project mower coordinates in the orientation shown by the Dreame app."""
+    return (
+        (max_x - x) * scale + padding,
+        (y - min_y) * scale + padding,
+    )
+
+
 @lru_cache(maxsize=2)
 def _font_bytes(*, bold: bool) -> bytes:
     encoded = MAP_FONT if bold else MAP_FONT_LIGHT

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -20,6 +20,7 @@ from .map_visuals import (
     map_font,
     map_render_style,
     marker_radius,
+    project_dreame_app_point,
 )
 from .models import DreameLawnMowerMapSummary
 
@@ -261,9 +262,15 @@ def render_vector_map_png(
     label_halo_width = max(1, int(round(_normalize_label_scale(label_scale) * 2)))
 
     def to_pixel(x: int, y: int) -> tuple[int, int]:
-        px = int((x - boundary.x1) * scale) + _PADDING
-        py = int((boundary.y2 - y) * scale) + _PADDING
-        return px, py
+        px, py = project_dreame_app_point(
+            x,
+            y,
+            max_x=boundary.x2,
+            min_y=boundary.y1,
+            scale=scale,
+            padding=_PADDING,
+        )
+        return int(px), int(py)
 
     for index, zone in enumerate(vector_map.zones):
         if len(zone.points) < 3:

--- a/tests/test_map_visuals.py
+++ b/tests/test_map_visuals.py
@@ -55,23 +55,31 @@ def test_bundled_map_font_supports_unicode_labels() -> None:
     assert bounds[3] > bounds[1]
 
 
-def test_app_and_vector_maps_share_the_same_coordinate_orientation() -> None:
-    boundary = ((0, 0), (1000, 0), (1000, 100), (0, 100))
-    upper_right_spot = ((750, 60), (900, 60), (900, 90), (750, 90))
+def test_app_and_vector_maps_follow_the_dreame_app_orientation() -> None:
+    boundary = ((0, 0), (1000, 0), (1000, 1000), (0, 1000))
+    source_upper_right_spot = (
+        (750, 600),
+        (900, 600),
+        (900, 900),
+        (750, 900),
+    )
     app_png, _, _ = render_app_map_payload_png(
         {
             "map": [{"data": boundary}],
-            "spot": [{"data": upper_right_spot}],
+            "spot": [{"data": source_upper_right_spot}],
         }
     )
     vector_png = render_vector_map_png(
         DreameLawnMowerVectorMap(
-            boundary=DreameLawnMowerVectorBoundary(0, 0, 1000, 100),
+            boundary=DreameLawnMowerVectorBoundary(0, 0, 1000, 1000),
             zones=(
                 DreameLawnMowerVectorZone(zone_id=1, points=boundary),
             ),
             spot_areas=(
-                DreameLawnMowerVectorZone(zone_id=2, points=upper_right_spot),
+                DreameLawnMowerVectorZone(
+                    zone_id=2,
+                    points=source_upper_right_spot,
+                ),
             ),
         )
     )
@@ -80,10 +88,12 @@ def test_app_and_vector_maps_share_the_same_coordinate_orientation() -> None:
     app_center = _blue_layer_center(app_png)
     vector_center = _blue_layer_center(vector_png)
 
-    assert app_center[0] > 0.5
-    assert app_center[1] < 0.5
-    assert vector_center[0] > 0.5
-    assert vector_center[1] < 0.5
+    # Dreame's app presents this asymmetric source landmark in the bottom-left.
+    # Keep that external reference explicit so matching two wrong renderers cannot pass.
+    assert app_center[0] < 0.5
+    assert app_center[1] > 0.5
+    assert vector_center[0] < 0.5
+    assert vector_center[1] > 0.5
 
 
 def test_map_theme_changes_the_complete_render_without_geometry_changes() -> None:


### PR DESCRIPTION
## Summary

- use one shared projection for app-action and batch-vector mower maps
- present both cameras in the physical orientation shown by the Dreame app while preserving the existing per-map display rotation
- anchor the contract with an asymmetric landmark so two internally consistent but inverted renderers cannot pass

## Context

v0.2.72 aligned the two Home Assistant cameras but selected the inverse of Dreame's mobile-app presentation. The reporter's named-zone comparison exposed that regression.

## Validation

- full Python 3.13 test suite and Ruff validation on Linux
- focused renderer contract checks on Windows and Linux
- visual comparison of both corrected renderer artifacts against the Dreame-app landmark
- independent read-only local review with no findings

Closes #159