### PR TITLE
Handle delayed targeted mowing confirmation

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -336,7 +336,7 @@ _SPOT_TASK_CONFIRMATION_STATUSES = _GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES | 
     "spot_cleaning",
     "spot_cleaning_paused",
 }
-_TARGETED_TASK_CONFIRMATION_OFFSETS_SECONDS = (0.5, 2.0, 5.0, 9.0, 12.0)
+_TARGETED_TASK_CONFIRMATION_OFFSETS_SECONDS = (0.5, 2.0, 5.0, 9.0, 12.0, 14.5)
 _TARGETED_TASK_CONFIRMATION_TIMEOUT_SECONDS = 15.0
 
 
@@ -860,6 +860,10 @@ class DreameLawnMowerClient(
                     snapshot = await self._async_cached_authoritative_snapshot()
                 except DreameLawnMowerConnectionError:
                     continue
+                readable = readable or (
+                    _task_confirmation_key(snapshot)
+                    != _task_confirmation_key(baseline)
+                )
             else:
                 readable = True
             if _targeted_task_confirmed(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -336,7 +336,8 @@ _SPOT_TASK_CONFIRMATION_STATUSES = _GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES | 
     "spot_cleaning",
     "spot_cleaning_paused",
 }
-_TARGETED_TASK_CONFIRMATION_DELAYS_SECONDS = (0.5, 1.5, 3.0, 5.0, 5.0)
+_TARGETED_TASK_CONFIRMATION_OFFSETS_SECONDS = (0.5, 2.0, 5.0, 9.0, 12.0)
+_TARGETED_TASK_CONFIRMATION_TIMEOUT_SECONDS = 15.0
 
 
 def _task_confirmation_key(snapshot: DreameLawnMowerSnapshot) -> tuple[Any, ...]:
@@ -711,17 +712,15 @@ class DreameLawnMowerClient(
         except _DreameLawnMowerCommandRejectedError:
             raise
         except DreameLawnMowerConnectionError as err:
-            return await self._async_reconcile_ambiguous_mutation(
-                "start zone mowing",
-                err,
-                lambda snapshot: _targeted_task_confirmed(
-                    snapshot,
-                    baseline,
-                    _ZONE_TASK_CONFIRMATION_STATUSES,
-                    expected_operation=_MOWING_TASK_ZONE,
-                    requested_target_ids=requested_zone_ids,
-                ),
+            await self._async_require_targeted_task_confirmation(
+                "zone mowing",
+                baseline,
+                _ZONE_TASK_CONFIRMATION_STATUSES,
+                expected_operation=_MOWING_TASK_ZONE,
+                requested_target_ids=requested_zone_ids,
+                original_error=err,
             )
+            return None
         await self._async_require_targeted_task_confirmation(
             "zone mowing",
             baseline,
@@ -754,16 +753,14 @@ class DreameLawnMowerClient(
         except _DreameLawnMowerCommandRejectedError:
             raise
         except DreameLawnMowerConnectionError as err:
-            return await self._async_reconcile_ambiguous_mutation(
-                "start edge mowing",
-                err,
-                lambda snapshot: _targeted_task_confirmed(
-                    snapshot,
-                    baseline,
-                    _EDGE_TASK_CONFIRMATION_STATUSES,
-                    expected_operation=_MOWING_TASK_EDGE,
-                ),
+            await self._async_require_targeted_task_confirmation(
+                "edge mowing",
+                baseline,
+                _EDGE_TASK_CONFIRMATION_STATUSES,
+                expected_operation=_MOWING_TASK_EDGE,
+                original_error=err,
             )
+            return None
         await self._async_require_targeted_task_confirmation(
             "edge mowing",
             baseline,
@@ -791,17 +788,15 @@ class DreameLawnMowerClient(
         except _DreameLawnMowerCommandRejectedError:
             raise
         except DreameLawnMowerConnectionError as err:
-            return await self._async_reconcile_ambiguous_mutation(
-                "start spot mowing",
-                err,
-                lambda snapshot: _targeted_task_confirmed(
-                    snapshot,
-                    baseline,
-                    _SPOT_TASK_CONFIRMATION_STATUSES,
-                    expected_operation=_MOWING_TASK_SPOT,
-                    requested_target_ids=requested_spot_ids,
-                ),
+            await self._async_require_targeted_task_confirmation(
+                "spot mowing",
+                baseline,
+                _SPOT_TASK_CONFIRMATION_STATUSES,
+                expected_operation=_MOWING_TASK_SPOT,
+                requested_target_ids=requested_spot_ids,
+                original_error=err,
             )
+            return None
         await self._async_require_targeted_task_confirmation(
             "spot mowing",
             baseline,
@@ -839,16 +834,34 @@ class DreameLawnMowerClient(
         *,
         expected_operation: int,
         requested_target_ids: frozenset[int] | None = None,
+        original_error: DreameLawnMowerConnectionError | None = None,
     ) -> None:
-        """Require authoritative task-type evidence after a successful write."""
+        """Require bounded task-type evidence after a targeted write attempt."""
         readable = False
-        for delay in _TARGETED_TASK_CONFIRMATION_DELAYS_SECONDS:
-            await asyncio.sleep(delay)
+        loop = asyncio.get_running_loop()
+        started_at = loop.time()
+        deadline = time.monotonic() + _TARGETED_TASK_CONFIRMATION_TIMEOUT_SECONDS
+        for offset in _TARGETED_TASK_CONFIRMATION_OFFSETS_SECONDS:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
+            delay = started_at + offset - loop.time()
+            if delay > 0:
+                await asyncio.sleep(min(delay, remaining))
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
+                break
             try:
-                snapshot = await self._async_refresh_authoritative_snapshot()
+                snapshot = await self._async_refresh_authoritative_snapshot(
+                    deadline=deadline,
+                )
             except DreameLawnMowerConnectionError:
-                continue
-            readable = True
+                try:
+                    snapshot = await self._async_cached_authoritative_snapshot()
+                except DreameLawnMowerConnectionError:
+                    continue
+            else:
+                readable = True
             if _targeted_task_confirmed(
                 snapshot,
                 baseline,
@@ -858,6 +871,12 @@ class DreameLawnMowerClient(
             ):
                 return
 
+        if original_error is not None:
+            raise DreameLawnMowerConnectionError(
+                f"The mower may have received the {label} request, but its exact "
+                "targeted task could not be confirmed after the connection was "
+                "interrupted. Refresh the mower state before trying again."
+            ) from original_error
         if readable:
             raise _DreameLawnMowerCommandRejectedError(
                 f"The mower acknowledged the {label} request but did not enter "

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -336,7 +336,7 @@ _SPOT_TASK_CONFIRMATION_STATUSES = _GENERIC_ACTIVE_TASK_CONFIRMATION_STATUSES | 
     "spot_cleaning",
     "spot_cleaning_paused",
 }
-_TARGETED_TASK_CONFIRMATION_DELAYS_SECONDS = (0.5, 1.5, 3.0)
+_TARGETED_TASK_CONFIRMATION_DELAYS_SECONDS = (0.5, 1.5, 3.0, 5.0, 5.0)
 
 
 def _task_confirmation_key(snapshot: DreameLawnMowerSnapshot) -> tuple[Any, ...]:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -266,18 +266,46 @@ class _DreameLawnMowerClientCoreMixin:
 
     async def _async_refresh_authoritative_snapshot(
         self,
+        *,
+        deadline: float | None = None,
     ) -> DreameLawnMowerSnapshot:
         """Force properties and apply heartbeat reconciliation before decisions."""
-        device = await asyncio.to_thread(self._sync_update_device, True)
+        if deadline is None:
+            device = await asyncio.to_thread(self._sync_update_device, True)
+        else:
+            device = await asyncio.to_thread(
+                self._sync_update_device,
+                True,
+                deadline=deadline,
+            )
         return await asyncio.to_thread(self._snapshot_from_device, device)
 
-    def _sync_update_device(self, force_request_properties: bool = False):
+    async def _async_cached_authoritative_snapshot(self) -> DreameLawnMowerSnapshot:
+        """Apply heartbeat reconciliation to the current in-memory device state."""
+        device = await asyncio.to_thread(self._ensure_device)
+        return await asyncio.to_thread(self._snapshot_from_device, device)
+
+    def _sync_update_device(
+        self,
+        force_request_properties: bool = False,
+        *,
+        deadline: float | None = None,
+    ):
         device = self._ensure_device()
         try:
             if force_request_properties:
-                device.update(force_request_properties=True)
+                if deadline is None:
+                    device.update(force_request_properties=True)
+                else:
+                    device.update(
+                        force_request_properties=True,
+                        deadline=deadline,
+                    )
             else:
-                device.update()
+                if deadline is None:
+                    device.update()
+                else:
+                    device.update(deadline=deadline)
         except DeviceException as err:
             raise DreameLawnMowerConnectionError(str(err)) from err
         return device

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -558,11 +558,7 @@ class DreameMowerDevice(
         if self._update_running:
             return
 
-        if not self.cloud_connected:
-            if deadline is not None:
-                raise DeviceUpdateFailedException(
-                    "The cloud connection is unavailable for the bounded update."
-                )
+        if not self.cloud_connected and deadline is None:
             self.connect_cloud()
             self.connect_device()
 

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device.py
@@ -546,7 +546,12 @@ class DreameMowerDevice(
 
 
 
-    def update(self, force_request_properties=False) -> None:
+    def update(
+        self,
+        force_request_properties=False,
+        *,
+        deadline: float | None = None,
+    ) -> None:
         """Get properties from the device."""
         _LOGGER.debug("Device update: %s", self._update_interval)
 
@@ -554,6 +559,10 @@ class DreameMowerDevice(
             return
 
         if not self.cloud_connected:
+            if deadline is not None:
+                raise DeviceUpdateFailedException(
+                    "The cloud connection is unavailable for the bounded update."
+                )
             self.connect_cloud()
             self.connect_device()
 
@@ -644,11 +653,22 @@ class DreameMowerDevice(
                 force_request_properties = True
 
             if not self._protocol.dreame_cloud or force_request_properties:
-                self._request_properties(properties)
+                if deadline is None:
+                    self._request_properties(properties)
+                else:
+                    self._request_properties(properties, deadline=deadline)
             elif self.status.map_backup_status:
-                self._request_properties([DreameMowerProperty.MAP_BACKUP_STATUS])
+                properties = [DreameMowerProperty.MAP_BACKUP_STATUS]
+                if deadline is None:
+                    self._request_properties(properties)
+                else:
+                    self._request_properties(properties, deadline=deadline)
             elif self.status.map_recovery_status:
-                self._request_properties([DreameMowerProperty.MAP_RECOVERY_STATUS])
+                properties = [DreameMowerProperty.MAP_RECOVERY_STATUS]
+                if deadline is None:
+                    self._request_properties(properties)
+                else:
+                    self._request_properties(properties, deadline=deadline)
         except Exception as ex:
             self._update_running = False
             raise DeviceUpdateFailedException(ex) from None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/device_state.py
@@ -508,7 +508,12 @@ class _DreameMowerDeviceStateMixin:
             key in _EXTERNAL_REALTIME_UPDATE_KEYS and previous_value != value
         )
 
-    def _request_properties(self, properties: list[DreameMowerProperty] = None) -> bool:
+    def _request_properties(
+        self,
+        properties: list[DreameMowerProperty] = None,
+        *,
+        deadline: float | None = None,
+    ) -> bool:
         """Request properties from the device."""
         if not properties:
             properties = self._default_properties
@@ -521,7 +526,11 @@ class _DreameMowerDeviceStateMixin:
                 if "aiid" not in mapping and (not self._ready or prop.value in self.data):
                     property_list.append({"did": str(prop.value), **mapping})
 
-        results = self._protocol.get_properties(property_list)
+        results = (
+            self._protocol.get_properties(property_list)
+            if deadline is None
+            else self._protocol.get_properties(property_list, deadline=deadline)
+        )
         return self._handle_properties(results)
 
     def _update_status(self, task_status: DreameMowerTaskStatus, status: DreameMowerStatus) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol.py
@@ -176,34 +176,71 @@ class DreameMowerProtocol:
         self.device_cloud.send_async(
             cloud_callback, method, parameters=parameters, retry_count=retry_count)
 
-    def send(self, method, parameters: Any = None, retry_count: int = 0) -> Any:
+    def send(
+        self,
+        method,
+        parameters: Any = None,
+        retry_count: int = 0,
+        *,
+        deadline: float | None = None,
+    ) -> Any:
         if not self.device_cloud:
             raise DeviceException("Cloud connection missing") from None
 
         if not self.device_cloud.logged_in:
             _LOGGER.info("send: Not logged in over cloud. Try to log in.")
             # Use different session for device cloud
-            self.device_cloud.login()
+            if deadline is None:
+                self.device_cloud.login()
+            else:
+                self.device_cloud.login(deadline=deadline)
             if self.device_cloud.logged_in and not self.device_cloud.device_id:
                 if self.cloud.device_id:
                     _LOGGER.info("send: cloud device id")
                     self.device_cloud._did = self.cloud.device_id
                 elif self._mac:
                     _LOGGER.info("send: using _mac")
-                    self.device_cloud.get_info(self._mac)
+                    if deadline is None:
+                        self.device_cloud.get_info(self._mac)
+                    else:
+                        self.device_cloud.get_info(self._mac, deadline=deadline)
 
         if not self.device_cloud.logged_in:
             raise DeviceException(
                 "Unable to login to device over cloud") from None
 
         _LOGGER.debug("DreameMowerProtocol.send %s %s", method, parameters)
+        send_options = {}
+        if deadline is not None:
+            send_options["deadline"] = deadline
         response = self.device_cloud.send(
-            method, parameters=parameters, retry_count=retry_count)
+            method,
+            parameters=parameters,
+            retry_count=retry_count,
+            **send_options,
+        )
         _LOGGER.debug("DreameMowerProtocol.send response %s", response)
         return response
 
-    def get_properties(self, parameters: Any = None, retry_count: int = 1) -> Any:
-        return self.send("get_properties", parameters=parameters, retry_count=retry_count)
+    def get_properties(
+        self,
+        parameters: Any = None,
+        retry_count: int = 1,
+        *,
+        deadline: float | None = None,
+    ) -> Any:
+        if deadline is None:
+            return self.send(
+                "get_properties",
+                parameters=parameters,
+                retry_count=retry_count,
+            )
+        return self.send(
+            "get_properties",
+            parameters=parameters,
+            retry_count=retry_count,
+            deadline=deadline,
+        )
 
     def set_property(self, siid: int, piid: int, value: Any = None, retry_count: int = 0) -> Any:
         return self.set_properties(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -877,10 +877,19 @@ class DreameMowerDreameHomeCloudProtocol:
             return data
         return None
 
-    def get_info(self, mac: str) -> Tuple[Optional[str], Optional[str]]:
+    def get_info(
+        self,
+        mac: str,
+        *,
+        deadline: float | None = None,
+    ) -> tuple[str | None, str | None]:
         if self._did is not None:
             return " ", self._host
-        devices = self.get_devices()
+        devices = (
+            self.get_devices()
+            if deadline is None
+            else self.get_devices(deadline=deadline)
+        )
         if devices is not None:
             found = list(
                 filter(

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from collections.abc import Awaitable
 from time import time
 from types import SimpleNamespace
 from typing import Any
@@ -43,6 +44,7 @@ from .control_options import (
     mowing_action_label,
 )
 from .coordinator import DreameLawnMowerCoordinator
+from .dreame_lawn_mower_client import DreameLawnMowerConnectionError
 from .dreame_lawn_mower_client.feature_capabilities import (
     resolved_feature_capabilities,
 )
@@ -73,6 +75,14 @@ ACTIVITY_MAP = {
     ACTIVITY_PAUSED: LawnMowerActivity.PAUSED,
     ACTIVITY_RETURNING: LawnMowerActivity.RETURNING,
 }
+
+
+async def _async_run_targeted_mowing_command(command: Awaitable[Any]) -> Any:
+    """Run a targeted command with Home Assistant service error semantics."""
+    try:
+        return await command
+    except DreameLawnMowerConnectionError as err:
+        raise HomeAssistantError(str(err)) from err
 
 
 def _normalize_contour_ids(contour_ids: Any) -> list[list[int]]:
@@ -492,7 +502,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
                 raise HomeAssistantError(
                     "No current-map edge contour is available to start."
                 )
-            await self.coordinator.client.async_start_edge_mowing([list(contour_id)])
+            await _async_run_targeted_mowing_command(
+                self.coordinator.client.async_start_edge_mowing([list(contour_id)])
+            )
             new_session = True
         elif action == MOWING_ACTION_ZONE:
             self._ensure_selected_map_matches_active()
@@ -505,7 +517,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             zone_id = self._selected_zone_id(zone_entries)
             if zone_id is None:
                 raise HomeAssistantError("No current-map zone is available to start.")
-            await self.coordinator.client.async_start_zone_mowing([zone_id])
+            await _async_run_targeted_mowing_command(
+                self.coordinator.client.async_start_zone_mowing([zone_id])
+            )
             new_session = True
         elif action == MOWING_ACTION_SPOT:
             self._ensure_selected_map_matches_active()
@@ -517,7 +531,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             spot_id = self._selected_spot_id(spot_entries)
             if spot_id is None:
                 raise HomeAssistantError("No current-map spot is available to start.")
-            await self.coordinator.client.async_start_spot_mowing([spot_id])
+            await _async_run_targeted_mowing_command(
+                self.coordinator.client.async_start_spot_mowing([spot_id])
+            )
             new_session = True
         else:
             new_session = await self.coordinator.client.async_start_mowing()
@@ -548,7 +564,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        await self.coordinator.client.async_start_zone_mowing(normalized)
+        await _async_run_targeted_mowing_command(
+            self.coordinator.client.async_start_zone_mowing(normalized)
+        )
         self.coordinator.selected_mowing_action = MOWING_ACTION_ZONE
         self.coordinator.selected_zone_id = (
             normalized[0] if len(normalized) == 1 else None
@@ -580,7 +598,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
         )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        await self.coordinator.client.async_start_spot_mowing(normalized)
+        await _async_run_targeted_mowing_command(
+            self.coordinator.client.async_start_spot_mowing(normalized)
+        )
         self.coordinator.selected_mowing_action = MOWING_ACTION_SPOT
         self.coordinator.selected_spot_id = (
             normalized[0] if len(normalized) == 1 else None
@@ -625,7 +645,9 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             )
         runtime_cache = getattr(self.coordinator, "runtime_telemetry_cache", None)
         observed_generation = runtime_mission_session_generation(runtime_cache)
-        await self.coordinator.client.async_start_edge_mowing(normalized)
+        await _async_run_targeted_mowing_command(
+            self.coordinator.client.async_start_edge_mowing(normalized)
+        )
         self.coordinator.selected_mowing_action = MOWING_ACTION_EDGE
         self.coordinator.selected_contour_id = (
             tuple(normalized[0]) if len(normalized) == 1 else None

--- a/tests/test_current_map_controls.py
+++ b/tests/test_current_map_controls.py
@@ -20,6 +20,9 @@ from custom_components.dreame_lawn_mower.control_options import (
     current_zone_entries,
 )
 from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    DreameLawnMowerCommandRejectedError,
+)
 from custom_components.dreame_lawn_mower.lawn_mower import DreameLawnMower
 from custom_components.dreame_lawn_mower.runtime_cache import (
     DreameLawnMowerRuntimeTelemetryCache,
@@ -1617,6 +1620,43 @@ def test_lawn_mower_zone_service_uses_validated_current_map_ids() -> None:
     assert entity.coordinator.selected_contour_id is None
     assert entity.coordinator.selected_spot_id is None
     entity.coordinator.async_request_refresh.assert_awaited_once()
+
+
+def test_lawn_mower_zone_service_raises_home_assistant_error_on_failed_confirmation(
+) -> None:
+    client = SimpleNamespace(
+        async_start_zone_mowing=AsyncMock(
+            side_effect=DreameLawnMowerCommandRejectedError(
+                "The mower task type could not be confirmed."
+            )
+        )
+    )
+    entity = object.__new__(DreameLawnMower)
+    entity.coordinator = SimpleNamespace(
+        client=client,
+        selected_map_index=None,
+        vector_map_details=_vector_map_details(),
+        batch_device_data=_batch_device_data(),
+        app_maps=_app_maps(),
+        selected_mowing_action="all_area",
+        selected_contour_id=(3, 0),
+        selected_zone_id=1,
+        selected_spot_id=2,
+        async_request_refresh=AsyncMock(),
+    )
+
+    with pytest.raises(
+        HomeAssistantError,
+        match="task type could not be confirmed",
+    ):
+        asyncio.run(entity.async_start_zone_mowing([1]))
+
+    client.async_start_zone_mowing.assert_awaited_once_with([1])
+    assert entity.coordinator.selected_mowing_action == "all_area"
+    assert entity.coordinator.selected_zone_id == 1
+    assert entity.coordinator.selected_contour_id == (3, 0)
+    assert entity.coordinator.selected_spot_id == 2
+    entity.coordinator.async_request_refresh.assert_not_awaited()
 
 
 def test_lawn_mower_zone_service_rejects_unknown_active_map_id() -> None:

--- a/tests/test_device_startup.py
+++ b/tests/test_device_startup.py
@@ -5,11 +5,16 @@ from __future__ import annotations
 from types import SimpleNamespace
 from unittest.mock import Mock
 
+import pytest
+
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     device as device_module,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.device import (
     DreameMowerDevice,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.exceptions import (
+    DeviceUpdateFailedException,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.map_manager import (
     DreameMapMowerMapManager,
@@ -61,6 +66,26 @@ def test_connect_device_defers_initial_map_request(monkeypatch) -> None:
     map_manager.update.assert_not_called()
     assert mower.available is True
     assert mower._ready is True
+
+
+def test_bounded_update_does_not_start_unbounded_reconnection() -> None:
+    mower = SimpleNamespace(
+        _update_running=False,
+        _update_interval=10,
+        cloud_connected=False,
+        connect_cloud=Mock(),
+        connect_device=Mock(),
+    )
+
+    with pytest.raises(DeviceUpdateFailedException, match="bounded update"):
+        DreameMowerDevice.update(
+            mower,
+            force_request_properties=True,
+            deadline=123.0,
+        )
+
+    mower.connect_cloud.assert_not_called()
+    mower.connect_device.assert_not_called()
 
 
 def test_background_map_failure_still_schedules_next_refresh(monkeypatch) -> None:

--- a/tests/test_device_startup.py
+++ b/tests/test_device_startup.py
@@ -68,16 +68,28 @@ def test_connect_device_defers_initial_map_request(monkeypatch) -> None:
     assert mower._ready is True
 
 
-def test_bounded_update_does_not_start_unbounded_reconnection() -> None:
+def test_bounded_update_skips_reconnection_and_attempts_http_readback() -> None:
+    readback_error = RuntimeError("stop after bounded readback dispatch")
     mower = SimpleNamespace(
         _update_running=False,
         _update_interval=10,
         cloud_connected=False,
+        device_connected=False,
         connect_cloud=Mock(),
         connect_device=Mock(),
+        capability=SimpleNamespace(backup_map=False),
+        status=SimpleNamespace(active=False),
+        _consumable_change=False,
+        _last_settings_request=10**20,
+        _map_manager=None,
+        _protocol=SimpleNamespace(dreame_cloud=True),
+        _request_properties=Mock(side_effect=readback_error),
     )
 
-    with pytest.raises(DeviceUpdateFailedException, match="bounded update"):
+    with pytest.raises(
+        DeviceUpdateFailedException,
+        match="stop after bounded readback dispatch",
+    ):
         DreameMowerDevice.update(
             mower,
             force_request_properties=True,
@@ -86,6 +98,7 @@ def test_bounded_update_does_not_start_unbounded_reconnection() -> None:
 
     mower.connect_cloud.assert_not_called()
     mower.connect_device.assert_not_called()
+    assert mower._request_properties.call_args.kwargs == {"deadline": 123.0}
 
 
 def test_background_map_failure_still_schedules_next_refresh(monkeypatch) -> None:

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -844,7 +844,7 @@ def test_acknowledged_targeted_task_rejects_wrong_mowing_mode(
                     started=True,
                     mowing=True,
                 )
-                for _ in range(5)
+                for _ in range(6)
             ],
         ]
     )
@@ -863,7 +863,7 @@ def test_acknowledged_targeted_task_rejects_wrong_mowing_mode(
         asyncio.run(getattr(client, method_name)(*arguments))
 
     getattr(client, sync_name).assert_called_once()
-    assert client._async_refresh_authoritative_snapshot.await_count == 6
+    assert client._async_refresh_authoritative_snapshot.await_count == 7
 
 
 def test_acknowledged_zone_task_accepts_generic_heartbeat_while_transiting() -> None:
@@ -943,7 +943,7 @@ def test_acknowledged_zone_task_accepts_late_realtime_heartbeat() -> None:
     response = {"r": 0, "d": {"r": 0}}
     client._sync_start_zone_mowing = Mock(return_value=response)
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, pending, pending, pending, confirmed]
+        side_effect=[baseline, *[pending for _ in range(5)], confirmed]
     )
 
     with patch(
@@ -955,7 +955,7 @@ def test_acknowledged_zone_task_accepts_late_realtime_heartbeat() -> None:
 
     assert result is response
     client._sync_start_zone_mowing.assert_called_once_with([2])
-    assert client._async_refresh_authoritative_snapshot.await_count == 5
+    assert client._async_refresh_authoritative_snapshot.await_count == 7
 
 
 def test_acknowledged_zone_task_confirmation_has_shared_deadline() -> None:
@@ -1062,6 +1062,56 @@ def test_acknowledged_zone_task_accepts_cached_heartbeat_after_failed_read() -> 
     client._sync_start_zone_mowing.assert_called_once_with([2])
     assert client._async_refresh_authoritative_snapshot.await_count == 2
     client._async_cached_authoritative_snapshot.assert_awaited_once_with()
+
+
+def test_acknowledged_zone_task_rejects_changed_cached_wrong_task() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        task_region_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    wrong_task = SimpleNamespace(
+        state="mowing",
+        task_status="auto_cleaning",
+        task_operation=1,
+        task_region_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    client._sync_start_zone_mowing = Mock(return_value={"r": 0})
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[
+            baseline,
+            *[DreameLawnMowerConnectionError("timed out") for _ in range(6)],
+        ]
+    )
+    client._async_cached_authoritative_snapshot = AsyncMock(
+        return_value=wrong_task
+    )
+
+    with (
+        patch(
+            "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+            "client.asyncio.sleep",
+            AsyncMock(),
+        ),
+        pytest.raises(
+            DreameLawnMowerCommandRejectedError,
+            match="did not enter the requested task",
+        ),
+    ):
+        asyncio.run(client.async_start_zone_mowing([2]))
+
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_cached_authoritative_snapshot.await_count == 6
 
 
 def test_zone_preflight_allows_different_region_target() -> None:
@@ -1206,7 +1256,7 @@ def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> N
     client._async_refresh_authoritative_snapshot = AsyncMock(
         side_effect=[
             baseline,
-            *[DreameLawnMowerConnectionError("offline") for _ in range(5)],
+            *[DreameLawnMowerConnectionError("offline") for _ in range(6)],
         ]
     )
     client._async_cached_authoritative_snapshot = AsyncMock(
@@ -1227,8 +1277,8 @@ def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> N
         asyncio.run(client.async_start_zone_mowing([2]))
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
-    assert client._async_refresh_authoritative_snapshot.await_count == 6
-    assert client._async_cached_authoritative_snapshot.await_count == 5
+    assert client._async_refresh_authoritative_snapshot.await_count == 7
+    assert client._async_cached_authoritative_snapshot.await_count == 6
 
 
 def test_targeted_task_does_not_dispatch_without_authoritative_preflight() -> None:
@@ -1292,7 +1342,7 @@ def test_acknowledged_targeted_task_rejects_cross_target_operation(
     )
     setattr(client, sync_name, Mock(return_value={"r": 0}))
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, *[wrong_task for _ in range(5)]]
+        side_effect=[baseline, *[wrong_task for _ in range(6)]]
     )
 
     with (
@@ -1306,7 +1356,7 @@ def test_acknowledged_targeted_task_rejects_cross_target_operation(
         asyncio.run(getattr(client, method_name)(*arguments))
 
     getattr(client, sync_name).assert_called_once()
-    assert client._async_refresh_authoritative_snapshot.await_count == 6
+    assert client._async_refresh_authoritative_snapshot.await_count == 7
 
 
 @pytest.mark.parametrize(
@@ -1487,7 +1537,7 @@ def test_acknowledged_zone_task_rejects_different_region_ids() -> None:
     )
     client._sync_start_zone_mowing = Mock(return_value={"r": 0})
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, *[wrong_zone_task for _ in range(5)]]
+        side_effect=[baseline, *[wrong_zone_task for _ in range(6)]]
     )
 
     with (
@@ -1501,7 +1551,7 @@ def test_acknowledged_zone_task_rejects_different_region_ids() -> None:
         asyncio.run(client.async_start_zone_mowing([2]))
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
-    assert client._async_refresh_authoritative_snapshot.await_count == 6
+    assert client._async_refresh_authoritative_snapshot.await_count == 7
 
 
 def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
@@ -1526,7 +1576,7 @@ def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
     )
     client._sync_start_spot_mowing = Mock(return_value={"r": 0})
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, *[wrong_spot_task for _ in range(5)]]
+        side_effect=[baseline, *[wrong_spot_task for _ in range(6)]]
     )
 
     with (
@@ -1540,7 +1590,7 @@ def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
         asyncio.run(client.async_start_spot_mowing([4]))
 
     client._sync_start_spot_mowing.assert_called_once_with([4])
-    assert client._async_refresh_authoritative_snapshot.await_count == 6
+    assert client._async_refresh_authoritative_snapshot.await_count == 7
 
 
 def test_normal_dock_uses_heartbeat_session_state_at_base() -> None:

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -775,7 +775,7 @@ def test_acknowledged_targeted_task_rejects_wrong_mowing_mode(
                     started=True,
                     mowing=True,
                 )
-                for _ in range(3)
+                for _ in range(5)
             ],
         ]
     )
@@ -794,7 +794,7 @@ def test_acknowledged_targeted_task_rejects_wrong_mowing_mode(
         asyncio.run(getattr(client, method_name)(*arguments))
 
     getattr(client, sync_name).assert_called_once()
-    assert client._async_refresh_authoritative_snapshot.await_count == 4
+    assert client._async_refresh_authoritative_snapshot.await_count == 6
 
 
 def test_acknowledged_zone_task_accepts_generic_heartbeat_while_transiting() -> None:
@@ -836,6 +836,57 @@ def test_acknowledged_zone_task_accepts_generic_heartbeat_while_transiting() -> 
     assert result is response
     client._sync_start_zone_mowing.assert_called_once_with([2])
     assert client._async_refresh_authoritative_snapshot.await_count == 2
+
+
+def test_acknowledged_zone_task_accepts_late_realtime_heartbeat() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        task_region_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    pending = SimpleNamespace(
+        state="mowing",
+        task_status="starting",
+        task_operation=None,
+        task_region_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    confirmed = SimpleNamespace(
+        state="mowing",
+        task_status="zone_cleaning",
+        task_operation=102,
+        task_region_ids=(2,),
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    response = {"r": 0, "d": {"r": 0}}
+    client._sync_start_zone_mowing = Mock(return_value=response)
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, pending, pending, pending, confirmed]
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(client.async_start_zone_mowing([2]))
+
+    assert result is response
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 5
 
 
 def test_zone_preflight_allows_different_region_target() -> None:
@@ -980,7 +1031,7 @@ def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> N
     client._async_refresh_authoritative_snapshot = AsyncMock(
         side_effect=[
             baseline,
-            *[DreameLawnMowerConnectionError("offline") for _ in range(3)],
+            *[DreameLawnMowerConnectionError("offline") for _ in range(5)],
         ]
     )
 
@@ -998,7 +1049,7 @@ def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> N
         asyncio.run(client.async_start_zone_mowing([2]))
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
-    assert client._async_refresh_authoritative_snapshot.await_count == 4
+    assert client._async_refresh_authoritative_snapshot.await_count == 6
 
 
 def test_targeted_task_does_not_dispatch_without_authoritative_preflight() -> None:
@@ -1062,7 +1113,7 @@ def test_acknowledged_targeted_task_rejects_cross_target_operation(
     )
     setattr(client, sync_name, Mock(return_value={"r": 0}))
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, wrong_task, wrong_task, wrong_task]
+        side_effect=[baseline, *[wrong_task for _ in range(5)]]
     )
 
     with (
@@ -1076,7 +1127,7 @@ def test_acknowledged_targeted_task_rejects_cross_target_operation(
         asyncio.run(getattr(client, method_name)(*arguments))
 
     getattr(client, sync_name).assert_called_once()
-    assert client._async_refresh_authoritative_snapshot.await_count == 4
+    assert client._async_refresh_authoritative_snapshot.await_count == 6
 
 
 @pytest.mark.parametrize(
@@ -1257,7 +1308,7 @@ def test_acknowledged_zone_task_rejects_different_region_ids() -> None:
     )
     client._sync_start_zone_mowing = Mock(return_value={"r": 0})
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, wrong_zone_task, wrong_zone_task, wrong_zone_task]
+        side_effect=[baseline, *[wrong_zone_task for _ in range(5)]]
     )
 
     with (
@@ -1271,7 +1322,7 @@ def test_acknowledged_zone_task_rejects_different_region_ids() -> None:
         asyncio.run(client.async_start_zone_mowing([2]))
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
-    assert client._async_refresh_authoritative_snapshot.await_count == 4
+    assert client._async_refresh_authoritative_snapshot.await_count == 6
 
 
 def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
@@ -1296,7 +1347,7 @@ def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
     )
     client._sync_start_spot_mowing = Mock(return_value={"r": 0})
     client._async_refresh_authoritative_snapshot = AsyncMock(
-        side_effect=[baseline, wrong_spot_task, wrong_spot_task, wrong_spot_task]
+        side_effect=[baseline, *[wrong_spot_task for _ in range(5)]]
     )
 
     with (
@@ -1310,7 +1361,7 @@ def test_acknowledged_spot_task_rejects_different_area_ids() -> None:
         asyncio.run(client.async_start_spot_mowing([4]))
 
     client._sync_start_spot_mowing.assert_called_once_with([4])
-    assert client._async_refresh_authoritative_snapshot.await_count == 4
+    assert client._async_refresh_authoritative_snapshot.await_count == 6
 
 
 def test_normal_dock_uses_heartbeat_session_state_at_base() -> None:

--- a/tests/test_docking.py
+++ b/tests/test_docking.py
@@ -614,6 +614,25 @@ def test_authoritative_confirmation_forces_device_property_request() -> None:
     client._snapshot_from_device.assert_called_once_with(device)
 
 
+def test_authoritative_confirmation_forwards_shared_deadline() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    device = SimpleNamespace(update=Mock())
+    snapshot = SimpleNamespace(state="paused")
+    client._ensure_device = Mock(return_value=device)
+    client._snapshot_from_device = Mock(return_value=snapshot)
+
+    result = asyncio.run(
+        client._async_refresh_authoritative_snapshot(deadline=123.0)
+    )
+
+    assert result is snapshot
+    device.update.assert_called_once_with(
+        force_request_properties=True,
+        deadline=123.0,
+    )
+    client._snapshot_from_device.assert_called_once_with(device)
+
+
 @pytest.mark.parametrize(
     (
         "method_name",
@@ -727,13 +746,63 @@ def test_lost_zone_acknowledgement_accepts_requested_task_transition() -> None:
 
     with patch(
         "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
-        "client_core.asyncio.sleep",
+        "client.asyncio.sleep",
         AsyncMock(),
     ):
         asyncio.run(client.async_start_zone_mowing([2]))
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
     assert client._async_refresh_authoritative_snapshot.await_count == 2
+    assert (
+        client._async_refresh_authoritative_snapshot.await_args_list[1].kwargs[
+            "deadline"
+        ]
+        > 0
+    )
+
+
+@pytest.mark.parametrize(
+    ("method_name", "sync_name", "arguments"),
+    [
+        ("async_start_zone_mowing", "_sync_start_zone_mowing", ([2],)),
+        ("async_start_edge_mowing", "_sync_start_edge_mowing", ([[3, 0]],)),
+        ("async_start_spot_mowing", "_sync_start_spot_mowing", ([4],)),
+    ],
+)
+def test_lost_targeted_acknowledgement_uses_bounded_confirmation_owner(
+    method_name: str,
+    sync_name: str,
+    arguments: tuple[object, ...],
+) -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        task_region_ids=None,
+        task_area_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    connection_error = DreameLawnMowerConnectionError("reply lost")
+    setattr(client, sync_name, Mock(side_effect=connection_error))
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        return_value=baseline
+    )
+    client._async_require_targeted_task_confirmation = AsyncMock()
+
+    result = asyncio.run(getattr(client, method_name)(*arguments))
+
+    assert result is None
+    getattr(client, sync_name).assert_called_once()
+    client._async_require_targeted_task_confirmation.assert_awaited_once()
+    assert (
+        client._async_require_targeted_task_confirmation.await_args.kwargs[
+            "original_error"
+        ]
+        is connection_error
+    )
 
 
 @pytest.mark.parametrize(
@@ -889,6 +958,112 @@ def test_acknowledged_zone_task_accepts_late_realtime_heartbeat() -> None:
     assert client._async_refresh_authoritative_snapshot.await_count == 5
 
 
+def test_acknowledged_zone_task_confirmation_has_shared_deadline() -> None:
+    async def run() -> None:
+        client = object.__new__(DreameLawnMowerClient)
+        baseline = SimpleNamespace(
+            state="charging",
+            task_status="idle",
+            task_operation=None,
+            task_region_ids=None,
+            current_zone_id=None,
+            active_segment_count=0,
+            mowing_session_active=False,
+        )
+        worker_finished = asyncio.Event()
+        refresh_count = 0
+
+        async def refresh(*, deadline: float | None = None) -> SimpleNamespace:
+            nonlocal refresh_count
+            refresh_count += 1
+            if refresh_count == 1:
+                assert deadline is None
+                return baseline
+            assert deadline is not None
+            while asyncio.get_running_loop().time() < deadline:
+                await asyncio.sleep(0)
+            worker_finished.set()
+            raise DreameLawnMowerConnectionError("readback deadline expired")
+
+        client._sync_start_zone_mowing = Mock(return_value={"r": 0})
+        client._async_refresh_authoritative_snapshot = AsyncMock(side_effect=refresh)
+        client._async_cached_authoritative_snapshot = AsyncMock(
+            return_value=baseline
+        )
+
+        with (
+            patch(
+                "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+                "client._TARGETED_TASK_CONFIRMATION_OFFSETS_SECONDS",
+                (0.0,),
+            ),
+            patch(
+                "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+                "client._TARGETED_TASK_CONFIRMATION_TIMEOUT_SECONDS",
+                0.01,
+            ),
+            pytest.raises(
+                DreameLawnMowerConnectionError,
+                match="every state readback failed",
+            ),
+        ):
+            await asyncio.wait_for(
+                client.async_start_zone_mowing([2]),
+                timeout=0.25,
+            )
+
+        client._sync_start_zone_mowing.assert_called_once_with([2])
+        assert client._async_refresh_authoritative_snapshot.await_count == 2
+        assert worker_finished.is_set()
+        client._async_cached_authoritative_snapshot.assert_awaited_once_with()
+
+    asyncio.run(run())
+
+
+def test_acknowledged_zone_task_accepts_cached_heartbeat_after_failed_read() -> None:
+    client = object.__new__(DreameLawnMowerClient)
+    baseline = SimpleNamespace(
+        state="charging",
+        task_status="idle",
+        task_operation=None,
+        task_region_ids=None,
+        current_zone_id=None,
+        active_segment_count=0,
+        mowing_session_active=False,
+    )
+    confirmed = SimpleNamespace(
+        state="mowing",
+        task_status="zone_cleaning",
+        task_operation=102,
+        task_region_ids=(2,),
+        current_zone_id=2,
+        active_segment_count=1,
+        mowing_session_active=True,
+        started=True,
+        mowing=True,
+    )
+    response = {"r": 0, "d": {"r": 0}}
+    client._sync_start_zone_mowing = Mock(return_value=response)
+    client._async_refresh_authoritative_snapshot = AsyncMock(
+        side_effect=[baseline, DreameLawnMowerConnectionError("timed out")]
+    )
+    client._async_cached_authoritative_snapshot = AsyncMock(
+        return_value=confirmed
+    )
+
+    with patch(
+        "custom_components.dreame_lawn_mower.dreame_lawn_mower_client."
+        "client.asyncio.sleep",
+        AsyncMock(),
+    ):
+        result = asyncio.run(client.async_start_zone_mowing([2]))
+
+    assert result is response
+    client._sync_start_zone_mowing.assert_called_once_with([2])
+    assert client._async_refresh_authoritative_snapshot.await_count == 2
+    client._async_cached_authoritative_snapshot.assert_awaited_once_with()
+
+
 def test_zone_preflight_allows_different_region_target() -> None:
     client = object.__new__(DreameLawnMowerClient)
     baseline = SimpleNamespace(
@@ -1034,6 +1209,9 @@ def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> N
             *[DreameLawnMowerConnectionError("offline") for _ in range(5)],
         ]
     )
+    client._async_cached_authoritative_snapshot = AsyncMock(
+        return_value=baseline
+    )
 
     with (
         patch(
@@ -1050,6 +1228,7 @@ def test_acknowledged_zone_task_fails_closed_when_readback_is_unavailable() -> N
 
     client._sync_start_zone_mowing.assert_called_once_with([2])
     assert client._async_refresh_authoritative_snapshot.await_count == 6
+    assert client._async_cached_authoritative_snapshot.await_count == 5
 
 
 def test_targeted_task_does_not_dispatch_without_authoritative_preflight() -> None:


### PR DESCRIPTION
## Summary

- retry authoritative targeted-task readback through one 15-second deadline that includes both retry delays and forced device reads
- preserve exact operation, requested target, active-session, and new-task identity checks before reporting success
- translate targeted start failures to Home Assistant errors so script continue-on-error handling can work as intended

## Behavior

Zone, edge, and spot starts use the same bounded confirmation owner for acknowledged and lost-acknowledgement responses, whether they come from the mower action or an explicit service. A late realtime heartbeat can confirm the task after a timed-out read, while a wrong task, wrong target, unreadable state, or missing identity still fails closed.

## Validation

Focused task/readback, protocol, device-startup, and Home Assistant error tests passed on Windows and Linux. The full Linux suite, separate config-flow/translation lane, scoped Ruff checks, compile checks, and diff checks also passed. Independent review findings were reproduced and addressed. No live mower command was issued for validation.

Fixes #170
Preserves the targeted-task safety contract added for #166.