### PR TITLE
Confirm targeted mowing tasks after acknowledgement

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,9 +607,15 @@ entity ID. The lawn mower entity exposes `available_zone_ids`, and zone selects
 use names saved in the Dreame app when vector-map metadata provides them. An
 unnamed zone retains the stable `Zone #<id>` fallback.
 
-Zone, spot, and edge actions are acknowledged by the mower before Home
-Assistant reports success. Unknown current-map IDs, map-scope mismatches, and
-device rejection responses are surfaced as failed actions.
+Zone, spot, and edge actions require both a mower acknowledgement and an
+authoritative task-type readback before Home Assistant reports success. If the
+mower acknowledges a zone request but starts whole-map mowing, the action fails
+instead of silently reporting the wrong job as successful. Explicit targeted
+services also update the local `Mowing Action` selection after confirmation.
+Unknown current-map IDs, map-scope mismatches, device rejection responses, and
+unconfirmed task types are surfaced as failed actions. A repeated targeted call
+is rejected before dispatch when the mower is already running the same task type
+and the integration cannot prove that a different target was requested.
 
 ## Troubleshooting
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -171,6 +171,9 @@ from .mowing_preferences import (
 from .mowing_preferences import (
     summarize_mowing_preference_info as summarize_mowing_preference_info,
 )
+from .mowing_tasks import MOWING_TASK_EDGE as _MOWING_TASK_EDGE
+from .mowing_tasks import MOWING_TASK_SPOT as _MOWING_TASK_SPOT
+from .mowing_tasks import MOWING_TASK_ZONE as _MOWING_TASK_ZONE
 from .mowing_tasks import MowingTaskResponseError as MowingTaskResponseError
 from .mowing_tasks import build_edge_mowing_request as build_edge_mowing_request
 from .mowing_tasks import build_spot_mowing_request as build_spot_mowing_request
@@ -314,23 +317,78 @@ camera_metadata_advertises_video = _client_camera.camera_metadata_advertises_vid
 camera_stream_block_reason = _client_camera.camera_stream_block_reason
 derive_tx_video_app_credentials = _client_camera.derive_tx_video_app_credentials
 
-_ZONE_TASK_CONFIRMATION_STATUSES = frozenset(
-    {"zone_cleaning", "segment_cleaning"}
+_GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES = frozenset(
+    {"starting", "mowing", "paused"}
 )
-_EDGE_TASK_CONFIRMATION_STATUSES = frozenset(
-    {"segment_cleaning", "zone_cleaning"}
-)
-_SPOT_TASK_CONFIRMATION_STATUSES = frozenset({"spot_cleaning"})
+_ZONE_TASK_CONFIRMATION_STATUSES = _GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES | {
+    "zone_cleaning",
+    "segment_cleaning",
+    "zone_cleaning_paused",
+    "segment_cleaning_paused",
+}
+_EDGE_TASK_CONFIRMATION_STATUSES = _GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES | {
+    "segment_cleaning",
+    "zone_cleaning",
+    "segment_cleaning_paused",
+    "zone_cleaning_paused",
+}
+_SPOT_TASK_CONFIRMATION_STATUSES = _GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES | {
+    "spot_cleaning",
+    "spot_cleaning_paused",
+}
+_TARGETED_TASK_CONFIRMATION_DELAYS_SECONDS = (0.5, 1.5, 3.0)
 
 
 def _task_confirmation_key(snapshot: DreameLawnMowerSnapshot) -> tuple[Any, ...]:
-    """Return state that must change when a new targeted task is accepted."""
+    """Return native task identity that must change for a new targeted task."""
     return (
         getattr(snapshot, "task_status", None),
-        getattr(snapshot, "state", None),
-        getattr(snapshot, "current_zone_id", None),
-        getattr(snapshot, "active_segment_count", None),
-        getattr(snapshot, "mowing_session_active", None),
+        getattr(snapshot, "task_operation", None),
+        getattr(snapshot, "task_region_ids", None),
+        getattr(snapshot, "task_area_ids", None),
+    )
+
+
+def _targeted_task_is_active(snapshot: DreameLawnMowerSnapshot) -> bool:
+    """Return whether session or physical evidence confirms an active task."""
+    return bool(
+        getattr(snapshot, "mowing_session_active", None) is True
+        or getattr(snapshot, "activity", None) in {"mowing", "paused"}
+        or getattr(snapshot, "started", False)
+        or getattr(snapshot, "mowing", False)
+        or getattr(snapshot, "paused", False)
+    )
+
+
+def _targeted_task_ids(
+    snapshot: DreameLawnMowerSnapshot,
+    expected_operation: int,
+) -> tuple[int, ...] | None:
+    """Return the native target ids owned by a targeted task operation."""
+    if expected_operation == _MOWING_TASK_ZONE:
+        return getattr(snapshot, "task_region_ids", None)
+    if expected_operation == _MOWING_TASK_SPOT:
+        return getattr(snapshot, "task_area_ids", None)
+    return None
+
+
+def _targeted_task_matches_preflight(
+    snapshot: DreameLawnMowerSnapshot,
+    expected_operation: int,
+    *,
+    requested_target_ids: frozenset[int] | None = None,
+) -> bool:
+    """Return whether an active snapshot already represents the requested task."""
+    if not _targeted_task_is_active(snapshot):
+        return False
+    if getattr(snapshot, "task_operation", None) != expected_operation:
+        return False
+    if requested_target_ids is None:
+        return True
+    task_target_ids = _targeted_task_ids(snapshot, expected_operation)
+    return (
+        task_target_ids is None
+        or frozenset(task_target_ids) == requested_target_ids
     )
 
 
@@ -339,26 +397,31 @@ def _targeted_task_confirmed(
     baseline: DreameLawnMowerSnapshot | None,
     expected_statuses: frozenset[str],
     *,
-    requested_zone_ids: frozenset[int] | None = None,
+    expected_operation: int,
+    requested_target_ids: frozenset[int] | None = None,
 ) -> bool:
     """Require requested task evidence and a transition from pre-command state."""
     if baseline is None:
         return False
+    if _targeted_task_matches_preflight(
+        baseline,
+        expected_operation,
+        requested_target_ids=requested_target_ids,
+    ):
+        return False
     task_status = str(getattr(snapshot, "task_status", "") or "").lower()
     if task_status not in expected_statuses:
         return False
-    if not (
-        getattr(snapshot, "mowing_session_active", None) is True
-        or getattr(snapshot, "started", False)
-        or getattr(snapshot, "mowing", False)
-    ):
+    if getattr(snapshot, "task_operation", None) != expected_operation:
         return False
-    current_zone_id = getattr(snapshot, "current_zone_id", None)
-    if (
-        requested_zone_ids
-        and current_zone_id is not None
-        and int(current_zone_id) not in requested_zone_ids
-    ):
+    if requested_target_ids:
+        task_target_ids = _targeted_task_ids(snapshot, expected_operation)
+        if (
+            task_target_ids is None
+            or frozenset(task_target_ids) != requested_target_ids
+        ):
+            return False
+    if not _targeted_task_is_active(snapshot):
         return False
     return _task_confirmation_key(snapshot) != _task_confirmation_key(baseline)
 
@@ -632,9 +695,16 @@ class DreameLawnMowerClient(
     async def async_start_zone_mowing(self, zone_ids: Sequence[int]) -> Any:
         """Start mower-native zone mowing for explicit map area ids."""
         normalized_zone_ids = [int(zone_id) for zone_id in zone_ids]
-        baseline = await self.async_get_cached_snapshot()
+        baseline = await self._async_refresh_authoritative_snapshot()
+        requested_zone_ids = frozenset(normalized_zone_ids)
+        self._require_targeted_task_preflight(
+            "zone mowing",
+            baseline,
+            _MOWING_TASK_ZONE,
+            requested_target_ids=requested_zone_ids,
+        )
         try:
-            return await asyncio.to_thread(
+            response = await asyncio.to_thread(
                 self._sync_start_zone_mowing,
                 normalized_zone_ids,
             )
@@ -648,9 +718,18 @@ class DreameLawnMowerClient(
                     snapshot,
                     baseline,
                     _ZONE_TASK_CONFIRMATION_STATUSES,
-                    requested_zone_ids=frozenset(normalized_zone_ids),
+                    expected_operation=_MOWING_TASK_ZONE,
+                    requested_target_ids=requested_zone_ids,
                 ),
             )
+        await self._async_require_targeted_task_confirmation(
+            "zone mowing",
+            baseline,
+            _ZONE_TASK_CONFIRMATION_STATUSES,
+            expected_operation=_MOWING_TASK_ZONE,
+            requested_target_ids=requested_zone_ids,
+        )
+        return response
 
     async def async_start_edge_mowing(
         self,
@@ -661,9 +740,14 @@ class DreameLawnMowerClient(
             [int(value) for value in contour_id[:2]]
             for contour_id in contour_ids
         ]
-        baseline = await self.async_get_cached_snapshot()
+        baseline = await self._async_refresh_authoritative_snapshot()
+        self._require_targeted_task_preflight(
+            "edge mowing",
+            baseline,
+            _MOWING_TASK_EDGE,
+        )
         try:
-            return await asyncio.to_thread(
+            response = await asyncio.to_thread(
                 self._sync_start_edge_mowing,
                 normalized_contour_ids,
             )
@@ -677,15 +761,30 @@ class DreameLawnMowerClient(
                     snapshot,
                     baseline,
                     _EDGE_TASK_CONFIRMATION_STATUSES,
+                    expected_operation=_MOWING_TASK_EDGE,
                 ),
             )
+        await self._async_require_targeted_task_confirmation(
+            "edge mowing",
+            baseline,
+            _EDGE_TASK_CONFIRMATION_STATUSES,
+            expected_operation=_MOWING_TASK_EDGE,
+        )
+        return response
 
     async def async_start_spot_mowing(self, spot_ids: Sequence[int]) -> Any:
         """Start mower-native spot mowing for explicit saved spot area ids."""
         normalized_spot_ids = [int(spot_id) for spot_id in spot_ids]
-        baseline = await self.async_get_cached_snapshot()
+        requested_spot_ids = frozenset(normalized_spot_ids)
+        baseline = await self._async_refresh_authoritative_snapshot()
+        self._require_targeted_task_preflight(
+            "spot mowing",
+            baseline,
+            _MOWING_TASK_SPOT,
+            requested_target_ids=requested_spot_ids,
+        )
         try:
-            return await asyncio.to_thread(
+            response = await asyncio.to_thread(
                 self._sync_start_spot_mowing,
                 normalized_spot_ids,
             )
@@ -699,8 +798,77 @@ class DreameLawnMowerClient(
                     snapshot,
                     baseline,
                     _SPOT_TASK_CONFIRMATION_STATUSES,
+                    expected_operation=_MOWING_TASK_SPOT,
+                    requested_target_ids=requested_spot_ids,
                 ),
             )
+        await self._async_require_targeted_task_confirmation(
+            "spot mowing",
+            baseline,
+            _SPOT_TASK_CONFIRMATION_STATUSES,
+            expected_operation=_MOWING_TASK_SPOT,
+            requested_target_ids=requested_spot_ids,
+        )
+        return response
+
+    @staticmethod
+    def _require_targeted_task_preflight(
+        label: str,
+        baseline: DreameLawnMowerSnapshot,
+        expected_operation: int,
+        *,
+        requested_target_ids: frozenset[int] | None = None,
+    ) -> None:
+        """Reject repeat targeted commands that lack new-task evidence."""
+        if _targeted_task_matches_preflight(
+            baseline,
+            expected_operation,
+            requested_target_ids=requested_target_ids,
+        ):
+            raise _DreameLawnMowerCommandRejectedError(
+                f"The mower is already executing a {label} task, so a new "
+                "targeted request cannot be verified. Wait for it to finish or "
+                "stop it before starting another task of this type."
+            )
+
+    async def _async_require_targeted_task_confirmation(
+        self,
+        label: str,
+        baseline: DreameLawnMowerSnapshot,
+        expected_statuses: frozenset[str],
+        *,
+        expected_operation: int,
+        requested_target_ids: frozenset[int] | None = None,
+    ) -> None:
+        """Require authoritative task-type evidence after a successful write."""
+        readable = False
+        for delay in _TARGETED_TASK_CONFIRMATION_DELAYS_SECONDS:
+            await asyncio.sleep(delay)
+            try:
+                snapshot = await self._async_refresh_authoritative_snapshot()
+            except DreameLawnMowerConnectionError:
+                continue
+            readable = True
+            if _targeted_task_confirmed(
+                snapshot,
+                baseline,
+                expected_statuses,
+                expected_operation=expected_operation,
+                requested_target_ids=requested_target_ids,
+            ):
+                return
+
+        if readable:
+            raise _DreameLawnMowerCommandRejectedError(
+                f"The mower acknowledged the {label} request but did not enter "
+                "the requested task. It may have started another mowing mode; "
+                "check the mower state and stop any incorrect task before retrying."
+            )
+        raise DreameLawnMowerConnectionError(
+            f"The mower acknowledged the {label} request, but its task type could "
+            "not be confirmed because every state readback failed. Check the mower "
+            "state before retrying."
+        )
 
     async def async_go_to_maintenance_point(self, point_id: int) -> Any:
         """Drive to one configured map maintenance point."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -267,7 +267,7 @@ class _DreameLawnMowerClientCoreMixin:
     async def _async_refresh_authoritative_snapshot(
         self,
     ) -> DreameLawnMowerSnapshot:
-        """Force a device-property read before confirming an ambiguous write."""
+        """Force properties and apply heartbeat reconciliation before decisions."""
         device = await asyncio.to_thread(self._sync_update_device, True)
         return await asyncio.to_thread(self._snapshot_from_device, device)
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -245,10 +245,14 @@ def _realtime_active_session_started_at(device: Any) -> float | None:
     return None
 
 
-def _active_task_region_ids(device: Any, *, activity: str) -> tuple[int, ...] | None:
-    """Return current task regions only while active device state confirms them."""
+def _active_task_metadata(
+    device: Any,
+    *,
+    activity: str,
+) -> tuple[int | None, tuple[int, ...] | None, tuple[int, ...] | None]:
+    """Return current task operation and targets while state confirms them."""
     if activity not in {"mowing", "paused"}:
-        return None
+        return None, None, None
     realtime_properties = getattr(device, "realtime_properties", {}) or {}
     # Local import avoids a module cycle: app_protocol owns this wire decoder
     # and also constructs the status-blob model defined in this module.
@@ -260,20 +264,33 @@ def _active_task_region_ids(device: Any, *, activity: str) -> tuple[int, ...] | 
     if active_session_started_at is not None and (
         task_last_seen is None or task_last_seen < active_session_started_at
     ):
-        return None
+        return None, None, None
     value = entry.get("value") if isinstance(entry, Mapping) else entry
     task = decode_mower_task_status(value)
     if not isinstance(task, Mapping):
-        return None
+        return None, None, None
     if task.get("executing") is not True or task.get("status") is not True:
-        return None
-    region_ids = task.get("region_ids")
-    if not isinstance(region_ids, list):
-        return None
-    active_region_ids = tuple(
-        dict.fromkeys(region_id for region_id in region_ids if region_id > 0)
+        return None, None, None
+    operation_value = task.get("operation")
+    operation = (
+        int(operation_value)
+        if isinstance(operation_value, int) and not isinstance(operation_value, bool)
+        else None
     )
-    return active_region_ids or None
+    active_target_ids: dict[str, tuple[int, ...] | None] = {}
+    for target_kind in ("region_ids", "area_ids"):
+        target_ids = task.get(target_kind)
+        active_target_ids[target_kind] = (
+            tuple(dict.fromkeys(target_id for target_id in target_ids if target_id > 0))
+            or None
+            if isinstance(target_ids, list)
+            else None
+        )
+    return (
+        operation,
+        active_target_ids["region_ids"],
+        active_target_ids["area_ids"],
+    )
 
 
 def _fault_recovery_confirmed(
@@ -412,6 +429,9 @@ class DreameLawnMowerSnapshot:
     task_status: str | None = None
     task_status_name: str | None = None
     task_status_source: str | None = None
+    task_operation: int | None = None
+    task_region_ids: tuple[int, ...] | None = None
+    task_area_ids: tuple[int, ...] | None = None
     task_status_event_at: float | None = field(
         default=None,
         repr=False,
@@ -1372,7 +1392,10 @@ def snapshot_from_device(
         getattr(device.status, "cleaning_time", None),
         getattr(current_map, "cleaning_time", None),
     )
-    active_task_regions = _active_task_region_ids(device, activity=activity)
+    task_operation, active_task_regions, active_task_areas = _active_task_metadata(
+        device,
+        activity=activity,
+    )
     active_segments = active_task_regions
     if active_segments is None and activity in {"mowing", "paused"}:
         active_segments = _coerce_sequence(
@@ -1401,6 +1424,9 @@ def snapshot_from_device(
         ),
         task_status=task_obj.name.lower() if task_obj is not None else None,
         task_status_name=getattr(device.status, "task_status_name", None),
+        task_operation=task_operation,
+        task_region_ids=active_task_regions,
+        task_area_ids=active_task_areas,
         task_status_event_at=_realtime_property_last_seen(
             device,
             REALTIME_TASK_STATUS_PROPERTY_KEY,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/runtime_state.py
@@ -69,6 +69,11 @@ def snapshot_with_heartbeat_task_state(
             mowing_session_active=status_blob.mowing_session_active,
             task_resumable=status_blob.task_resumable,
         )
+    if status_blob.mowing_session_active is False:
+        # Native task metadata belongs only to the active mowing session that
+        # produced it. Do not let a retained TASK property make an idle mower
+        # look as though it is still executing the previous targeted request.
+        changes.update(task_operation=None, task_region_ids=None, task_area_ids=None)
 
     if status_blob.heartbeat_docked is True:
         changes.update(raw_docked=True, docked=True)

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -549,6 +549,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
         await self.coordinator.client.async_start_zone_mowing(normalized)
+        self.coordinator.selected_mowing_action = MOWING_ACTION_ZONE
+        self.coordinator.selected_zone_id = (
+            normalized[0] if len(normalized) == 1 else None
+        )
+        self.coordinator.selected_spot_id = None
+        self.coordinator.selected_contour_id = None
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
@@ -575,6 +581,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
         await self.coordinator.client.async_start_spot_mowing(normalized)
+        self.coordinator.selected_mowing_action = MOWING_ACTION_SPOT
+        self.coordinator.selected_spot_id = (
+            normalized[0] if len(normalized) == 1 else None
+        )
+        self.coordinator.selected_zone_id = None
+        self.coordinator.selected_contour_id = None
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,
@@ -614,6 +626,12 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
         await self.coordinator.client.async_start_edge_mowing(normalized)
+        self.coordinator.selected_mowing_action = MOWING_ACTION_EDGE
+        self.coordinator.selected_contour_id = (
+            tuple(normalized[0]) if len(normalized) == 1 else None
+        )
+        self.coordinator.selected_zone_id = None
+        self.coordinator.selected_spot_id = None
         begin_runtime_mission_session(
             runtime_cache,
             observed_generation=observed_generation,

--- a/custom_components/dreame_lawn_mower/services.yaml
+++ b/custom_components/dreame_lawn_mower/services.yaml
@@ -1,7 +1,8 @@
 start_zone_mowing:
   name: Start zone mowing
   description: >-
-    Start mower-native mowing for one or more saved zones on the active map.
+    Start mower-native mowing for one or more saved zones on the active map and
+    confirm that the mower entered a zone task.
   target:
     entity:
       integration: dreame_lawn_mower
@@ -16,7 +17,8 @@ start_zone_mowing:
 start_spot_mowing:
   name: Start spot mowing
   description: >-
-    Start mower-native mowing for one or more saved spot areas on the active map.
+    Start mower-native mowing for one or more saved spot areas on the active map
+    and confirm that the mower entered a spot task.
   target:
     entity:
       integration: dreame_lawn_mower
@@ -31,8 +33,9 @@ start_spot_mowing:
 start_edge_mowing:
   name: Start edge mowing
   description: >-
-    Start mowing for one or more explicit current-map edge contour IDs. Each
-    contour ID is a two-item list in the form [edge_id, contour_index].
+    Start mowing for one or more explicit current-map edge contour IDs and
+    confirm that the mower entered an edge task. Each contour ID is a two-item
+    list in the form [edge_id, contour_index].
   target:
     entity:
       integration: dreame_lawn_mower

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -1049,12 +1049,20 @@ def test_lawn_mower_start_edge_service_uses_explicit_contours() -> None:
         batch_device_data=_batch_device_data(),
         vector_map_details=_vector_map_details(),
         selected_map_index=None,
+        selected_mowing_action="all_area",
+        selected_contour_id=None,
+        selected_zone_id=3,
+        selected_spot_id=2,
         async_request_refresh=AsyncMock(),
     )
 
     asyncio.run(entity.async_start_edge_mowing([[1, 0], ("3", "0")]))
 
     client.async_start_edge_mowing.assert_awaited_once_with([[1, 0], [3, 0]])
+    assert entity.coordinator.selected_mowing_action == MOWING_ACTION_EDGE
+    assert entity.coordinator.selected_contour_id is None
+    assert entity.coordinator.selected_zone_id is None
+    assert entity.coordinator.selected_spot_id is None
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
@@ -1594,12 +1602,20 @@ def test_lawn_mower_zone_service_uses_validated_current_map_ids() -> None:
         vector_map_details=_vector_map_details(),
         batch_device_data=_batch_device_data(),
         app_maps=_app_maps(),
+        selected_mowing_action="all_area",
+        selected_contour_id=(3, 0),
+        selected_zone_id=1,
+        selected_spot_id=2,
         async_request_refresh=AsyncMock(),
     )
 
     asyncio.run(entity.async_start_zone_mowing([1, 3]))
 
     client.async_start_zone_mowing.assert_awaited_once_with([1, 3])
+    assert entity.coordinator.selected_mowing_action == MOWING_ACTION_ZONE
+    assert entity.coordinator.selected_zone_id is None
+    assert entity.coordinator.selected_contour_id is None
+    assert entity.coordinator.selected_spot_id is None
     entity.coordinator.async_request_refresh.assert_awaited_once()
 
 
@@ -1631,10 +1647,18 @@ def test_lawn_mower_spot_service_sends_saved_area_ids_not_coordinates() -> None:
         vector_map_details=_vector_map_details(),
         batch_device_data=_batch_device_data(),
         app_maps=_app_maps(),
+        selected_mowing_action="all_area",
+        selected_contour_id=(3, 0),
+        selected_zone_id=1,
+        selected_spot_id=None,
         async_request_refresh=AsyncMock(),
     )
 
     asyncio.run(entity.async_start_spot_mowing([2]))
 
     client.async_start_spot_mowing.assert_awaited_once_with([2])
+    assert entity.coordinator.selected_mowing_action == MOWING_ACTION_SPOT
+    assert entity.coordinator.selected_spot_id == 2
+    assert entity.coordinator.selected_zone_id is None
+    assert entity.coordinator.selected_contour_id is None
     entity.coordinator.async_request_refresh.assert_awaited_once()

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -581,15 +581,14 @@ def test_explicit_start_rejection_is_not_reconciled_from_old_state() -> None:
     client._async_refresh_authoritative_snapshot.assert_not_awaited()
 
 
-def test_explicit_zone_rejection_is_not_reconciled_from_old_state() -> None:
+def test_explicit_zone_rejection_is_not_reconciled_after_preflight() -> None:
     client = object.__new__(DreameLawnMowerClient)
-    client.async_get_cached_snapshot = AsyncMock(
-        return_value=SimpleNamespace(task_status="idle")
-    )
     client._sync_start_zone_mowing = Mock(
         side_effect=DreameLawnMowerCommandRejectedError("mower is busy")
     )
-    client._async_refresh_authoritative_snapshot = AsyncMock()
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        return_value=SimpleNamespace(task_status="idle")
+    )
 
     with pytest.raises(
         DreameLawnMowerCommandRejectedError,
@@ -598,7 +597,7 @@ def test_explicit_zone_rejection_is_not_reconciled_from_old_state() -> None:
         asyncio.run(client.async_start_zone_mowing([1]))
 
     client._sync_start_zone_mowing.assert_called_once_with([1])
-    client._async_refresh_authoritative_snapshot.assert_not_awaited()
+    client._async_refresh_authoritative_snapshot.assert_awaited_once_with()
 
 
 def test_authoritative_confirmation_forces_device_property_request() -> None:
@@ -616,85 +615,114 @@ def test_authoritative_confirmation_forces_device_property_request() -> None:
 
 
 @pytest.mark.parametrize(
-    ("method_name", "sync_name", "arguments", "task_status"),
+    (
+        "method_name",
+        "sync_name",
+        "arguments",
+        "task_status",
+        "task_operation",
+        "task_region_ids",
+        "task_area_ids",
+    ),
     [
-        ("async_start_zone_mowing", "_sync_start_zone_mowing", ([2],), "zone_cleaning"),
+        (
+            "async_start_zone_mowing",
+            "_sync_start_zone_mowing",
+            ([1, 2],),
+            "zone_cleaning",
+            102,
+            (1, 2),
+            None,
+        ),
         (
             "async_start_edge_mowing",
             "_sync_start_edge_mowing",
             ([[3, 0]],),
             "segment_cleaning",
+            101,
+            None,
+            None,
         ),
-        ("async_start_spot_mowing", "_sync_start_spot_mowing", ([4],), "spot_cleaning"),
+        (
+            "async_start_spot_mowing",
+            "_sync_start_spot_mowing",
+            ([4],),
+            "spot_cleaning",
+            103,
+            None,
+            (4,),
+        ),
     ],
 )
-def test_lost_targeted_task_acknowledgement_rejects_unchanged_active_task(
+def test_targeted_task_preflight_rejects_same_active_task_before_dispatch(
     method_name: str,
     sync_name: str,
     arguments: tuple[object, ...],
     task_status: str,
+    task_operation: int,
+    task_region_ids: tuple[int, ...] | None,
+    task_area_ids: tuple[int, ...] | None,
 ) -> None:
     client = object.__new__(DreameLawnMowerClient)
     baseline = SimpleNamespace(
         state="mowing",
         task_status=task_status,
+        task_operation=task_operation,
+        task_region_ids=task_region_ids,
+        task_area_ids=task_area_ids,
         current_zone_id=1,
         active_segment_count=1,
         mowing_session_active=True,
         started=True,
         mowing=True,
     )
-    client.async_get_cached_snapshot = AsyncMock(return_value=baseline)
     setattr(
         client,
         sync_name,
-        Mock(side_effect=DreameLawnMowerConnectionError("reply lost")),
+        Mock(return_value={"r": 0}),
     )
     client._async_refresh_authoritative_snapshot = AsyncMock(
         return_value=baseline
     )
 
-    with (
-        patch(
-            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
-            "client_core.asyncio.sleep",
-            AsyncMock(),
-        ),
-        pytest.raises(
-            DreameLawnMowerConnectionError,
-            match="could not be confirmed",
-        ),
+    with pytest.raises(
+        DreameLawnMowerCommandRejectedError,
+        match="already executing",
     ):
         asyncio.run(getattr(client, method_name)(*arguments))
 
-    getattr(client, sync_name).assert_called_once()
-    assert client._async_refresh_authoritative_snapshot.await_count == 3
+    getattr(client, sync_name).assert_not_called()
+    client._async_refresh_authoritative_snapshot.assert_awaited_once_with()
 
 
 def test_lost_zone_acknowledgement_accepts_requested_task_transition() -> None:
     client = object.__new__(DreameLawnMowerClient)
-    client.async_get_cached_snapshot = AsyncMock(
-        return_value=SimpleNamespace(
-            state="mowing",
-            task_status="auto_cleaning",
-            current_zone_id=None,
-            active_segment_count=0,
-            mowing_session_active=True,
-        )
+    baseline = SimpleNamespace(
+        state="mowing",
+        task_status="auto_cleaning",
+        task_operation=1,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=True,
     )
     client._sync_start_zone_mowing = Mock(
         side_effect=DreameLawnMowerConnectionError("reply lost")
     )
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        return_value=SimpleNamespace(
-            state="mowing",
-            task_status="zone_cleaning",
-            current_zone_id=2,
-            active_segment_count=1,
-            mowing_session_active=True,
-            started=True,
-            mowing=True,
-        )
+        side_effect=[
+            baseline,
+            SimpleNamespace(
+                state="mowing",
+                task_status="zone_cleaning",
+                task_operation=102,
+                task_region_ids=(2,),
+                current_zone_id=2,
+                active_segment_count=1,
+                mowing_session_active=True,
+                started=True,
+                mowing=True,
+            ),
+        ]
     )
 
     with patch(
@@ -705,7 +733,584 @@ def test_lost_zone_acknowledgement_accepts_requested_task_transition() -> None:
         asyncio.run(client.async_start_zone_mowing([2]))
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+@pytest.mark.parametrize(
+    ("method_name", "sync_name", "arguments"),
+    [
+        ("async_start_zone_mowing", "_sync_start_zone_mowing", ([2],)),
+        ("async_start_edge_mowing", "_sync_start_edge_mowing", ([[3, 0]],)),
+        ("async_start_spot_mowing", "_sync_start_spot_mowing", ([4],)),
+    ],
+)
+def test_acknowledged_targeted_task_rejects_wrong_mowing_mode(
+    method_name: str,
+    sync_name: str,
+    arguments: tuple[object, ...],
+) -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+        started=False,
+        mowing=False,
+    )
+    setattr(client, sync_name, Mock(return_value={"r": 0}))
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[
+            baseline,
+            *[
+                SimpleNamespace(
+                    state="mowing",
+                    task_status="auto_cleaning",
+                    task_operation=1,
+                    current_zone_id=None,
+                    active_segment_count=0,
+                    mowing_session_active=True,
+                    started=True,
+                    mowing=True,
+                )
+                for _ in range(3)
+            ],
+        ]
+    )
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(
+            DreameLawnMowerCommandRejectedError,
+            match="acknowledged.*did not enter the requested task",
+        ),
+    ):
+        asyncio.run(getattr(client, method_name)(*arguments))
+
+    getattr(client, sync_name).assert_called_once()
+    assert client._async_refresh_authoritative_snapshot.await_count == 4
+
+
+def test_acknowledged_zone_task_accepts_generic_heartbeat_while_transiting() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    response = {"r": 0, "d": {"r": 0}}
+    client._sync_start_zone_mowing = Mock(return_value=response)
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[
+            baseline,
+            SimpleNamespace(
+                state="mowing",
+                task_status="mowing",
+                task_operation=102,
+                task_region_ids=(2,),
+                current_zone_id=1,
+                active_segment_count=1,
+                mowing_session_active=True,
+                started=True,
+                mowing=True,
+            ),
+        ]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(client.async_start_zone_mowing([2]))
+
+    assert result is response
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+def test_zone_preflight_allows_different_region_target() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="mowing",
+        task_status="zone_cleaning",
+        task_operation=102,
+        task_region_ids=(1,),
+        current_zone_id=1,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    confirmed_task = SimpleNamespace(
+        state="mowing",
+        task_status="zone_cleaning",
+        task_operation=102,
+        task_region_ids=(2,),
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    response = {"r": 0}
+    client._sync_start_zone_mowing = Mock(return_value=response)
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, confirmed_task]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(client.async_start_zone_mowing([2]))
+
+    assert result is response
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+def test_spot_preflight_allows_different_area_target() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="mowing",
+        activity="mowing",
+        task_status="spot_cleaning",
+        task_operation=103,
+        task_area_ids=(4,),
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    confirmed_task = SimpleNamespace(
+        state="mowing",
+        activity="mowing",
+        task_status="spot_cleaning",
+        task_operation=103,
+        task_area_ids=(5,),
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    response = {"r": 0}
+    client._sync_start_spot_mowing = Mock(return_value=response)
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, confirmed_task]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(client.async_start_spot_mowing([5]))
+
+    assert result is response
+    client._sync_start_spot_mowing.assert_called_once_with([5])
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+def test_zone_preflight_ignores_stale_task_identity_after_session_ends() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    idle_baseline = SimpleNamespace(
+        state="idle",
+        activity="docked",
+        task_status="idle",
+        task_operation=102,
+        task_region_ids=(2,),
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=False,
+        started=False,
+        mowing=False,
+        paused=False,
+    )
+    confirmed_task = SimpleNamespace(
+        state="mowing",
+        activity="mowing",
+        task_status="zone_cleaning",
+        task_operation=102,
+        task_region_ids=(2,),
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+        paused=False,
+    )
+    response = {"r": 0}
+    client._sync_start_zone_mowing = Mock(return_value=response)
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[idle_baseline, confirmed_task]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(client.async_start_zone_mowing([2]))
+
+    assert result is response
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    client._sync_start_zone_mowing = Mock(return_value={"r": 0})
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[
+            baseline,
+            *[DreameLawnMowerConnectionError("offline") for _ in range(3)],
+        ]
+    )
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(
+            DreameLawnMowerConnectionError,
+            match="every state readback failed",
+        ),
+    ):
+        asyncio.run(client.async_start_zone_mowing([2]))
+
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 4
+
+
+def test_targeted_task_does_not_dispatch_without_authoritative_preflight() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    client._sync_start_zone_mowing = Mock(return_value={"r": 0})
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=DreameLawnMowerConnectionError("offline")
+    )
+
+    with pytest.raises(DreameLawnMowerConnectionError, match="offline"):
+        asyncio.run(client.async_start_zone_mowing([2]))
+
+    client._sync_start_zone_mowing.assert_not_called()
     client._async_refresh_authoritative_snapshot.assert_awaited_once_with()
+
+
+@pytest.mark.parametrize(
+    ("method_name", "sync_name", "arguments", "task_status", "wrong_operation"),
+    [
+        (
+            "async_start_zone_mowing",
+            "_sync_start_zone_mowing",
+            ([2],),
+            "segment_cleaning",
+            101,
+        ),
+        (
+            "async_start_edge_mowing",
+            "_sync_start_edge_mowing",
+            ([[3, 0]],),
+            "zone_cleaning",
+            102,
+        ),
+    ],
+)
+def test_acknowledged_targeted_task_rejects_cross_target_operation(
+    method_name: str,
+    sync_name: str,
+    arguments: tuple[object, ...],
+    task_status: str,
+    wrong_operation: int,
+) -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    wrong_task = SimpleNamespace(
+        state="mowing",
+        task_status=task_status,
+        task_operation=wrong_operation,
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    setattr(client, sync_name, Mock(return_value={"r": 0}))
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, wrong_task, wrong_task, wrong_task]
+    )
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(DreameLawnMowerCommandRejectedError),
+    ):
+        asyncio.run(getattr(client, method_name)(*arguments))
+
+    getattr(client, sync_name).assert_called_once()
+    assert client._async_refresh_authoritative_snapshot.await_count == 4
+
+
+@pytest.mark.parametrize(
+    ("method_name", "sync_name", "arguments", "task_status", "task_operation"),
+    [
+        (
+            "async_start_zone_mowing",
+            "_sync_start_zone_mowing",
+            ([2],),
+            "segment_cleaning",
+            102,
+        ),
+        (
+            "async_start_edge_mowing",
+            "_sync_start_edge_mowing",
+            ([[3, 0]],),
+            "zone_cleaning",
+            101,
+        ),
+    ],
+)
+def test_acknowledged_targeted_task_accepts_status_alias_with_matching_operation(
+    method_name: str,
+    sync_name: str,
+    arguments: tuple[object, ...],
+    task_status: str,
+    task_operation: int,
+) -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    confirmed_task = SimpleNamespace(
+        state="mowing",
+        task_status=task_status,
+        task_operation=task_operation,
+        task_region_ids=(2,),
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    response = {"r": 0}
+    setattr(client, sync_name, Mock(return_value=response))
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, confirmed_task]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(getattr(client, method_name)(*arguments))
+
+    assert result is response
+    getattr(client, sync_name).assert_called_once()
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+@pytest.mark.parametrize(
+    (
+        "method_name",
+        "sync_name",
+        "arguments",
+        "task_status",
+        "task_operation",
+        "task_region_ids",
+        "task_area_ids",
+    ),
+    [
+        (
+            "async_start_zone_mowing",
+            "_sync_start_zone_mowing",
+            ([2],),
+            "zone_cleaning_paused",
+            102,
+            (2,),
+            None,
+        ),
+        (
+            "async_start_edge_mowing",
+            "_sync_start_edge_mowing",
+            ([[3, 0]],),
+            "segment_cleaning_paused",
+            101,
+            None,
+            None,
+        ),
+        (
+            "async_start_spot_mowing",
+            "_sync_start_spot_mowing",
+            ([4],),
+            "spot_cleaning_paused",
+            103,
+            None,
+            (4,),
+        ),
+    ],
+)
+def test_acknowledged_targeted_task_accepts_immediate_paused_state(
+    method_name: str,
+    sync_name: str,
+    arguments: tuple[object, ...],
+    task_status: str,
+    task_operation: int,
+    task_region_ids: tuple[int, ...] | None,
+    task_area_ids: tuple[int, ...] | None,
+) -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        activity="docked",
+        task_status="idle",
+        task_operation=None,
+        mowing_session_active=False,
+        started=False,
+        mowing=False,
+        paused=False,
+    )
+    paused_task = SimpleNamespace(
+        state="paused",
+        activity="paused",
+        task_status=task_status,
+        task_operation=task_operation,
+        task_region_ids=task_region_ids,
+        task_area_ids=task_area_ids,
+        mowing_session_active=None,
+        started=False,
+        mowing=False,
+        paused=True,
+    )
+    response = {"r": 0}
+    setattr(client, sync_name, Mock(return_value=response))
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, paused_task]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(getattr(client, method_name)(*arguments))
+
+    assert result is response
+    getattr(client, sync_name).assert_called_once()
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+def test_acknowledged_zone_task_rejects_different_region_ids() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        task_region_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    wrong_zone_task = SimpleNamespace(
+        state="mowing",
+        task_status="zone_cleaning",
+        task_operation=102,
+        task_region_ids=(3,),
+        current_zone_id=3,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    client._sync_start_zone_mowing = Mock(return_value={"r": 0})
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, wrong_zone_task, wrong_zone_task, wrong_zone_task]
+    )
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(DreameLawnMowerCommandRejectedError),
+    ):
+        asyncio.run(client.async_start_zone_mowing([2]))
+
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 4
+
+
+def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        activity="docked",
+        task_status="idle",
+        task_operation=None,
+        task_area_ids=None,
+        mowing_session_active=False,
+    )
+    wrong_spot_task = SimpleNamespace(
+        state="mowing",
+        activity="mowing",
+        task_status="spot_cleaning",
+        task_operation=103,
+        task_area_ids=(5,),
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    client._sync_start_spot_mowing = Mock(return_value={"r": 0})
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, wrong_spot_task, wrong_spot_task, wrong_spot_task]
+    )
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(DreameLawnMowerCommandRejectedError),
+    ):
+        asyncio.run(client.async_start_spot_mowing([4]))
+
+    client._sync_start_spot_mowing.assert_called_once_with([4])
+    assert client._async_refresh_authoritative_snapshot.await_count == 4
 
 
 def test_normal_dock_uses_heartbeat_session_state_at_base() -> None:

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -832,6 +832,54 @@ def test_snapshot_counts_active_task_regions_from_mova_task_payload() -> None:
 
     assert snapshot.activity == "mowing"
     assert snapshot.active_segment_count == 2
+    assert snapshot.task_operation == 102
+    assert snapshot.task_region_ids == (1, 3)
+    assert snapshot.task_area_ids is None
+
+
+def test_snapshot_preserves_active_spot_area_ids_from_task_payload() -> None:
+    descriptor = descriptor_from_cloud_record(
+        {
+            "did": "device-1",
+            "model": "mova.mower.g2584a",
+            "customName": "MOVA mower",
+        },
+        account_type="mova",
+        country="us",
+    )
+
+    assert descriptor is not None
+
+    device = _FakeDevice()
+    device.status.state = SimpleNamespace(name="MOWING")
+    device.status.state_name = "mowing"
+    device.status.running = True
+    device.status.attributes = {
+        **device.status.attributes,
+        "charging": False,
+        "mower_state": "mowing",
+        "running": True,
+        "started": True,
+    }
+    device.realtime_properties["2.1"] = {
+        "value": 1,
+        "last_seen": 124.0,
+        "changed_at": 122.0,
+    }
+    device.realtime_properties["2.50"] = {
+        "value": (
+            '{"d":{"area_id":[4,6],"exe":true,"o":103,'
+            '"region_id":[],"status":true},"t":"TASK"}'
+        ),
+        "last_seen": 123.0,
+    }
+
+    snapshot = snapshot_from_device(descriptor, device)
+
+    assert snapshot.activity == "mowing"
+    assert snapshot.task_operation == 103
+    assert snapshot.task_region_ids is None
+    assert snapshot.task_area_ids == (4, 6)
 
 
 def test_snapshot_rejects_task_regions_older_than_active_state() -> None:
@@ -877,6 +925,9 @@ def test_snapshot_rejects_task_regions_older_than_active_state() -> None:
 
     assert snapshot.activity == "mowing"
     assert snapshot.active_segment_count == 4
+    assert snapshot.task_operation is None
+    assert snapshot.task_region_ids is None
+    assert snapshot.task_area_ids is None
 
 
 def test_snapshot_preserves_task_regions_across_active_state_transitions() -> None:
@@ -923,6 +974,8 @@ def test_snapshot_preserves_task_regions_across_active_state_transitions() -> No
 
     assert snapshot.activity == "paused"
     assert snapshot.active_segment_count == 2
+    assert snapshot.task_operation == 102
+    assert snapshot.task_region_ids == (1, 3)
 
 
 def test_snapshot_falls_back_when_active_task_has_no_regions() -> None:
@@ -963,6 +1016,8 @@ def test_snapshot_falls_back_when_active_task_has_no_regions() -> None:
 
     assert snapshot.activity == "mowing"
     assert snapshot.active_segment_count == 3
+    assert snapshot.task_operation == 102
+    assert snapshot.task_region_ids is None
 
 
 def test_snapshot_rejects_retained_task_regions_while_docked() -> None:
@@ -1001,6 +1056,9 @@ def test_snapshot_rejects_retained_task_regions_while_docked() -> None:
 
     assert snapshot.activity == "docked"
     assert snapshot.active_segment_count is None
+    assert snapshot.task_operation is None
+    assert snapshot.task_region_ids is None
+    assert snapshot.task_area_ids is None
 
 
 def test_field_trip_returning_fixture_matches_normalized_state() -> None:

--- a/tests/test_runtime_state.py
+++ b/tests/test_runtime_state.py
@@ -123,8 +123,13 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
 
     assert status_blob is not None
     status_blob = replace(status_blob, received_at="1970-01-01T00:00:20+00:00")
-    reconciled = snapshot_with_heartbeat_task_state(
+    stale_task_snapshot = replace(
         _snapshot(model=model, display_model=display_model),
+        task_operation=102,
+        task_region_ids=(2,),
+    )
+    reconciled = snapshot_with_heartbeat_task_state(
+        stale_task_snapshot,
         status_blob,
         observed_at=20.0,
         active_state_observed_at=19.0,
@@ -141,6 +146,9 @@ def test_idle_in_station_heartbeat_corrects_stale_paused_snapshot(
     assert reconciled.task_status == "idle"
     assert reconciled.task_status_source == "heartbeat_realtime"
     assert reconciled.mowing_session_active is False
+    assert reconciled.task_operation is None
+    assert reconciled.task_region_ids is None
+    assert reconciled.task_area_ids is None
     assert reconciled.mission_task_id == status_blob.candidate_runtime_task_id
 
 
@@ -276,6 +284,63 @@ def test_a3_realtime_standby_is_shared_by_callback_and_map_guard() -> None:
     assert switch_result == {"map_index": 1}
     client._sync_switch_current_map.assert_called_once_with(1)
     client.async_get_current_app_map_index.assert_awaited_once_with()
+
+
+def test_authoritative_preflight_snapshot_applies_newer_idle_heartbeat() -> None:
+    """Safety refreshes share the same heartbeat reconciliation as HA updates."""
+    raw_snapshot = replace(
+        _snapshot(
+            model="dreame.mower.g2541e",
+            display_model="A3 AWD Pro 3500",
+        ),
+        task_operation=102,
+        task_region_ids=(2,),
+    )
+    device = SimpleNamespace(
+        _state_lock=RLock(),
+        update=Mock(),
+        realtime_properties={
+            MOWER_RAW_STATUS_PROPERTY_KEY: {
+                "value": list(_A3_STANDBY_FRAME),
+                "last_seen": 100.0,
+            }
+        },
+    )
+    client = object.__new__(DreameLawnMowerClient)
+    client._descriptor = raw_snapshot.descriptor
+    client._latest_snapshot = None
+    client._ensure_device = Mock(return_value=device)
+
+    with (
+        patch.object(
+            client_core_module,
+            "snapshot_from_device",
+            return_value=raw_snapshot,
+        ),
+        patch.object(client_core_module.time, "time", return_value=101.0),
+    ):
+        first_snapshot = asyncio.run(client._async_refresh_authoritative_snapshot())
+
+    assert first_snapshot.activity == "paused"
+    device.realtime_properties[MOWER_RAW_STATUS_PROPERTY_KEY]["last_seen"] = 102.0
+
+    with (
+        patch.object(
+            client_core_module,
+            "snapshot_from_device",
+            return_value=raw_snapshot,
+        ),
+        patch.object(client_core_module.time, "time", return_value=103.0),
+    ):
+        reconciled = asyncio.run(client._async_refresh_authoritative_snapshot())
+
+    assert reconciled.state == "idle"
+    assert reconciled.activity == "docked"
+    assert reconciled.mowing_session_active is False
+    assert reconciled.task_operation is None
+    assert reconciled.task_region_ids is None
+    device.update.assert_called_with(force_request_properties=True)
+    assert device.update.call_count == 2
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary

- force an authoritative, heartbeat-reconciled preflight before explicit zone, edge, or spot mowing commands
- require active native TASK operation and exact zone-region or spot-area targets to confirm the requested task actually started
- accept native and generic heartbeat running/paused statuses only when operation, targets, active evidence, and task-identity transition all agree
- reject wrong-mode, wrong-target, unreadable, inactive, and unverifiable repeat-task outcomes instead of reporting silent success
- discard stale native task identity when authoritative heartbeat evidence ends the mowing session
- treat current physical zone as mower position during transit, not the requested task target
- update Home Assistant's local mowing-action selection only after device confirmation

## Compatibility

Firmware task-status aliases remain supported; native operation codes distinguish zone, edge, and spot tasks. Repeating the same active task is rejected when a new task identity cannot be proven, while a different known zone or spot target remains supported through exact native target readback. Idle or docked snapshots cannot be mistaken for an active task solely because an older TASK property remains cached.

## Validation

- full test suite on Linux
- focused operation, target-ID, heartbeat/preflight, paused-state, transit, map-control, service, model, and public-export tests
- Ruff and whitespace checks
- independent owner-level closure audit plus targeted remediation confirmation

Fixes https://github.com/EvotecIT/homeassistant-dreamelawnmower/issues/166