### PR TITLE
Fix preference controls for A1 Pro 2000 map slots

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ brand name:
 | Dreame A3 AWD Pro 3500 | `dreame.mower.g2541e` | **Recognized** | Model mapping and diagnostics report; broader live confirmation is still needed |
 | Dreame A1 | `dreame.mower.p2255` | **Field-reported** | EU account setup, core state, battery, error state, map camera, docking state, and a real docked-to-mowing start are confirmed; live video is explicitly unsupported |
 | Dreame A1 Pro | `dreame.mower.g2422` | **Recognized** | Model mapping and mower-specific state semantics; needs fixtures and live validation |
+| Dreame A1 Pro 2000 | `dreame.mower.g2540d` | **Field-reported** | EU account setup, core state, maps, and app map selection on firmware `4.3.6_0623`; SETTINGS slot alignment has regression coverage, while write controls and model-specific device codes still need supervised live validation |
 | Newer A-series mower | `dreame.mower.g3255` | **Recognized** | Raw identifier observed; retail name and feature coverage are not yet confirmed |
 
 MOVAhome account login is supported. Other MOVA-branded mowers, rebadges,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -1671,9 +1671,13 @@ class DreameLawnMowerCoordinator(
             preference_read_generation = self._begin_preference_read()
             try:
                 try:
+                    map_index_hints, map_slot_index_hints = (
+                        _app_preference_map_index_hints(self.app_maps)
+                    )
                     preferences = await self.client.async_get_batch_mowing_preferences(
                         include_raw=False,
-                        map_index_hints=_app_map_index_hints(self.app_maps),
+                        map_index_hints=map_index_hints,
+                        map_slot_index_hints=map_slot_index_hints,
                     )
                 except Exception as err:  # noqa: BLE001 - retry on next event pass
                     _LOGGER.debug("Failed to refresh mowing preferences: %s", err)
@@ -1757,6 +1761,9 @@ class DreameLawnMowerCoordinator(
     ) -> tuple[dict[str, Any], dict[str, Any], dict[str, Any], int]:
         """Fetch batch schedule, settings, and OTA payloads in parallel."""
         cached_schedule = None if force else self._fresh_batch_schedule()
+        map_index_hints, map_slot_index_hints = _app_preference_map_index_hints(
+            self.app_maps
+        )
         if cached_schedule is None:
             schedule_generation = self._begin_schedule_read()
             map_index_hint = self._schedule_map_index_hint()
@@ -1767,7 +1774,8 @@ class DreameLawnMowerCoordinator(
                 ),
                 self.client.async_get_batch_mowing_preferences(
                     include_raw=False,
-                    map_index_hints=_app_map_index_hints(self.app_maps),
+                    map_index_hints=map_index_hints,
+                    map_slot_index_hints=map_slot_index_hints,
                 ),
                 self.client.async_get_batch_ota_info(include_raw=False),
             )
