### PR TITLE
Preserve confirmed mowing preference state during batch convergence

### DIFF
--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -43,7 +43,7 @@ from .coordinator_refresh import (
     runtime_tracking_active,
 )
 from .diagnostic_events import DreameLawnMowerDiagnosticEventStore
-from .dreame_lawn_mower_client.exceptions import write_was_attempted
+from .dreame_lawn_mower_client.exceptions import attempted_write_fields
 from .dreame_lawn_mower_client.feature_capabilities import FEATURE_LIVE_VIDEO
 from .dreame_lawn_mower_client.models import (
     DreameLawnMowerStatusBlob,
@@ -1582,13 +1582,14 @@ class DreameLawnMowerCoordinator(
                     confirm_write=confirm_write,
                 )
             except Exception as err:  # noqa: BLE001 - reconcile attempted writes
-                if execute and write_was_attempted(err):
+                attempted_fields = attempted_write_fields(err)
+                if execute and attempted_fields:
                     self._pending_preference_confirmations = (
                         invalidate_preference_confirmations(
                             getattr(self, "_pending_preference_confirmations", []),
                             map_index=map_index,
                             area_id=area_id,
-                            fields=list(changes),
+                            fields=attempted_fields,
                         )
                     )
                     await self._async_reconcile_mowing_preference_write(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -43,6 +43,7 @@ from .coordinator_refresh import (
     runtime_tracking_active,
 )
 from .diagnostic_events import DreameLawnMowerDiagnosticEventStore
+from .dreame_lawn_mower_client.exceptions import write_was_attempted
 from .dreame_lawn_mower_client.feature_capabilities import FEATURE_LIVE_VIDEO
 from .dreame_lawn_mower_client.models import (
     DreameLawnMowerStatusBlob,
@@ -1580,8 +1581,8 @@ class DreameLawnMowerCoordinator(
                     execute=execute,
                     confirm_write=confirm_write,
                 )
-            except Exception:  # noqa: BLE001 - reconcile possibly applied writes
-                if execute:
+            except Exception as err:  # noqa: BLE001 - reconcile attempted writes
+                if execute and write_was_attempted(err):
                     self._pending_preference_confirmations = (
                         invalidate_preference_confirmations(
                             getattr(self, "_pending_preference_confirmations", []),

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -54,6 +54,14 @@ from .dreame_lawn_mower_client.schedule import (
     encode_schedule_payload_text,
 )
 from .performance import DreameLawnMowerPerformanceTracker
+from .preference_cache import (
+    CONFIRMED_PREFERENCE_RETENTION,
+    PendingPreferenceConfirmation,
+    invalidate_preference_confirmations,
+    merge_confirmed_preference_readback,
+    reconcile_pending_preference_readbacks,
+    retain_confirmed_preference_write,
+)
 from .runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
     observe_runtime_session_state,
@@ -192,6 +200,11 @@ class DreameLawnMowerCoordinator(
         self._batch_schedule_read_completed_at: float | None = None
         self._schedule_write_lock = asyncio.Lock()
         self._preference_write_lock = asyncio.Lock()
+        self._pending_preference_confirmations: list[
+            PendingPreferenceConfirmation
+        ] = []
+        self._preference_read_generation = 0
+        self._active_preference_read_generations: set[int] = set()
         self._device_settings_write_lock = asyncio.Lock()
         self._device_refresh_lock = asyncio.Lock()
         self._device_snapshot_generation = 0
@@ -1503,35 +1516,50 @@ class DreameLawnMowerCoordinator(
             return self.batch_device_data
 
         schedule_generation = getattr(self, "_schedule_cache_generation", 0)
+        preference_read_generation = self._begin_preference_read()
         try:
-            (
-                batch_schedule,
-                batch_mowing_preferences,
-                batch_ota_info,
-                batch_schedule_generation,
-            ) = await self._async_fetch_batch_device_data(force=force)
-        except Exception as err:  # noqa: BLE001 - best-effort extra metadata
-            _LOGGER.debug("Failed to refresh batch device data: %s", err)
-            return self.batch_device_data
+            try:
+                (
+                    batch_schedule,
+                    batch_mowing_preferences,
+                    batch_ota_info,
+                    batch_schedule_generation,
+                ) = await self._async_fetch_batch_device_data(force=force)
+            except Exception as err:  # noqa: BLE001 - best-effort extra metadata
+                _LOGGER.debug("Failed to refresh batch device data: %s", err)
+                return self.batch_device_data
 
-        payload = {
-            "captured_at": now.isoformat(),
-            "source": source,
-            "batch_schedule": batch_schedule,
-            "batch_mowing_preferences": batch_mowing_preferences,
-            "batch_ota_info": batch_ota_info,
-        }
-        self.batch_device_data = payload
-        self.batch_device_data_refreshed_at = now
-        if batch_schedule is not self.schedules and self._schedule_refresh_is_current(
-            schedule_generation
-        ):
-            self._cache_batch_schedules(
-                batch_schedule,
-                now=now,
-                read_generation=batch_schedule_generation,
+            batch_mowing_preferences = self._reconcile_pending_preference_readbacks(
+                batch_mowing_preferences,
+                now=datetime.now(UTC),
+                allow_convergence=self._preference_read_can_converge(
+                    preference_read_generation
+                ),
             )
-        return payload
+
+            payload = {
+                "captured_at": now.isoformat(),
+                "source": source,
+                "batch_schedule": batch_schedule,
+                "batch_mowing_preferences": batch_mowing_preferences,
+                "batch_ota_info": batch_ota_info,
+            }
+            self.batch_device_data = payload
+            self.batch_device_data_refreshed_at = (
+                self._batch_device_data_refreshed_at_for_preferences(now)
+            )
+            if (
+                batch_schedule is not self.schedules
+                and self._schedule_refresh_is_current(schedule_generation)
+            ):
+                self._cache_batch_schedules(
+                    batch_schedule,
+                    now=now,
+                    read_generation=batch_schedule_generation,
+                )
+            return payload
+        finally:
+            self._finish_preference_read(preference_read_generation)
 
     async def async_plan_mowing_preference_update(
         self,
@@ -1554,13 +1582,23 @@ class DreameLawnMowerCoordinator(
                 )
             except Exception:  # noqa: BLE001 - reconcile possibly applied writes
                 if execute:
+                    self._pending_preference_confirmations = (
+                        invalidate_preference_confirmations(
+                            getattr(self, "_pending_preference_confirmations", []),
+                            map_index=map_index,
+                            area_id=area_id,
+                            fields=list(changes),
+                        )
+                    )
                     await self._async_reconcile_mowing_preference_write(
                         suppress_errors=True,
                     )
                 raise
             self.last_preference_write_result = result
             if execute:
-                await self._async_reconcile_mowing_preference_write()
+                await self._async_reconcile_mowing_preference_write(
+                    confirmed_result=result,
+                )
             else:
                 self.async_update_listeners()
             return result
@@ -1568,6 +1606,7 @@ class DreameLawnMowerCoordinator(
     async def _async_reconcile_mowing_preference_write(
         self,
         *,
+        confirmed_result: Mapping[str, Any] | None = None,
         suppress_errors: bool = False,
     ) -> None:
         """Refresh coordinator state after a possibly applied preference write."""
@@ -1594,10 +1633,28 @@ class DreameLawnMowerCoordinator(
             return
 
         try:
-            await self.async_refresh_batch_device_data(
-                force=True,
-                source="mowing_preference_write",
+            confirmed_at = datetime.now(UTC)
+            self._pending_preference_confirmations = (
+                retain_confirmed_preference_write(
+                    getattr(self, "_pending_preference_confirmations", []),
+                    confirmed_result or {},
+                    confirmed_at=confirmed_at,
+                )
             )
+            reconciled = merge_confirmed_preference_readback(
+                self.batch_device_data,
+                confirmed_result or {},
+                confirmed_at=confirmed_at,
+            )
+            if reconciled is not None:
+                reconciled["captured_at"] = confirmed_at.isoformat()
+                reconciled["source"] = "mowing_preference_write_readback"
+                self.batch_device_data = reconciled
+            else:
+                await self.async_refresh_batch_device_data(
+                    force=True,
+                    source="mowing_preference_write",
+                )
             await self.async_request_refresh()
         finally:
             self.async_update_listeners()
@@ -1609,24 +1666,87 @@ class DreameLawnMowerCoordinator(
     ) -> dict[str, Any] | None:
         """Refresh only SETTINGS.* after the mower announces a change."""
         async with self._preference_write_lock:
+            preference_read_generation = self._begin_preference_read()
             try:
-                preferences = await self.client.async_get_batch_mowing_preferences(
-                    include_raw=False,
-                    map_index_hints=_app_map_index_hints(self.app_maps),
-                )
-            except Exception as err:  # noqa: BLE001 - retry on the next event pass
-                _LOGGER.debug("Failed to refresh mowing preferences: %s", err)
-                return None
-            if not _batch_mowing_preferences_read_succeeded(preferences):
-                _LOGGER.debug("Mowing preference refresh returned no usable maps")
-                return None
+                try:
+                    preferences = await self.client.async_get_batch_mowing_preferences(
+                        include_raw=False,
+                        map_index_hints=_app_map_index_hints(self.app_maps),
+                    )
+                except Exception as err:  # noqa: BLE001 - retry on next event pass
+                    _LOGGER.debug("Failed to refresh mowing preferences: %s", err)
+                    return None
+                if not _batch_mowing_preferences_read_succeeded(preferences):
+                    _LOGGER.debug("Mowing preference refresh returned no usable maps")
+                    return None
 
-            payload = dict(self.batch_device_data or {})
-            payload["captured_at"] = datetime.now(UTC).isoformat()
-            payload["source"] = source
-            payload["batch_mowing_preferences"] = preferences
-            self.batch_device_data = payload
-            return preferences
+                preferences = self._reconcile_pending_preference_readbacks(
+                    preferences,
+                    now=datetime.now(UTC),
+                    allow_convergence=self._preference_read_can_converge(
+                        preference_read_generation
+                    ),
+                )
+
+                payload = dict(self.batch_device_data or {})
+                payload["captured_at"] = datetime.now(UTC).isoformat()
+                payload["source"] = source
+                payload["batch_mowing_preferences"] = preferences
+                self.batch_device_data = payload
+                return preferences
+            finally:
+                self._finish_preference_read(preference_read_generation)
+
+    def _reconcile_pending_preference_readbacks(
+        self,
+        preferences: Mapping[str, Any],
+        *,
+        now: datetime,
+        allow_convergence: bool,
+    ) -> dict[str, Any]:
+        """Keep exact write fields until batch preference state catches up."""
+        reconciled, pending = reconcile_pending_preference_readbacks(
+            preferences,
+            getattr(self, "_pending_preference_confirmations", []),
+            now=now,
+            allow_convergence=allow_convergence,
+        )
+        self._pending_preference_confirmations = pending
+        return reconciled
+
+    def _batch_device_data_refreshed_at_for_preferences(
+        self,
+        now: datetime,
+    ) -> datetime:
+        """Schedule another batch read no later than confirmation expiry."""
+        pending = getattr(self, "_pending_preference_confirmations", [])
+        if not pending:
+            return now
+        earliest_expiry = min(
+            item.confirmed_at + CONFIRMED_PREFERENCE_RETENTION for item in pending
+        )
+        return min(now, earliest_expiry - BATCH_DEVICE_DATA_REFRESH_INTERVAL)
+
+    def _begin_preference_read(self) -> int:
+        """Track a preference read until its result can no longer publish."""
+        generation = getattr(self, "_preference_read_generation", 0) + 1
+        self._preference_read_generation = generation
+        active = getattr(self, "_active_preference_read_generations", None)
+        if active is None:
+            active = set()
+            self._active_preference_read_generations = active
+        active.add(generation)
+        return generation
+
+    def _preference_read_can_converge(self, generation: int) -> bool:
+        """Return whether no other preference read can publish after this one."""
+        return getattr(self, "_active_preference_read_generations", set()) == {
+            generation
+        }
+
+    def _finish_preference_read(self, generation: int) -> None:
+        """Mark a preference read as unable to publish further state."""
+        getattr(self, "_active_preference_read_generations", set()).discard(generation)
 
     async def _async_fetch_batch_device_data(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -660,12 +660,18 @@ class _DreameLawnMowerClientSettingsMixin:
             ),
         }
         if execute:
-            write_attempted = False
-            try:
-                responses: list[Any] = []
-                response_payloads: list[Any] = []
-                for request in request_sequence:
-                    write_attempted = True
+            possibly_applied_fields: list[str] = []
+            responses: list[Any] = []
+            response_payloads: list[Any] = []
+            for request in request_sequence:
+                request_fields = (
+                    [MOWING_PREFERENCE_MODE_FIELD]
+                    if request.get("t") == "PREP"
+                    else list(updated_preference)
+                    if isinstance(updated_preference, Mapping)
+                    else list(setting_changes)
+                )
+                try:
                     response = self._sync_call_app_action(request)
                     is_preference_write = request.get("t") in {"PRE", "PREP"}
                     response_data = _ensure_app_write_succeeded(
@@ -673,8 +679,24 @@ class _DreameLawnMowerClientSettingsMixin:
                         operation="Preference write",
                         allow_missing_data=is_preference_write,
                     )
+                except DreameLawnMowerCommandRejectedError as err:
+                    if possibly_applied_fields:
+                        mark_write_attempted(err, fields=possibly_applied_fields)
+                    raise
+                except Exception as err:
+                    mark_write_attempted(
+                        err,
+                        fields=(*possibly_applied_fields, *request_fields),
+                    )
+                    raise
+                possibly_applied_fields.extend(request_fields)
+                try:
                     responses.append(_json_safe(response, max_depth=4))
                     response_payloads.append(_json_safe(response_data, max_depth=4))
+                except Exception as err:
+                    mark_write_attempted(err, fields=possibly_applied_fields)
+                    raise
+            try:
                 result["readback"] = self._sync_verify_mowing_preference_readback(
                     map_index=map_index,
                     area_id=area_id,
@@ -695,8 +717,8 @@ class _DreameLawnMowerClientSettingsMixin:
                     result["responses"] = responses
                     result["response_data"] = response_payloads
             except Exception as err:
-                if write_attempted:
-                    mark_write_attempted(err)
+                if possibly_applied_fields:
+                    mark_write_attempted(err, fields=possibly_applied_fields)
                 raise
         return result
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -51,6 +51,7 @@ from .debug_ota_catalog import (
 from .exceptions import (
     DreameLawnMowerCommandRejectedError,
     DreameLawnMowerConnectionError,
+    mark_write_attempted,
 )
 from .exceptions import (
     DreameLawnMowerError as DreameLawnMowerError,
@@ -659,37 +660,44 @@ class _DreameLawnMowerClientSettingsMixin:
             ),
         }
         if execute:
-            responses: list[Any] = []
-            response_payloads: list[Any] = []
-            for request in request_sequence:
-                response = self._sync_call_app_action(request)
-                is_preference_write = request.get("t") in {"PRE", "PREP"}
-                response_data = _ensure_app_write_succeeded(
-                    response,
-                    operation="Preference write",
-                    allow_missing_data=is_preference_write,
+            write_attempted = False
+            try:
+                responses: list[Any] = []
+                response_payloads: list[Any] = []
+                for request in request_sequence:
+                    write_attempted = True
+                    response = self._sync_call_app_action(request)
+                    is_preference_write = request.get("t") in {"PRE", "PREP"}
+                    response_data = _ensure_app_write_succeeded(
+                        response,
+                        operation="Preference write",
+                        allow_missing_data=is_preference_write,
+                    )
+                    responses.append(_json_safe(response, max_depth=4))
+                    response_payloads.append(_json_safe(response_data, max_depth=4))
+                result["readback"] = self._sync_verify_mowing_preference_readback(
+                    map_index=map_index,
+                    area_id=area_id,
+                    setting_changes=setting_changes,
+                    requested_mode=requested_mode,
                 )
-                responses.append(_json_safe(response, max_depth=4))
-                response_payloads.append(_json_safe(response_data, max_depth=4))
-            result["readback"] = self._sync_verify_mowing_preference_readback(
-                map_index=map_index,
-                area_id=area_id,
-                setting_changes=setting_changes,
-                requested_mode=requested_mode,
-            )
-            result["verification_source"] = "preference_readback"
-            result["notes"].append(
-                "The requested values were confirmed through exact mower "
-                "preference readback."
-            )
-            result["executed"] = True
-            result["request_verified"] = True
-            if len(responses) == 1:
-                result["response"] = responses[0]
-                result["response_data"] = response_payloads[0]
-            else:
-                result["responses"] = responses
-                result["response_data"] = response_payloads
+                result["verification_source"] = "preference_readback"
+                result["notes"].append(
+                    "The requested values were confirmed through exact mower "
+                    "preference readback."
+                )
+                result["executed"] = True
+                result["request_verified"] = True
+                if len(responses) == 1:
+                    result["response"] = responses[0]
+                    result["response_data"] = response_payloads[0]
+                else:
+                    result["responses"] = responses
+                    result["response_data"] = response_payloads
+            except Exception as err:
+                if write_attempted:
+                    mark_write_attempted(err)
+                raise
         return result
 
     def _sync_verify_mowing_preference_readback(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings_helpers.py
@@ -177,7 +177,12 @@ def _mowing_preference_overview(preference: Mapping[str, Any]) -> dict[str, Any]
             "obstacle_avoidance_ai_classes"
         ),
         "edge_mowing_safe": preference.get("edge_mowing_safe"),
+        "obstacle_avoidance_sensitivity": preference.get(
+            "obstacle_avoidance_sensitivity"
+        ),
         "edge_cutting_attachment": preference.get("edge_cutting_attachment"),
+        "steering_mode": preference.get("steering_mode"),
+        "cutter_position_height": preference.get("cutter_position_height"),
     }
 
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_shared_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_shared_helpers.py
@@ -8,6 +8,7 @@ from datetime import UTC, datetime
 from typing import Any
 
 from .exceptions import (
+    DreameLawnMowerCommandRejectedError,
     DreameLawnMowerConnectionError,
 )
 from .exceptions import (
@@ -78,9 +79,13 @@ def _ensure_app_write_succeeded(
     allow_missing_data: bool = False,
 ) -> Any:
     """Require an explicit mower acknowledgement for a state-changing request."""
-    if not isinstance(value, Mapping) or value.get("r") != 0:
+    if not isinstance(value, Mapping) or value.get("r") is None:
         raise DreameLawnMowerConnectionError(
             f"{operation} failed: the mower did not acknowledge the request."
+        )
+    if value.get("r") != 0:
+        raise DreameLawnMowerCommandRejectedError(
+            f"{operation} failed: the mower rejected the request."
         )
     if "d" not in value and not allow_missing_data:
         raise DreameLawnMowerConnectionError(
@@ -88,8 +93,8 @@ def _ensure_app_write_succeeded(
         )
     data = value.get("d")
     if isinstance(data, Mapping) and data.get("r") not in (None, 0):
-        raise DreameLawnMowerConnectionError(
-            f"{operation} failed: the mower rejected the request: {value}"
+        raise DreameLawnMowerCommandRejectedError(
+            f"{operation} failed: the mower rejected the request."
         )
     return data
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/exceptions.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/exceptions.py
@@ -34,6 +34,19 @@ class DreameLawnMowerCommandRejectedError(DreameLawnMowerConnectionError):
     """The mower explicitly rejected a state-changing app command."""
 
 
+_WRITE_ATTEMPTED_ATTRIBUTE = "_dreame_write_attempted"
+
+
+def mark_write_attempted(error: Exception) -> None:
+    """Record that a state-changing request may have reached the mower."""
+    setattr(error, _WRITE_ATTEMPTED_ATTRIBUTE, True)
+
+
+def write_was_attempted(error: BaseException) -> bool:
+    """Return whether an error followed a state-changing request attempt."""
+    return getattr(error, _WRITE_ATTEMPTED_ATTRIBUTE, False) is True
+
+
 class DreameLawnMowerCloudAPIError(DeviceException):
     """A privacy-safe numeric error returned by the Dreame cloud API."""
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/exceptions.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/exceptions.py
@@ -1,3 +1,6 @@
+from collections.abc import Sequence
+
+
 class DeviceException(Exception):
     """Exception wrapping any communication errors with the device."""
 
@@ -34,17 +37,23 @@ class DreameLawnMowerCommandRejectedError(DreameLawnMowerConnectionError):
     """The mower explicitly rejected a state-changing app command."""
 
 
-_WRITE_ATTEMPTED_ATTRIBUTE = "_dreame_write_attempted"
+_WRITE_ATTEMPTED_FIELDS_ATTRIBUTE = "_dreame_write_attempted_fields"
 
 
-def mark_write_attempted(error: Exception) -> None:
+def mark_write_attempted(error: Exception, *, fields: Sequence[str]) -> None:
     """Record that a state-changing request may have reached the mower."""
-    setattr(error, _WRITE_ATTEMPTED_ATTRIBUTE, True)
+    attempted_fields = dict.fromkeys((*attempted_write_fields(error), *fields))
+    setattr(error, _WRITE_ATTEMPTED_FIELDS_ATTRIBUTE, tuple(attempted_fields))
 
 
-def write_was_attempted(error: BaseException) -> bool:
-    """Return whether an error followed a state-changing request attempt."""
-    return getattr(error, _WRITE_ATTEMPTED_ATTRIBUTE, False) is True
+def attempted_write_fields(error: BaseException) -> tuple[str, ...]:
+    """Return fields whose state-changing requests may have reached the mower."""
+    fields = getattr(error, _WRITE_ATTEMPTED_FIELDS_ATTRIBUTE, ())
+    return (
+        tuple(field for field in fields if isinstance(field, str))
+        if isinstance(fields, Sequence) and not isinstance(fields, str | bytes)
+        else ()
+    )
 
 
 class DreameLawnMowerCloudAPIError(DeviceException):

--- a/custom_components/dreame_lawn_mower/preference_cache.py
+++ b/custom_components/dreame_lawn_mower/preference_cache.py
@@ -1,0 +1,465 @@
+"""Reconcile exact mower preference write readback with batch snapshots."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any
+
+CONFIRMED_PREFERENCE_RETENTION = timedelta(minutes=2)
+PREFERENCE_MODE_FIELD = "preference_mode"
+
+_PREFERENCE_FIELD_COMPANIONS: dict[str, tuple[str, ...]] = {
+    "efficient_mode": ("efficient_mode_name",),
+    "mowing_direction_mode": (
+        "mowing_direction_mode_name",
+        "mowing_direction_method_name",
+    ),
+    "edge_mowing_walk_mode": (
+        "edge_mowing_walk_mode_name",
+        "turning_method_name",
+    ),
+    "cutter_position": ("cutter_position_name",),
+    "obstacle_avoidance_ai": ("obstacle_avoidance_ai_classes",),
+    "obstacle_avoidance_ai_classes": ("obstacle_avoidance_ai",),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class PendingPreferenceConfirmation:
+    """One exactly confirmed field awaiting agreement from batch readback."""
+
+    confirmed_at: datetime
+    map_index: int
+    area_id: int | None
+    field: str
+    values: Mapping[str, Any]
+
+
+def retain_confirmed_preference_write(
+    pending: Sequence[PendingPreferenceConfirmation],
+    write_result: Mapping[str, Any],
+    *,
+    confirmed_at: datetime,
+) -> list[PendingPreferenceConfirmation]:
+    """Retain the exact fields confirmed by a successful mower readback."""
+    confirmations = _confirmations_from_write(write_result, confirmed_at=confirmed_at)
+    if not confirmations:
+        return list(pending)
+
+    replaced_keys = {_confirmation_key(item) for item in confirmations}
+    retained = [
+        item
+        for item in pending
+        if confirmed_at - item.confirmed_at <= CONFIRMED_PREFERENCE_RETENTION
+        and _confirmation_key(item) not in replaced_keys
+        and not _confirmation_contradicted_by_write(item, write_result)
+    ]
+    retained.extend(confirmations)
+    return retained
+
+
+def invalidate_preference_confirmations(
+    pending: Sequence[PendingPreferenceConfirmation],
+    *,
+    map_index: int,
+    area_id: int | None,
+    fields: Sequence[str],
+) -> list[PendingPreferenceConfirmation]:
+    """Drop older values whose attempted rewrite has an uncertain outcome."""
+    invalidated_keys = {
+        (
+            map_index,
+            None if field == PREFERENCE_MODE_FIELD else area_id,
+            _canonical_field(field),
+        )
+        for field in fields
+    }
+    return [
+        item for item in pending if _confirmation_key(item) not in invalidated_keys
+    ]
+
+
+def reconcile_pending_preference_readbacks(
+    batch_preferences: Mapping[str, Any],
+    pending: Sequence[PendingPreferenceConfirmation],
+    *,
+    now: datetime,
+    allow_convergence: bool = True,
+) -> tuple[dict[str, Any], list[PendingPreferenceConfirmation]]:
+    """Overlay recent exact confirmations until batch state converges."""
+    active = [
+        item
+        for item in pending
+        if now - item.confirmed_at <= CONFIRMED_PREFERENCE_RETENTION
+    ]
+    if not active:
+        return _as_dict(batch_preferences), []
+
+    incoming_valid = _valid_batch_preferences(batch_preferences)
+    unresolved = (
+        [
+            item
+            for item in active
+            if not incoming_valid or not _confirmation_matches(batch_preferences, item)
+        ]
+        if allow_convergence
+        else active
+    )
+    if not unresolved:
+        return _as_dict(batch_preferences), []
+
+    reconciled = dict(batch_preferences)
+    for confirmation in unresolved:
+        applied = _apply_confirmation(reconciled, confirmation)
+        if applied is None:
+            with_restored_target = _restore_confirmation_target(
+                reconciled,
+                confirmation,
+            )
+            if with_restored_target is not None:
+                applied = _apply_confirmation(with_restored_target, confirmation)
+        if applied is not None:
+            reconciled = applied
+    return reconciled, unresolved
+
+
+def merge_confirmed_preference_readback(
+    batch_device_data: Mapping[str, Any] | None,
+    write_result: Mapping[str, Any],
+    *,
+    confirmed_at: datetime | None = None,
+) -> dict[str, Any] | None:
+    """Merge exact changed fields into a valid cached batch snapshot."""
+    if not isinstance(batch_device_data, Mapping):
+        return None
+    batch_preferences = batch_device_data.get("batch_mowing_preferences")
+    if not _valid_batch_preferences(batch_preferences):
+        return None
+
+    timestamp = confirmed_at or datetime.now().astimezone()
+    confirmations = _confirmations_from_write(write_result, confirmed_at=timestamp)
+    if not confirmations:
+        return None
+
+    reconciled_preferences = dict(batch_preferences)
+    for confirmation in confirmations:
+        applied = _apply_confirmation(
+            reconciled_preferences,
+            confirmation,
+        )
+        if applied is None:
+            return None
+        reconciled_preferences = applied
+    updated_batch_data = dict(batch_device_data)
+    updated_batch_data["batch_mowing_preferences"] = reconciled_preferences
+    return updated_batch_data
+
+
+def _confirmations_from_write(
+    write_result: Mapping[str, Any],
+    *,
+    confirmed_at: datetime,
+) -> list[PendingPreferenceConfirmation]:
+    if not _is_confirmed_write(write_result):
+        return []
+    map_index = _plain_int(write_result.get("map_index"))
+    readback = write_result.get("readback")
+    changed_fields = write_result.get("changed_fields")
+    if (
+        map_index is None
+        or not isinstance(readback, Mapping)
+        or not _field_sequence(changed_fields)
+    ):
+        return []
+
+    readback_map = readback.get("map")
+    if (
+        not isinstance(readback_map, Mapping)
+        or _plain_int(readback_map.get("idx")) != map_index
+    ):
+        return []
+
+    confirmations: list[PendingPreferenceConfirmation] = []
+    if PREFERENCE_MODE_FIELD in changed_fields:
+        mode_values = {
+            key: readback_map[key]
+            for key in ("mode", "mode_name")
+            if readback_map.get(key) is not None
+        }
+        if "mode" in mode_values:
+            confirmations.append(
+                PendingPreferenceConfirmation(
+                    confirmed_at=confirmed_at,
+                    map_index=map_index,
+                    area_id=None,
+                    field=PREFERENCE_MODE_FIELD,
+                    values=mode_values,
+                )
+            )
+
+    setting_fields = [
+        field for field in changed_fields if field != PREFERENCE_MODE_FIELD
+    ]
+    if not setting_fields:
+        return confirmations
+
+    area_id = _plain_int(write_result.get("area_id"))
+    readback_preference = readback.get("preference")
+    if (
+        area_id is None
+        or not isinstance(readback_preference, Mapping)
+        or _plain_int(readback_preference.get("area_id")) != area_id
+    ):
+        return confirmations
+
+    for field in setting_fields:
+        canonical_field = _canonical_field(field)
+        related_fields = (field, *_PREFERENCE_FIELD_COMPANIONS.get(field, ()))
+        values = {
+            key: readback_preference[key]
+            for key in related_fields
+            if key in readback_preference and readback_preference[key] is not None
+        }
+        if field not in values and canonical_field not in values:
+            continue
+        confirmations.append(
+            PendingPreferenceConfirmation(
+                confirmed_at=confirmed_at,
+                map_index=map_index,
+                area_id=area_id,
+                field=canonical_field,
+                values=values,
+            )
+        )
+    return confirmations
+
+
+def _confirmation_matches(
+    batch_preferences: Mapping[str, Any],
+    confirmation: PendingPreferenceConfirmation,
+) -> bool:
+    target = _confirmation_target(batch_preferences, confirmation)
+    return isinstance(target, Mapping) and all(
+        target.get(key) == value for key, value in confirmation.values.items()
+    )
+
+
+def _apply_confirmation(
+    batch_preferences: Mapping[str, Any],
+    confirmation: PendingPreferenceConfirmation,
+) -> dict[str, Any] | None:
+    maps = batch_preferences.get("maps")
+    if not _mapping_sequence(maps):
+        return None
+    map_position = _mapping_position(maps, "idx", confirmation.map_index)
+    if map_position is None:
+        return None
+
+    updated_map = dict(maps[map_position])
+    if confirmation.area_id is None:
+        updated_map.update(confirmation.values)
+    else:
+        preferences = updated_map.get("preferences")
+        if not _mapping_sequence(preferences):
+            return None
+        preference_position = _mapping_position(
+            preferences,
+            "area_id",
+            confirmation.area_id,
+        )
+        if preference_position is None:
+            return None
+        updated_preference = dict(preferences[preference_position])
+        updated_preference.update(confirmation.values)
+        updated_preferences = list(preferences)
+        updated_preferences[preference_position] = updated_preference
+        updated_map["preferences"] = updated_preferences
+
+    updated_maps = list(maps)
+    updated_maps[map_position] = updated_map
+    updated_batch_preferences = dict(batch_preferences)
+    updated_batch_preferences["maps"] = updated_maps
+    return updated_batch_preferences
+
+
+def _restore_confirmation_target(
+    batch_preferences: Mapping[str, Any],
+    confirmation: PendingPreferenceConfirmation,
+) -> dict[str, Any] | None:
+    """Restore only target identity and exactly confirmed values."""
+    batch_maps = batch_preferences.get("maps")
+    usable_batch_maps = list(batch_maps) if _mapping_sequence(batch_maps) else []
+    batch_map_position = _mapping_position(
+        usable_batch_maps,
+        "idx",
+        confirmation.map_index,
+    )
+    if batch_map_position is None:
+        updated_maps = usable_batch_maps
+        restored_map: dict[str, Any] = {
+            "idx": confirmation.map_index,
+            "available": confirmation.area_id is not None,
+            "area_count": 1 if confirmation.area_id is not None else 0,
+            "preferences": [],
+        }
+        if confirmation.area_id is None:
+            restored_map.update(confirmation.values)
+        else:
+            restored_map["preferences"] = [
+                {
+                    "map_index": confirmation.map_index,
+                    "area_id": confirmation.area_id,
+                    **confirmation.values,
+                }
+            ]
+        updated_maps.append(restored_map)
+        updated = dict(batch_preferences)
+        updated["maps"] = updated_maps
+        return updated
+    if confirmation.area_id is None:
+        return dict(batch_preferences)
+
+    batch_map = usable_batch_maps[batch_map_position]
+    batch_areas = batch_map.get("preferences")
+    if not _mapping_sequence(batch_areas):
+        updated_areas: list[Mapping[str, Any]] = []
+    elif _mapping_position(batch_areas, "area_id", confirmation.area_id) is not None:
+        return dict(batch_preferences)
+    else:
+        updated_areas = list(batch_areas)
+    updated_areas.append(
+        {
+            "map_index": confirmation.map_index,
+            "area_id": confirmation.area_id,
+            **confirmation.values,
+        }
+    )
+    updated_map = dict(batch_map)
+    updated_map["preferences"] = updated_areas
+    updated_map["area_count"] = len(updated_areas)
+    updated_map["available"] = bool(updated_areas)
+    updated_maps = usable_batch_maps
+    updated_maps[batch_map_position] = updated_map
+    updated = dict(batch_preferences)
+    updated["maps"] = updated_maps
+    return updated
+
+
+def _confirmation_target(
+    batch_preferences: Mapping[str, Any],
+    confirmation: PendingPreferenceConfirmation,
+) -> Mapping[str, Any] | None:
+    maps = batch_preferences.get("maps")
+    if not _mapping_sequence(maps):
+        return None
+    map_position = _mapping_position(maps, "idx", confirmation.map_index)
+    if map_position is None:
+        return None
+    target_map = maps[map_position]
+    if confirmation.area_id is None:
+        return target_map
+    preferences = target_map.get("preferences")
+    if not _mapping_sequence(preferences):
+        return None
+    preference_position = _mapping_position(
+        preferences,
+        "area_id",
+        confirmation.area_id,
+    )
+    return None if preference_position is None else preferences[preference_position]
+
+
+def _valid_batch_preferences(value: Any) -> bool:
+    return bool(
+        isinstance(value, Mapping)
+        and value.get("available") is True
+        and not value.get("errors")
+        and _mapping_sequence(value.get("maps"))
+    )
+
+
+def _is_confirmed_write(write_result: Mapping[str, Any]) -> bool:
+    return bool(
+        write_result.get("executed") is True
+        and write_result.get("request_verified") is True
+        and write_result.get("verification_source") == "preference_readback"
+    )
+
+
+def _confirmation_key(
+    confirmation: PendingPreferenceConfirmation,
+) -> tuple[int, int | None, str]:
+    return confirmation.map_index, confirmation.area_id, confirmation.field
+
+
+def _confirmation_contradicted_by_write(
+    confirmation: PendingPreferenceConfirmation,
+    write_result: Mapping[str, Any],
+) -> bool:
+    """Return whether later exact readback disproves an older confirmation."""
+    if _plain_int(write_result.get("map_index")) != confirmation.map_index:
+        return False
+    readback = write_result.get("readback")
+    if not isinstance(readback, Mapping):
+        return False
+    target = (
+        readback.get("map")
+        if confirmation.area_id is None
+        else readback.get("preference")
+        if _plain_int(write_result.get("area_id")) == confirmation.area_id
+        else None
+    )
+    return isinstance(target, Mapping) and any(
+        key in target and target.get(key) != value
+        for key, value in confirmation.values.items()
+    )
+
+
+def _canonical_field(field: str) -> str:
+    return (
+        "obstacle_avoidance_ai"
+        if field == "obstacle_avoidance_ai_classes"
+        else field
+    )
+
+
+def _mapping_position(
+    values: Sequence[Any],
+    key: str,
+    expected: int,
+) -> int | None:
+    return next(
+        (
+            position
+            for position, entry in enumerate(values)
+            if isinstance(entry, Mapping) and _plain_int(entry.get(key)) == expected
+        ),
+        None,
+    )
+
+
+def _plain_int(value: Any) -> int | None:
+    return value if isinstance(value, int) and not isinstance(value, bool) else None
+
+
+def _as_dict(value: Mapping[str, Any]) -> dict[str, Any]:
+    """Preserve normal decoded dict identity when no reconciliation is needed."""
+    return value if isinstance(value, dict) else dict(value)
+
+
+def _field_sequence(value: Any) -> bool:
+    return bool(
+        isinstance(value, Sequence)
+        and not isinstance(value, str | bytes | bytearray)
+        and all(isinstance(item, str) for item in value)
+    )
+
+
+def _mapping_sequence(value: Any) -> bool:
+    return bool(
+        isinstance(value, Sequence)
+        and not isinstance(value, str | bytes | bytearray)
+        and all(isinstance(item, Mapping) for item in value)
+    )

--- a/custom_components/dreame_lawn_mower/preference_cache.py
+++ b/custom_components/dreame_lawn_mower/preference_cache.py
@@ -45,16 +45,21 @@ def retain_confirmed_preference_write(
 ) -> list[PendingPreferenceConfirmation]:
     """Retain the exact fields confirmed by a successful mower readback."""
     confirmations = _confirmations_from_write(write_result, confirmed_at=confirmed_at)
-    if not confirmations:
-        return list(pending)
-
-    replaced_keys = {_confirmation_key(item) for item in confirmations}
     retained = [
         item
         for item in pending
         if confirmed_at - item.confirmed_at <= CONFIRMED_PREFERENCE_RETENTION
-        and _confirmation_key(item) not in replaced_keys
-        and not _confirmation_contradicted_by_write(item, write_result)
+        and (
+            not _is_confirmed_write(write_result)
+            or not _confirmation_contradicted_by_write(item, write_result)
+        )
+    ]
+    if not confirmations:
+        return retained
+
+    replaced_keys = {_confirmation_key(item) for item in confirmations}
+    retained = [
+        item for item in retained if _confirmation_key(item) not in replaced_keys
     ]
     retained.extend(confirmations)
     return retained

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -1441,7 +1441,7 @@ def test_failed_preference_verification_still_reconciles_coordinator_state() -> 
     coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
     coordinator.async_request_refresh = AsyncMock()
     attempted_error = RuntimeError("readback did not confirm")
-    mark_write_attempted(attempted_error)
+    mark_write_attempted(attempted_error, fields=["preference_mode"])
     coordinator.client = SimpleNamespace(
         async_plan_app_mowing_preference_update=AsyncMock(
             side_effect=attempted_error
@@ -1514,6 +1514,75 @@ def test_failed_preference_plan_preserves_confirmation_without_write_attempt() -
     coordinator.async_refresh_batch_device_data.assert_not_awaited()
     coordinator.async_request_refresh.assert_not_awaited()
     coordinator.async_update_listeners.assert_not_called()
+
+
+def test_failed_preference_sequence_invalidates_only_attempted_fields() -> None:
+    confirmed_at = datetime.now(UTC)
+    pending = retain_confirmed_preference_write(
+        [],
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        },
+        confirmed_at=confirmed_at,
+    )
+    pending = retain_confirmed_preference_write(
+        pending,
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": 1,
+            "changed_fields": ["mowing_height_cm"],
+            "readback": {
+                "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+                "preference": {"area_id": 1, "mowing_height_cm": 7.0},
+            },
+        },
+        confirmed_at=confirmed_at + timedelta(seconds=1),
+    )
+    attempted_error = RuntimeError("mode write failed")
+    mark_write_attempted(attempted_error, fields=["preference_mode"])
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator._pending_preference_confirmations = pending
+    coordinator.last_preference_write_result = None
+    coordinator.async_update_listeners = Mock()
+    coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_mowing_preference_update=AsyncMock(
+            side_effect=attempted_error
+        )
+    )
+
+    with pytest.raises(RuntimeError, match="mode write failed"):
+        asyncio.run(
+            coordinator.async_plan_mowing_preference_update(
+                map_index=0,
+                area_id=1,
+                changes={"preference_mode": "custom", "mowing_height_cm": 5.0},
+                execute=True,
+                confirm_write=True,
+            )
+        )
+
+    assert [item.field for item in coordinator._pending_preference_confirmations] == [
+        "mowing_height_cm"
+    ]
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
+    )
 
 
 def _coordinator_for_confirmed_preference_write(
@@ -2326,7 +2395,7 @@ def test_preference_reconciliation_listener_does_not_mask_write_error() -> None:
     coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
     coordinator.async_request_refresh = AsyncMock()
     attempted_error = RuntimeError("readback did not confirm")
-    mark_write_attempted(attempted_error)
+    mark_write_attempted(attempted_error, fields=["preference_mode"])
     coordinator.client = SimpleNamespace(
         async_plan_app_mowing_preference_update=AsyncMock(
             side_effect=attempted_error

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -2088,6 +2088,45 @@ def test_later_exact_readback_retires_contradicted_confirmation() -> None:
     assert [item.field for item in pending] == ["obstacle_avoidance_sensitivity"]
 
 
+def test_noop_exact_readback_retires_contradicted_confirmation() -> None:
+    confirmed_at = datetime.now(UTC)
+    pending = retain_confirmed_preference_write(
+        [],
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": 1,
+            "changed_fields": ["mowing_height_cm"],
+            "readback": {
+                "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+                "preference": {"area_id": 1, "mowing_height_cm": 7.0},
+            },
+        },
+        confirmed_at=confirmed_at,
+    )
+
+    pending = retain_confirmed_preference_write(
+        pending,
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": 1,
+            "changed_fields": [],
+            "readback": {
+                "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+                "preference": {"area_id": 1, "mowing_height_cm": 6.0},
+            },
+        },
+        confirmed_at=confirmed_at + timedelta(seconds=10),
+    )
+
+    assert pending == []
+
+
 def test_batch_freshness_expires_with_pending_preference_confirmation() -> None:
     confirmed_at = datetime.now(UTC)
     coordinator = object.__new__(DreameLawnMowerCoordinator)

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from contextlib import suppress
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock, patch
 
@@ -26,6 +26,10 @@ from custom_components.dreame_lawn_mower.coordinator_connectivity import (
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     FEATURE_LIVE_VIDEO,
+)
+from custom_components.dreame_lawn_mower.preference_cache import (
+    reconcile_pending_preference_readbacks,
+    retain_confirmed_preference_write,
 )
 from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
@@ -1412,6 +1416,22 @@ def test_preference_updates_are_serialized_around_full_payload_operation() -> No
 def test_failed_preference_verification_still_reconciles_coordinator_state() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._preference_write_lock = asyncio.Lock()
+    coordinator._pending_preference_confirmations = retain_confirmed_preference_write(
+        [],
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 1,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 1, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        },
+        confirmed_at=datetime.now(UTC),
+    )
     coordinator.last_preference_write_result = None
     coordinator.batch_device_data_refreshed_at = datetime.now(UTC)
     coordinator.async_update_listeners = Mock()
@@ -1428,7 +1448,7 @@ def test_failed_preference_verification_still_reconciles_coordinator_state() -> 
             coordinator.async_plan_mowing_preference_update(
                 map_index=1,
                 area_id=None,
-                changes={"preference_mode": "global"},
+                changes={"preference_mode": "custom"},
                 execute=True,
                 confirm_write=True,
             )
@@ -1441,6 +1461,767 @@ def test_failed_preference_verification_still_reconciles_coordinator_state() -> 
     )
     coordinator.async_request_refresh.assert_awaited_once_with()
     coordinator.async_update_listeners.assert_called_once_with()
+    assert coordinator._pending_preference_confirmations == []
+
+
+def _coordinator_for_confirmed_preference_write(
+    *,
+    batch_device_data,
+    confirmed,
+):
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator._pending_preference_confirmations = []
+    coordinator.last_preference_write_result = None
+    coordinator.batch_device_data = batch_device_data
+    coordinator.batch_device_data_refreshed_at = datetime.now(UTC)
+    coordinator.async_update_listeners = Mock()
+    coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_mowing_preference_update=AsyncMock(return_value=confirmed)
+    )
+    return coordinator
+
+
+def test_confirmed_preference_mode_readback_wins_over_stale_batch_cache() -> None:
+    stale_batch = {
+        "captured_at": "before-write",
+        "source": "batch_device_data",
+        "batch_mowing_preferences": {
+            "available": True,
+            "maps": [
+                {
+                    "idx": 0,
+                    "mode": 1,
+                    "mode_name": "custom",
+                    "preferences": [{"area_id": 0, "mowing_height_cm": 6.0}],
+                }
+            ],
+        },
+    }
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    coordinator = _coordinator_for_confirmed_preference_write(
+        batch_device_data=stale_batch,
+        confirmed=confirmed,
+    )
+
+    result = asyncio.run(
+        coordinator.async_plan_mowing_preference_update(
+            map_index=0,
+            area_id=None,
+            changes={"preference_mode": "global"},
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    assert result is confirmed
+    assert coordinator.last_preference_write_result is confirmed
+    assert coordinator.batch_device_data is not stale_batch
+    assert stale_batch["batch_mowing_preferences"]["maps"][0]["mode"] == 1
+    assert coordinator.batch_device_data["source"] == (
+        "mowing_preference_write_readback"
+    )
+    reconciled_map = coordinator.batch_device_data["batch_mowing_preferences"]["maps"][
+        0
+    ]
+    assert reconciled_map["mode"] == 0
+    assert reconciled_map["mode_name"] == "global"
+    assert coordinator.batch_device_data_refreshed_at is None
+    coordinator.async_refresh_batch_device_data.assert_not_awaited()
+    coordinator.async_request_refresh.assert_awaited_once_with()
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
+def test_confirmed_preference_setting_readback_updates_only_target_area() -> None:
+    batch_device_data = {
+        "batch_mowing_preferences": {
+            "available": True,
+            "maps": [
+                {
+                    "idx": 0,
+                    "available": True,
+                    "area_count": 2,
+                    "mode": 1,
+                    "mode_name": "custom",
+                    "preferences": [
+                        {
+                            "area_id": 1,
+                            "mowing_height_cm": 6.0,
+                            "obstacle_avoidance_sensitivity": 1,
+                        },
+                        {"area_id": 2, "mowing_height_cm": 5.0},
+                    ],
+                }
+            ],
+        }
+    }
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": 1,
+        "changed_fields": [
+            "mowing_height_cm",
+            "obstacle_avoidance_sensitivity",
+        ],
+        "readback": {
+            "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+            "preference": {
+                "map_index": 0,
+                "area_id": 1,
+                "reported_version": 51,
+                "mowing_height_cm": 7.0,
+                "obstacle_avoidance_sensitivity": 2,
+            },
+        },
+    }
+    coordinator = _coordinator_for_confirmed_preference_write(
+        batch_device_data=batch_device_data,
+        confirmed=confirmed,
+    )
+
+    asyncio.run(
+        coordinator.async_plan_mowing_preference_update(
+            map_index=0,
+            area_id=1,
+            changes={
+                "mowing_height_cm": 7.0,
+                "obstacle_avoidance_sensitivity": 2,
+            },
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    preferences = coordinator.batch_device_data["batch_mowing_preferences"]["maps"][0][
+        "preferences"
+    ]
+    assert preferences[0]["mowing_height_cm"] == 7.0
+    assert preferences[0]["obstacle_avoidance_sensitivity"] == 2
+    assert "reported_version" not in preferences[0]
+    assert preferences[1] == {"area_id": 2, "mowing_height_cm": 5.0}
+    coordinator.async_refresh_batch_device_data.assert_not_awaited()
+
+
+def test_inflight_batch_read_cannot_replace_confirmed_preference_cache() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        batch_schedule = {"available": True, "schedules": []}
+        coordinator.schedules = batch_schedule
+        coordinator.batch_device_data = None
+        coordinator.batch_device_data_refreshed_at = None
+        coordinator._schedule_cache_generation = 0
+        coordinator._pending_preference_confirmations = []
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.async_update_listeners = Mock()
+        read_started = asyncio.Event()
+        release_read = asyncio.Event()
+        read_count = 0
+
+        async def fetch_batch_device_data(**_kwargs):
+            nonlocal read_count
+            read_count += 1
+            if read_count == 1:
+                read_started.set()
+                await release_read.wait()
+            return (
+                batch_schedule,
+                {
+                    "available": True,
+                    "maps": [
+                        {
+                            "idx": 0,
+                            "mode": 1,
+                            "mode_name": "custom",
+                            "preferences": [],
+                        }
+                    ],
+                },
+                {"available": True},
+                0,
+            )
+
+        coordinator._async_fetch_batch_device_data = fetch_batch_device_data
+        refresh = asyncio.create_task(
+            coordinator.async_refresh_batch_device_data(
+                force=True,
+                source="background_before_write",
+            )
+        )
+        await read_started.wait()
+        confirmed = {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        }
+        await coordinator._async_reconcile_mowing_preference_write(
+            confirmed_result=confirmed,
+        )
+        assert read_count == 2
+        release_read.set()
+
+        result = await refresh
+
+        assert result is not None
+        assert result["batch_mowing_preferences"]["maps"][0]["mode_name"] == (
+            "global"
+        )
+
+    asyncio.run(scenario())
+
+
+def test_matching_read_does_not_unprotect_older_inflight_batch() -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        batch_schedule = {"available": True, "schedules": []}
+        coordinator.schedules = batch_schedule
+        coordinator.batch_device_data = None
+        coordinator.batch_device_data_refreshed_at = None
+        coordinator._schedule_cache_generation = 0
+        confirmed = {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        }
+        coordinator._pending_preference_confirmations = (
+            retain_confirmed_preference_write(
+                [],
+                confirmed,
+                confirmed_at=datetime.now(UTC),
+            )
+        )
+        older_read_started = asyncio.Event()
+        release_older_read = asyncio.Event()
+        read_count = 0
+
+        async def fetch_batch_device_data(**_kwargs):
+            nonlocal read_count
+            read_count += 1
+            mode = 1
+            if read_count == 1:
+                older_read_started.set()
+                await release_older_read.wait()
+            else:
+                mode = 0
+            return (
+                batch_schedule,
+                {
+                    "available": True,
+                    "maps": [
+                        {
+                            "idx": 0,
+                            "mode": mode,
+                            "mode_name": "global" if mode == 0 else "custom",
+                            "preferences": [],
+                        }
+                    ],
+                },
+                {"available": True},
+                0,
+            )
+
+        coordinator._async_fetch_batch_device_data = fetch_batch_device_data
+        older = asyncio.create_task(
+            coordinator.async_refresh_batch_device_data(force=True)
+        )
+        await older_read_started.wait()
+        matching = await coordinator.async_refresh_batch_device_data(force=True)
+
+        assert matching is not None
+        assert matching["batch_mowing_preferences"]["maps"][0]["mode"] == 0
+        assert coordinator._pending_preference_confirmations
+
+        release_older_read.set()
+        older_result = await older
+
+        assert older_result is not None
+        assert older_result["batch_mowing_preferences"]["maps"][0]["mode"] == 0
+        assert coordinator._pending_preference_confirmations
+
+    asyncio.run(scenario())
+
+
+def test_confirmed_preference_readback_without_cache_uses_batch_fallback() -> None:
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    coordinator = _coordinator_for_confirmed_preference_write(
+        batch_device_data=None,
+        confirmed=confirmed,
+    )
+
+    asyncio.run(
+        coordinator.async_plan_mowing_preference_update(
+            map_index=0,
+            area_id=None,
+            changes={"preference_mode": "global"},
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
+    )
+    coordinator.async_request_refresh.assert_awaited_once_with()
+    coordinator.async_update_listeners.assert_called_once_with()
+
+
+def test_confirmed_preference_readback_with_invalid_cache_uses_batch_fallback() -> None:
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    coordinator = _coordinator_for_confirmed_preference_write(
+        batch_device_data={
+            "batch_mowing_preferences": {
+                "available": False,
+                "errors": ["partial read"],
+                "maps": [
+                    {
+                        "idx": 0,
+                        "mode": 1,
+                        "mode_name": "custom",
+                        "preferences": [],
+                    }
+                ],
+            }
+        },
+        confirmed=confirmed,
+    )
+
+    asyncio.run(
+        coordinator.async_plan_mowing_preference_update(
+            map_index=0,
+            area_id=None,
+            changes={"preference_mode": "global"},
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
+    )
+    assert coordinator._pending_preference_confirmations
+
+
+def test_confirmed_preference_readback_with_missing_map_uses_batch_fallback() -> None:
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    coordinator = _coordinator_for_confirmed_preference_write(
+        batch_device_data={
+            "batch_mowing_preferences": {
+                "available": True,
+                "errors": [],
+                "maps": [
+                    {
+                        "idx": 1,
+                        "mode": 1,
+                        "mode_name": "custom",
+                        "preferences": [],
+                    }
+                ],
+            }
+        },
+        confirmed=confirmed,
+    )
+
+    asyncio.run(
+        coordinator.async_plan_mowing_preference_update(
+            map_index=0,
+            area_id=None,
+            changes={"preference_mode": "global"},
+            execute=True,
+            confirm_write=True,
+        )
+    )
+
+    coordinator.async_refresh_batch_device_data.assert_awaited_once_with(
+        force=True,
+        source="mowing_preference_write",
+    )
+
+
+def test_stale_batch_missing_area_retains_only_current_confirmed_target() -> None:
+    confirmed_at = datetime.now(UTC)
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": 1,
+        "changed_fields": ["mowing_height_cm"],
+        "readback": {
+            "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+            "preference": {
+                "map_index": 0,
+                "area_id": 1,
+                "mowing_height_cm": 7.0,
+            },
+        },
+    }
+    pending = retain_confirmed_preference_write(
+        [],
+        confirmed,
+        confirmed_at=confirmed_at,
+    )
+    incoming = {
+        "available": True,
+        "maps": [
+            {
+                "idx": 0,
+                "available": True,
+                "area_count": 1,
+                "mode": 1,
+                "mode_name": "custom",
+                "preferences": [{"area_id": 2, "mowing_height_cm": 6.0}],
+            }
+        ],
+    }
+
+    result, remaining = reconcile_pending_preference_readbacks(
+        incoming,
+        pending,
+        now=confirmed_at + timedelta(seconds=5),
+    )
+
+    areas = result["maps"][0]["preferences"]
+    assert areas == [
+        {"area_id": 2, "mowing_height_cm": 6.0},
+        {"map_index": 0, "area_id": 1, "mowing_height_cm": 7.0},
+    ]
+    assert result["maps"][0]["area_count"] == 2
+    assert result["maps"][0]["available"] is True
+    assert remaining == pending
+
+
+def test_failed_preference_read_preserves_error_and_unrelated_map_evidence() -> None:
+    confirmed_at = datetime.now(UTC)
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    pending = retain_confirmed_preference_write(
+        [],
+        confirmed,
+        confirmed_at=confirmed_at,
+    )
+    incoming = {
+        "available": False,
+        "errors": [{"stage": "settings", "error": "partial read"}],
+        "maps": [
+            {"idx": 0, "mode": 1, "mode_name": "custom", "preferences": []},
+            {
+                "idx": 1,
+                "mode": 1,
+                "mode_name": "custom",
+                "preferences": [{"area_id": 4, "mowing_height_cm": 5.0}],
+            },
+        ],
+    }
+
+    result, remaining = reconcile_pending_preference_readbacks(
+        incoming,
+        pending,
+        now=confirmed_at + timedelta(seconds=5),
+    )
+
+    assert result["available"] is False
+    assert result["errors"] == [{"stage": "settings", "error": "partial read"}]
+    assert result["maps"][0]["mode_name"] == "global"
+    assert result["maps"][1] is incoming["maps"][1]
+    assert remaining == pending
+
+
+def test_active_preference_confirmations_are_not_evicted_by_new_writes() -> None:
+    confirmed_at = datetime.now(UTC)
+    pending = []
+    for area_id in range(20):
+        pending = retain_confirmed_preference_write(
+            pending,
+            {
+                "executed": True,
+                "request_verified": True,
+                "verification_source": "preference_readback",
+                "map_index": 0,
+                "area_id": area_id,
+                "changed_fields": ["mowing_height_cm"],
+                "readback": {
+                    "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+                    "preference": {
+                        "area_id": area_id,
+                        "mowing_height_cm": 4.0,
+                    },
+                },
+            },
+            confirmed_at=confirmed_at + timedelta(seconds=area_id),
+        )
+
+    assert len(pending) == 20
+
+    pending = retain_confirmed_preference_write(
+        pending,
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 1,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 1, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        },
+        confirmed_at=confirmed_at + timedelta(minutes=3),
+    )
+
+    assert len(pending) == 1
+
+
+def test_later_exact_readback_retires_contradicted_confirmation() -> None:
+    confirmed_at = datetime.now(UTC)
+    pending = retain_confirmed_preference_write(
+        [],
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": 1,
+            "changed_fields": ["mowing_height_cm"],
+            "readback": {
+                "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+                "preference": {"area_id": 1, "mowing_height_cm": 7.0},
+            },
+        },
+        confirmed_at=confirmed_at,
+    )
+
+    pending = retain_confirmed_preference_write(
+        pending,
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": 1,
+            "changed_fields": ["obstacle_avoidance_sensitivity"],
+            "readback": {
+                "map": {"idx": 0, "mode": 1, "mode_name": "custom"},
+                "preference": {
+                    "area_id": 1,
+                    "mowing_height_cm": 6.0,
+                    "obstacle_avoidance_sensitivity": 2,
+                },
+            },
+        },
+        confirmed_at=confirmed_at + timedelta(seconds=10),
+    )
+
+    assert [item.field for item in pending] == ["obstacle_avoidance_sensitivity"]
+
+
+def test_batch_freshness_expires_with_pending_preference_confirmation() -> None:
+    confirmed_at = datetime.now(UTC)
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._pending_preference_confirmations = retain_confirmed_preference_write(
+        [],
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 0,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        },
+        confirmed_at=confirmed_at,
+    )
+
+    refreshed_at = coordinator._batch_device_data_refreshed_at_for_preferences(
+        confirmed_at + timedelta(seconds=30)
+    )
+
+    assert (
+        refreshed_at + coordinator_module.BATCH_DEVICE_DATA_REFRESH_INTERVAL
+        == confirmed_at + timedelta(minutes=2)
+    )
+
+
+def test_event_preference_refresh_preserves_recent_exact_confirmation() -> None:
+    stale_preferences = {
+        "available": True,
+        "errors": [],
+        "maps": [
+            {
+                "idx": 0,
+                "mode": 1,
+                "mode_name": "custom",
+                "preferences": [],
+            }
+        ],
+    }
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator._pending_preference_confirmations = retain_confirmed_preference_write(
+        [],
+        confirmed,
+        confirmed_at=datetime.now(UTC),
+    )
+    coordinator.app_maps = {"maps": [{"idx": 0}]}
+    coordinator.batch_device_data = None
+    coordinator.client = SimpleNamespace(
+        async_get_batch_mowing_preferences=AsyncMock(return_value=stale_preferences)
+    )
+
+    result = asyncio.run(
+        coordinator.async_refresh_mowing_preferences(source="preference_event")
+    )
+
+    assert result is not None
+    assert result["maps"][0]["mode_name"] == "global"
+    assert coordinator.batch_device_data["batch_mowing_preferences"] is result
+
+
+def test_preference_confirmation_clears_on_convergence_and_expires() -> None:
+    confirmed_at = datetime.now(UTC)
+    confirmed = {
+        "executed": True,
+        "request_verified": True,
+        "verification_source": "preference_readback",
+        "map_index": 0,
+        "area_id": None,
+        "changed_fields": ["preference_mode"],
+        "readback": {
+            "map": {"idx": 0, "mode": 0, "mode_name": "global"},
+            "preference": None,
+        },
+    }
+    pending = retain_confirmed_preference_write(
+        [],
+        confirmed,
+        confirmed_at=confirmed_at,
+    )
+    converged = {
+        "available": True,
+        "maps": [
+            {
+                "idx": 0,
+                "mode": 0,
+                "mode_name": "global",
+                "preferences": [],
+            }
+        ],
+    }
+    stale = {
+        "available": True,
+        "maps": [
+            {
+                "idx": 0,
+                "mode": 1,
+                "mode_name": "custom",
+                "preferences": [],
+            }
+        ],
+    }
+
+    converged_result, converged_pending = reconcile_pending_preference_readbacks(
+        converged,
+        pending,
+        now=confirmed_at + timedelta(seconds=5),
+    )
+    expired_result, expired_pending = reconcile_pending_preference_readbacks(
+        stale,
+        pending,
+        now=confirmed_at + timedelta(minutes=2, seconds=1),
+    )
+
+    assert converged_result is converged
+    assert converged_pending == []
+    assert expired_result is stale
+    assert expired_pending == []
 
 
 def test_preference_reconciliation_listener_does_not_mask_write_error() -> None:

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -27,6 +27,9 @@ from custom_components.dreame_lawn_mower.coordinator_connectivity import (
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     FEATURE_LIVE_VIDEO,
 )
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.exceptions import (
+    mark_write_attempted,
+)
 from custom_components.dreame_lawn_mower.preference_cache import (
     reconcile_pending_preference_readbacks,
     retain_confirmed_preference_write,
@@ -1437,9 +1440,11 @@ def test_failed_preference_verification_still_reconciles_coordinator_state() -> 
     coordinator.async_update_listeners = Mock()
     coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
     coordinator.async_request_refresh = AsyncMock()
+    attempted_error = RuntimeError("readback did not confirm")
+    mark_write_attempted(attempted_error)
     coordinator.client = SimpleNamespace(
         async_plan_app_mowing_preference_update=AsyncMock(
-            side_effect=RuntimeError("readback did not confirm")
+            side_effect=attempted_error
         )
     )
 
@@ -1462,6 +1467,53 @@ def test_failed_preference_verification_still_reconciles_coordinator_state() -> 
     coordinator.async_request_refresh.assert_awaited_once_with()
     coordinator.async_update_listeners.assert_called_once_with()
     assert coordinator._pending_preference_confirmations == []
+
+
+def test_failed_preference_plan_preserves_confirmation_without_write_attempt() -> None:
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator._preference_write_lock = asyncio.Lock()
+    coordinator._pending_preference_confirmations = retain_confirmed_preference_write(
+        [],
+        {
+            "executed": True,
+            "request_verified": True,
+            "verification_source": "preference_readback",
+            "map_index": 1,
+            "area_id": None,
+            "changed_fields": ["preference_mode"],
+            "readback": {
+                "map": {"idx": 1, "mode": 0, "mode_name": "global"},
+                "preference": None,
+            },
+        },
+        confirmed_at=datetime.now(UTC),
+    )
+    original_confirmations = coordinator._pending_preference_confirmations
+    coordinator.last_preference_write_result = None
+    coordinator.async_update_listeners = Mock()
+    coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
+    coordinator.async_request_refresh = AsyncMock()
+    coordinator.client = SimpleNamespace(
+        async_plan_app_mowing_preference_update=AsyncMock(
+            side_effect=ValueError("invalid preference value")
+        )
+    )
+
+    with pytest.raises(ValueError, match="invalid preference value"):
+        asyncio.run(
+            coordinator.async_plan_mowing_preference_update(
+                map_index=1,
+                area_id=None,
+                changes={"preference_mode": "invalid"},
+                execute=True,
+                confirm_write=True,
+            )
+        )
+
+    assert coordinator._pending_preference_confirmations is original_confirmations
+    coordinator.async_refresh_batch_device_data.assert_not_awaited()
+    coordinator.async_request_refresh.assert_not_awaited()
+    coordinator.async_update_listeners.assert_not_called()
 
 
 def _coordinator_for_confirmed_preference_write(
@@ -2273,9 +2325,11 @@ def test_preference_reconciliation_listener_does_not_mask_write_error() -> None:
     )
     coordinator.async_refresh_batch_device_data = AsyncMock(return_value={})
     coordinator.async_request_refresh = AsyncMock()
+    attempted_error = RuntimeError("readback did not confirm")
+    mark_write_attempted(attempted_error)
     coordinator.client = SimpleNamespace(
         async_plan_app_mowing_preference_update=AsyncMock(
-            side_effect=RuntimeError("readback did not confirm")
+            side_effect=attempted_error
         )
     )
 

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -563,10 +563,10 @@ def test_plan_app_mowing_preference_update_can_execute_confirmed_request() -> No
 def test_preference_write_accepts_data_less_success_after_exact_readback() -> None:
     client = _client()
     before = decode_mowing_preference_payload(
-        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1, 2, 0, 1]
+        [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1, 2, 0, 1, 35]
     )
     after = decode_mowing_preference_payload(
-        [221, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 3, 1, 2, 0, 1]
+        [221, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 3, 1, 2, 0, 1, 35]
     )
     reads = iter(
         [
@@ -597,11 +597,36 @@ def test_preference_write_accepts_data_less_success_after_exact_readback() -> No
         "people",
         "animals",
     ]
+    assert result["readback"]["preference"]["obstacle_avoidance_sensitivity"] == 2
+    assert result["readback"]["preference"]["steering_mode"] == 1
+    assert result["readback"]["preference"]["cutter_position_height"] == 35
     assert requests == [
         {
             "m": "s",
             "t": "PRE",
-            "d": [220, 0, 0, 1, 40, 2, 90, 1, 0, 1, 1, 2, 1, 15, 20, 3, 1, 2, 0, 1],
+            "d": [
+                220,
+                0,
+                0,
+                1,
+                40,
+                2,
+                90,
+                1,
+                0,
+                1,
+                1,
+                2,
+                1,
+                15,
+                20,
+                3,
+                1,
+                2,
+                0,
+                1,
+                35,
+            ],
         }
     ]
 

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -7,7 +7,7 @@ from unittest.mock import patch
 import pytest
 
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.exceptions import (
-    write_was_attempted,
+    attempted_write_fields,
 )
 from dreame_lawn_mower_client import (
     DreameLawnMowerClient,
@@ -806,7 +806,10 @@ def test_preference_write_still_rejects_failed_outer_response() -> None:
         "r": 5,
     }
 
-    with pytest.raises(DreameLawnMowerConnectionError, match="did not acknowledge"):
+    with pytest.raises(
+        DreameLawnMowerCommandRejectedError,
+        match="rejected",
+    ) as exc_info:
         client._sync_plan_app_mowing_preference_update(
             map_index=0,
             area_id=0,
@@ -814,6 +817,8 @@ def test_preference_write_still_rejects_failed_outer_response() -> None:
             execute=True,
             confirm_write=True,
         )
+
+    assert attempted_write_fields(exc_info.value) == ()
 
 
 def test_plan_app_mowing_preference_update_can_build_mode_only_request() -> None:
@@ -947,7 +952,7 @@ def test_preference_write_rejects_acknowledged_mode_without_matching_readback() 
         )
 
     assert [call.args[0] for call in sleep.call_args_list] == [1.0, 2.0]
-    assert write_was_attempted(exc_info.value) is True
+    assert attempted_write_fields(exc_info.value) == ("preference_mode",)
 
 
 def test_plan_app_mowing_preference_update_targets_global_area_zero() -> None:
@@ -1089,6 +1094,98 @@ def test_plan_app_mowing_preference_update_can_execute_mode_and_settings_sequenc
     assert [request["t"] for request in requests] == ["PREP", "PRE"]
 
 
+def test_preference_write_error_reports_only_attempted_command_fields() -> None:
+    client = _client()
+    preference = decode_mowing_preference_payload(
+        [8, 0, 11, 1, 40, 2, 35, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: _preference_result(  # type: ignore[method-assign]  # noqa: ARG005
+        preference
+    )
+    attempted_commands: list[str] = []
+
+    def fail_first_write(request):  # noqa: ANN001, ANN202
+        attempted_commands.append(request["t"])
+        raise RuntimeError("mode write failed")
+
+    client._sync_call_app_action = fail_first_write  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="mode write failed") as exc_info:
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=11,
+            changes={"preference_mode": "custom", "mowing_height_cm": 4.5},
+            execute=True,
+            confirm_write=True,
+        )
+
+    assert attempted_commands == ["PREP"]
+    assert attempted_write_fields(exc_info.value) == ("preference_mode",)
+
+
+def test_preference_write_error_reports_full_attempted_area_payload() -> None:
+    client = _client()
+    preference = decode_mowing_preference_payload(
+        [8, 0, 11, 1, 40, 2, 35, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: _preference_result(  # type: ignore[method-assign]  # noqa: ARG005
+        preference
+    )
+    attempted_commands: list[str] = []
+
+    def fail_area_write(request):  # noqa: ANN001, ANN202
+        attempted_commands.append(request["t"])
+        if request["t"] == "PREP":
+            return {"r": 0}
+        raise RuntimeError("area write failed")
+
+    client._sync_call_app_action = fail_area_write  # type: ignore[method-assign]
+
+    with pytest.raises(RuntimeError, match="area write failed") as exc_info:
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=11,
+            changes={"preference_mode": "custom", "mowing_height_cm": 4.5},
+            execute=True,
+            confirm_write=True,
+        )
+
+    attempted_fields = attempted_write_fields(exc_info.value)
+    assert attempted_commands == ["PREP", "PRE"]
+    assert "preference_mode" in attempted_fields
+    assert "mowing_height_cm" in attempted_fields
+    assert "efficient_mode" in attempted_fields
+
+
+def test_rejected_area_command_reports_only_prior_mode_write() -> None:
+    client = _client()
+    preference = decode_mowing_preference_payload(
+        [8, 0, 11, 1, 40, 2, 35, 1, 0, 1, 1, 2, 1, 15, 20, 7, 1]
+    )
+    client._sync_get_mowing_preferences = lambda **kwargs: _preference_result(  # type: ignore[method-assign]  # noqa: ARG005
+        preference
+    )
+
+    def reject_area_write(request):  # noqa: ANN001, ANN202
+        return {"r": 0} if request["t"] == "PREP" else {"r": 5}
+
+    client._sync_call_app_action = reject_area_write  # type: ignore[method-assign]
+
+    with pytest.raises(
+        DreameLawnMowerCommandRejectedError,
+        match="rejected",
+    ) as exc_info:
+        client._sync_plan_app_mowing_preference_update(
+            map_index=0,
+            area_id=11,
+            changes={"preference_mode": "custom", "mowing_height_cm": 4.5},
+            execute=True,
+            confirm_write=True,
+        )
+
+    assert attempted_write_fields(exc_info.value) == ("preference_mode",)
+
+
 def test_plan_app_mowing_preference_update_rejects_global_mode_with_zone_changes() -> (
     None
 ):
@@ -1105,7 +1202,7 @@ def test_plan_app_mowing_preference_update_rejects_global_mode_with_zone_changes
             confirm_write=True,
         )
 
-    assert write_was_attempted(exc_info.value) is False
+    assert attempted_write_fields(exc_info.value) == ()
 
 
 def test_plan_app_mowing_preference_update_rejects_unconfirmed_execute() -> None:

--- a/tests/test_mowing_preferences.py
+++ b/tests/test_mowing_preferences.py
@@ -6,6 +6,9 @@ from unittest.mock import patch
 
 import pytest
 
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.exceptions import (
+    write_was_attempted,
+)
 from dreame_lawn_mower_client import (
     DreameLawnMowerClient,
     DreameLawnMowerCommandRejectedError,
@@ -933,7 +936,7 @@ def test_preference_write_rejects_acknowledged_mode_without_matching_readback() 
         pytest.raises(
             DreameLawnMowerCommandRejectedError,
             match="readback did not confirm.*preference_mode",
-        ),
+        ) as exc_info,
     ):
         client._sync_plan_app_mowing_preference_update(
             map_index=0,
@@ -944,6 +947,7 @@ def test_preference_write_rejects_acknowledged_mode_without_matching_readback() 
         )
 
     assert [call.args[0] for call in sleep.call_args_list] == [1.0, 2.0]
+    assert write_was_attempted(exc_info.value) is True
 
 
 def test_plan_app_mowing_preference_update_targets_global_area_zero() -> None:
@@ -1092,12 +1096,16 @@ def test_plan_app_mowing_preference_update_rejects_global_mode_with_zone_changes
     cloud = _FakePreferenceCloud()
     client._sync_get_cloud_protocol = lambda: cloud
 
-    with pytest.raises(ValueError, match="preference_mode=global"):
+    with pytest.raises(ValueError, match="preference_mode=global") as exc_info:
         client._sync_plan_app_mowing_preference_update(
             map_index=0,
             area_id=11,
             changes={"preference_mode": "global", "mowing_height_cm": 5},
+            execute=True,
+            confirm_write=True,
         )
+
+    assert write_was_attempted(exc_info.value) is False
 
 
 def test_plan_app_mowing_preference_update_rejects_unconfirmed_execute() -> None:


### PR DESCRIPTION
## Summary

- preserve only preference fields confirmed by exact mower readback while lagging batch and event refreshes converge
- coordinate concurrent publishers and carry command-scoped failure evidence, so only PREP/PRE fields that may have applied are invalidated while rejected or unattempted commands preserve prior confirmations
- retire older confirmations whenever later exact readback contradicts them, including successful no-op writes
- preserve incoming failure evidence and unrelated map data while restoring only minimal missing targets and their derived metadata
- retain exact readback for every writable preference field without advancing full batch freshness, and schedule refresh at the earliest confirmation expiry

Fixes the stale readback regression reported in https://github.com/EvotecIT/homeassistant-dreamelawnmower/issues/157.

## Validation

- full Home Assistant test suite on Linux/WSL
- focused coordinator, concurrency, command-sequence failure, explicit rejection, no-op write, partial-read, retention, and mowing-preference regression suites
- Ruff and diff checks