### PR TITLE
Fix A3 standby state oscillation and map switching

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -547,7 +547,16 @@ class DreameLawnMowerClient(
         except DreameLawnMowerConnectionError:
             status_blob = None
         if status_blob is not None:
-            snapshot = snapshot_with_heartbeat_task_state(snapshot, status_blob)
+            snapshot = snapshot_with_heartbeat_task_state(
+                snapshot,
+                status_blob,
+                observed_at=time.time(),
+                active_state_observed_at=getattr(
+                    self,
+                    "_raw_runtime_state_observed_at",
+                    None,
+                ),
+            )
 
         try:
             cloud_device_info = await asyncio.to_thread(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -93,6 +93,28 @@ def _decoded_realtime_status_blob(
     )
 
 
+def _raw_runtime_state_signature(
+    snapshot: DreameLawnMowerSnapshot,
+) -> tuple[Any, ...]:
+    """Return the safety-relevant property state before heartbeat correction."""
+    return (
+        snapshot.state,
+        snapshot.activity,
+        snapshot.task_status,
+        snapshot.mowing_session_active,
+        snapshot.started,
+        snapshot.raw_started,
+        snapshot.paused,
+        snapshot.mowing,
+        snapshot.returning,
+        snapshot.raw_returning,
+        snapshot.docked,
+        snapshot.raw_docked,
+        snapshot.charging,
+        snapshot.raw_charging,
+    )
+
+
 def _device_start_session_identity(device: Any) -> bool | None:
     """Return the cached start-versus-resume branch used by the device."""
     from .device_types import DreameMowerTaskStatus
@@ -270,12 +292,27 @@ class _DreameLawnMowerClientCoreMixin:
                 device,
                 previous_snapshot=getattr(self, "_latest_snapshot", None),
             )
+            observed_at = time.time()
+            runtime_signature = _raw_runtime_state_signature(snapshot)
+            if getattr(self, "_raw_runtime_state_signature", None) != runtime_signature:
+                self._raw_runtime_state_signature = runtime_signature
+                self._raw_runtime_state_observed_at = observed_at
+            active_state_observed_at = getattr(
+                self,
+                "_raw_runtime_state_observed_at",
+                observed_at,
+            )
             status_blob = _decoded_realtime_status_blob(
                 device,
                 MOWER_RAW_STATUS_PROPERTY_KEY,
             )
             if status_blob is not None:
-                snapshot = snapshot_with_heartbeat_task_state(snapshot, status_blob)
+                snapshot = snapshot_with_heartbeat_task_state(
+                    snapshot,
+                    status_blob,
+                    observed_at=observed_at,
+                    active_state_observed_at=active_state_observed_at,
+                )
         self._latest_snapshot = snapshot
         return snapshot
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -64,9 +64,33 @@ from .payload_utils import (
 )
 from .runtime_state import (
     RESUME_MOWING_REQUEST,
+    snapshot_with_heartbeat_task_state,
 )
 
 _MUTATION_CONFIRMATION_DELAYS_SECONDS = (0.5, 1.5, 3.0)
+
+
+def _decoded_realtime_status_blob(
+    device: Any,
+    property_key: str,
+) -> DreameLawnMowerStatusBlob | None:
+    """Decode one cached realtime status property with its own timestamp."""
+    realtime_entry = (getattr(device, "realtime_properties", {}) or {}).get(
+        property_key
+    )
+    if not isinstance(realtime_entry, Mapping):
+        return None
+    decoded = decode_mower_status_blob(
+        realtime_entry.get("value"),
+        source="realtime",
+        property_key=property_key,
+    )
+    if decoded is None:
+        return None
+    return replace(
+        decoded,
+        received_at=_property_entry_received_at(realtime_entry),
+    )
 
 
 def _device_start_session_identity(device: Any) -> bool | None:
@@ -239,19 +263,19 @@ class _DreameLawnMowerClientCoreMixin:
     def _snapshot_from_device(self, device: Any) -> DreameLawnMowerSnapshot:
         """Normalize one coherent device state and retain recovery context."""
         state_lock = getattr(device, "_state_lock", None)
-        if state_lock is None:
+        state_context = state_lock if state_lock is not None else nullcontext()
+        with state_context:
             snapshot = snapshot_from_device(
                 self._descriptor,
                 device,
                 previous_snapshot=getattr(self, "_latest_snapshot", None),
             )
-        else:
-            with state_lock:
-                snapshot = snapshot_from_device(
-                    self._descriptor,
-                    device,
-                    previous_snapshot=getattr(self, "_latest_snapshot", None),
-                )
+            status_blob = _decoded_realtime_status_blob(
+                device,
+                MOWER_RAW_STATUS_PROPERTY_KEY,
+            )
+            if status_blob is not None:
+                snapshot = snapshot_with_heartbeat_task_state(snapshot, status_blob)
         self._latest_snapshot = snapshot
         return snapshot
 
@@ -503,20 +527,9 @@ class _DreameLawnMowerClientCoreMixin:
         else:
             device = self._ensure_device()
 
-        realtime_entry = (getattr(device, "realtime_properties", {}) or {}).get(
-            property_key
-        )
-        if isinstance(realtime_entry, Mapping):
-            decoded = decode_mower_status_blob(
-                realtime_entry.get("value"),
-                source="realtime",
-                property_key=property_key,
-            )
-            if decoded is not None:
-                return replace(
-                    decoded,
-                    received_at=_property_entry_received_at(realtime_entry),
-                )
+        decoded = _decoded_realtime_status_blob(device, property_key)
+        if decoded is not None:
+            return decoded
 
         if not include_cloud:
             return None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_shared_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_shared_helpers.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 from collections.abc import Mapping, Sequence
 from datetime import UTC, datetime
 from typing import Any
@@ -38,8 +39,13 @@ def _positive_int(value: Any) -> int | None:
 
 
 def _epoch_to_iso(value: Any) -> str | None:
-    parsed = _positive_int(value)
-    if parsed is None:
+    if isinstance(value, bool):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not math.isfinite(parsed) or parsed < 0:
         return None
     timestamp = parsed / 1000 if parsed > 10_000_000_000 else parsed
     try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 from collections.abc import Mapping
 from dataclasses import replace
 from datetime import UTC, datetime
@@ -10,6 +11,9 @@ from typing import Any
 from .models import DreameLawnMowerSnapshot, DreameLawnMowerStatusBlob
 
 RESUME_MOWING_REQUEST = {"m": "a", "p": 0, "o": 5}
+
+_INACTIVE_HEARTBEAT_MAX_AGE_SECONDS = 130.0
+_HEARTBEAT_CLOCK_SKEW_SECONDS = 5.0
 
 _ACTIVE_TASK_CONTROL_STATES = {
     "starting": "mowing",
@@ -22,9 +26,27 @@ _ACTIVE_TASK_CONTROL_STATES = {
 def snapshot_with_heartbeat_task_state(
     snapshot: DreameLawnMowerSnapshot,
     status_blob: DreameLawnMowerStatusBlob,
+    *,
+    observed_at: float | None = None,
 ) -> DreameLawnMowerSnapshot:
     """Apply heartbeat-confirmed task and physical docking state."""
     task_status = status_blob.task_status
+    heartbeat_may_weaken_active_state = (
+        status_blob.mowing_session_active is False
+        or (
+            status_blob.heartbeat_docked is True
+            and status_blob.mowing_session_active is not True
+        )
+    )
+    if heartbeat_may_weaken_active_state and not _inactive_heartbeat_is_current(
+        snapshot,
+        status_blob,
+        observed_at=observed_at,
+    ):
+        # A cached inactive heartbeat must never clear newer or unorderable
+        # paused/running evidence. Active heartbeat evidence remains fail-closed.
+        return snapshot
+
     changes: dict[str, Any] = {}
     if status_blob.candidate_runtime_task_id is not None:
         changes["mission_task_id"] = status_blob.candidate_runtime_task_id
@@ -77,6 +99,33 @@ def _heartbeat_event_at(status_blob: DreameLawnMowerStatusBlob) -> float | None:
     if parsed.tzinfo is None:
         parsed = parsed.replace(tzinfo=UTC)
     return parsed.timestamp()
+
+
+def _inactive_heartbeat_is_current(
+    snapshot: DreameLawnMowerSnapshot,
+    status_blob: DreameLawnMowerStatusBlob,
+    *,
+    observed_at: float | None,
+) -> bool:
+    """Return whether inactive heartbeat evidence is fresh and correctly ordered."""
+    heartbeat_event_at = _heartbeat_event_at(status_blob)
+    if heartbeat_event_at is None:
+        return False
+
+    now = time.time() if observed_at is None else float(observed_at)
+    if heartbeat_event_at > now + _HEARTBEAT_CLOCK_SKEW_SECONDS:
+        return False
+    if now - heartbeat_event_at > _INACTIVE_HEARTBEAT_MAX_AGE_SECONDS:
+        return False
+
+    for event_at in (snapshot.state_event_at, snapshot.task_status_event_at):
+        if (
+            isinstance(event_at, int | float)
+            and not isinstance(event_at, bool)
+            and float(event_at) > heartbeat_event_at
+        ):
+            return False
+    return True
 
 
 def snapshot_with_cloud_presence(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import time
 from collections.abc import Mapping
 from dataclasses import replace
@@ -14,6 +15,9 @@ RESUME_MOWING_REQUEST = {"m": "a", "p": 0, "o": 5}
 
 _INACTIVE_HEARTBEAT_MAX_AGE_SECONDS = 130.0
 _HEARTBEAT_CLOCK_SKEW_SECONDS = 5.0
+# ISO timestamps retain microseconds while vendor reception clocks can expose
+# a slightly finer float. Treat only that serialization quantum as equal.
+_EVENT_ORDERING_TOLERANCE_SECONDS = 0.000001
 
 _ACTIVE_TASK_CONTROL_STATES = {
     "starting": "mowing",
@@ -28,6 +32,7 @@ def snapshot_with_heartbeat_task_state(
     status_blob: DreameLawnMowerStatusBlob,
     *,
     observed_at: float | None = None,
+    active_state_observed_at: float | None = None,
 ) -> DreameLawnMowerSnapshot:
     """Apply heartbeat-confirmed task and physical docking state."""
     task_status = status_blob.task_status
@@ -42,6 +47,7 @@ def snapshot_with_heartbeat_task_state(
         snapshot,
         status_blob,
         observed_at=observed_at,
+        active_state_observed_at=active_state_observed_at,
     ):
         # A cached inactive heartbeat must never clear newer or unorderable
         # paused/running evidence. Active heartbeat evidence remains fail-closed.
@@ -106,6 +112,7 @@ def _inactive_heartbeat_is_current(
     status_blob: DreameLawnMowerStatusBlob,
     *,
     observed_at: float | None,
+    active_state_observed_at: float | None,
 ) -> bool:
     """Return whether inactive heartbeat evidence is fresh and correctly ordered."""
     heartbeat_event_at = _heartbeat_event_at(status_blob)
@@ -118,14 +125,45 @@ def _inactive_heartbeat_is_current(
     if now - heartbeat_event_at > _INACTIVE_HEARTBEAT_MAX_AGE_SECONDS:
         return False
 
-    for event_at in (snapshot.state_event_at, snapshot.task_status_event_at):
+    state_event_at = _numeric_event_at(snapshot.state_event_at)
+    task_event_at = _numeric_event_at(snapshot.task_status_event_at)
+    active_observed_at = _numeric_event_at(active_state_observed_at)
+    physical_state_active = bool(
+        snapshot.activity in {"mowing", "paused", "returning"}
+        or snapshot.paused
+        or snapshot.mowing
+        or snapshot.returning
+    )
+    task_state_active = bool(
+        snapshot.mowing_session_active is True
+        or snapshot.task_status in _ACTIVE_TASK_CONTROL_STATES
+    )
+    if (
+        (physical_state_active and state_event_at is None)
+        or (task_state_active and task_event_at is None)
+    ) and active_observed_at is None:
+        return False
+
+    event_times = [state_event_at, task_event_at]
+    if (physical_state_active and state_event_at is None) or (
+        task_state_active and task_event_at is None
+    ):
+        event_times.append(active_observed_at)
+    for event_at in event_times:
         if (
-            isinstance(event_at, int | float)
-            and not isinstance(event_at, bool)
-            and float(event_at) > heartbeat_event_at
+            event_at is not None
+            and event_at > heartbeat_event_at + _EVENT_ORDERING_TOLERANCE_SECONDS
         ):
             return False
     return True
+
+
+def _numeric_event_at(value: Any) -> float | None:
+    """Return a finite event timestamp without accepting booleans."""
+    if not isinstance(value, int | float) or isinstance(value, bool):
+        return None
+    parsed = float(value)
+    return parsed if math.isfinite(parsed) else None
 
 
 def snapshot_with_cloud_presence(

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -14,6 +14,31 @@ from dreame_lawn_mower_client import (
     key_definition_label,
 )
 
+_A3_STANDBY_STATUS_FRAME = (
+    206,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    99,
+    97,
+    255,
+    0,
+    0,
+    128,
+    204,
+    186,
+    0,
+    128,
+    206,
+)
+
 
 def test_property_annotations_label_known_mower_state_and_error_keys() -> None:
     state_entry = DreameLawnMowerClient._annotate_cloud_property_entry(
@@ -191,7 +216,6 @@ def test_client_status_blob_prefers_cached_realtime_payload() -> None:
             }
         },
     )()
-
     decoded = client._sync_get_status_blob(include_cloud=False)
 
     assert decoded is not None
@@ -203,6 +227,28 @@ def test_client_status_blob_prefers_cached_realtime_payload() -> None:
     assert decoded.task_status == "idle"
     assert decoded.mowing_session_active is False
     assert decoded.notes == ()
+
+
+def test_client_status_blob_preserves_fractional_reception_time() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client._device = type(
+        "FakeDevice",
+        (),
+        {
+            "realtime_properties": {
+                "1.1": {
+                    "last_seen": 1_700_000_000.75,
+                    "value": list(_A3_STANDBY_STATUS_FRAME),
+                },
+            }
+        },
+    )()
+    client._ensure_device = lambda: client._device
+
+    decoded = client._sync_get_status_blob(include_cloud=False)
+
+    assert decoded is not None
+    assert decoded.received_at == "2023-11-14T22:13:20.750000+00:00"
 
 
 def test_status_blob_decoder_exposes_candidate_battery_byte() -> None:

--- a/tests/test_app_protocol_annotations.py
+++ b/tests/test_app_protocol_annotations.py
@@ -237,7 +237,7 @@ def test_client_status_blob_preserves_fractional_reception_time() -> None:
         {
             "realtime_properties": {
                 "1.1": {
-                    "last_seen": 1_700_000_000.75,
+                    "last_seen": 1_700_000_000.7500002,
                     "value": list(_A3_STANDBY_STATUS_FRAME),
                 },
             }

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -2,8 +2,11 @@
 
 from __future__ import annotations
 
+import asyncio
 from dataclasses import replace
+from threading import RLock
 from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
 
 import pytest
 
@@ -18,6 +21,8 @@ from dreame_lawn_mower_client._loader import load_internal_module
 snapshot_with_heartbeat_task_state = load_internal_module(
     "runtime_state"
 ).snapshot_with_heartbeat_task_state
+client_core_module = load_internal_module("client_core")
+DreameLawnMowerClient = load_internal_module("client").DreameLawnMowerClient
 
 
 def _snapshot(
@@ -154,6 +159,75 @@ def test_a3_standby_heartbeat_corrects_stale_paused_snapshot() -> None:
     assert reconciled.task_status == "idle"
     assert reconciled.mowing_session_active is False
     assert reconciled.task_resumable is False
+
+
+def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
+    """MQTT publication and safety reads must share the reconciled state."""
+    raw_snapshot = _snapshot(
+        model="dreame.mower.g2541e",
+        display_model="A3 AWD Pro 3500",
+    )
+    device = SimpleNamespace(
+        _state_lock=RLock(),
+        realtime_properties={
+            MOWER_RAW_STATUS_PROPERTY_KEY: {
+                "value": [
+                    206,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    0,
+                    99,
+                    97,
+                    255,
+                    0,
+                    0,
+                    128,
+                    204,
+                    186,
+                    0,
+                    128,
+                    206,
+                ],
+                "last_seen": 1_787_575_147,
+            }
+        },
+    )
+    client = object.__new__(DreameLawnMowerClient)
+    client._descriptor = raw_snapshot.descriptor
+    client._latest_snapshot = None
+    client._ensure_device = lambda: device
+    client._sync_update_device = lambda force=False: device  # noqa: ARG005
+    client._sync_switch_current_map = lambda map_index: {"map_index": map_index}
+    client.async_get_current_app_map_index = AsyncMock(return_value=1)
+
+    with patch.object(
+        client_core_module,
+        "snapshot_from_device",
+        return_value=raw_snapshot,
+    ):
+        reconciled = asyncio.run(client.async_get_cached_snapshot())
+        switch_result = asyncio.run(client.async_switch_current_map(1))
+
+    assert reconciled.state == "idle"
+    assert reconciled.activity == "docked"
+    assert reconciled.docked is True
+    assert reconciled.started is False
+    assert reconciled.paused is False
+    assert reconciled.task_status == "idle"
+    assert reconciled.task_status_source == "heartbeat_realtime"
+    assert reconciled.task_status_event_at == 1_787_575_147.0
+    assert reconciled.mowing_session_active is False
+    assert client._latest_snapshot.state == "idle"
+    assert client._latest_snapshot.activity == "docked"
+    assert switch_result == {"map_index": 1}
+    client.async_get_current_app_map_index.assert_awaited_once_with()
 
 
 def test_active_paused_session_keeps_task_activity_while_recording_dock() -> None:

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -127,6 +127,7 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
         _snapshot(model=model, display_model=display_model),
         status_blob,
         observed_at=20.0,
+        active_state_observed_at=19.0,
     )
 
     assert reconciled.state == "idle"
@@ -182,6 +183,7 @@ def test_a3_standby_heartbeat_corrects_stale_paused_snapshot() -> None:
         ),
         status_blob,
         observed_at=20.0,
+        active_state_observed_at=19.0,
     )
 
     assert reconciled.state == "idle"
@@ -200,13 +202,13 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
         model="dreame.mower.g2541e",
         display_model="A3 AWD Pro 3500",
     )
-    heartbeat_received_at = time.time()
+    first_heartbeat_received_at = 100.0
     device = SimpleNamespace(
         _state_lock=RLock(),
         realtime_properties={
             MOWER_RAW_STATUS_PROPERTY_KEY: {
                 "value": list(_A3_STANDBY_0X61_FRAME),
-                "last_seen": heartbeat_received_at,
+                "last_seen": first_heartbeat_received_at,
             }
         },
     )
@@ -215,13 +217,41 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
     client._latest_snapshot = None
     client._ensure_device = lambda: device
     client._sync_update_device = lambda force=False: device  # noqa: ARG005
-    client._sync_switch_current_map = lambda map_index: {"map_index": map_index}
+    client._sync_switch_current_map = Mock(
+        side_effect=lambda map_index: {"map_index": map_index}
+    )
     client.async_get_current_app_map_index = AsyncMock(return_value=1)
 
-    with patch.object(
-        client_core_module,
-        "snapshot_from_device",
-        return_value=raw_snapshot,
+    with (
+        patch.object(
+            client_core_module,
+            "snapshot_from_device",
+            return_value=raw_snapshot,
+        ),
+        patch.object(client_core_module.time, "time", return_value=101.0),
+    ):
+        first_snapshot = asyncio.run(client.async_get_cached_snapshot())
+        with pytest.raises(
+            DreameLawnMowerCommandRejectedError,
+            match="Finish or cancel",
+        ):
+            asyncio.run(client.async_switch_current_map(1))
+
+    assert first_snapshot.state == "paused"
+    assert first_snapshot.activity == "paused"
+    client._sync_switch_current_map.assert_not_called()
+
+    heartbeat_received_at = 102.0
+    device.realtime_properties[MOWER_RAW_STATUS_PROPERTY_KEY]["last_seen"] = (
+        heartbeat_received_at
+    )
+    with (
+        patch.object(
+            client_core_module,
+            "snapshot_from_device",
+            return_value=raw_snapshot,
+        ),
+        patch.object(client_core_module.time, "time", return_value=103.0),
     ):
         reconciled = asyncio.run(client.async_get_cached_snapshot())
         switch_result = asyncio.run(client.async_switch_current_map(1))
@@ -241,7 +271,108 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
     assert client._latest_snapshot.state == "idle"
     assert client._latest_snapshot.activity == "docked"
     assert switch_result == {"map_index": 1}
+    client._sync_switch_current_map.assert_called_once_with(1)
     client.async_get_current_app_map_index.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("state", "activity", "paused", "mowing"),
+    [
+        ("paused", "paused", True, False),
+        ("mowing", "mowing", False, True),
+    ],
+)
+def test_fresh_inactive_heartbeat_cannot_weaken_new_untimestamped_active_state(
+    state: str,
+    activity: str,
+    paused: bool,
+    mowing: bool,
+) -> None:
+    """A first local active observation outranks an older cached heartbeat."""
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_0X61_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(
+        status_blob,
+        received_at="1970-01-01T00:01:40+00:00",
+    )
+    active_snapshot = replace(
+        _snapshot(),
+        state=state,
+        state_name=state,
+        activity=activity,
+        paused=paused,
+        mowing=mowing,
+        started=True,
+        state_event_at=None,
+        task_status_event_at=None,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        active_snapshot,
+        status_blob,
+        observed_at=101.0,
+        active_state_observed_at=101.0,
+    )
+
+    assert reconciled is active_snapshot
+    assert reconciled.activity == activity
+    assert reconciled.mowing_session_active is None
+
+
+def test_refresh_keeps_new_untimestamped_active_observation() -> None:
+    raw_snapshot = _snapshot(
+        model="dreame.mower.g2541e",
+        display_model="A3 AWD Pro 3500",
+    )
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_0X61_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+    assert status_blob is not None
+    status_blob = replace(
+        status_blob,
+        received_at="1970-01-01T00:01:40+00:00",
+    )
+    device = SimpleNamespace(
+        _state_lock=RLock(),
+        info=SimpleNamespace(raw={}, model=raw_snapshot.descriptor.model),
+        name=raw_snapshot.descriptor.name,
+        host=None,
+        mac=None,
+        token=None,
+        realtime_properties={
+            MOWER_RAW_STATUS_PROPERTY_KEY: {
+                "value": list(_A3_STANDBY_0X61_FRAME),
+                "last_seen": 100.0,
+            }
+        },
+    )
+    client = object.__new__(DreameLawnMowerClient)
+    client._descriptor = raw_snapshot.descriptor
+    client._latest_snapshot = None
+    client._sync_update_device = lambda force=False: device  # noqa: ARG005
+    client._sync_get_status_blob = lambda include_cloud, refresh: status_blob  # noqa: ARG005
+    client._sync_get_cached_cloud_device_info = lambda: None
+
+    with (
+        patch.object(
+            client_core_module,
+            "snapshot_from_device",
+            return_value=raw_snapshot,
+        ),
+        patch.object(client_core_module.time, "time", return_value=101.0),
+    ):
+        refreshed = asyncio.run(client.async_refresh())
+
+    assert refreshed.state == "paused"
+    assert refreshed.activity == "paused"
+    assert refreshed.mowing_session_active is None
 
 
 @pytest.mark.parametrize(
@@ -288,7 +419,7 @@ def test_unproven_inactive_heartbeat_does_not_clear_paused_state(
     assert reconciled.mowing_session_active is None
 
 
-def test_same_message_fractional_timestamps_do_not_hide_current_heartbeat() -> None:
+def test_submicrosecond_same_message_heartbeat_remains_current() -> None:
     status_blob = decode_mower_status_blob(
         _A3_STANDBY_0X61_FRAME,
         source="realtime",
@@ -298,24 +429,50 @@ def test_same_message_fractional_timestamps_do_not_hide_current_heartbeat() -> N
     assert status_blob is not None
     status_blob = replace(
         status_blob,
-        received_at="1970-01-01T00:00:20.750000+00:00",
+        received_at="2023-11-14T22:13:20.750000+00:00",
     )
     paused_snapshot = replace(
         _snapshot(),
-        state_event_at=20.75,
-        task_status_event_at=20.75,
+        state_event_at=1_700_000_000.7500002,
+        task_status_event_at=1_700_000_000.7500002,
     )
 
     reconciled = snapshot_with_heartbeat_task_state(
         paused_snapshot,
         status_blob,
-        observed_at=21.0,
+        observed_at=1_700_000_001.0,
     )
 
     assert reconciled.state == "idle"
     assert reconciled.activity == "docked"
     assert reconciled.paused is False
     assert reconciled.mowing_session_active is False
+
+
+def test_genuinely_newer_subsecond_state_still_blocks_inactive_heartbeat() -> None:
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_0X61_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(
+        status_blob,
+        received_at="2023-11-14T22:13:20.750000+00:00",
+    )
+    paused_snapshot = replace(
+        _snapshot(),
+        state_event_at=1_700_000_000.750002,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        paused_snapshot,
+        status_blob,
+        observed_at=1_700_000_001.0,
+    )
+
+    assert reconciled is paused_snapshot
 
 
 def test_stale_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
@@ -444,6 +601,7 @@ def test_idle_in_station_heartbeat_preserves_bare_active_error() -> None:
         error_snapshot,
         status_blob,
         observed_at=20.0,
+        active_state_observed_at=19.0,
     )
 
     assert reconciled.state == "paused"

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import asyncio
+import time
 from dataclasses import replace
 from threading import RLock
 from types import SimpleNamespace
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, Mock, patch
 
 import pytest
 
@@ -23,6 +24,34 @@ snapshot_with_heartbeat_task_state = load_internal_module(
 ).snapshot_with_heartbeat_task_state
 client_core_module = load_internal_module("client_core")
 DreameLawnMowerClient = load_internal_module("client").DreameLawnMowerClient
+DreameLawnMowerCommandRejectedError = load_internal_module(
+    "exceptions"
+).DreameLawnMowerCommandRejectedError
+
+_A3_STANDBY_0X61_FRAME = (
+    206,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    0,
+    99,
+    97,
+    255,
+    0,
+    0,
+    128,
+    204,
+    186,
+    0,
+    128,
+    206,
+)
 
 
 def _snapshot(
@@ -93,9 +122,11 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
     )
 
     assert status_blob is not None
+    status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
     reconciled = snapshot_with_heartbeat_task_state(
         _snapshot(model=model, display_model=display_model),
         status_blob,
+        observed_at=20.0,
     )
 
     assert reconciled.state == "idle"
@@ -143,12 +174,14 @@ def test_a3_standby_heartbeat_corrects_stale_paused_snapshot() -> None:
     )
 
     assert status_blob is not None
+    status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
     reconciled = snapshot_with_heartbeat_task_state(
         _snapshot(
             model="dreame.mower.g2541e",
             display_model="A3 AWD Pro 3500",
         ),
         status_blob,
+        observed_at=20.0,
     )
 
     assert reconciled.state == "idle"
@@ -167,35 +200,13 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
         model="dreame.mower.g2541e",
         display_model="A3 AWD Pro 3500",
     )
+    heartbeat_received_at = time.time()
     device = SimpleNamespace(
         _state_lock=RLock(),
         realtime_properties={
             MOWER_RAW_STATUS_PROPERTY_KEY: {
-                "value": [
-                    206,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    0,
-                    99,
-                    97,
-                    255,
-                    0,
-                    0,
-                    128,
-                    204,
-                    186,
-                    0,
-                    128,
-                    206,
-                ],
-                "last_seen": 1_787_575_147,
+                "value": list(_A3_STANDBY_0X61_FRAME),
+                "last_seen": heartbeat_received_at,
             }
         },
     )
@@ -222,12 +233,123 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
     assert reconciled.paused is False
     assert reconciled.task_status == "idle"
     assert reconciled.task_status_source == "heartbeat_realtime"
-    assert reconciled.task_status_event_at == 1_787_575_147.0
+    assert reconciled.task_status_event_at == pytest.approx(
+        heartbeat_received_at,
+        abs=0.000001,
+    )
     assert reconciled.mowing_session_active is False
     assert client._latest_snapshot.state == "idle"
     assert client._latest_snapshot.activity == "docked"
     assert switch_result == {"map_index": 1}
     client.async_get_current_app_map_index.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("received_at", "state_event_at", "task_status_event_at", "observed_at"),
+    [
+        (None, None, None, 21.0),
+        ("1970-01-01T00:00:20+00:00", 21.0, None, 21.0),
+        ("1970-01-01T00:00:20+00:00", None, 21.0, 21.0),
+        ("1970-01-01T00:00:20+00:00", None, None, 151.0),
+        ("1970-01-01T00:00:30+00:00", None, None, 20.0),
+    ],
+    ids=("missing-time", "newer-state", "newer-task", "stale", "future"),
+)
+def test_unproven_inactive_heartbeat_does_not_clear_paused_state(
+    received_at: str | None,
+    state_event_at: float | None,
+    task_status_event_at: float | None,
+    observed_at: float,
+) -> None:
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_0X61_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(status_blob, received_at=received_at)
+    paused_snapshot = replace(
+        _snapshot(),
+        state_event_at=state_event_at,
+        task_status_event_at=task_status_event_at,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        paused_snapshot,
+        status_blob,
+        observed_at=observed_at,
+    )
+
+    assert reconciled is paused_snapshot
+    assert reconciled.state == "paused"
+    assert reconciled.activity == "paused"
+    assert reconciled.paused is True
+    assert reconciled.mowing_session_active is None
+
+
+def test_same_message_fractional_timestamps_do_not_hide_current_heartbeat() -> None:
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_0X61_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(
+        status_blob,
+        received_at="1970-01-01T00:00:20.750000+00:00",
+    )
+    paused_snapshot = replace(
+        _snapshot(),
+        state_event_at=20.75,
+        task_status_event_at=20.75,
+    )
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        paused_snapshot,
+        status_blob,
+        observed_at=21.0,
+    )
+
+    assert reconciled.state == "idle"
+    assert reconciled.activity == "docked"
+    assert reconciled.paused is False
+    assert reconciled.mowing_session_active is False
+
+
+def test_stale_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
+    raw_snapshot = _snapshot(
+        model="dreame.mower.g2541e",
+        display_model="A3 AWD Pro 3500",
+    )
+    device = SimpleNamespace(
+        _state_lock=RLock(),
+        realtime_properties={
+            MOWER_RAW_STATUS_PROPERTY_KEY: {
+                "value": list(_A3_STANDBY_0X61_FRAME),
+                "last_seen": time.time() - 131.0,
+            }
+        },
+    )
+    client = object.__new__(DreameLawnMowerClient)
+    client._descriptor = raw_snapshot.descriptor
+    client._latest_snapshot = None
+    client._sync_update_device = lambda force=False: device  # noqa: ARG005
+    client._sync_switch_current_map = Mock()
+
+    with patch.object(
+        client_core_module,
+        "snapshot_from_device",
+        return_value=raw_snapshot,
+    ):
+        with pytest.raises(
+            DreameLawnMowerCommandRejectedError,
+            match="Finish or cancel",
+        ):
+            asyncio.run(client.async_switch_current_map(1))
+
+    client._sync_switch_current_map.assert_not_called()
 
 
 def test_active_paused_session_keeps_task_activity_while_recording_dock() -> None:
@@ -316,8 +438,13 @@ def test_idle_in_station_heartbeat_preserves_bare_active_error() -> None:
     )
 
     assert status_blob is not None