@@ -1779,7 +1787,8 @@ class DreameLawnMowerCoordinator(
         batch_mowing_preferences, batch_ota_info = await asyncio.gather(
             self.client.async_get_batch_mowing_preferences(
                 include_raw=False,
-                map_index_hints=_app_map_index_hints(self.app_maps),
+                map_index_hints=map_index_hints,
+                map_slot_index_hints=map_slot_index_hints,
             ),
             self.client.async_get_batch_ota_info(include_raw=False),
         )
@@ -2442,6 +2451,48 @@ def _app_map_index_hints(app_maps: Mapping[str, Any] | None) -> list[int]:
             continue
         indices.append(index)
     return indices
+
+
+def _app_map_slot_index_hints(app_maps: Mapping[str, Any] | None) -> list[int]:
+    """Return every app map slot id for full SETTINGS-array alignment."""
+    if not isinstance(app_maps, Mapping) or app_maps.get("map_list_valid") is not True:
+        return []
+    maps = app_maps.get("maps") if isinstance(app_maps, Mapping) else None
+    if not isinstance(maps, Sequence) or isinstance(maps, str | bytes | bytearray):
+        return []
+
+    indices: list[int] = []
+    for entry in maps:
+        if not isinstance(entry, Mapping):
+            return []
+        index = entry.get("idx")
+        if (
+            not isinstance(index, int)
+            or isinstance(index, bool)
+            or index < 0
+            or index in indices
+        ):
+            return []
+        indices.append(index)
+    return indices
+
+
+def _app_preference_map_index_hints(
+    app_maps: Mapping[str, Any] | None,
+) -> tuple[list[int], list[int]]:
+    """Return created and full slot hints only from one authoritative MAPL."""
+    maps = app_maps.get("maps") if isinstance(app_maps, Mapping) else None
+    if not isinstance(maps, Sequence) or isinstance(maps, str | bytes | bytearray):
+        return [], []
+    slot_indices = _app_map_slot_index_hints(app_maps)
+    if len(slot_indices) != len(maps):
+        return [], []
+    created_indices = [
+        index
+        for index, entry in zip(slot_indices, maps, strict=True)
+        if isinstance(entry, Mapping) and entry.get("created") is not False
+    ]
+    return created_indices, slot_indices
 
 
 def _app_map_hints_are_authoritative(

--- a/custom_components/dreame_lawn_mower/debug.py
+++ b/custom_components/dreame_lawn_mower/debug.py
@@ -25,7 +25,7 @@ from .dreame_lawn_mower_client.models import (
     remote_control_state_safe,
 )
 
-DIAGNOSTIC_SCHEMA_VERSION = 9
+DIAGNOSTIC_SCHEMA_VERSION = 10
 UNKNOWN_REALTIME_PREFIX = "UNKNOWN_REALTIME_"
 
 REDACT_KEYS = {

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/batch_device_data.py
@@ -100,6 +100,7 @@ def decode_batch_mowing_preferences(
     include_raw: bool = False,
     map_indices: Sequence[int] | None = None,
     map_index_hints: Sequence[int] | None = None,
+    map_slot_index_hints: Sequence[int] | None = None,
 ) -> dict[str, Any]:
     """Decode `SETTINGS.*` batch device data into readable preference summaries."""
     result: dict[str, Any] = {
@@ -108,6 +109,7 @@ def decode_batch_mowing_preferences(
         "property_hint": "2.52",
         "maps": [],
         "errors": [],
+        "payload_shape": _batch_text_shape(batch_data, "SETTINGS"),
     }
 
     payload_text = batch_data_text(batch_data, "SETTINGS")
@@ -123,6 +125,7 @@ def decode_batch_mowing_preferences(
         result["errors"].append({"stage": "settings", "error": str(err)})
         return result
 
+    result["payload_shape"]["payload_type"] = _shape_type(payload)
     if not isinstance(payload, Sequence) or isinstance(
         payload, (str, bytes, bytearray)
     ):
@@ -137,11 +140,34 @@ def decode_batch_mowing_preferences(
         else None
     )
     index_hints = _map_index_hints(map_index_hints)
+    slot_index_hints, slot_hint_warning = _strict_map_slot_index_hints(
+        map_slot_index_hints
+    )
+    if slot_hint_warning is not None:
+        resolved_index_hints = []
+        alignment = "payload_order"
+    elif len(slot_index_hints) == len(payload):
+        resolved_index_hints = slot_index_hints
+        alignment = "app_map_slots"
+    elif index_hints:
+        resolved_index_hints = index_hints
+        alignment = "created_app_maps"
+    else:
+        resolved_index_hints = []
+        alignment = "payload_order"
+    map_shapes: list[dict[str, Any]] = []
     for payload_index, map_entry in enumerate(payload):
         map_index = _batch_preference_map_index(
             map_entry,
             payload_index=payload_index,
-            map_index_hints=index_hints,
+            map_index_hints=resolved_index_hints,
+        )
+        map_shapes.append(
+            _batch_preference_map_shape(
+                map_entry,
+                payload_index=payload_index,
+                resolved_map_index=map_index,
+            )
         )
         if selected_indices is not None and map_index not in selected_indices:
             continue
@@ -153,6 +179,15 @@ def decode_batch_mowing_preferences(
         if entry.get("available"):
             result["available"] = True
         result["maps"].append(entry)
+
+    result["payload_shape"].update(
+        {
+            "map_entry_count": len(payload),
+            "alignment": alignment,
+            "alignment_warning": slot_hint_warning,
+            "map_entries": map_shapes,
+        }
+    )
 
     return result
 
@@ -167,6 +202,25 @@ def _map_index_hints(values: Sequence[int] | None) -> list[int]:
             continue
         hints.append(index)
     return hints
+
+
+def _strict_map_slot_index_hints(
+    values: Sequence[int] | None,
+) -> tuple[list[int], str | None]:
+    """Validate authoritative app-map slot hints without repairing them."""
+    if values is None:
+        return [], None
+    hints: list[int] = []
+    for value in values:
+        if (
+            not isinstance(value, int)
+            or isinstance(value, bool)
+            or value < 0
+            or value in hints
+        ):
+            return [], "invalid_app_map_slot_hints"
+        hints.append(value)
+    return hints, None
 
 
 def _batch_preference_map_index(
@@ -271,6 +325,79 @@ def batch_data_text(
     if size is not None:
         text = text[:size]
     return text
+
+
+def _batch_text_shape(
+    batch_data: Mapping[str, Any],
+    prefix: str,
+) -> dict[str, Any]:
+    """Return value-free transport details for diagnostics."""
+    chunk_indices = [
+        index
+        for index in range(_DEFAULT_BATCH_CHUNK_COUNT)
+        if f"{prefix}.{index}" in batch_data
+    ]
+    text = batch_data_text(batch_data, prefix)
+    return {
+        "chunk_indices": chunk_indices,
+        "chunk_count": len(chunk_indices),
+        "declared_size": _batch_text_size(batch_data, prefix),
+        "received_size": len(text) if text is not None else 0,
+    }
+
+
+def _batch_preference_map_shape(
+    value: Any,
+    *,
+    payload_index: int,
+    resolved_map_index: int,
+) -> dict[str, Any]:
+    """Return map preference field names and types without their values."""
+    shape: dict[str, Any] = {
+        "payload_index": payload_index,
+        "resolved_map_index": resolved_map_index,
+        "entry_type": _shape_type(value),
+    }
+    if not isinstance(value, Mapping):
+        return shape
+
+    shape["entry_keys"] = sorted(str(key) for key in value)
+    settings = value.get("settings")
+    shape["settings_type"] = _shape_type(settings)
+    if not isinstance(settings, Mapping):
+        return shape
+
+    field_keys: set[str] = set()
+    setting_value_types: set[str] = set()
+    for preference in settings.values():
+        setting_value_types.add(_shape_type(preference))
+        if isinstance(preference, Mapping):
+            field_keys.update(str(key) for key in preference)
+    shape.update(
+        {
+            "settings_entry_count": len(settings),
+            "settings_value_types": sorted(setting_value_types),
+            "preference_field_keys": sorted(field_keys),
+        }
+    )
+    return shape
+
+
+def _shape_type(value: Any) -> str:
+    """Return a stable JSON-oriented type name."""
+    if value is None:
+        return "null"
+    if isinstance(value, bool):
+        return "bool"
+    if isinstance(value, Mapping):
+        return "object"
+    if isinstance(value, Sequence) and not isinstance(value, (str, bytes, bytearray)):
+        return "array"
+    if isinstance(value, str):
+        return "string"
+    if isinstance(value, int | float):
+        return "number"
+    return type(value).__name__
 
 
 def _decode_batch_preference_map_entry(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -1407,6 +1407,7 @@ class DreameLawnMowerClient(
         include_raw: bool = False,
         map_indices: Sequence[int] | None = None,
         map_index_hints: Sequence[int] | None = None,
+        map_slot_index_hints: Sequence[int] | None = None,
     ) -> dict[str, Any]:
         """Fetch and decode mower preferences from batch device data."""
         return await asyncio.to_thread(
@@ -1414,6 +1415,7 @@ class DreameLawnMowerClient(
             include_raw,
             map_indices,
             map_index_hints,
+            map_slot_index_hints,
         )
 
     async def async_get_batch_ota_info(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_settings.py
@@ -1020,6 +1020,7 @@ class _DreameLawnMowerClientSettingsMixin:
         include_raw: bool = False,
         map_indices: Sequence[int] | None = None,
         map_index_hints: Sequence[int] | None = None,
+        map_slot_index_hints: Sequence[int] | None = None,
     ) -> dict[str, Any]:
         """Fetch and decode mower preferences from batch device data."""
         batch_data = self._sync_get_batch_device_data(_batch_settings_keys())
@@ -1041,6 +1042,7 @@ class _DreameLawnMowerClientSettingsMixin:
             include_raw=include_raw,
             map_indices=map_indices,
             map_index_hints=map_index_hints,
+            map_slot_index_hints=map_slot_index_hints,
         )
 
     def _sync_get_batch_ota_info(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/models.py
@@ -29,6 +29,7 @@ OPERATIONAL_HUMAN_DETECTION_NOTICE_MODELS = frozenset({"dreame.mower.q2501a", "q
 MODEL_NAME_MAP = {
     "dreame.mower.p2255": "A1",
     "dreame.mower.g2422": "A1 Pro",
+    "dreame.mower.g2540d": "A1 Pro 2000",
     "dreame.mower.g2408": "A2",
     "dreame.mower.g2568d": "A2 3000",
     "dreame.mower.g2541e": "A3 AWD Pro 3500",
@@ -45,6 +46,7 @@ MODEL_NAME_MAP = {
 DISPLAY_NAME_ALIASES = {
     "a1": "A1",
     "a1 pro": "A1 Pro",
+    "a1 pro 2000": "A1 Pro 2000",
     "a2": "A2",
     "a3 awd 1000": "A3 AWD 1000",
     "a3 awd pro 3500": "A3 AWD Pro 3500",

--- a/custom_components/dreame_lawn_mower/reporting.py
+++ b/custom_components/dreame_lawn_mower/reporting.py
@@ -108,12 +108,82 @@ def build_coordinator_diagnostics(coordinator: object) -> dict[str, Any]:
             performance.as_dict() if hasattr(performance, "as_dict") else None
         ),
         "maintenance_points": build_maintenance_point_diagnostics(coordinator),
+        "mowing_preferences": _mowing_preference_diagnostics(coordinator),
         "work_log_totals": _work_log_totals_diagnostics(coordinator),
         "video_runtime": sanitize_debug_data(video_diagnostics),
         "last_maintenance_point_probe": (
             dict(last_map_probe) if isinstance(last_map_probe, Mapping) else None
         ),
     }
+
+
+def _mowing_preference_diagnostics(coordinator: object) -> dict[str, Any] | None:
+    """Return preference alignment and schema evidence without setting values."""
+    batch = getattr(coordinator, "batch_device_data", None)
+    preferences = (
+        batch.get("batch_mowing_preferences") if isinstance(batch, Mapping) else None
+    )
+    if not isinstance(preferences, Mapping):
+        return None
+
+    maps = preferences.get("maps")
+    map_summaries: list[dict[str, Any]] = []
+    if isinstance(maps, Sequence) and not isinstance(
+        maps,
+        str | bytes | bytearray,
+    ):
+        for entry in maps:
+            if not isinstance(entry, Mapping):
+                continue
+            items = entry.get("preferences")
+            preference_count = 0
+            if isinstance(items, Sequence) and not isinstance(
+                items,
+                str | bytes | bytearray,
+            ):
+                for item in items:
+                    if not isinstance(item, Mapping):
+                        continue
+                    preference_count += 1
+            entry_errors = entry.get("errors")
+            map_summaries.append(
+                {
+                    "idx": entry.get("idx"),
+                    "available": entry.get("available"),
+                    "mode": entry.get("mode"),
+                    "mode_name": entry.get("mode_name"),
+                    "area_count": entry.get("area_count"),
+                    "preference_count": preference_count,
+                    "error_count": (
+                        len(entry_errors)
+                        if isinstance(entry_errors, Sequence)
+                        and not isinstance(entry_errors, str | bytes | bytearray)
+                        else 1
+                        if entry.get("error")
+                        else 0
+                    ),
+                }
+            )
+
+    errors = preferences.get("errors")
+    error_count = (
+        len(errors)
+        if isinstance(errors, Sequence)
+        and not isinstance(errors, str | bytes | bytearray)
+        else 0
+    )
+    result = {
+        "captured_at": batch.get("captured_at"),
+        "source": preferences.get("source"),
+        "available": preferences.get("available"),
+        "property_hint": preferences.get("property_hint"),
+        "map_count": len(map_summaries),
+        "maps": map_summaries,
+        "error_count": error_count,
+        "errors": errors if error_count else [],
+        "payload_shape": preferences.get("payload_shape"),
+    }
+    return sanitize_debug_data(result)
 
 
 def _work_log_totals_diagnostics(coordinator: object) -> dict[str, Any] | None:

--- a/tests/test_batch_device_data.py
+++ b/tests/test_batch_device_data.py
@@ -246,6 +246,13 @@ def test_decode_batch_mowing_preferences_decodes_map_settings() -> None:
         "objects",
     ]
     assert result["maps"][1]["preferences"][0]["mowing_height_cm"] == 3.5
+    assert result["payload_shape"]["alignment"] == "payload_order"
+    assert result["payload_shape"]["map_entry_count"] == 2
+    assert result["payload_shape"]["map_entries"][0]["settings_entry_count"] == 2
+    assert "mowingHeight" in result["payload_shape"]["map_entries"][0][
+        "preference_field_keys"
+    ]
+    assert "raw_setting" not in result["payload_shape"]["map_entries"][0]
 
 
 def test_decode_batch_mowing_preferences_aligns_with_app_map_index_hints() -> None:
@@ -259,6 +266,7 @@ def test_decode_batch_mowing_preferences_aligns_with_app_map_index_hints() -> No
             "SETTINGS.info": str(len(settings_text)),
         },
         map_index_hints=[1, 2],
+        map_slot_index_hints=[0, 1, 2],
     )
 
     assert [entry["idx"] for entry in result["maps"]] == [1, 2]
@@ -266,6 +274,7 @@ def test_decode_batch_mowing_preferences_aligns_with_app_map_index_hints() -> No
     assert result["maps"][0]["preferences"][0]["mowing_height_cm"] == 4.0
     assert result["maps"][1]["preferences"][0]["map_index"] == 2
     assert result["maps"][1]["preferences"][0]["mowing_height_cm"] == 3.5
+    assert result["payload_shape"]["alignment"] == "created_app_maps"
 
     filtered = decode_batch_mowing_preferences(
         {
@@ -276,10 +285,101 @@ def test_decode_batch_mowing_preferences_aligns_with_app_map_index_hints() -> No
         },
         map_indices=[1],
         map_index_hints=[1, 2],
+        map_slot_index_hints=[0, 1, 2],
     )
 
     assert [entry["idx"] for entry in filtered["maps"]] == [1]
     assert filtered["maps"][0]["preferences"][0]["mowing_height_cm"] == 4.0
+
+
+def test_decode_batch_mowing_preferences_preserves_uncreated_map_slots() -> None:
+    settings_text = json.dumps(
+        [
+            {"mode": 0, "settings": {}},
+            {
+                "mode": 0,
+                "settings": {
+                    "0": {
+                        "id": 0,
+                        "version": 78,
+                        "mowingHeight": 5,
+                        "efficientMode": 0,
+                    }
+                },
+            },
+        ],
+        separators=(",", ":"),
+    )
+
+    result = decode_batch_mowing_preferences(
+        {
+            "SETTINGS.0": settings_text,
+            "SETTINGS.info": str(len(settings_text)),
+        },
+        map_index_hints=[1],
+        map_slot_index_hints=[0, 1],
+    )
+
+    assert [entry["idx"] for entry in result["maps"]] == [0, 1]
+    assert result["maps"][0]["available"] is False
+    assert result["maps"][1]["available"] is True
+    assert result["maps"][1]["preferences"][0]["mowing_height_cm"] == 5.0
+    assert result["payload_shape"]["alignment"] == "app_map_slots"
+    assert [
+        entry["resolved_map_index"]
+        for entry in result["payload_shape"]["map_entries"]
+    ] == [0, 1]
+
+
+@pytest.mark.parametrize(
+    "slot_hints",
+    [
+        [1, 1, 2],
+        [True, 2],
+        [1, "invalid"],
+        [1, -1],
+    ],
+)
+def test_decode_batch_mowing_preferences_rejects_invalid_slot_hints(
+    slot_hints: list[object],
+) -> None:
+    settings_text = json.dumps(
+        [
+            {"mode": 0, "settings": {}},
+            {"mode": 0, "settings": {}},
+        ],
+        separators=(",", ":"),
+    )
+
+    result = decode_batch_mowing_preferences(
+        {"SETTINGS.0": settings_text},
+        map_index_hints=[8, 9],
+        map_slot_index_hints=slot_hints,  # type: ignore[arg-type]
+    )
+
+    assert [entry["idx"] for entry in result["maps"]] == [0, 1]
+    assert result["payload_shape"]["alignment"] == "payload_order"
+    assert (
+        result["payload_shape"]["alignment_warning"]
+        == "invalid_app_map_slot_hints"
+    )
+
+
+def test_explicit_batch_map_id_overrides_valid_slot_hint() -> None:
+    settings_text = json.dumps(
+        [{"idx": 7, "mode": 0, "settings": {}}],
+        separators=(",", ":"),
+    )
+
+    result = decode_batch_mowing_preferences(
+        {"SETTINGS.0": settings_text},
+        map_index_hints=[3],
+        map_slot_index_hints=[1],
+    )
+
+    assert [entry["idx"] for entry in result["maps"]] == [7]
+    assert result["payload_shape"]["alignment"] == "app_map_slots"
+    assert result["payload_shape"]["map_entries"][0]["resolved_map_index"] == 7
 
 
 def test_decode_batch_ota_info_decodes_flags() -> None:

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -830,7 +830,11 @@ def test_cached_preference_event_refreshes_only_preferences_once() -> None:
     coordinator._last_device_settings_event_at = None
     coordinator._last_mowing_preferences_event_at = None
     coordinator._preference_write_lock = asyncio.Lock()
-    coordinator.app_maps = {"current_map_index": 0, "maps": [{"idx": 0}]}
+    coordinator.app_maps = {
+        "map_list_valid": True,
+        "current_map_index": 0,
+        "maps": [{"idx": 0}],
+    }
     coordinator.batch_device_data = {
         "batch_schedule": {"available": True},
         "batch_ota_info": {"available": True},
@@ -859,6 +863,7 @@ def test_cached_preference_event_refreshes_only_preferences_once() -> None:
     coordinator.client.async_get_batch_mowing_preferences.assert_awaited_once_with(
         include_raw=False,
         map_index_hints=[0],
+        map_slot_index_hints=[0],
     )
     assert coordinator.batch_device_data["batch_schedule"] == {"available": True}
     assert coordinator.batch_device_data["batch_ota_info"] == {"available": True}

--- a/tests/test_debug_payload.py
+++ b/tests/test_debug_payload.py
@@ -164,7 +164,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
         device=device,
     )
 
-    assert payload["diagnostic_schema_version"] == 9
+    assert payload["diagnostic_schema_version"] == 10
     assert payload["entry"]["username"] == "**REDACTED**"
     assert payload["entry"]["password"] == "**REDACTED**"
     assert payload["entry"]["token"] == "**REDACTED**"
@@ -272,7 +272,7 @@ def test_build_debug_payload_redacts_sensitive_fields() -> None:
     }
     assert payload["state_reconciliation"]["warnings"] == []
     assert payload["triage"] == {
-        "schema_version": 9,
+        "schema_version": 10,
         "known_model": True,
         "model": "dreame.mower.g2408",
         "display_model": "A2",
@@ -512,7 +512,7 @@ def test_build_debug_payload_highlights_state_disagreements() -> None:
         "raw_mower_state_looks_docked_but_raw_docked_false",
         "raw_mower_state_differs_from_state_name",
     ]
-    assert payload["triage"]["schema_version"] == 9
+    assert payload["triage"]["schema_version"] == 10
     assert payload["triage"]["error"] == {
         "active": True,
         "code": 73,

--- a/tests/test_diagnostics_download.py
+++ b/tests/test_diagnostics_download.py
@@ -168,7 +168,7 @@ def test_downloaded_diagnostics_combines_report_entities_and_recent_events(
         diagnostics_module.async_get_config_entry_diagnostics(hass, entry)
     )
 
-    assert payload["diagnostic_schema_version"] == 9
+    assert payload["diagnostic_schema_version"] == 10
     assert payload["report_context"]["integration_version"] == "0.3.0"
     assert payload["report_context"]["home_assistant"]["arch"] == "aarch64"
     assert "user" not in payload["report_context"]["home_assistant"]

--- a/tests/test_dreame_models.py
+++ b/tests/test_dreame_models.py
@@ -216,13 +216,14 @@ def test_display_name_for_model_prefers_known_mapping_over_fallback_name() -> No
 @pytest.mark.parametrize(
     ("model", "expected_name"),
     [
+        ("dreame.mower.g2540d", "A1 Pro 2000"),
         ("mova.mower.g2405a", "MOVA 600"),
         ("mova.mower.g2405b", "MOVA 600 Kit"),
         ("mova.mower.g2405c", "MOVA 1000"),
         ("mova.mower.g2529b", "LiDAX Ultra 800"),
     ],
 )
-def test_display_name_for_older_mova_models(
+def test_display_name_for_submitted_model_identifiers(
     model: str,
     expected_name: str,
 ) -> None:

--- a/tests/test_dynamic_entity_availability.py
+++ b/tests/test_dynamic_entity_availability.py
@@ -7,6 +7,8 @@ import json
 from datetime import UTC, datetime
 from types import SimpleNamespace
 
+import pytest
+
 from custom_components.dreame_lawn_mower import button as button_module
 from custom_components.dreame_lawn_mower.binary_sensor import (
     BINARY_SENSORS,
@@ -22,7 +24,11 @@ from custom_components.dreame_lawn_mower.button import (
     DreameLawnMowerDockWithoutStoppingButton,
     DreameLawnMowerResetMaintenanceButton,
 )
-from custom_components.dreame_lawn_mower.coordinator import _app_map_index_hints
+from custom_components.dreame_lawn_mower.coordinator import (
+    _app_map_index_hints,
+    _app_map_slot_index_hints,
+    _app_preference_map_index_hints,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
     decode_batch_mowing_preferences,
 )
@@ -2503,6 +2509,7 @@ def test_selected_zone_preferences_follow_hinted_app_map_cards() -> None:
         separators=(",", ":"),
     )
     app_maps = {
+        "map_list_valid": True,
         "current_map_index": 1,
         "maps": [
             {"idx": 0, "created": False, "current": False},
@@ -2526,6 +2533,7 @@ def test_selected_zone_preferences_follow_hinted_app_map_cards() -> None:
             "SETTINGS.info": str(len(settings_text)),
         },
         map_index_hints=_app_map_index_hints(app_maps),
+        map_slot_index_hints=_app_map_slot_index_hints(app_maps),
     )
     coordinator = SimpleNamespace(
         data=SimpleNamespace(activity="paused"),
@@ -2555,6 +2563,54 @@ def test_selected_zone_preferences_follow_hinted_app_map_cards() -> None:
     assert efficiency_entity.native_value == "standard"
     assert height_entity.extra_state_attributes["selected_map_index"] == 2
     assert height_entity.extra_state_attributes["reported_version"] == 18
+
+
+@pytest.mark.parametrize(
+    "app_maps",
+    [
+        {"maps": [{"idx": 0}]},
+        {"map_list_valid": False, "maps": [{"idx": 0}]},
+        {"map_list_valid": True, "maps": [{"idx": 1}, {"idx": 1}]},
+        {"map_list_valid": True, "maps": [{"idx": True}]},
+        {"map_list_valid": True, "maps": [{"idx": 0}, {"name": "missing"}]},
+    ],
+)
+def test_app_map_slot_hints_require_one_authoritative_valid_list(
+    app_maps: dict[str, object],
+) -> None:
+    assert _app_map_slot_index_hints(app_maps) == []
+
+
+def test_preference_hints_discard_both_channels_for_ambiguous_map_list() -> None:
+    app_maps = {
+        "map_list_valid": True,
+        "maps": [
+            {"idx": 1, "created": True},
+            {"idx": 1, "created": True},
+            {"idx": 2, "created": True},
+        ],
+    }
+    map_index_hints, map_slot_index_hints = _app_preference_map_index_hints(
+        app_maps
+    )
+    settings_text = json.dumps(
+        [
+            {"mode": 0, "settings": {}},
+            {"mode": 0, "settings": {}},
+        ],
+        separators=(",", ":"),
+    )
+
+    result = decode_batch_mowing_preferences(
+        {"SETTINGS.0": settings_text},
+        map_index_hints=map_index_hints,
+        map_slot_index_hints=map_slot_index_hints,
+    )
+
+    assert map_index_hints == []
+    assert map_slot_index_hints == []
+    assert [entry["idx"] for entry in result["maps"]] == [0, 1]
+    assert result["payload_shape"]["alignment"] == "payload_order"
 
 
 def test_selected_zone_preference_sensors_hide_unavailable_zone_settings() -> None:

--- a/tests/test_mowing_preference_controls.py
+++ b/tests/test_mowing_preference_controls.py
@@ -3,12 +3,20 @@
 from __future__ import annotations
 
 import asyncio
+import json
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
 
 import pytest
 from homeassistant.exceptions import HomeAssistantError
 
+from custom_components.dreame_lawn_mower.coordinator import (
+    _app_map_index_hints,
+    _app_map_slot_index_hints,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    decode_batch_mowing_preferences,
+)
 from custom_components.dreame_lawn_mower.mowing_preference_control import (
     mowing_height_limits,
 )
@@ -252,6 +260,58 @@ def test_global_mowing_height_reads_and_writes_area_zero() -> None:
         execute=True,
         confirm_write=True,
     )
+
+
+def test_global_controls_follow_active_map_after_uncreated_settings_slot() -> None:
+    coordinator = _coordinator(mode_name="global")
+    coordinator.app_maps = {
+        "map_list_valid": True,
+        "current_map_index": 1,
+        "maps": [
+            {"idx": 0, "created": False, "current": False},
+            {
+                "idx": 1,
+                "created": True,
+                "current": True,
+                "name": "Garden",
+            },
+        ],
+    }
+    settings_text = json.dumps(
+        [
+            {"mode": 0, "settings": {}},
+            {
+                "mode": 0,
+                "settings": {
+                    "0": {
+                        "id": 0,
+                        "version": 78,
+                        "mowingHeight": 5,
+                        "efficientMode": 0,
+                    }
+                },
+            },
+        ],
+        separators=(",", ":"),
+    )
+    coordinator.batch_device_data = {
+        "batch_mowing_preferences": decode_batch_mowing_preferences(
+            {
+                "SETTINGS.0": settings_text,
+                "SETTINGS.info": str(len(settings_text)),
+            },
+            map_index_hints=_app_map_index_hints(coordinator.app_maps),
+            map_slot_index_hints=_app_map_slot_index_hints(coordinator.app_maps),
+        )
+    }
+
+    entity = object.__new__(DreameLawnMowerSelectedMapMowingHeightNumber)
+    entity.coordinator = coordinator
+
+    assert entity.available is True
+    assert entity.native_value == 5.0
+    assert entity.extra_state_attributes["selected_map_index"] == 1
+    assert entity.extra_state_attributes["preference_scope"] == "global"
 
 
 def test_global_mowing_height_requires_global_mode() -> None:

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -122,10 +122,92 @@ def test_coordinator_diagnostics_sanitize_last_failure() -> None:
             "app_maps": [],
             "vector_maps": [],
         },
+        "mowing_preferences": None,
         "work_log_totals": None,
         "video_runtime": None,
         "last_maintenance_point_probe": None,
     }
+
+
+def test_coordinator_diagnostics_report_preference_shape_without_values() -> None:
+    payload_shape = {
+        "chunk_indices": [0, 1],
+        "chunk_count": 2,
+        "declared_size": 512,
+        "received_size": 512,
+        "payload_type": "array",
+        "map_entry_count": 2,
+        "alignment": "app_map_slots",
+        "map_entries": [
+            {
+                "payload_index": 0,
+                "resolved_map_index": 0,
+                "entry_type": "object",
+                "entry_keys": ["mode", "settings"],
+                "settings_type": "object",
+                "settings_entry_count": 0,
+                "settings_value_types": [],
+                "preference_field_keys": [],
+            },
+            {
+                "payload_index": 1,
+                "resolved_map_index": 1,
+                "entry_type": "object",
+                "entry_keys": ["mode", "settings"],
+                "settings_type": "object",
+                "settings_entry_count": 1,
+                "settings_value_types": ["object"],
+                "preference_field_keys": ["id", "mowingHeight", "version"],
+            },
+        ],
+    }
+    diagnostics = build_coordinator_diagnostics(
+        SimpleNamespace(
+            batch_device_data={
+                "captured_at": "2026-09-01T09:33:05+00:00",
+                "batch_mowing_preferences": {
+                    "source": "batch_device_data_mowing_preferences",
+                    "available": True,
+                    "property_hint": "2.52",
+                    "payload_shape": payload_shape,
+                    "maps": [
+                        {
+                            "idx": 0,
+                            "available": False,
+                            "mode": 0,
+                            "mode_name": "global",
+                            "area_count": 0,
+                            "preferences": [],
+                        },
+                        {
+                            "idx": 1,
+                            "available": True,
+                            "mode": 0,
+                            "mode_name": "global",
+                            "area_count": 1,
+                            "preferences": [
+                                {
+                                    "area_id": 0,
+                                    "mowing_height_cm": 5.0,
+                                    "edge_mowing_auto": True,
+                                    "raw_setting": {"token": "secret"},
+                                }
+                            ],
+                        },
+                    ],
+                    "errors": [],
+                },
+            }
+        )
+    )
+
+    preferences = diagnostics["mowing_preferences"]
+    assert preferences["map_count"] == 2
+    assert [entry["idx"] for entry in preferences["maps"]] == [0, 1]
+    assert preferences["maps"][1]["preference_count"] == 1
+    assert preferences["payload_shape"] == payload_shape
+    assert "5.0" not in repr(preferences)
+    assert "secret" not in repr(preferences)
 
 
 def test_coordinator_diagnostics_collect_video_runtime_privately() -> None:


### PR DESCRIPTION
## Summary

- recognize `dreame.mower.g2540d` as the Dreame A1 Pro 2000
- align full SETTINGS arrays with all validated app-map slots, including uncreated placeholder slots
- preserve compact SETTINGS compatibility by using created-map hints only when the complete MAPL is authoritative
- reject ambiguous, duplicate, boolean, or malformed slot hints instead of repairing them into a potentially wrong map association
- add value-free SETTINGS transport and schema details to downloaded diagnostics and advance the diagnostic schema to version 10

## Why this fixes the report

The submitted mower has two app-map slots: slot 0 is an uncreated placeholder and slot 1 is the active garden. The integration previously removed slot 0 before aligning the two-entry SETTINGS array. Both decoded entries could then receive map index 1, and consumers selected the first, empty preference record. This made the active map's height, direction, efficiency, edge, and obstacle controls unavailable.

The decoder now distinguishes complete slot arrays from compact created-map arrays and falls back conservatively when MAPL is not fully valid. Explicit map identifiers in SETTINGS continue to take precedence.

Runtime task metrics remain unavailable while the mower is docked, and Spot or Maintenance Point selectors remain unavailable when the selected map contains no corresponding objects. Those states are separate from this preference fix.

## Validation

- Ruff repository check
- 1,749 tests passed and 1 skipped under WSL
- focused coverage for full and compact arrays, placeholder slots, malformed and duplicate hints, boolean and partial hints, explicit map identifiers, active global controls, and privacy-safe diagnostics
- independent parser/diagnostics review completed; its map-hint ambiguity finding was reproduced and remediated

No physical mower write was performed. Preference writes and model-specific device-code meanings still require supervised live evidence.

Closes #175
