### PR TITLE
Render LiDAX connector paths separately

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ brand name:
 | MOVA 600 | `mova.mower.g2405a` | **Recognized** | Model identity and shared mower state/device-code semantics; controls, maps, media, and model-specific code overrides still need live validation |
 | MOVA 600 Kit | `mova.mower.g2405b` | **Recognized** | Model identity and shared mower state/device-code semantics; controls, maps, media, and model-specific code overrides still need live validation |
 | MOVA 1000 | `mova.mower.g2405c` | **Recognized** | Model identity, station-brush maintenance code, and mowing-start lifecycle semantics; login, controls, maps, media, and model-specific code overrides still need live validation |
-| MOVA LiDAX Ultra 800 | `mova.mower.g2529b` | **Recognized** | Model identity and shared mower state/device-code semantics; controls, maps, media, and model-specific code overrides still need live validation |
+| MOVA LiDAX Ultra 800 | `mova.mower.g2529b` | **Field-reported** | MOVAhome EU login, core state and controls, maps, map selection, and mowing preferences on firmware `4.3.6_0453`; connector paths are currently rendered as lawn areas by the app-map renderer |
 | MOVA LiDAX Ultra 1000 | `mova.mower.g2529c` | **Field-reported** | MOVAhome EU login, commands, battery, and model-specific cloud property handling |
 | MOVA LiDAX Ultra 2000 | `mova.mower.g2529f` | **Field-reported** | MOVAhome US login, core state and commands, maps, and cloud live video on firmware `4.3.6_0453` |
 | MOVA LiDAX Ultra 2000 AWD | `mova.mower.g2584a` | **Field-reported** | MOVAhome US login, realtime state, zone mowing, docking, maps, and cloud live video on firmware `4.3.6_0439` |

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ brand name:
 | MOVA 600 | `mova.mower.g2405a` | **Recognized** | Model identity and shared mower state/device-code semantics; controls, maps, media, and model-specific code overrides still need live validation |
 | MOVA 600 Kit | `mova.mower.g2405b` | **Recognized** | Model identity and shared mower state/device-code semantics; controls, maps, media, and model-specific code overrides still need live validation |
 | MOVA 1000 | `mova.mower.g2405c` | **Recognized** | Model identity, station-brush maintenance code, and mowing-start lifecycle semantics; login, controls, maps, media, and model-specific code overrides still need live validation |
-| MOVA LiDAX Ultra 800 | `mova.mower.g2529b` | **Field-reported** | MOVAhome EU login, core state and controls, maps, map selection, and mowing preferences on firmware `4.3.6_0453`; connector paths are currently rendered as lawn areas by the app-map renderer |
+| MOVA LiDAX Ultra 800 | `mova.mower.g2529b` | **Field-reported** | MOVAhome EU login, core state and controls, maps, map selection, and mowing preferences on firmware `4.3.6_0453`; app-map connector corridors are distinguished from mowing zones |
 | MOVA LiDAX Ultra 1000 | `mova.mower.g2529c` | **Field-reported** | MOVAhome EU login, commands, battery, and model-specific cloud property handling |
 | MOVA LiDAX Ultra 2000 | `mova.mower.g2529f` | **Field-reported** | MOVAhome US login, core state and commands, maps, and cloud live video on firmware `4.3.6_0453` |
 | MOVA LiDAX Ultra 2000 AWD | `mova.mower.g2584a` | **Field-reported** | MOVAhome US login, realtime state, zone mowing, docking, maps, and cloud live video on firmware `4.3.6_0439` |

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -463,7 +463,10 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         value.get("cut_relation") if isinstance(value.get("cut_relation"), list) else []
     )
 
+    zone_maps = [item for item in maps if not _is_app_map_pathway(item)]
+    pathways = [item for item in maps if _is_app_map_pathway(item)]
     boundary_point_count = 0
+    pathway_boundary_point_count = 0
     spot_boundary_point_count = 0
     semantic_boundary_point_count = 0
     trajectory_point_count = 0
@@ -471,7 +474,7 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
     semantic_key_counts: dict[str, int] = {}
     total_area = value.get("total_area")
     map_area_total = 0.0
-    for item in maps:
+    for item in zone_maps:
         if not isinstance(item, Mapping):
             continue
         coordinates = item.get("data")
@@ -483,6 +486,15 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         area = item.get("area")
         if isinstance(area, int | float):
             map_area_total += float(area)
+    for item in pathways:
+        if not isinstance(item, Mapping):
+            continue
+        coordinates = item.get("data")
+        if isinstance(coordinates, Sequence) and not isinstance(
+            coordinates,
+            str | bytes | bytearray,
+        ):
+            pathway_boundary_point_count += len(coordinates)
     for item in spots:
         if not isinstance(item, Mapping):
             continue
@@ -519,8 +531,10 @@ def _app_map_payload_summary(value: Any) -> dict[str, Any]:
         "name": value.get("name"),
         "total_area": total_area,
         "map_area_total": round(map_area_total, 2),
