### PR TITLE
Decode A3 standby heartbeat state

### DIFF
--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -250,7 +250,11 @@ def _status_blob_summary(key: object, value: Any) -> dict[str, Any] | None:
     }
     if str(key) not in status_blob_keys:
         return None
-    decoded = decode_mower_status_blob(value, source="debug")
+    decoded = decode_mower_status_blob(
+        value,
+        source="debug",
+        property_key=str(key),
+    )
     if decoded is None:
         return None
     return {

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/app_protocol.py
@@ -223,10 +223,42 @@ def _first_mapping_value(
     return None
 
 
+_STANDARD_HEARTBEAT_LENGTH: Final[int] = 20
+_A3_IDLE_HEARTBEAT_LENGTH: Final[int] = 22
+_A3_IDLE_HEARTBEAT_MAIN_STATE_BYTE: Final[int] = 0xC1
+_A3_IDLE_HEARTBEAT_SUBSTATE: Final[int] = 0xFF
+_A3_IDLE_HEARTBEAT_DOCKING_STATE: Final[int] = 0
+
+
+def _is_supported_heartbeat_frame(
+    raw: Sequence[int],
+    *,
+    frame_valid: bool,
+    property_key: str | None,
+) -> bool:
+    """Return whether task/docking fields are proven for this frame shape."""
+    if not frame_valid:
+        return False
+    if len(raw) == _STANDARD_HEARTBEAT_LENGTH:
+        return True
+    # A3 firmware appends two tail bytes to raw status property 1.1. Only its
+    # exact observed idle-in-station fields are decoded until supervised
+    # captures prove other 22-byte states. Runtime property 1.4 shares this
+    # decoder but its payload bytes must never be interpreted as a heartbeat.
+    return bool(
+        len(raw) == _A3_IDLE_HEARTBEAT_LENGTH
+        and property_key == MOWER_RAW_STATUS_PROPERTY_KEY
+        and raw[12] == _A3_IDLE_HEARTBEAT_MAIN_STATE_BYTE
+        and raw[13] == _A3_IDLE_HEARTBEAT_SUBSTATE
+        and raw[14] == _A3_IDLE_HEARTBEAT_DOCKING_STATE
+    )
+
+
 def decode_mower_status_blob(
     value: object,
     *,
     source: str | None = None,
+    property_key: str | None = None,
 ) -> DreameLawnMowerStatusBlob | None:
     """Return a conservative structure for app realtime/status byte blobs.
 
@@ -239,13 +271,18 @@ def decode_mower_status_blob(
     if raw is None:
         return None
 
-    notes: list[str] = []
-    if len(raw) != 20:
-        notes.append("unexpected_length")
-
     frame_start = raw[0] if raw else None
     frame_end = raw[-1] if raw else None
     frame_valid = bool(len(raw) >= 2 and frame_start == 0xCE and frame_end == 0xCE)
+    supported_heartbeat = _is_supported_heartbeat_frame(
+        raw,
+        frame_valid=frame_valid,
+        property_key=property_key,
+    )
+
+    notes: list[str] = []
+    if len(raw) != _STANDARD_HEARTBEAT_LENGTH and not supported_heartbeat:
+        notes.append("unexpected_length")
     if not frame_valid:
         notes.append("invalid_frame_markers")
 
@@ -261,7 +298,7 @@ def decode_mower_status_blob(
     heartbeat_docking_state = None
     heartbeat_docking_state_name = None
     heartbeat_docked = None
-    if frame_valid and len(raw) == 20:
+    if supported_heartbeat:
         heartbeat_docking_state = (raw[14] & 0x1C) >> 2
         heartbeat_docking_state_name = _HEARTBEAT_DOCKING_STATES.get(
             heartbeat_docking_state
@@ -269,7 +306,11 @@ def decode_mower_status_blob(
         if heartbeat_docking_state_name is not None:
             heartbeat_docked = heartbeat_docking_state == 0
 
-    task_state = _decode_heartbeat_task_state(raw, frame_valid=frame_valid)
+    task_state = _decode_heartbeat_task_state(
+        raw,
+        frame_valid=frame_valid,
+        property_key=property_key,
+    )
     notes.extend(task_state.pop("notes", ()))
 
     runtime_telemetry = _decode_runtime_blob_candidates(raw, frame_valid=frame_valid)
@@ -339,9 +380,14 @@ def _decode_heartbeat_task_state(
     raw: Sequence[int],
     *,
     frame_valid: bool,
+    property_key: str | None,
 ) -> dict[str, object]:
-    """Decode the active mowing session state from a 20-byte heartbeat."""
-    if not frame_valid or len(raw) != 20:
+    """Decode the active mowing session state from a supported heartbeat."""
+    if not _is_supported_heartbeat_frame(
+        raw,
+        frame_valid=frame_valid,
+        property_key=property_key,
+    ):
         return {}
 
     main_state = (raw[12] & 0x0F) - 1

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -510,6 +510,7 @@ class _DreameLawnMowerClientCoreMixin:
             decoded = decode_mower_status_blob(
                 realtime_entry.get("value"),
                 source="realtime",
+                property_key=property_key,
             )
             if decoded is not None:
                 return replace(
@@ -526,6 +527,7 @@ class _DreameLawnMowerClientCoreMixin:
                 decoded = decode_mower_status_blob(
                     entry.get("value"),
                     source="cloud",
+                    property_key=property_key,
                 )
                 if decoded is not None:
                     return replace(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core_helpers.py
@@ -461,7 +461,11 @@ def _operation_property_summary(
             MOWER_RUNTIME_STATUS_PROPERTY_KEY,
         }
         if key_text in status_blob_keys:
-            decoded = decode_mower_status_blob(property_value, source="operation")
+            decoded = decode_mower_status_blob(
+                property_value,
+                source="operation",
+                property_key=key_text,
+            )
             status_blob = decoded.as_dict() if decoded is not None else None
         task_status = None
         if key_text == MOWER_TASK_PROPERTY_KEY:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -2362,7 +2362,7 @@ class _DreameLawnMowerClientMapsMixin:
                 rendered["decoded_label"] = label
                 rendered["decoded_label_source"] = "bundled_mower_errors"
         elif key in {MOWER_RAW_STATUS_PROPERTY_KEY, MOWER_RUNTIME_STATUS_PROPERTY_KEY}:
-            status_blob = decode_mower_status_blob(value)
+            status_blob = decode_mower_status_blob(value, property_key=key)
             if status_blob is not None:
                 status_blob = replace(
                     status_blob,

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -3,6 +3,8 @@
 from __future__ import annotations
 
 from dreame_lawn_mower_client import (
+    MOWER_RAW_STATUS_PROPERTY_KEY,
+    MOWER_RUNTIME_STATUS_PROPERTY_KEY,
     DreameLawnMowerClient,
     DreameLawnMowerDescriptor,
     decode_mower_status_blob,
@@ -146,8 +148,8 @@ def test_client_status_blob_prefers_cached_realtime_payload() -> None:
         descriptor=DreameLawnMowerDescriptor(
             did="1",
             name="Mower",
-            model="dreame.mower.g2408",
-            display_model="A2",
+            model="dreame.mower.g2541e",
+            display_model="A3 AWD Pro 3500",
             account_type="dreame",
             country="eu",
         ),
@@ -165,20 +167,22 @@ def test_client_status_blob_prefers_cached_realtime_payload() -> None:
                         0,
                         0,
                         0,
-                        16,
                         0,
-                        33,
+                        0,
+                        0,
                         0,
                         0,
                         0,
                         100,
-                        1,
+                        193,
                         255,
                         0,
                         0,
                         128,
-                        212,
-                        196,
+                        204,
+                        186,
+                        0,
+                        128,
                         206,
                     ],
                 },
@@ -193,6 +197,10 @@ def test_client_status_blob_prefers_cached_realtime_payload() -> None:
     assert decoded.received_at == "2023-11-14T22:13:20+00:00"
     assert decoded.frame_valid is True
     assert decoded.candidate_battery_level == 100
+    assert decoded.heartbeat_docked is True
+    assert decoded.task_status == "idle"
+    assert decoded.mowing_session_active is False
+    assert decoded.notes == ()
 
 
 def test_status_blob_decoder_exposes_candidate_battery_byte() -> None:
@@ -250,12 +258,13 @@ def test_status_blob_decoder_accepts_a3_awd_pro_22_byte_frame() -> None:
             0,
             0,
             128,
-            184,
-            196,
+            204,
+            186,
             0,
-            0,
+            128,
             206,
-        ]
+        ],
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
 
     assert decoded is not None
@@ -264,9 +273,15 @@ def test_status_blob_decoder_accepts_a3_awd_pro_22_byte_frame() -> None:
     assert decoded.candidate_battery_level == 100
     assert decoded.candidate_runtime_pose_x == 0
     assert decoded.candidate_runtime_pose_y == 0
-    assert decoded.heartbeat_docking_state is None
-    assert decoded.heartbeat_docking_state_name is None
-    assert decoded.heartbeat_docked is None
+    assert decoded.heartbeat_docking_state == 0
+    assert decoded.heartbeat_docking_state_name == "in_station"
+    assert decoded.heartbeat_docked is True
+    assert decoded.main_state == 0
+    assert decoded.sub_state == 255
+    assert decoded.task_status == "idle"
+    assert decoded.mowing_session_active is False
+    assert decoded.task_resumable is False
+    assert decoded.notes == ()
 
 
 def test_status_blob_decoder_does_not_treat_heartbeat_bytes_as_pose() -> None:
@@ -306,6 +321,84 @@ def test_status_blob_decoder_does_not_treat_heartbeat_bytes_as_pose() -> None:
     assert decoded.sub_state is None
     assert decoded.task_status is None
     assert decoded.mowing_session_active is None
+    assert decoded.heartbeat_docked is None
+    assert decoded.notes == ("unexpected_length",)
+
+
+def test_runtime_blob_collision_does_not_decode_a3_idle_heartbeat() -> None:
+    decoded = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            100,
+            193,
+            255,
+            0,
+            0,
+            128,
+            204,
+            186,
+            0,
+            128,
+            206,
+        ],
+        property_key=MOWER_RUNTIME_STATUS_PROPERTY_KEY,
+    )
+
+    assert decoded is not None
+    assert decoded.heartbeat_docking_state is None
+    assert decoded.heartbeat_docked is None
+    assert decoded.main_state is None
+    assert decoded.sub_state is None
+    assert decoded.task_status is None
+    assert decoded.mowing_session_active is None
+    assert decoded.task_resumable is None
+    assert decoded.notes == ("unexpected_length",)
+
+
+def test_unconfirmed_a3_status_variant_remains_fail_closed() -> None:
+    decoded = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            100,
+            65,
+            255,
+            0,
+            0,
+            128,
+            202,
+            186,
+            0,
+            128,
+            206,
+        ],
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert decoded is not None
+    assert decoded.heartbeat_docked is None
+    assert decoded.task_status is None
+    assert decoded.mowing_session_active is None
+    assert decoded.notes == ("unexpected_length",)
 
 
 def test_status_blob_decoder_exposes_paused_resumable_session_at_dock() -> None:

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -8,6 +8,7 @@ from types import SimpleNamespace
 import pytest
 
 from dreame_lawn_mower_client import (
+    MOWER_RAW_STATUS_PROPERTY_KEY,
     DreameLawnMowerDescriptor,
     DreameLawnMowerSnapshot,
     decode_mower_status_blob,
@@ -83,6 +84,7 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
             206,
         ],
         source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
 
     assert status_blob is not None
@@ -103,6 +105,55 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
     assert reconciled.task_status_source == "heartbeat_realtime"
     assert reconciled.mowing_session_active is False
     assert reconciled.mission_task_id == status_blob.candidate_runtime_task_id
+
+
+def test_a3_standby_heartbeat_corrects_stale_paused_snapshot() -> None:
+    status_blob = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            100,
+            193,
+            255,
+            0,
+            0,
+            128,
+            204,
+            186,
+            0,
+            128,
+            206,
+        ],
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    reconciled = snapshot_with_heartbeat_task_state(
+        _snapshot(
+            model="dreame.mower.g2541e",
+            display_model="A3 AWD Pro 3500",
+        ),
+        status_blob,
+    )
+
+    assert reconciled.state == "idle"
+    assert reconciled.activity == "docked"
+    assert reconciled.docked is True
+    assert reconciled.raw_docked is True
+    assert reconciled.started is False
+    assert reconciled.task_status == "idle"
+    assert reconciled.mowing_session_active is False
+    assert reconciled.task_resumable is False
 
 
 def test_active_paused_session_keeps_task_activity_while_recording_dock() -> None:


### PR DESCRIPTION
## Summary

- decode the A3 AWD Pro 22-byte standby-at-station heartbeat from raw status property `1.1`
- reconcile stale paused/started values to idle and docked so maintenance movement is available when the mower is actually in standby
- keep runtime property `1.4`, unscoped payloads, and unobserved 22-byte variants fail-closed

## Context

Fresh diagnostics in #157 captured the Dreame app reporting Standby while Home Assistant reported Paused. The frame was valid but the integration rejected it solely because A3 firmware appended two bytes to the established heartbeat shape.

The new decoding is deliberately limited to the exact supervised idle-in-station signature. Existing 20-byte heartbeat behavior is unchanged.

## Validation

- Ruff
- focused protocol, runtime-state, docking, and remote-control tests on Python 3.13
- full Linux Python 3.13 suite: 1,576 passed, 1 skipped
- Home Assistant config-flow and translation lane: 26 passed
- independent read-only review plus targeted confirmation of property-scoping remediation

Refs #157