### PR TITLE
Confirm mower preference writes through exact readback

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,7 +403,10 @@ the current app preference payload, applies the requested field changes
 locally, and exposes the candidate `PRE` request in a notification plus the
 disabled-by-default `Last Preference Write` diagnostic sensor. It sends a live
 preference write only when both `execute: true` and
-`confirm_preference_write: true` are provided.
+`confirm_preference_write: true` are provided. After every live `PRE` or `PREP`
+acknowledgement, the integration reads the selected map preferences again and
+requires the requested mode and field values to match. A generic success reply
+does not count as confirmation when the mower keeps its previous settings.
 
 The guarded preference fields include per-zone safe edge mowing through
 `edge_mowing_safe`, EdgeMaster through `edge_cutting_attachment`, and mowing

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1544,27 +1544,63 @@ class DreameLawnMowerCoordinator(
     ) -> dict[str, Any]:
         """Serialize full-payload mowing preference reads and writes."""
         async with self._preference_write_lock:
-            result = await self.client.async_plan_app_mowing_preference_update(
-                map_index=map_index,
-                area_id=area_id,
-                changes=changes,
-                execute=execute,
-                confirm_write=confirm_write,
-            )
+            try:
+                result = await self.client.async_plan_app_mowing_preference_update(
+                    map_index=map_index,
+                    area_id=area_id,
+                    changes=changes,
+                    execute=execute,
+                    confirm_write=confirm_write,
+                )
+            except Exception:  # noqa: BLE001 - reconcile possibly applied writes
+                if execute:
+                    await self._async_reconcile_mowing_preference_write(
+                        suppress_errors=True,
+                    )
+                raise
             self.last_preference_write_result = result
             if execute:
-                self.batch_device_data_refreshed_at = None
-                try:
-                    await self.async_refresh_batch_device_data(
-                        force=True,
-                        source="mowing_preference_write",
-                    )
-                    await self.async_request_refresh()
-                finally:
-                    self.async_update_listeners()
+                await self._async_reconcile_mowing_preference_write()
             else:
                 self.async_update_listeners()
             return result