-        "map_area_count": len(maps),
+        "map_area_count": len(zone_maps),
         "boundary_point_count": boundary_point_count,
+        "pathway_count": len(pathways),
+        "pathway_boundary_point_count": pathway_boundary_point_count,
         "spot_count": len(spots),
         "spot_boundary_point_count": spot_boundary_point_count,
         "point_count": len(point_entries),
@@ -666,6 +680,8 @@ def _app_map_entry_view_metadata(entry: Mapping[str, Any]) -> dict[str, Any]:
         "map_area_count": summary.get("map_area_count"),
         "map_area_total": summary.get("map_area_total"),
         "boundary_point_count": summary.get("boundary_point_count"),
+        "pathway_count": summary.get("pathway_count"),
+        "pathway_boundary_point_count": summary.get("pathway_boundary_point_count"),
         "spot_count": summary.get("spot_count"),
         "point_count": summary.get("point_count"),
         "point_entry_shapes": summary.get("point_entry_shapes"),
@@ -700,6 +716,7 @@ def _app_map_view_summary(
         active_area_count=int(payload_summary.get("map_area_count") or 0),
         active_point_count=int(payload_summary.get("point_count") or 0),
         path_point_count=int(payload_summary.get("trajectory_point_count") or 0),
+        pathway_count=int(payload_summary.get("pathway_count") or 0),
         spot_area_count=int(payload_summary.get("spot_count") or 0),
     )
 