+    status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
     error_snapshot = replace(_snapshot(), activity="error", error_code=None)
-    reconciled = snapshot_with_heartbeat_task_state(error_snapshot, status_blob)
+    reconciled = snapshot_with_heartbeat_task_state(
+        error_snapshot,
+        status_blob,
+        observed_at=20.0,
+    )
 
     assert reconciled.state == "paused"
     assert reconciled.activity == "error"


### PR DESCRIPTION
## Summary

- reconcile cached realtime mower status before every snapshot publication, preventing A3 standby state from alternating between paused and docked
- use that same reconciled snapshot for the map-switch safety check
- require a distinct newer idle heartbeat before it can weaken an untimestamped active property observation
- accept inactive/docked heartbeat evidence only when it is recent and not superseded by a newer state or task event
- preserve fractional MQTT reception timestamps and account only for ISO microsecond quantization during ordering

This follows up on #157 using the reporter's v0.2.75 diagnostics. The fix is not present in v0.2.75; the reporter will need a later release to retest it.

## Validation

- full Python test suite on Windows and Linux
- Home Assistant config-flow and translation loading on Linux
- Ruff, compileall, and diff checks
- focused regressions for untimestamped active observations, the reporter's A3 `0x61` standby frame, cached publication, refresh, map switching, and sub-microsecond ordering