### PR TITLE
Keep A3 standby stable across heartbeat cadence

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -14,6 +14,10 @@ from .models import DreameLawnMowerSnapshot, DreameLawnMowerStatusBlob
 RESUME_MOWING_REQUEST = {"m": "a", "p": 0, "o": 5}
 
 _INACTIVE_HEARTBEAT_MAX_AGE_SECONDS = 130.0
+# Supervised A3 captures show unchanged 22-byte standby frames repeating every
+# five minutes. Keep one coordinator interval of delivery margin while newer
+# property/session evidence below remains authoritative.
+_A3_IDLE_HEARTBEAT_MAX_AGE_SECONDS = 365.0
 _HEARTBEAT_CLOCK_SKEW_SECONDS = 5.0
 # ISO timestamps retain microseconds while vendor reception clocks can expose
 # a slightly finer float. Treat only that serialization quantum as equal.
@@ -122,7 +126,12 @@ def _inactive_heartbeat_is_current(
     now = time.time() if observed_at is None else float(observed_at)
     if heartbeat_event_at > now + _HEARTBEAT_CLOCK_SKEW_SECONDS:
         return False
-    if now - heartbeat_event_at > _INACTIVE_HEARTBEAT_MAX_AGE_SECONDS:
+    heartbeat_max_age = (
+        _A3_IDLE_HEARTBEAT_MAX_AGE_SECONDS
+        if _is_a3_idle_heartbeat(status_blob)
+        else _INACTIVE_HEARTBEAT_MAX_AGE_SECONDS
+    )
+    if now - heartbeat_event_at > heartbeat_max_age:
         return False
 
     state_event_at = _numeric_event_at(snapshot.state_event_at)
@@ -156,6 +165,19 @@ def _inactive_heartbeat_is_current(
         ):
             return False
     return True
+
+
+def _is_a3_idle_heartbeat(status_blob: DreameLawnMowerStatusBlob) -> bool:
+    """Return whether this is the supervised 22-byte A3 standby frame."""
+    return bool(
+        status_blob.length == 22
+        and status_blob.frame_valid
+        and status_blob.main_state == 0
+        and status_blob.sub_state == 0xFF
+        and status_blob.task_status == "idle"
+        and status_blob.mowing_session_active is False
+        and status_blob.heartbeat_docked is True
+    )
 
 
 def _numeric_event_at(value: Any) -> float | None:

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -28,7 +28,7 @@ DreameLawnMowerCommandRejectedError = load_internal_module(
     "exceptions"
 ).DreameLawnMowerCommandRejectedError
 
-_A3_STANDBY_0X61_FRAME = (
+_A3_STANDBY_FRAME = (
     206,
     0,
     0,
@@ -36,17 +36,17 @@ _A3_STANDBY_0X61_FRAME = (
     0,
     0,
     0,
+    5,
     0,
     0,
     0,
-    0,
-    99,
-    97,
+    50,
+    177,
     255,
     0,
     0,
     128,
-    204,
+    200,
     186,
     0,
     128,
@@ -207,7 +207,7 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
         _state_lock=RLock(),
         realtime_properties={
             MOWER_RAW_STATUS_PROPERTY_KEY: {
-                "value": list(_A3_STANDBY_0X61_FRAME),
+                "value": list(_A3_STANDBY_FRAME),
                 "last_seen": first_heartbeat_received_at,
             }
         },
@@ -245,13 +245,16 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
     device.realtime_properties[MOWER_RAW_STATUS_PROPERTY_KEY]["last_seen"] = (
         heartbeat_received_at
     )
+    # The reporter's unchanged A3 standby frame arrived every five minutes.
+    # At diagnostic capture it was 154 seconds old, beyond the generic
+    # two-refresh freshness window but still the current supervised frame.
     with (
         patch.object(
             client_core_module,
             "snapshot_from_device",
             return_value=raw_snapshot,
         ),
-        patch.object(client_core_module.time, "time", return_value=103.0),
+        patch.object(client_core_module.time, "time", return_value=256.0),
     ):
         reconciled = asyncio.run(client.async_get_cached_snapshot())
         switch_result = asyncio.run(client.async_switch_current_map(1))
@@ -290,7 +293,7 @@ def test_fresh_inactive_heartbeat_cannot_weaken_new_untimestamped_active_state(
 ) -> None:
     """A first local active observation outranks an older cached heartbeat."""
     status_blob = decode_mower_status_blob(
-        _A3_STANDBY_0X61_FRAME,
+        _A3_STANDBY_FRAME,
         source="realtime",
         property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
@@ -330,7 +333,7 @@ def test_refresh_keeps_new_untimestamped_active_observation() -> None:
         display_model="A3 AWD Pro 3500",
     )
     status_blob = decode_mower_status_blob(
-        _A3_STANDBY_0X61_FRAME,
+        _A3_STANDBY_FRAME,
         source="realtime",
         property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
@@ -348,7 +351,7 @@ def test_refresh_keeps_new_untimestamped_active_observation() -> None:
         token=None,
         realtime_properties={
             MOWER_RAW_STATUS_PROPERTY_KEY: {
-                "value": list(_A3_STANDBY_0X61_FRAME),
+                "value": list(_A3_STANDBY_FRAME),
                 "last_seen": 100.0,
             }
         },
@@ -393,7 +396,7 @@ def test_unproven_inactive_heartbeat_does_not_clear_paused_state(
     observed_at: float,
 ) -> None:
     status_blob = decode_mower_status_blob(
-        _A3_STANDBY_0X61_FRAME,
+        _A3_STANDBY_FRAME,
         source="realtime",
         property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
@@ -421,7 +424,7 @@ def test_unproven_inactive_heartbeat_does_not_clear_paused_state(
 
 def test_submicrosecond_same_message_heartbeat_remains_current() -> None:
     status_blob = decode_mower_status_blob(
-        _A3_STANDBY_0X61_FRAME,
+        _A3_STANDBY_FRAME,
         source="realtime",
         property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
@@ -451,7 +454,7 @@ def test_submicrosecond_same_message_heartbeat_remains_current() -> None:
 
 def test_genuinely_newer_subsecond_state_still_blocks_inactive_heartbeat() -> None:
     status_blob = decode_mower_status_blob(
-        _A3_STANDBY_0X61_FRAME,
+        _A3_STANDBY_FRAME,
         source="realtime",
         property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
     )
@@ -475,7 +478,7 @@ def test_genuinely_newer_subsecond_state_still_blocks_inactive_heartbeat() -> No
     assert reconciled is paused_snapshot
 
 
-def test_stale_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
+def test_expired_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
     raw_snapshot = _snapshot(
         model="dreame.mower.g2541e",
         display_model="A3 AWD Pro 3500",
@@ -484,8 +487,8 @@ def test_stale_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
         _state_lock=RLock(),
         realtime_properties={
             MOWER_RAW_STATUS_PROPERTY_KEY: {
-                "value": list(_A3_STANDBY_0X61_FRAME),
-                "last_seen": time.time() - 131.0,
+                "value": list(_A3_STANDBY_FRAME),
+                "last_seen": time.time() - 366.0,
             }
         },
     )
@@ -507,6 +510,51 @@ def test_stale_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
             asyncio.run(client.async_switch_current_map(1))
 
     client._sync_switch_current_map.assert_not_called()
+
+
+def test_standard_inactive_heartbeat_keeps_short_freshness_window() -> None:
+    """The A3 cadence allowance must not weaken generic heartbeat safety."""
+    status_blob = decode_mower_status_blob(
+        [
+            206,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            128,
+            87,
+            113,
+            255,
+            0,
+            0,
+            128,
+            206,
+            186,
+            206,
+        ],
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
+    paused_snapshot = _snapshot()
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        paused_snapshot,
+        status_blob,
+        observed_at=151.0,
+        active_state_observed_at=19.0,
+    )
+
+    assert reconciled is paused_snapshot
+    assert reconciled.state == "paused"
+    assert reconciled.activity == "paused"
 
 
 def test_active_paused_session_keeps_task_activity_while_recording_dock() -> None:

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -254,7 +254,7 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
             "snapshot_from_device",
             return_value=raw_snapshot,
         ),
-        patch.object(client_core_module.time, "time", return_value=256.0),
+        patch.object(client_core_module.time, "time", return_value=256.614),
     ):
         reconciled = asyncio.run(client.async_get_cached_snapshot())
         switch_result = asyncio.run(client.async_switch_current_map(1))
@@ -510,6 +510,53 @@ def test_expired_a3_heartbeat_cannot_bypass_map_switch_guard() -> None:
             asyncio.run(client.async_switch_current_map(1))
 
     client._sync_switch_current_map.assert_not_called()
+
+
+@pytest.mark.parametrize("age_seconds", [154.614, 300.013, 365.0])
+def test_a3_idle_heartbeat_covers_observed_cadence_and_boundary(
+    age_seconds: float,
+) -> None:
+    """Supervised A3 standby evidence remains current through its full window."""
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        _snapshot(),
+        status_blob,
+        observed_at=20.0 + age_seconds,
+        active_state_observed_at=19.0,
+    )
+
+    assert reconciled.state == "idle"
+    assert reconciled.activity == "docked"
+    assert reconciled.mowing_session_active is False
+
+
+def test_a3_idle_heartbeat_expires_immediately_above_boundary() -> None:
+    status_blob = decode_mower_status_blob(
+        _A3_STANDBY_FRAME,
+        source="realtime",
+        property_key=MOWER_RAW_STATUS_PROPERTY_KEY,
+    )
+
+    assert status_blob is not None
+    status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
+    paused_snapshot = _snapshot()
+
+    reconciled = snapshot_with_heartbeat_task_state(
+        paused_snapshot,
+        status_blob,
+        observed_at=385.000001,
+        active_state_observed_at=19.0,
+    )
+
+    assert reconciled is paused_snapshot
 
 
 def test_standard_inactive_heartbeat_keeps_short_freshness_window() -> None:


### PR DESCRIPTION
Addresses #157.

The fresh v0.2.76 diagnostics showed that the supported A3 AWD Pro standby heartbeat was still being discarded after 130 seconds even though unchanged 22-byte status frames repeat every five minutes. That expiry recreated the paused/docked oscillation and caused map and maintenance safety checks to see the stale paused properties.

This change:

- keeps the exact supervised 22-byte A3 idle-in-station heartbeat current for the observed five-minute cadence plus one Home Assistant refresh interval;
- preserves the existing 130-second limit for ordinary inactive heartbeat frames;
- continues to prefer any newer mowing, paused, returning, or task-session evidence;
- fails closed once the A3 standby frame exceeds the bounded window.

Regression coverage uses the reporter's exact frame and timing evidence, checks the observed cadence and inclusive boundary, and verifies both cached-state publication and authoritative map-switch guarding.