@@ -715,6 +732,7 @@ def _app_map_view_details(
         "total_area": payload_summary.get("total_area"),
         "map_area_total": payload_summary.get("map_area_total"),
         "zone_count": payload_summary.get("map_area_count"),
+        "pathway_count": payload_summary.get("pathway_count"),
         "spot_area_count": payload_summary.get("spot_count"),
         "clean_point_count": payload_summary.get("point_count"),
         "trajectory_count": payload_summary.get("trajectory_count"),
@@ -750,15 +768,24 @@ def _render_app_map_payload_png(
     if not isinstance(payload, Mapping):
         raise ValueError("App map payload is missing.")
 
-    map_entries = _app_map_coordinate_entries(payload.get("map"), "Area")
+    all_map_entries = _app_map_coordinate_entries(payload.get("map"), "Area")
+    map_entries = [entry for entry in all_map_entries if not entry["pathway"]]
+    pathway_entries = [entry for entry in all_map_entries if entry["pathway"]]
     spot_entries = _app_map_coordinate_entries(payload.get("spot"), "Spot")
     map_polygons = [entry["points"] for entry in map_entries]
+    pathway_polygons = [entry["points"] for entry in pathway_entries]
     spot_polygons = [entry["points"] for entry in spot_entries]
     trajectories = _app_map_coordinate_sets(payload.get("trajectory"))
     points = _app_map_points(payload.get("point"))
     all_points = [
         point
-        for group in [*map_polygons, *spot_polygons, *trajectories, points]
+        for group in [
+            *map_polygons,
+            *pathway_polygons,
+            *spot_polygons,
+            *trajectories,
+            points,
+        ]
         for point in group
     ]
     if not all_points:
@@ -797,6 +824,22 @@ def _render_app_map_payload_png(
     image = Image.new("RGBA", (width, height), style.background)
     overlay = Image.new("RGBA", (width, height), (0, 0, 0, 0))
     draw = ImageDraw.Draw(overlay)
+
+    pathway_color = style.navigation_path
+    pathway_fill = (*pathway_color[:3], min(pathway_color[3], 48))
+    for polygon in pathway_polygons:
+        projected = [project(point) for point in polygon]
+        if len(projected) >= 3:
+            draw.polygon(
+                projected,
+                fill=pathway_fill,
+                outline=pathway_color,
+            )
+            draw.line(
+                projected + [projected[0]],
+                fill=pathway_color,
+                width=line_width(style, 2),
+            )
 
     for index, polygon in enumerate(sorted(map_polygons, key=len, reverse=True)):
         projected = [project(point) for point in polygon]
@@ -884,9 +927,22 @@ def _app_map_coordinate_entries(
                 {
                     "points": points,
                     "label": _app_map_entry_label(item, label_prefix),
+                    "pathway": _is_app_map_pathway(item),
                 }
             )
     return result
+
+
+def _is_app_map_pathway(item: Any) -> bool:
+    """Return whether an app-map polygon is connector metadata, not a zone."""
+    if not isinstance(item, Mapping):
+        return False
+    entry_id = item.get("id")
+    return (
+        isinstance(entry_id, int)
+        and not isinstance(entry_id, bool)
+        and 200 <= entry_id < 300
+    )
 
 
 def _app_map_coordinate_sets(value: Any) -> list[list[tuple[float, float]]]:

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -209,6 +209,71 @@ def test_app_map_renderer_applies_saved_spot_presentation() -> None:
     assert all(image.size == (width, height) for image in pixels.values())
 
 
+def test_app_map_renderer_draws_200_series_entries_as_connector_corridors() -> None:
+    payload = {
+        "map": [
+            {
+                "id": 1,
+                "area": 100,
+                "data": [[0, 0], [100, 0], [100, 100], [0, 100]],
+            },
+            {
+                "id": 201,
+                "area": 0,
+                "data": [[100, 40], [200, 40], [200, 60], [100, 60]],
+            },
+        ]
+    }
+
+    png, width, height = render_app_map_payload_png(payload)
+    rendered = Image.open(BytesIO(png)).convert("RGB")
+    style = map_render_style()
+    scale = (width - 96) / 200
+    connector_center = (
+        round((200 - 150) * scale + 48),
+        round(50 * scale + 48),
+    )
+    expected_fill = Image.alpha_composite(
+        Image.new("RGBA", (1, 1), style.background),
+        Image.new(
+            "RGBA",
+            (1, 1),
+            (*style.navigation_path[:3], min(style.navigation_path[3], 48)),
+        ),
+    ).convert("RGB").getpixel((0, 0))
+
+    assert height > 320
+    assert rendered.getpixel(connector_center) == expected_fill
+
+
+def test_app_map_renderer_keeps_300_series_entries_as_zones() -> None:
+    payload = {
+        "map": [
+            {
+                "id": 300,
+                "name": "Future zone",
+                "area": 100,
+                "data": [[0, 0], [100, 0], [100, 100], [0, 100]],
+            }
+        ]
+    }
+
+    png, width, _ = render_app_map_payload_png(payload)
+    rendered = Image.open(BytesIO(png)).convert("RGB")
+    style = map_render_style()
+    scale = (width - 96) / 100
+    zone_interior = (
+        round((100 - 20) * scale + 48),
+        round(20 * scale + 48),
+    )
+    expected_fill = Image.alpha_composite(
+        Image.new("RGBA", (1, 1), style.background),
+        Image.new("RGBA", (1, 1), style.zone_fills[0]),
+    ).convert("RGB").getpixel((0, 0))
+
+    assert rendered.getpixel(zone_interior) == expected_fill
+
+
 def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
     client = _client()
     cloud = _FakeAppMapCloud(
@@ -271,6 +336,8 @@ def test_app_maps_downloads_chunks_and_summarizes_payload() -> None:
         "map_area_total": 12.5,
         "map_area_count": 1,
         "boundary_point_count": 3,
+        "pathway_count": 0,
+        "pathway_boundary_point_count": 0,
         "spot_count": 1,
         "spot_boundary_point_count": 0,
         "point_count": 5,
@@ -671,9 +738,20 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
             "total_area": 1,
             "map": [
                 {
+                    "id": 1,
                     "area": 1,
                     "data": [[0, 0], [100, 0], [100, 100], [0, 100]],
-                }
+                },
+                {
+                    "id": 201,
+                    "area": 0,
+                    "data": [[100, 40], [200, 40], [200, 60], [100, 60]],
+                },
+                {
+                    "id": 300,
+                    "area": 2,
+                    "data": [[200, 0], [300, 0], [300, 100], [200, 100]],
+                },
             ],
             "spot": [{"data": [[20, 20], [40, 20], [40, 40], [20, 40]]}],
             "point": [[50, 50]],
@@ -698,7 +776,8 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
     assert view.summary is not None
     assert view.summary.available is True
     assert view.summary.map_id == 0
-    assert view.summary.segment_count == 1
+    assert view.summary.segment_count == 2
+    assert view.summary.pathway_count == 1
     assert view.summary.no_go_area_count == 0
     assert view.summary.spot_area_count == 1
     assert view.summary.path_point_count == 3
@@ -731,9 +810,11 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
                 "hash_match": True,
                 "payload_keys": ["map", "point", "spot", "total_area", "trajectory"],
                 "total_area": 1,
-                "map_area_count": 1,
-                "map_area_total": 1.0,
-                "boundary_point_count": 4,
+                "map_area_count": 2,
+                "map_area_total": 3.0,
+                "boundary_point_count": 8,
+                "pathway_count": 1,
+                "pathway_boundary_point_count": 4,
                 "spot_count": 1,
                 "point_count": 1,
                 "point_entry_shapes": [


### PR DESCRIPTION
## Summary

- record field-reported MOVA LiDAX Ultra 800 support on firmware `4.3.6_0453`
- render app-map IDs `200`–`299` as neutral connector corridors instead of colored, labeled mowing zones
- report zone and pathway counts separately while preserving unknown `300`-series entries as zones

## Evidence

The diagnostics in issue #177 report three vector-map zones but six app-map polygons. The MOVAhome screenshot confirms that IDs `1`–`3` are mowing zones and IDs `201`–`203` are connector corridors.

## Validation

- focused app-map tests, including `201` connector and `300` zone regressions
- portable test suite and Ruff checks
- representative rendered map inspected against the submitted MOVAhome layout

Live confirmation on the reporter's mower remains useful after the updated integration is installed.