+
+    async def _async_reconcile_mowing_preference_write(
+        self,
+        *,
+        suppress_errors: bool = False,
+    ) -> None:
+        """Refresh coordinator state after a possibly applied preference write."""
+        self.batch_device_data_refreshed_at = None
+        if suppress_errors:
+            try:
+                await self.async_refresh_batch_device_data(
+                    force=True,
+                    source="mowing_preference_write",
+                )
+                await self.async_request_refresh()
+            except Exception as err:  # noqa: BLE001 - preserve write failure
+                _LOGGER.debug(
+                    "Failed to reconcile mower preferences after a write error: %s",
+                    err,
+                )
+            try:
+                self.async_update_listeners()
+            except Exception as err:  # noqa: BLE001 - preserve write failure
+                _LOGGER.debug(
+                    "Failed to notify preference listeners after a write error: %s",
+                    err,
+                )
+            return
+
+        try:
+            await self.async_refresh_batch_device_data(
+                force=True,
+                source="mowing_preference_write",
+            )
+            await self.async_request_refresh()
+        finally:
+            self.async_update_listeners()
 
     async def async_refresh_mowing_preferences(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -909,54 +909,71 @@ class _DreameLawnMowerClientSettingsMixin:
                     areas = []
 
                 preferences: list[dict[str, Any]] = []
+                area_errors: list[dict[str, Any]] = []
                 for area in areas:
                     if not isinstance(area, Mapping):
                         continue
                     area_id = _positive_int(area.get("area_id"))
                     if area_id is None:
                         continue
-                    preference_result = self._sync_call_app_action(
-                        {
-                            "m": "g",
-                            "t": "PRE",
-                            "d": {"idx": map_index, "region": area_id},
+                    try:
+                        preference_result = self._sync_call_app_action(
+                            {
+                                "m": "g",
+                                "t": "PRE",
+                                "d": {"idx": map_index, "region": area_id},
+                            }
+                        )
+                        preference_data = _app_action_data(preference_result)
+                        if not isinstance(preference_data, Sequence) or isinstance(
+                            preference_data,
+                            str | bytes | bytearray,
+                        ):
+                            raise DreameLawnMowerConnectionError(
+                                "PRE returned invalid preference data for map "
+                                f"{map_index} area {area_id}."
+                            )
+                        preference = decode_mowing_preference_payload(preference_data)
+                        reported_map_index = _positive_int(
+                            preference.get("map_index")
+                        )
+                        reported_area_id = _positive_int(preference.get("area_id"))
+                        if (
+                            reported_map_index != map_index
+                            or reported_area_id != area_id
+                        ):
+                            raise DreameLawnMowerConnectionError(
+                                "PRE returned mismatched preference identity for "
+                                f"requested map {map_index} area {area_id}: payload "
+                                f"map {reported_map_index} area {reported_area_id}."
+                            )
+                        preference["reported_version"] = area.get("version")
+                        if include_raw:
+                            preference["raw_response"] = _json_safe(
+                                preference_result,
+                                max_depth=4,
+                            )
+                            preference["raw_payload"] = _json_safe(
+                                list(preference_data),
+                                max_depth=2,
+                            )
+                        preferences.append(preference)
+                    except Exception as err:  # noqa: BLE001 - isolate each area
+                        area_error = {
+                            "idx": map_index,
+                            "area_id": area_id,
+                            "stage": "preference",
+                            "error": str(err),
                         }
-                    )
-                    preference_data = _app_action_data(preference_result)
-                    if not isinstance(preference_data, Sequence) or isinstance(
-                        preference_data,
-                        str | bytes | bytearray,
-                    ):
-                        raise DreameLawnMowerConnectionError(
-                            f"PRE returned invalid preference data for map {map_index} "
-                            f"area {area_id}."
-                        )
-                    preference = decode_mowing_preference_payload(preference_data)
-                    reported_map_index = _positive_int(preference.get("map_index"))
-                    reported_area_id = _positive_int(preference.get("area_id"))
-                    if (
-                        reported_map_index != map_index
-                        or reported_area_id != area_id
-                    ):
-                        raise DreameLawnMowerConnectionError(
-                            "PRE returned mismatched preference identity for requested "
-                            f"map {map_index} area {area_id}: payload map "
-                            f"{reported_map_index} area {reported_area_id}."
-                        )
-                    preference["reported_version"] = area.get("version")
-                    if include_raw:
-                        preference["raw_response"] = _json_safe(
-                            preference_result,
-                            max_depth=4,
-                        )
-                        preference["raw_payload"] = _json_safe(
-                            list(preference_data),
-                            max_depth=2,
-                        )
-                    preferences.append(preference)
+                        area_errors.append(area_error)
+                        result["errors"].append(area_error)
 
                 entry["preferences"] = preferences
                 entry["available"] = bool(preferences)
+                if area_errors:
+                    entry["errors"] = area_errors
+                    if not preferences:
+                        entry["error"] = area_errors[0]["error"]
                 if preferences:
                     result["available"] = True
             except Exception as err:  # noqa: BLE001 - keep probing other maps

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -91,6 +91,7 @@ from .work_log import (
     work_log_totals_from_app_data,
 )
 
+_MOWING_PREFERENCE_READBACK_DELAYS_SECONDS = (0.0, 1.0, 2.0)
 SCHEDULE_CURRENT_TASK_TIMEOUT_SECONDS = 5.0
 SCHEDULE_READ_DEADLINE_SECONDS = 10.0
 SCHEDULE_READ_TIMEOUT_SECONDS = 5.0
@@ -660,37 +661,27 @@ class _DreameLawnMowerClientSettingsMixin:
         if execute:
             responses: list[Any] = []
             response_payloads: list[Any] = []
-            preference_readback_required = False
             for request in request_sequence:
                 response = self._sync_call_app_action(request)
-                is_preference_settings_write = request.get("t") == "PRE"
-                missing_response_data = (
-                    is_preference_settings_write
-                    and isinstance(response, Mapping)
-                    and "d" not in response
-                )
+                is_preference_write = request.get("t") in {"PRE", "PREP"}
                 response_data = _ensure_app_write_succeeded(
                     response,
                     operation="Preference write",
-                    allow_missing_data=is_preference_settings_write,
+                    allow_missing_data=is_preference_write,
                 )
-                preference_readback_required |= missing_response_data
                 responses.append(_json_safe(response, max_depth=4))
                 response_payloads.append(_json_safe(response_data, max_depth=4))
-            if preference_readback_required:
-                result["readback"] = self._sync_verify_mowing_preference_readback(
-                    map_index=map_index,
-                    area_id=area_id,
-                    setting_changes=setting_changes,
-                    requested_mode=requested_mode,
-                )
-                result["verification_source"] = "preference_readback"
-                result["notes"].append(
-                    "The PRE response omitted data; the requested values were "
-                    "confirmed through mower preference readback."
-                )
-            else:
-                result["verification_source"] = "response_data"
+            result["readback"] = self._sync_verify_mowing_preference_readback(
+                map_index=map_index,
+                area_id=area_id,
+                setting_changes=setting_changes,
+                requested_mode=requested_mode,
+            )
+            result["verification_source"] = "preference_readback"
+            result["notes"].append(
+                "The requested values were confirmed through exact mower "
+                "preference readback."
+            )
             result["executed"] = True
             result["request_verified"] = True
             if len(responses) == 1:
@@ -709,7 +700,41 @@ class _DreameLawnMowerClientSettingsMixin:
         setting_changes: Mapping[str, Any],
         requested_mode: int | None,
     ) -> dict[str, Any]:
-        """Require exact PRE/PREI readback after a data-less success response."""
+        """Require bounded exact PRE/PREI readback after acknowledgement."""
+        last_error: (
+            DreameLawnMowerCommandRejectedError | DreameLawnMowerConnectionError | None
+        ) = None
+        for delay in _MOWING_PREFERENCE_READBACK_DELAYS_SECONDS:
+            if delay:
+                time.sleep(delay)
+            try:
+                return self._sync_read_mowing_preference_confirmation(
+                    map_index=map_index,
+                    area_id=area_id,
+                    setting_changes=setting_changes,
+                    requested_mode=requested_mode,
+                )
+            except (
+                DreameLawnMowerCommandRejectedError,
+                DreameLawnMowerConnectionError,
+            ) as err:
+                last_error = err
+
+        if last_error is not None:
+            raise last_error
+        raise DreameLawnMowerConnectionError(
+            "The mower preference readback could not be attempted."
+        )
+
+    def _sync_read_mowing_preference_confirmation(
+        self,
+        *,
+        map_index: int,
+        area_id: int | None,
+        setting_changes: Mapping[str, Any],
+        requested_mode: int | None,
+    ) -> dict[str, Any]:
+        """Perform one exact mower preference readback attempt."""
         preferences = self._sync_get_mowing_preferences(map_indices=[map_index])
         maps = preferences.get("maps")
         preference_map = (
@@ -726,9 +751,8 @@ class _DreameLawnMowerClientSettingsMixin:
         )
         if not isinstance(preference_map, Mapping):
             raise DreameLawnMowerConnectionError(
-                "Preference write returned success without response data, but the "
-                "mower did not return the target map for readback. Refresh the mower "
-                "before trying again."
+                "The mower acknowledged the preference write but did not return the "
+                "target map for readback. Refresh the mower before trying again."
             )
 
         unconfirmed_fields: list[str] = []
@@ -753,9 +777,9 @@ class _DreameLawnMowerClientSettingsMixin:
                 )
             if readback_preference is None:
                 raise DreameLawnMowerConnectionError(
-                    "Preference write returned success without response data, but the "
-                    "mower did not return the target area for readback. Refresh the "
-                    "mower before trying again."
+                    "The mower acknowledged the preference write but did not return "
+                    "the target area for readback. Refresh the mower before trying "
+                    "again."
                 )
             _, remaining_changes = apply_mowing_preference_changes(
                 readback_preference,
@@ -767,8 +791,8 @@ class _DreameLawnMowerClientSettingsMixin:
         if unconfirmed_fields:
             fields = ", ".join(dict.fromkeys(unconfirmed_fields))
             raise DreameLawnMowerCommandRejectedError(
-                "The mower returned success without response data, but preference "
-                f"readback did not confirm the requested fields: {fields}."
+                "The mower acknowledged the preference write, but readback did not "
+                f"confirm the requested fields: {fields}."
             )
 
         return {

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
+import pytest
 from homeassistant.helpers.update_coordinator import DataUpdateCoordinator
 
 from custom_components.dreame_lawn_mower import (
@@ -1406,6 +1407,75 @@ def test_preference_updates_are_serialized_around_full_payload_operation() -> No
 
     assert maximum_active == 1
     assert coordinator.async_update_listeners.call_count == 2
+
+
+def test_failed_preference_verification_still_reconciles_coordinator_state() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator.last_preference_write_result = None
+    coordinator.batch_device_data_refreshed_at = datetime.now(UTC)
+    coordinator.async_update_listeners = Mock()
+    coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_mowing_preference_update=AsyncMock(
+            side_effect=RuntimeError("readback did not confirm")
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="readback did not confirm"):
+        asyncio.run(
+            coordinator.async_plan_mowing_preference_update(
+                map_index=1,
+                area_id=None,
+                changes={"preference_mode": "global"},
+                execute=True,
+                confirm_write=True,
+            )
+        )
+
+    assert coordinator.batch_device_data_refreshed_at is None
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
+    )
+    coordinator.async_request_refresh.assert_awaited_once_with()
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
+def test_preference_reconciliation_listener_does_not_mask_write_error() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator.last_preference_write_result = None
+    coordinator.batch_device_data_refreshed_at = datetime.now(UTC)
+    coordinator.async_update_listeners = Mock(
+        side_effect=RuntimeError("listener failed")
+    )
+    coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_mowing_preference_update=AsyncMock(
+            side_effect=RuntimeError("readback did not confirm")
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="readback did not confirm"):
+        asyncio.run(
+            coordinator.async_plan_mowing_preference_update(
+                map_index=1,
+                area_id=None,
+                changes={"preference_mode": "global"},
+                execute=True,
+                confirm_write=True,
+            )
+        )
+
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
+    )
+    coordinator.async_request_refresh.assert_awaited_once_with()
+    coordinator.async_update_listeners.assert_called_once_with()
 
 
 def test_runtime_map_identity_does_not_fall_back_after_fresh_unknown_map() -> None:

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -265,6 +265,8 @@ def test_get_mowing_preferences_rejects_mismatched_payload_identity(
         aiid: int = 50,
     ) -> dict[str, object]:
         result = call_app_action(payload, siid=siid, aiid=aiid)
+        if payload.get("t") == "PREI" and payload.get("m") == "g":
+            result["out"][0]["d"]["ver"] = [[11, 8]]
         if payload.get("t") == "PRE" and payload.get("m") == "g":
             preference = result["out"][0]["d"]
             preference[1] = payload_map_index
@@ -279,6 +281,45 @@ def test_get_mowing_preferences_rejects_mismatched_payload_identity(
     assert result["available"] is False
     assert result["maps"][0]["preferences"] == []
     assert "mismatched preference identity" in result["maps"][0]["error"]
+
+
+def test_get_mowing_preferences_preserves_unaffected_areas() -> None:
+    client = _client()
+    cloud = _FakePreferenceCloud()
+    call_app_action = cloud.call_app_action
+
+    def fail_unrelated_area(
+        payload: dict[str, object],
+        *,
+        siid: int = 2,
+        aiid: int = 50,
+    ) -> dict[str, object]:
+        if (
+            payload.get("m") == "g"
+            and payload.get("t") == "PRE"
+            and payload.get("d") == {"idx": 0, "region": 12}
+        ):
+            cloud.calls.append(payload)
+            return {"out": [{"m": "r", "r": 0, "d": None}]}
+        return call_app_action(payload, siid=siid, aiid=aiid)
+
+    cloud.call_app_action = fail_unrelated_area  # type: ignore[method-assign]
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    result = client._sync_get_mowing_preferences(map_indices=[0])
+
+    assert result["available"] is True
+    assert [item["area_id"] for item in result["maps"][0]["preferences"]] == [11]
+    assert result["maps"][0]["available"] is True
+    assert result["maps"][0]["errors"] == [
+        {
+            "idx": 0,
+            "area_id": 12,
+            "stage": "preference",
+            "error": "PRE returned invalid preference data for map 0 area 12.",
+        }
+    ]
+    assert result["errors"] == result["maps"][0]["errors"]
 
 
 def test_encode_mowing_preference_payload_round_trips_decoded_values() -> None:
@@ -638,6 +679,90 @@ def test_preference_write_retries_until_exact_readback_catches_up() -> None:
     assert result["request_verified"] is True
     assert result["readback"]["preference"]["version"] == 221
     sleep.assert_called_once_with(1.0)
+
+
+def test_preference_write_ignores_unrelated_area_readback_failure() -> None:
+    client = _client()
+    cloud = _FakePreferenceCloud()
+    call_app_action = cloud.call_app_action
+
+    def fail_unrelated_area(
+        payload: dict[str, object],
+        *,
+        siid: int = 2,
+        aiid: int = 50,
+    ) -> dict[str, object]:
+        if (
+            payload.get("m") == "g"
+            and payload.get("t") == "PRE"
+            and payload.get("d") == {"idx": 0, "region": 12}
+        ):
+            cloud.calls.append(payload)
+            return {"out": [{"m": "r", "r": 0, "d": None}]}
+        return call_app_action(payload, siid=siid, aiid=aiid)
+
+    cloud.call_app_action = fail_unrelated_area  # type: ignore[method-assign]
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    result = client._sync_plan_app_mowing_preference_update(
+        map_index=0,
+        area_id=11,
+        changes={"mowing_height_cm": 5.0},
+        execute=True,
+        confirm_write=True,
+    )
+
+    assert result["executed"] is True
+    assert result["request_verified"] is True
+    assert result["readback"]["preference"]["area_id"] == 11
+    assert result["readback"]["preference"]["mowing_height_cm"] == 5.0
+
+
+def test_preference_write_fails_closed_when_target_area_readback_fails() -> None:
+    client = _client()
+    cloud = _FakePreferenceCloud()
+    call_app_action = cloud.call_app_action
+    write_started = False
+
+    def fail_target_after_write(
+        payload: dict[str, object],
+        *,
+        siid: int = 2,
+        aiid: int = 50,
+    ) -> dict[str, object]:
+        nonlocal write_started
+        if payload.get("m") == "s" and payload.get("t") == "PRE":
+            write_started = True
+        if (
+            write_started
+            and payload.get("m") == "g"
+            and payload.get("t") == "PRE"
+            and payload.get("d") == {"idx": 0, "region": 11}
+        ):
+            cloud.calls.append(payload)
+            return {"out": [{"m": "r", "r": 0, "d": None}]}
+        return call_app_action(payload, siid=siid, aiid=aiid)
+
+    cloud.call_app_action = fail_target_after_write  # type: ignore[method-assign]
+    client._sync_get_cloud_protocol = lambda: cloud
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client_settings.time.sleep"
+        ),
+        pytest.raises(
+            DreameLawnMowerConnectionError,
+            match="did not return the target area",
+        ),
+    ):
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=11,
+            changes={"mowing_height_cm": 5.0},
+            execute=True,
+            confirm_write=True,
+        )
 
 
 def test_preference_write_still_rejects_failed_outer_response() -> None:

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from unittest.mock import patch
+
 import pytest
 
 from dreame_lawn_mower_client import (
@@ -23,6 +25,8 @@ class _FakePreferenceCloud:
 
     def __init__(self) -> None:
         self.calls: list[dict[str, object]] = []
+        self.modes = {0: 1, 1: 0}
+        self.preference_payloads: dict[tuple[int, int], list[int]] = {}
 
     def call_app_action(
         self,
@@ -48,39 +52,48 @@ class _FakePreferenceCloud:
         if command == "PREI":
             idx = int(payload["d"]["idx"])
             data = (
-                {"type": 1, "ver": [[11, 8], [12, 9]]}
+                {"type": self.modes[idx], "ver": [[11, 8], [12, 9]]}
                 if idx == 0
                 else {
-                    "type": 0,
+                    "type": self.modes[idx],
                     "ver": [],
                 }
             )
             return {"out": [{"m": "r", "r": 0, "d": data}]}
         if command == "PRE":
             if payload.get("m") == "s":
+                preference_payload = list(payload["d"])
+                self.preference_payloads[
+                    (int(preference_payload[1]), int(preference_payload[2]))
+                ] = preference_payload
                 return {"out": [{"m": "r", "r": 0, "d": {"r": 0, "ok": True}}]}
+            idx = int(payload["d"]["idx"])
             region = int(payload["d"]["region"])
-            payload_data = [
-                8,
-                0,
-                region,
-                1,
-                40,
-                2,
-                90,
-                1,
-                0,
-                1,
-                1,
-                2,
-                1,
-                15,
-                20,
-                7,
-                1,
-            ]
+            payload_data = self.preference_payloads.get(
+                (idx, region),
+                [
+                    8,
+                    idx,
+                    region,
+                    1,
+                    40,
+                    2,
+                    90,
+                    1,
+                    0,
+                    1,
+                    1,
+                    2,
+                    1,
+                    15,
+                    20,
+                    7,
+                    1,
+                ],
+            )
             return {"out": [{"m": "r", "r": 0, "d": payload_data}]}
         if command == "PREP":
+            self.modes[int(payload["d"]["idx"])] = int(payload["d"]["value"])
             return {"out": [{"m": "r", "r": 0, "d": {"r": 0, "ok": True}}]}
         raise AssertionError(f"Unexpected app command: {payload}")
 
@@ -493,8 +506,17 @@ def test_plan_app_mowing_preference_update_can_execute_confirmed_request() -> No
     assert result["executed"] is True
     assert result["execute_supported"] is True
     assert result["request_verified"] is True
+    assert result["verification_source"] == "preference_readback"
     assert result["response_data"] == {"r": 0, "ok": True}
-    assert [call["t"] for call in cloud.calls] == ["PREI", "PRE", "PRE", "PRE"]
+    assert [call["t"] for call in cloud.calls] == [
+        "PREI",
+        "PRE",
+        "PRE",
+        "PRE",
+        "PREI",
+        "PRE",
+        "PRE",
+    ]
 
 
 def test_preference_write_accepts_data_less_success_after_exact_readback() -> None:
@@ -543,7 +565,7 @@ def test_preference_write_accepts_data_less_success_after_exact_readback() -> No
     ]
 
 
-def test_preference_write_rejects_data_less_success_without_matching_readback() -> None:
+def test_preference_write_rejects_acknowledgement_without_matching_readback() -> None:
     client = _client()
     unchanged = decode_mowing_preference_payload(
         [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
@@ -554,11 +576,18 @@ def test_preference_write_rejects_data_less_success_without_matching_readback() 
     client._sync_call_app_action = lambda request: {  # type: ignore[method-assign]  # noqa: ARG005
         "m": "r",
         "r": 0,
+        "d": {"r": 0, "ok": True},
     }
 
-    with pytest.raises(
-        DreameLawnMowerCommandRejectedError,
-        match="did not confirm.*obstacle_avoidance_ai_classes",
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client_settings.time.sleep"
+        ) as sleep,
+        pytest.raises(
+            DreameLawnMowerCommandRejectedError,
+            match="did not confirm.*obstacle_avoidance_ai_classes",
+        ),
     ):
         client._sync_plan_app_mowing_preference_update(
             map_index=0,
@@ -567,6 +596,48 @@ def test_preference_write_rejects_data_less_success_without_matching_readback() 
             execute=True,
             confirm_write=True,
         )
+
+    assert [call.args[0] for call in sleep.call_args_list] == [1.0, 2.0]
+
+
+def test_preference_write_retries_until_exact_readback_catches_up() -> None:
+    client = _client()
+    before = decode_mowing_preference_payload(
+        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    after = decode_mowing_preference_payload(
+        [221, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 3, 1]
+    )
+    reads = iter(
+        [
+            _preference_result(before),
+            _preference_result(before),
+            _preference_result(after),
+        ]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: next(reads)  # type: ignore[method-assign]  # noqa: ARG005
+    client._sync_call_app_action = lambda request: {  # type: ignore[method-assign]  # noqa: ARG005
+        "m": "r",
+        "r": 0,
+        "d": {"r": 0, "ok": True},
+    }
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client_settings.time.sleep"
+    ) as sleep:
+        result = client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=0,
+            changes={"obstacle_avoidance_ai_classes": ["people", "animals"]},
+            execute=True,
+            confirm_write=True,
+        )
+
+    assert result["executed"] is True
+    assert result["request_verified"] is True
+    assert result["readback"]["preference"]["version"] == 221
+    sleep.assert_called_once_with(1.0)
 
 
 def test_preference_write_still_rejects_failed_outer_response() -> None:
@@ -638,8 +709,91 @@ def test_plan_app_mowing_preference_update_can_execute_mode_only_request() -> No
 
     assert result["executed"] is True
     assert result["request_verified"] is True
+    assert result["verification_source"] == "preference_readback"
     assert result["response_data"] == {"r": 0, "ok": True}
-    assert [call["t"] for call in cloud.calls] == ["PREI", "PRE", "PRE", "PREP"]
+    assert [call["t"] for call in cloud.calls] == [
+        "PREI",
+        "PRE",
+        "PRE",
+        "PREP",
+        "PREI",
+        "PRE",
+        "PRE",
+    ]
+
+
+def test_preference_write_accepts_data_less_mode_success_after_exact_readback() -> (
+    None
+):
+    client = _client()
+    before = _preference_result(
+        decode_mowing_preference_payload(
+            [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+        )
+    )
+    after = _preference_result(
+        decode_mowing_preference_payload(
+            [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+        )
+    )
+    after["maps"][0]["mode"] = 1
+    after["maps"][0]["mode_name"] = "custom"
+    reads = iter([before, after])
+    client._sync_get_mowing_preferences = lambda **kwargs: next(reads)  # type: ignore[method-assign]  # noqa: ARG005
+    client._sync_call_app_action = lambda request: {  # type: ignore[method-assign]  # noqa: ARG005
+        "m": "r",
+        "r": 0,
+    }
+
+    result = client._sync_plan_app_mowing_preference_update(
+        map_index=0,
+        area_id=None,
+        changes={"preference_mode": "custom"},
+        execute=True,
+        confirm_write=True,
+    )
+
+    assert result["executed"] is True
+    assert result["request_verified"] is True
+    assert result["verification_source"] == "preference_readback"
+    assert result["response_data"] is None
+
+
+def test_preference_write_rejects_acknowledged_mode_without_matching_readback() -> (
+    None
+):
+    client = _client()
+    unchanged = decode_mowing_preference_payload(
+        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: _preference_result(  # type: ignore[method-assign]  # noqa: ARG005
+        unchanged
+    )
+    client._sync_call_app_action = lambda request: {  # type: ignore[method-assign]  # noqa: ARG005
+        "m": "r",
+        "r": 0,
+        "d": {"r": 0, "ok": True},
+    }
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client_settings.time.sleep"
+        ) as sleep,
+        pytest.raises(
+            DreameLawnMowerCommandRejectedError,
+            match="readback did not confirm.*preference_mode",
+        ),
+    ):
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=None,
+            changes={"preference_mode": "custom"},
+            execute=True,
+            confirm_write=True,
+        )
+
+    assert [call.args[0] for call in sleep.call_args_list] == [1.0, 2.0]
 
 
 def test_plan_app_mowing_preference_update_targets_global_area_zero() -> None:
@@ -697,46 +851,55 @@ def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequenc
 ):
     client = _client()
     requests: list[dict[str, object]] = []
-    client._sync_get_mowing_preferences = lambda *args, **kwargs: {
-        "available": True,
-        "maps": [
-            {
-                "idx": 1,
-                "mode": 0,
-                "mode_name": "global",
-                "area_count": 1,
-                "preferences": [
-                    {
-                        "version": 10,
-                        "map_index": 1,
-                        "area_id": 5,
-                        "reported_version": 10,
-                        "efficient_mode": 1,
-                        "mowing_height_cm": 3.5,
-                        "mowing_direction_mode": 1,
-                        "mowing_direction_degrees": 10,
-                        "edge_mowing_auto": True,
-                        "edge_mowing_walk_mode": 0,
-                        "edge_mowing_obstacle_avoidance": True,
-                        "cutter_position": 0,
-                        "edge_mowing_num": 1,
-                        "obstacle_avoidance_enabled": True,
-                        "obstacle_avoidance_height_cm": 5,
-                        "obstacle_avoidance_distance_cm": 10,
-                        "obstacle_avoidance_ai": 7,
-                        "obstacle_avoidance_ai_classes": [
-                            "people",
-                            "animals",
-                            "objects",
-                        ],
-                        "edge_mowing_safe": True,
-                    }
-                ],
-            }
-        ],
+    preference = {
+        "version": 10,
+        "map_index": 1,
+        "area_id": 5,
+        "reported_version": 10,
+        "efficient_mode": 1,
+        "mowing_height_cm": 3.5,
+        "mowing_direction_mode": 1,
+        "mowing_direction_degrees": 10,
+        "edge_mowing_auto": True,
+        "edge_mowing_walk_mode": 0,
+        "edge_mowing_obstacle_avoidance": True,
+        "cutter_position": 0,
+        "edge_mowing_num": 1,
+        "obstacle_avoidance_enabled": True,
+        "obstacle_avoidance_height_cm": 5,
+        "obstacle_avoidance_distance_cm": 10,
+        "obstacle_avoidance_ai": 7,
+        "obstacle_avoidance_ai_classes": ["people", "animals", "objects"],
+        "edge_mowing_safe": True,
     }
+
+    def read_preferences(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        readback = dict(preference)
+        mode = 0
+        if requests:
+            mode = 1
+            readback["mowing_height_cm"] = 4.0
+        return {
+            "available": True,
+            "maps": [
+                {
+                    "idx": 1,
+                    "mode": mode,
+                    "mode_name": "custom" if mode == 1 else "global",
+                    "area_count": 1,
+                    "preferences": [readback],
+                }
+            ],
+        }
+
+    client._sync_get_mowing_preferences = read_preferences
     client._sync_call_app_action = lambda request: (
-        requests.append(request) or {"r": 0, "d": {"r": 0, "ok": True}}
+        requests.append(request)
+        or (
+            {"r": 0}
+            if request["t"] == "PREP"
+            else {"r": 0, "d": {"r": 0, "ok": True}}
+        )
     )
 
     result = client._sync_plan_app_mowing_preference_update(
@@ -748,6 +911,7 @@ def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequenc
     )
 
     assert result["executed"] is True
+    assert result["verification_source"] == "preference_readback"
     assert result["changed_fields"] == ["preference_mode", "mowing_height_cm"]
     assert result["request_candidate"] == {
         "sequence": [
@@ -767,7 +931,7 @@ def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequenc
             "d": [10, 1, 5, 1, 40, 1, 10, 1, 0, 1, 0, 1, 1, 5, 10, 7, 1],
         },
     ]
-    assert result["response_data"] == [{"r": 0, "ok": True}, {"r": 0, "ok": True}]
+    assert result["response_data"] == [None, {"r": 0, "ok": True}]
     assert [request["t"] for request in requests] == ["PREP", "PRE"]
 
 


### PR DESCRIPTION
## Summary

- require exact mower readback after every live `PRE` or `PREP` preference acknowledgement
- retry readback over a bounded three-attempt window while the mower read model catches up
- preserve successfully decoded areas when an unrelated area returns malformed preference data
- reject mode, cutting-height, and other preference writes when the target readback keeps its previous values or cannot be read
- accept data-less acknowledgements only when subsequent readback confirms the requested state
- reconcile Home Assistant preference state after possibly applied writes even when verification fails

## User impact

A temporary success response can no longer leave the preference selector showing a value the mower did not retain. Brief read-model lag no longer creates a false failure: confirmation checks immediately, after one second, and after another two seconds before rejecting the write. A bad read from an unrelated area no longer blocks confirmation of the intended area, while target-area verification remains fail-closed. Combined mode and per-area writes continue through both commands and verify the complete requested result.

The attached issue diagnostics also confirm that Map 1 has no configured spot, while Map 2 has one. In Custom mode, per-zone height is edited through `Selected Zone Mowing Height`; the whole-map height control remains intentionally unavailable.

## Validation

- full test suite on Linux
- focused PRE/PREP, delayed-readback, partial-area failure, coordinator reconciliation, map-control, and preference-entity tests
- Ruff and whitespace checks
- independent read-only review with targeted remediation confirmation
- owner-level closure audit of per-area readback and exact target confirmation

Follow-up to https://github.com/EvotecIT/homeassistant-dreamelawnmower/issues/157