### PR TITLE
Add authenticated interactive mowing map scenes

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -43,13 +43,13 @@ jobs:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: "1"
         run: >-
           pytest tests
-          --ignore=tests/components/dreame_lawn_mower/test_config_flow.py
+          --ignore=tests/components
           --ignore=tests/test_translations.py
 
-      - name: Home Assistant config flow and translation loading
+      - name: Home Assistant component and translation tests
         run: >-
           pytest
-          tests/components/dreame_lawn_mower/test_config_flow.py
+          tests/components
           tests/test_translations.py
 
   xp2p-runtime-arm64:

--- a/README.md
+++ b/README.md
@@ -536,6 +536,19 @@ selected map boundary is retained in diagnostics but withheld from the image,
 and persisted mower trail data is not presented as live while the session is
 inactive.
 
+The primary map camera also exposes `mowing_map_api_path` for compatible versions
+of [Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card). This
+read-only interface delivers the garden background separately from current
+position and observed movement, so a moving marker does not require downloading
+another full map image. The card can pan, zoom, fit the garden, and centre on a
+fresh mower position while keeping battery and mission figures visible.
+
+The interface requires the same read permission as the map camera. Geometry is
+kept out of entity attributes and recorder state. A missing map identity or stale
+position does not produce a live marker. Movement trails are not cut-area masks:
+the interactive background omits historical mowing paths and decorative stripes
+instead of presenting them as verified completed coverage.
+
 Under **Settings → Devices & services → Dreame Lawn Mower → Configure**, choose
 an Emerald, Mint, Dark, Midnight, or High contrast theme and adjust label, line, and
 marker scale. **Saved spot area display** can hide spot rectangles, show only

--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -22,6 +22,7 @@ from .const import (
 )
 from .coordinator import DreameLawnMowerCoordinator
 from .map_preview import CONF_MAP_RESTART_PREVIEW, async_remove_restart_preview
+from .mowing_map_api import MOWING_MAP_API_KEY, MowingMapAPI, async_setup_mowing_map_api
 from .notifications import DreameLawnMowerNotificationManager
 from .option_updates import EntryUpdateSnapshot
 from .performance import format_performance_sample
@@ -134,6 +135,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
         hass.data.setdefault(DOMAIN, {})[entry.entry_id] = coordinator
         async_setup_point_cloud_api(hass)
+        async_setup_mowing_map_api(hass)
         coordinator.loaded_platforms = platforms
         await setup_cycle.measure("services", lambda: async_setup_services(hass))
         await setup_cycle.measure(
@@ -208,6 +210,9 @@ async def async_unload_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         point_cloud_api = hass.data[DOMAIN].get(POINT_CLOUD_API_DATA_KEY)
         if isinstance(point_cloud_api, DreameLawnMowerPointCloudAPI):
             point_cloud_api.purge_entry(entry.entry_id)
+        mowing_map_api = hass.data[DOMAIN].get(MOWING_MAP_API_KEY)
+        if isinstance(mowing_map_api, MowingMapAPI):
+            await mowing_map_api.purge_entry(entry.entry_id)
         await coordinator.async_shutdown()
         if not any(
             isinstance(value, DreameLawnMowerCoordinator)

--- a/custom_components/dreame_lawn_mower/camera.py
+++ b/custom_components/dreame_lawn_mower/camera.py
@@ -24,7 +24,6 @@ from .const import (
     CONF_MAP_MARKER_IMAGE,
     CONF_MAP_MARKER_SCALE,
     CONF_MAP_MOWING_PATH_STYLE,
-    CONF_MAP_ROTATION,
     CONF_MAP_ROTATIONS,
     CONF_MAP_SPOT_AREA_STYLE,
     CONF_MAP_STROKE_SCALE,
@@ -32,7 +31,6 @@ from .const import (
     DEFAULT_MAP_LABEL_SCALE,
     DEFAULT_MAP_MARKER_SCALE,
     DEFAULT_MAP_MOWING_PATH_STYLE,
-    DEFAULT_MAP_ROTATION,
     DEFAULT_MAP_SPOT_AREA_STYLE,
     DEFAULT_MAP_STROKE_SCALE,
     DEFAULT_MAP_THEME,
@@ -70,7 +68,9 @@ from .map_cache import (
     map_camera_should_refresh,
 )
 from .map_image_variants import MapImageVariants
+from .map_presentation import map_rotation, map_style
 from .map_preview import CONF_MAP_RESTART_PREVIEW, RestartMapPreview, preview_scope
+from .mowing_map_api import mowing_map_api_path
 from .point_cloud_api import current_point_cloud_api_path
 from .video_camera import DreameLawnMowerVideoCamera
 
@@ -124,6 +124,7 @@ class DreameLawnMowerMapCamera(
     _requires_map_capability = True
     _prewarm_map_image = True
     _supports_restart_preview = True
+    _supports_mowing_scene = True
     _refresh_cached_view_on_coordinator_update = True
     # Camera attributes describe the current rendered/diagnostic view. Persisting
     # their large map payloads on every refresh creates unbounded recorder churn.
@@ -252,6 +253,10 @@ class DreameLawnMowerMapCamera(
             selected_map_index=self.coordinator.selected_map_index,
         )
         attributes["restart_preview"] = self._preview_saved_at is not None
+        if self._supports_mowing_scene:
+            attributes["mowing_map_api_path"] = mowing_map_api_path(
+                self.coordinator.entry.entry_id
+            )
         attributes["restart_preview_saved_at"] = self._preview_saved_at
         return attributes
 
@@ -516,14 +521,7 @@ class DreameLawnMowerMapCamera(
 
     def _rotation_for_map_index(self, map_index: int | None) -> int:
         """Share each saved map's display orientation with the contact sheet."""
-        rotations = self.coordinator.entry.options.get(CONF_MAP_ROTATIONS, {})
-        if isinstance(rotations, dict) and map_index is not None:
-            value = rotations.get(str(map_index), rotations.get(map_index))
-            if value in (0, 90, 180, 270):
-                return int(value)
-        return int(
-            self.coordinator.entry.options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION)
-        )
+        return map_rotation(self.coordinator.entry.options, map_index)
 
     @property
     def _selected_map_index(self) -> int | None:
@@ -534,27 +532,10 @@ class DreameLawnMowerMapCamera(
 
     @property
     def _map_style(self) -> MapRenderStyle:
-        options = self.coordinator.entry.options
-        return map_render_style(
-            options.get(CONF_MAP_THEME, DEFAULT_MAP_THEME),
-            rotation=self._map_rotation,
-            stroke_scale=options.get(
-                CONF_MAP_STROKE_SCALE,
-                DEFAULT_MAP_STROKE_SCALE,
-            ),
-            marker_scale=options.get(
-                CONF_MAP_MARKER_SCALE,
-                DEFAULT_MAP_MARKER_SCALE,
-            ),
+        return map_style(
+            self.coordinator.entry.options,
+            self._selected_map_index,
             marker_image=self._map_marker_image,
-            spot_area_style=options.get(
-                CONF_MAP_SPOT_AREA_STYLE,
-                DEFAULT_MAP_SPOT_AREA_STYLE,
-            ),
-            mowing_path_style=options.get(
-                CONF_MAP_MOWING_PATH_STYLE,
-                DEFAULT_MAP_MOWING_PATH_STYLE,
-            ),
         )
 
     @property
@@ -598,6 +579,7 @@ class DreameLawnMowerLivePathMapCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "Live Path Map"
     _supports_restart_preview = False
+    _supports_mowing_scene = False
     _attr_icon = "mdi:map-marker-path"
     _attr_entity_registry_enabled_default = False
     _refresh_cached_view_on_coordinator_update = False
@@ -643,6 +625,7 @@ class DreameLawnMowerMapDataCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "Map Diagnostics"
     _supports_restart_preview = False
+    _supports_mowing_scene = False
     _attr_icon = "mdi:code-json"
     _attr_entity_registry_enabled_default = False
     _requires_map_capability = False
@@ -733,6 +716,7 @@ class DreameLawnMowerAllMapsCamera(DreameLawnMowerMapCamera):
 
     _attr_name = "All Maps"
     _supports_restart_preview = False
+    _supports_mowing_scene = False
     _attr_icon = "mdi:map-multiple-outline"
     _attr_entity_registry_enabled_default = False
     _requires_map_capability = False

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -222,12 +222,29 @@ class DreameLawnMowerRefreshMixin:
             False,
         )
         previous_app_maps_refreshed_at = self.app_maps_refreshed_at
+        mission_generation = runtime_mission_session_generation(
+            self.runtime_telemetry_cache
+        )
         await cycle.measure(
             "active_app_maps",
             lambda: self.async_refresh_app_maps(force=force_map_identity),
         )
+        runtime_snapshot = snapshot
         if self._snapshot_is_stale(snapshot):
-            return False
+            # A pose update can overtake the slower map read without changing
+            # the mission. Hydrate the newest published snapshot, never revive
+            # the stale foreground snapshot or cross a mission boundary.
+            if (
+                mission_generation is None
+                or mission_generation
+                != runtime_mission_session_generation(self.runtime_telemetry_cache)
+            ):
+                return False
+            runtime_snapshot = self._snapshot_for_publication(snapshot)
+            if not getattr(
+                runtime_snapshot, "available", False
+            ) or not runtime_tracking_active(runtime_snapshot):
+                return False
         map_identity_refreshed = bool(
             getattr(self, "app_maps_refresh_succeeded", False)
             and (
@@ -241,14 +258,14 @@ class DreameLawnMowerRefreshMixin:
         runtime_current = await cycle.measure(
             "active_runtime_status",
             lambda: self._async_refresh_runtime_status(
-                snapshot,
+                runtime_snapshot,
                 runtime_map_index=runtime_map_index,
             ),
         )
-        if not runtime_current or self._snapshot_is_stale(snapshot):
+        if not runtime_current or self._snapshot_is_stale(runtime_snapshot):
             return False
         self._runtime_map_identity_verified = map_identity_refreshed
-        return True
+        return runtime_snapshot is snapshot
 
     async def _async_refresh_runtime_status(
         self,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -68,8 +68,18 @@ def runtime_tracking_active(snapshot: DreameLawnMowerSnapshot) -> bool:
 class DreameLawnMowerRefreshMixin:
     """Keep blocking state refreshes separate from optional metadata hydration."""
 
-    def _snapshot_is_stale(self, snapshot: DreameLawnMowerSnapshot) -> bool:
+    def _snapshot_is_stale(
+        self,
+        snapshot: DreameLawnMowerSnapshot,
+        *,
+        observed_generation: int | None = None,
+    ) -> bool:
         """Return whether a newer device snapshot already owns coordinator state."""
+        if observed_generation is not None and max(
+            getattr(self, "_device_snapshot_generation", 0),
+            getattr(self, "_published_device_snapshot_generation", 0),
+        ) > observed_generation:
+            return True
         stale_check = getattr(self, "_device_snapshot_is_stale", None)
         return bool(callable(stale_check) and stale_check(snapshot))
 
@@ -274,6 +284,9 @@ class DreameLawnMowerRefreshMixin:
         runtime_map_index: int | None = None,
     ) -> bool:
         """Refresh optional runtime telemetry without failing the main snapshot."""
+        # Keep the fetch-order token independently of bounded snapshot history:
+        # the snapshot can be borrowed from a realtime task that releases it.
+        observed_device_generation = getattr(self, "_device_snapshot_generation", None)
         runtime_active = runtime_tracking_active(snapshot)
         session_started_at = runtime_mission_session_started_at(
             self.runtime_telemetry_cache
@@ -297,7 +310,9 @@ class DreameLawnMowerRefreshMixin:
                 refresh=False,
                 include_cloud=True,
             )
-            if self._snapshot_is_stale(snapshot) or (
+            if self._snapshot_is_stale(
+                snapshot, observed_generation=observed_device_generation
+            ) or (
                 observed_mission_generation is not None
                 and runtime_mission_session_generation(
                     self.runtime_telemetry_cache
@@ -340,7 +355,9 @@ class DreameLawnMowerRefreshMixin:
             )
             return True
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
-            if self._snapshot_is_stale(snapshot) or (
+            if self._snapshot_is_stale(
+                snapshot, observed_generation=observed_device_generation
+            ) or (
                 observed_mission_generation is not None
                 and runtime_mission_session_generation(
                     self.runtime_telemetry_cache

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -48,6 +48,7 @@ from .client_map_helpers import (
     _validate_point_cloud_map_index,
     _validate_positive_number,
 )
+from .client_mowing_map import _DreameLawnMowerClientMowingMapMixin
 from .client_shared_helpers import (
     _app_action_data,
     _property_entry_received_at,
@@ -164,7 +165,9 @@ def _app_map_inventory_identity(
     )
 
 
-class _DreameLawnMowerClientMapsMixin(_DreameLawnMowerClientAppMapsMixin):
+class _DreameLawnMowerClientMapsMixin(
+    _DreameLawnMowerClientAppMapsMixin, _DreameLawnMowerClientMowingMapMixin
+):
     def _sync_get_current_app_map_index_readback(self) -> int | None:
         """Read only MAPL and return its unambiguous current map index."""
         try:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
@@ -3,11 +3,38 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Mapping
 from typing import Any
 
 from .map_visuals import MapRenderStyle
 from .mowing_map import MowingMapScene, build_mowing_map_scene, mowing_map_overlay
 from .vector_map import parse_batch_vector_map
+
+MAX_SCENE_INPUT_UNITS = 4 * 1024 * 1024
+MAX_SCENE_CHUNKS = 1024
+
+
+def bounded_mowing_map_batch(batch: Mapping[str, Any] | None) -> dict[str, Any]:
+    """Bound map parsing by input characters/bytes and chunk count.
+
+    The existing cloud response is already decoded. Do not copy or parse its
+    device-sized M_PATH history, or unrelated batch properties, for a background.
+    """
+    geometry: dict[str, Any] = {}
+    size = 0
+    for key, value in (batch or {}).items():
+        if not isinstance(key, str) or not key.startswith("MAP."):
+            continue
+        if len(key) > 64 or len(geometry) >= MAX_SCENE_CHUNKS:
+            raise ValueError("The current map exceeds the chunk budget.")
+        if isinstance(value, (str, bytes)):
+            size += len(value)
+        elif key != "MAP.info" or not isinstance(value, int):
+            continue
+        if size > MAX_SCENE_INPUT_UNITS:
+            raise ValueError("The current map exceeds the input budget.")
+        geometry[key] = value
+    return geometry
 
 
 class _DreameLawnMowerClientMowingMapMixin:
@@ -28,13 +55,7 @@ class _DreameLawnMowerClientMowingMapMixin:
         self, *, map_index: int, style: MapRenderStyle, label_scale: float
     ) -> MowingMapScene:
         batch = self._sync_get_vector_map_batch_data()
-        # Historical M_PATH can be device-sized and is not needed for this
-        # contract. Let the existing parser own every geometry detail.
-        geometry = {
-            key: value
-            for key, value in (batch or {}).items()
-            if not str(key).startswith("M_PATH")
-        }
+        geometry = bounded_mowing_map_batch(batch)
         vector_map = parse_batch_vector_map(geometry, current_map_index=map_index)
         if vector_map is None:
             raise ValueError("No geometry is available for the current map.")

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
@@ -1,0 +1,58 @@
+"""Read-only client entry points for independent mowing map layers."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any
+
+from .map_visuals import MapRenderStyle
+from .mowing_map import MowingMapScene, build_mowing_map_scene, mowing_map_overlay
+from .vector_map import parse_batch_vector_map
+
+
+class _DreameLawnMowerClientMowingMapMixin:
+    """Reuse the client transport and session owner; keep HTTP out of the core."""
+
+    async def async_get_mowing_map_scene(
+        self, *, map_index: int, style: MapRenderStyle, label_scale: float = 1.0
+    ) -> MowingMapScene:
+        """Read current-map geometry and build a background off the event loop."""
+        return await asyncio.to_thread(
+            self._sync_get_mowing_map_scene,
+            map_index=map_index,
+            style=style,
+            label_scale=label_scale,
+        )
+
+    def _sync_get_mowing_map_scene(
+        self, *, map_index: int, style: MapRenderStyle, label_scale: float
+    ) -> MowingMapScene:
+        batch = self._sync_get_vector_map_batch_data()
+        # Historical M_PATH can be device-sized and is not needed for this
+        # contract. Let the existing parser own every geometry detail.
+        geometry = {
+            key: value
+            for key, value in (batch or {}).items()
+            if not str(key).startswith("M_PATH")
+        }
+        vector_map = parse_batch_vector_map(geometry, current_map_index=map_index)
+        if vector_map is None:
+            raise ValueError("No geometry is available for the current map.")
+        return build_mowing_map_scene(vector_map, style=style, label_scale=label_scale)
+
+    def mowing_map_runtime_overlay(self, scene: MowingMapScene) -> dict[str, Any]:
+        """Read the existing session cache without requesting mower operations."""
+        blob = self._latest_runtime_status_blob
+        if (
+            blob is not None
+            and blob.candidate_runtime_task_id is not None
+            and blob.candidate_runtime_task_id != self._runtime_live_task_id
+        ):
+            blob = None
+        return mowing_map_overlay(
+            scene,
+            blob,
+            map_index=self._runtime_live_map_index,
+            active=self._runtime_session_active is True,
+            track_segments=self._runtime_live_track_segments,
+        )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map_projection.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/map_projection.py
@@ -1,0 +1,70 @@
+"""One pixel projection for vector backgrounds and independent live overlays."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+
+from .map_geometry import rotate_canvas_point
+
+
+@dataclass(frozen=True, slots=True)
+class MapProjection:
+    """Describe the native-coordinate to clockwise-rotated canvas transform.
+
+    Native X is mirrored by the map renderer. Keeping this transform alongside
+    a background prevents frontends from estimating bounds from image pixels.
+    """
+
+    max_x: float
+    min_y: float
+    scale: float
+    padding: int
+    native_width: int
+    native_height: int
+    rotation: int = 0
+
+    @property
+    def width(self) -> int:
+        """Return the final canvas width after display rotation."""
+        return self.native_height if self.rotation in (90, 270) else self.native_width
+
+    @property
+    def height(self) -> int:
+        """Return the final canvas height after display rotation."""
+        return self.native_width if self.rotation in (90, 270) else self.native_height
+
+    def point(self, x: float, y: float) -> tuple[int, int]:
+        """Project a native point using the renderer's exact rounding rule."""
+        return rotate_canvas_point(
+            (
+                (self.max_x - x) * self.scale + self.padding,
+                (y - self.min_y) * self.scale + self.padding,
+            ),
+            self.native_width,
+            self.native_height,
+            self.rotation,
+        )
+
+
+def vector_map_projection(
+    x1: float, y1: float, x2: float, y2: float, *, rotation: int = 0
+) -> MapProjection:
+    """Build the bounded projection shared by vector PNGs and mowing scenes."""
+    if not all(math.isfinite(value) for value in (x1, y1, x2, y2)):
+        raise ValueError("Map bounds must be finite.")
+    if x2 < x1 or y2 < y1 or rotation not in (0, 90, 180, 270):
+        raise ValueError("Invalid map bounds or rotation.")
+    width, height = max(x2 - x1, 1), max(y2 - y1, 1)
+    padding = 40
+    scale = min((2048 - 2 * padding) / width, (2048 - 2 * padding) / height)
+    scale = max(scale, 400 / max(width, height, 1))
+    return MapProjection(
+        max_x=x2,
+        min_y=y1,
+        scale=scale,
+        padding=padding,
+        native_width=int(width * scale) + 2 * padding,
+        native_height=int(height * scale) + 2 * padding,
+        rotation=rotation,
+    )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
@@ -58,7 +58,9 @@ def build_mowing_map_scene(
         *vector_map.forbidden_areas,
         *vector_map.spot_areas,
     )
-    if sum(len(shape.points) for shape in shapes) > MAX_SCENE_POINTS:
+    point_count = sum(len(shape.points) for shape in shapes)
+    point_count += len(vector_map.clean_points) + len(vector_map.cruise_points)
+    if point_count > MAX_SCENE_POINTS:
         raise ValueError("The current map exceeds the interactive geometry budget.")
     # M_PATH records do not establish current-session cutting coverage. Keep
     # them out of the immutable background and use observed runtime tracks only.

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
@@ -1,0 +1,172 @@
+"""Private, bounded map backgrounds and current-session overlay contracts."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Sequence
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from typing import Any
+
+from .map_projection import MapProjection, vector_map_projection
+from .map_visuals import MapRenderStyle
+from .models import DreameLawnMowerStatusBlob
+from .vector_map import DreameLawnMowerVectorMap, render_vector_map_png
+
+MAX_SCENE_POINTS = 50_000
+MAX_BACKGROUND_BYTES = 4 * 1024 * 1024
+MAX_TRAIL_POINTS = 4096
+POSITION_MAX_AGE_SECONDS = 90
+
+
+@dataclass(frozen=True, slots=True)
+class MowingMapScene:
+    """An immutable background whose revision excludes all runtime telemetry."""
+
+    revision: str
+    map_index: int
+    map_id: int
+    name: str
+    image_png: bytes
+    projection: MapProjection
+    bounds: tuple[int, int, int, int]
+
+    def contains(self, x: Any, y: Any) -> bool:
+        """Accept finite native coordinates inside this map's bounding box."""
+        return (
+            _finite(x)
+            and _finite(y)
+            and self.bounds[0] <= x <= self.bounds[2]
+            and self.bounds[1] <= y <= self.bounds[3]
+        )
+
+
+def build_mowing_map_scene(
+    vector_map: DreameLawnMowerVectorMap,
+    *,
+    style: MapRenderStyle,
+    label_scale: float = 1.0,
+) -> MowingMapScene:
+    """Render static geometry once; never label historical paths as coverage."""
+    boundary = vector_map.boundary
+    if boundary is None:
+        raise ValueError("The current map has no drawable boundary.")
+    shapes = (
+        *vector_map.zones,
+        *vector_map.paths,
+        *vector_map.forbidden_areas,
+        *vector_map.spot_areas,
+    )
+    if sum(len(shape.points) for shape in shapes) > MAX_SCENE_POINTS:
+        raise ValueError("The current map exceeds the interactive geometry budget.")
+    # M_PATH records do not establish current-session cutting coverage. Keep
+    # them out of the immutable background and use observed runtime tracks only.
+    background = replace(vector_map, mow_paths=(), maps={})
+    image_png = render_vector_map_png(
+        background, style=replace(style, zone_pattern="solid"), label_scale=label_scale
+    )
+    if not image_png or len(image_png) > MAX_BACKGROUND_BYTES:
+        raise ValueError("The current map background is unavailable or too large.")
+    projection = vector_map_projection(
+        boundary.x1, boundary.y1, boundary.x2, boundary.y2, rotation=style.rotation
+    )
+    identity = f"{vector_map.map_index}:{vector_map.map_id}:{style.rotation}:".encode()
+    revision = hashlib.sha256(identity + image_png).hexdigest()
+    return MowingMapScene(
+        revision,
+        vector_map.map_index,
+        vector_map.map_id,
+        vector_map.name,
+        image_png,
+        projection,
+        (boundary.x1, boundary.y1, boundary.x2, boundary.y2),
+    )
+
+
+def mowing_map_overlay(
+    scene: MowingMapScene,
+    blob: DreameLawnMowerStatusBlob | None,
+    *,
+    map_index: int | None,
+    active: bool,
+    track_segments: Sequence[Sequence[tuple[int, int]]] = (),
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Project fresh, identity-matched telemetry without fetching or rendering.
+
+    A movement trail is not a cut-area mask. Missing, stale, out-of-bounds or
+    differently scoped evidence deliberately produces no live marker or trail.
+    """
+    result: dict[str, Any] = {
+        "position": None,
+        "trail": [],
+        "updated_at": None,
+        "position_status": "unavailable",
+        "coverage_available": False,
+        "trail_kind": "observed_movement",
+        "max_age_seconds": POSITION_MAX_AGE_SECONDS,
+    }
+    if map_index != scene.map_index:
+        result["position_status"] = "map_mismatch"
+        return result
+    if blob is None or not blob.frame_valid:
+        return result
+    try:
+        updated = datetime.fromisoformat(blob.received_at or "")
+        if updated.tzinfo is None:
+            return result
+        age = ((now or datetime.now(UTC)) - updated).total_seconds()
+    except (ValueError, TypeError, OverflowError):
+        return result
+    if not -5 <= age <= POSITION_MAX_AGE_SECONDS:
+        result["position_status"] = "stale"
+        return result
+    result["updated_at"] = updated.isoformat()
+    x, y = blob.candidate_runtime_pose_x, blob.candidate_runtime_pose_y
+    if scene.contains(x, y):
+        px, py = scene.projection.point(x, y)
+        heading = blob.candidate_runtime_heading_deg
+        result["position"] = {
+            "x": px,
+            "y": py,
+            # The native X mirror reverses yaw. Screen angles are clockwise
+            # from up, matching an upright SVG marker's rotation convention.
+            "heading": ((270 - heading + scene.projection.rotation) % 360)
+            if _finite(heading)
+            else None,
+        }
+        result["position_status"] = "current"
+    else:
+        result["position_status"] = "out_of_bounds"
+    if active:
+        # Retain recent segments, never joining across invalid points or gaps.
+        remaining = MAX_TRAIL_POINTS
+        retained: list[list[list[int]]] = []
+        for segment in reversed(track_segments[-64:]):
+            if remaining < 2:
+                break
+            part: list[list[int]] = []
+            parts: list[list[list[int]]] = []
+            for point in segment[-remaining:]:
+                if len(point) == 2 and scene.contains(*point):
+                    part.append(list(scene.projection.point(*point)))
+                else:
+                    if len(part) >= 2:
+                        parts.append(part)
+                    part = []
+            if len(part) >= 2:
+                parts.append(part)
+            remaining -= sum(len(part) for part in parts)
+            retained[0:0] = parts
+        result["trail"] = retained
+    return result
+
+
+def _finite(value: Any) -> bool:
+    """Reject booleans, missing values and non-finite numeric telemetry."""
+    return (
+        isinstance(value, (int, float))
+        and not isinstance(value, bool)
+        and math.isfinite(value)
+    )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
@@ -65,8 +65,16 @@ def build_mowing_map_scene(
     # M_PATH records do not establish current-session cutting coverage. Keep
     # them out of the immutable background and use observed runtime tracks only.
     background = replace(vector_map, mow_paths=(), maps={})
+    # Garden geometry is not a cut-area mask. Keep it subdued and let the host
+    # theme show through, while retaining zone hues and all safety overlays.
+    interactive_style = replace(
+        style,
+        background=(0, 0, 0, 0),
+        zone_fills=tuple((*color[:3], min(color[3], 64)) for color in style.zone_fills),
+        zone_pattern="solid",
+    )
     image_png = render_vector_map_png(
-        background, style=replace(style, zone_pattern="solid"), label_scale=label_scale
+        background, style=interactive_style, label_scale=label_scale
     )
     if not image_png or len(image_png) > MAX_BACKGROUND_BYTES:
         raise ValueError("The current map background is unavailable or too large.")

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -14,7 +14,8 @@ from typing import Any
 from PIL import Image, ImageDraw
 
 from .map_drawing import draw_lawn_polygon, draw_navigation_path
-from .map_geometry import polygon_label_point, rotate_canvas_point
+from .map_geometry import polygon_label_point
+from .map_projection import vector_map_projection
 from .map_visuals import (
     MapRenderStyle,
     draw_position_marker,
@@ -22,7 +23,6 @@ from .map_visuals import (
     map_font,
     map_render_style,
     marker_radius,
-    project_dreame_app_point,
 )
 from .models import DreameLawnMowerMapSummary
 
@@ -30,9 +30,6 @@ _PATH_SENTINEL = (32767, -32768)
 _SHAPE_RECTANGLE = 2
 _SHAPE_CIRCLE = 3
 _CIRCLE_SEGMENTS = 36
-_MAX_IMAGE_SIDE = 2048
-_MIN_IMAGE_SIDE = 400
-_PADDING = 40
 _LABEL_FONT_SIZE = 18
 _MIN_LABEL_SCALE = 0.5
 _MAX_LABEL_SCALE = 4.0
@@ -243,26 +240,17 @@ def render_vector_map_png(
         return None
 
     boundary = vector_map.boundary
-    map_width = max(boundary.width, 1)
-    map_height = max(boundary.height, 1)
-    scale = min(
-        (_MAX_IMAGE_SIDE - (2 * _PADDING)) / map_width,
-        (_MAX_IMAGE_SIDE - (2 * _PADDING)) / map_height,
-    )
-    scale = max(scale, _MIN_IMAGE_SIDE / max(map_width, map_height, 1))
-
-    image_width = int(map_width * scale) + (2 * _PADDING)
-    image_height = int(map_height * scale) + (2 * _PADDING)
     style = style or map_render_style()
+    projection = vector_map_projection(
+        boundary.x1, boundary.y1, boundary.x2, boundary.y2, rotation=style.rotation
+    )
+    image_width, image_height = projection.width, projection.height
     pixel_scale = max(image_width, image_height) / 900
     style = replace(
         style,
         stroke_scale=style.stroke_scale * pixel_scale,
         marker_scale=style.marker_scale * pixel_scale,
     )
-    native_width, native_height = image_width, image_height
-    if style.rotation in (90, 270):
-        image_width, image_height = image_height, image_width
     runtime_track_segments = filter_runtime_track_segments(
         vector_map,
         runtime_track_segments,
@@ -279,17 +267,7 @@ def render_vector_map_png(
     )
 
     def to_pixel(x: int, y: int) -> tuple[int, int]:
-        px, py = project_dreame_app_point(
-            x,
-            y,
-            max_x=boundary.x2,
-            min_y=boundary.y1,
-            scale=scale,
-            padding=_PADDING,
-        )
-        return rotate_canvas_point(
-            (px, py), native_width, native_height, style.rotation
-        )
+        return projection.point(x, y)
 
     for path in vector_map.paths:
         draw_navigation_path(image, [to_pixel(x, y) for x, y in path.points], style)

--- a/custom_components/dreame_lawn_mower/map_presentation.py
+++ b/custom_components/dreame_lawn_mower/map_presentation.py
@@ -1,0 +1,53 @@
+"""Shared presentation options for camera and interactive map consumers."""
+
+from collections.abc import Mapping
+from typing import Any
+
+from .const import (
+    CONF_MAP_MARKER_SCALE,
+    CONF_MAP_MOWING_PATH_STYLE,
+    CONF_MAP_ROTATION,
+    CONF_MAP_ROTATIONS,
+    CONF_MAP_SPOT_AREA_STYLE,
+    CONF_MAP_STROKE_SCALE,
+    CONF_MAP_THEME,
+    DEFAULT_MAP_MARKER_SCALE,
+    DEFAULT_MAP_MOWING_PATH_STYLE,
+    DEFAULT_MAP_ROTATION,
+    DEFAULT_MAP_SPOT_AREA_STYLE,
+    DEFAULT_MAP_STROKE_SCALE,
+    DEFAULT_MAP_THEME,
+)
+from .dreame_lawn_mower_client.map_visuals import MapRenderStyle, map_render_style
+
+
+def map_rotation(options: Mapping[str, Any], map_index: int | None) -> int:
+    """Resolve a saved map's override before the global display rotation."""
+    rotations = options.get(CONF_MAP_ROTATIONS, {})
+    if isinstance(rotations, Mapping) and map_index is not None:
+        value = rotations.get(str(map_index), rotations.get(map_index))
+        if value in (0, 90, 180, 270):
+            return int(value)
+    return int(options.get(CONF_MAP_ROTATION, DEFAULT_MAP_ROTATION))
+
+
+def map_style(
+    options: Mapping[str, Any],
+    map_index: int | None,
+    *,
+    marker_image: bytes | None = None,
+) -> MapRenderStyle:
+    """Translate HA options once into the renderer's reusable style contract."""
+    return map_render_style(
+        options.get(CONF_MAP_THEME, DEFAULT_MAP_THEME),
+        rotation=map_rotation(options, map_index),
+        stroke_scale=options.get(CONF_MAP_STROKE_SCALE, DEFAULT_MAP_STROKE_SCALE),
+        marker_scale=options.get(CONF_MAP_MARKER_SCALE, DEFAULT_MAP_MARKER_SCALE),
+        marker_image=marker_image,
+        spot_area_style=options.get(
+            CONF_MAP_SPOT_AREA_STYLE, DEFAULT_MAP_SPOT_AREA_STYLE
+        ),
+        mowing_path_style=options.get(
+            CONF_MAP_MOWING_PATH_STYLE, DEFAULT_MAP_MOWING_PATH_STYLE
+        ),
+    )

--- a/custom_components/dreame_lawn_mower/mowing_map_api.py
+++ b/custom_components/dreame_lawn_mower/mowing_map_api.py
@@ -1,0 +1,259 @@
+"""Authenticated read-only map layers, with no geometry in HA recorder state."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+from typing import Any
+
+from aiohttp import web
+from homeassistant.auth.permissions.const import POLICY_READ
+from homeassistant.components.http import HomeAssistantView
+from homeassistant.core import HomeAssistant, callback
+from homeassistant.helpers import entity_registry as er
+
+from .const import CONF_MAP_LABEL_SCALE, DEFAULT_MAP_LABEL_SCALE, DOMAIN
+from .control_options import active_map_index
+from .dreame_lawn_mower_client.client_maps import _app_map_inventory_identity
+from .dreame_lawn_mower_client.mowing_map import MowingMapScene
+from .map_presentation import map_style
+
+MOWING_MAP_API_KEY = "mowing_map_api"
+MOWING_MAP_API_PATH = f"/api/{DOMAIN}/mowing-map"
+_CACHE_SECONDS = 60
+_MAX_ENTRIES = 4
+_HEADERS = {
+    "Cache-Control": "private, no-store",
+    "Vary": "Authorization",
+    "X-Content-Type-Options": "nosniff",
+}
+
+
+def mowing_map_api_path(entry_id: str) -> str:
+    """Advertise the read-only scene endpoint without embedding credentials."""
+    return f"{MOWING_MAP_API_PATH}/{entry_id}"
+
+
+@dataclass(frozen=True, slots=True)
+class _SceneEntry:
+    coordinator: Any
+    context: tuple[Any, ...]
+    scene: MowingMapScene
+    created_at: float
+
+
+class MowingMapAPI:
+    """Coalesce background reads; overlay requests reuse current client telemetry."""
+
+    def __init__(self, hass: HomeAssistant) -> None:
+        self.hass = hass
+        self._cache: OrderedDict[str, _SceneEntry] = OrderedDict()
+        self._inflight: dict[str, asyncio.Task[_SceneEntry]] = {}
+        self._failures: OrderedDict[str, tuple[Any, tuple[Any, ...], float]] = (
+            OrderedDict()
+        )
+
+    def coordinator(self, entry_id: str) -> Any:
+        """Resolve a loaded integration, never a cached unloaded instance."""
+        coordinator = self.hass.data.get(DOMAIN, {}).get(entry_id)
+        if coordinator is None or not hasattr(coordinator, "client"):
+            raise web.HTTPNotFound()
+        return coordinator
+
+    def context(self, coordinator: Any) -> tuple[Any, ...]:
+        """Include map generation and presentation, but no moving telemetry."""
+        app_maps = coordinator.app_maps
+        index = active_map_index(app_maps)
+        if index is None or not app_maps or app_maps.get("map_list_valid") is not True:
+            raise web.HTTPConflict(text="The current map identity is not available.")
+        identity = _app_map_inventory_identity(app_maps.get("maps") or ())
+        if identity is None:
+            raise web.HTTPConflict(text="The current map generation is not available.")
+        options = coordinator.entry.options
+        return (
+            index,
+            identity,
+            map_style(options, index),
+            float(options.get(CONF_MAP_LABEL_SCALE, DEFAULT_MAP_LABEL_SCALE)),
+        )
+
+    def authorize(self, request: web.Request, entry_id: str) -> Any:
+        """Apply the same entity-read permission as the map camera."""
+        coordinator = self.coordinator(entry_id)
+        user = request.get("hass_user")
+        entity_id = er.async_get(self.hass).async_get_entity_id(
+            "camera", DOMAIN, f"{coordinator.client.descriptor.unique_id}_map"
+        )
+        if (
+            user is None
+            or entity_id is None
+            or not user.permissions.check_entity(entity_id, POLICY_READ)
+        ):
+            raise web.HTTPForbidden()
+        return coordinator
+
+    async def scene(self, entry_id: str) -> _SceneEntry:
+        """Reuse a recent static scene and share one bounded background refresh."""
+        coordinator = self.coordinator(entry_id)
+        context = self.context(coordinator)
+        cached = self._cache.get(entry_id)
+        failure = self._failures.get(entry_id)
+        if (
+            failure is not None
+            and failure[0] is coordinator
+            and failure[1] == context
+            and time.monotonic() - failure[2] < 15
+        ):
+            raise web.HTTPBadGateway(
+                text="The current map could not be loaded.",
+                headers={**_HEADERS, "Retry-After": "15"},
+            )
+        if (
+            cached is not None
+            and cached.coordinator is coordinator
+            and cached.context == context
+            and time.monotonic() - cached.created_at < _CACHE_SECONDS
+        ):
+            self._cache.move_to_end(entry_id)
+            return cached
+        task = self._inflight.get(entry_id)
+        if task is None:
+            if len(self._inflight) >= _MAX_ENTRIES:
+                raise web.HTTPServiceUnavailable(headers={"Retry-After": "5"})
+            task = self.hass.async_create_task(
+                self._load(entry_id, coordinator, context),
+                f"{DOMAIN} mowing map background",
+            )
+            self._inflight[entry_id] = task
+            task.add_done_callback(lambda completed: self._finish(entry_id, completed))
+        # A disconnected dashboard must not abandon a worker or trigger another
+        # cloud read while the original worker is still finishing.
+        entry = await asyncio.shield(task)
+        if entry.coordinator is not self.coordinator(
+            entry_id
+        ) or entry.context != self.context(entry.coordinator):
+            raise web.HTTPConflict(text="The map changed while loading.")
+        return entry
+
+    def _finish(self, entry_id: str, task: asyncio.Task[_SceneEntry]) -> None:
+        if self._inflight.get(entry_id) is task:
+            self._inflight.pop(entry_id, None)
+        if not task.cancelled():
+            task.exception()  # Retrieve errors when the last HTTP waiter left.
+
+    async def _load(
+        self, entry_id: str, coordinator: Any, context: tuple[Any, ...]
+    ) -> _SceneEntry:
+        try:
+            scene = await coordinator.client.async_get_mowing_map_scene(
+                map_index=context[0],
+                style=context[2],
+                label_scale=context[3],
+            )
+        except Exception as err:
+            self._failures[entry_id] = (coordinator, context, time.monotonic())
+            self._failures.move_to_end(entry_id)
+            while len(self._failures) > _MAX_ENTRIES:
+                self._failures.popitem(last=False)
+            raise web.HTTPBadGateway(
+                text="The current map could not be loaded.",
+                headers={**_HEADERS, "Retry-After": "15"},
+            ) from err
+        if coordinator is not self.coordinator(entry_id) or context != self.context(
+            coordinator
+        ):
+            raise web.HTTPConflict(text="The map changed while loading.")
+        entry = _SceneEntry(coordinator, context, scene, time.monotonic())
+        self._failures.pop(entry_id, None)
+        self._cache[entry_id] = entry
+        self._cache.move_to_end(entry_id)
+        while len(self._cache) > _MAX_ENTRIES:
+            self._cache.popitem(last=False)
+        return entry
+
+    async def purge_entry(self, entry_id: str) -> None:
+        """Drop private state and drain a pending read during entry unload."""
+        self._cache.pop(entry_id, None)
+        self._failures.pop(entry_id, None)
+        task = self._inflight.get(entry_id)
+        if task is not None:
+            # The client read uses a worker thread: cancellation would stop the
+            # await, not the worker. Drain it before this entry can be replaced.
+            await asyncio.gather(asyncio.shield(task), return_exceptions=True)
+        self._cache.pop(entry_id, None)
+        self._failures.pop(entry_id, None)
+
+
+class MowingMapView(HomeAssistantView):
+    """Deliver compact overlays and a stable reference to the static background."""
+
+    url = f"{MOWING_MAP_API_PATH}/{{entry_id}}"
+    name = "api:dreame_lawn_mower:mowing_map"
+    requires_auth = True
+
+    def __init__(self, api: MowingMapAPI) -> None:
+        self._api = api
+
+    async def get(self, request: web.Request, entry_id: str) -> web.Response:
+        self._api.authorize(request, entry_id)
+        entry = await self._api.scene(entry_id)
+        scene = entry.scene
+        return web.json_response(
+            {
+                "schema_version": 1,
+                "revision": scene.revision,
+                "map_index": scene.map_index,
+                "map_id": scene.map_id,
+                "name": scene.name,
+                "width": scene.projection.width,
+                "height": scene.projection.height,
+                "background_path": (
+                    f"{mowing_map_api_path(entry_id)}/background/{scene.revision}"
+                ),
+                "overlay": entry.coordinator.client.mowing_map_runtime_overlay(scene),
+            },
+            headers=_HEADERS,
+        )
+
+
+class MowingMapBackgroundView(HomeAssistantView):
+    """Only serve the exact background generation advertised in a scene."""
+
+    url = f"{MOWING_MAP_API_PATH}/{{entry_id}}/background/{{revision}}"
+    name = "api:dreame_lawn_mower:mowing_map_background"
+    requires_auth = True
+
+    def __init__(self, api: MowingMapAPI) -> None:
+        self._api = api
+
+    async def get(
+        self, request: web.Request, entry_id: str, revision: str
+    ) -> web.Response:
+        coordinator = self._api.authorize(request, entry_id)
+        entry = self._api._cache.get(entry_id)
+        if (
+            entry is None
+            or entry.coordinator is not coordinator
+            or entry.context != self._api.context(coordinator)
+            or entry.scene.revision != revision
+        ):
+            raise web.HTTPConflict(text="Refresh the map scene before its background.")
+        return web.Response(
+            body=entry.scene.image_png, content_type="image/png", headers=_HEADERS
+        )
+
+
+@callback
+def async_setup_mowing_map_api(hass: HomeAssistant) -> MowingMapAPI:
+    """Register read-only map delivery once per HA instance."""
+    domain_data = hass.data.setdefault(DOMAIN, {})
+    existing = domain_data.get(MOWING_MAP_API_KEY)
+    if isinstance(existing, MowingMapAPI):
+        return existing
+    api = MowingMapAPI(hass)
+    hass.http.register_view(MowingMapView(api))
+    hass.http.register_view(MowingMapBackgroundView(api))
+    domain_data[MOWING_MAP_API_KEY] = api
+    return api

--- a/tests/components/dreame_lawn_mower/test_mowing_map_http.py
+++ b/tests/components/dreame_lawn_mower/test_mowing_map_http.py
@@ -1,0 +1,103 @@
+"""Exercise private map delivery through Home Assistant's real HTTP auth stack."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+from homeassistant.components.http.auth import async_sign_path
+from homeassistant.helpers import entity_registry as er
+from homeassistant.setup import async_setup_component
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.dreame_lawn_mower.const import DOMAIN
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import map_projection
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.mowing_map import (
+    MowingMapScene,
+)
+from custom_components.dreame_lawn_mower.mowing_map_api import (
+    async_setup_mowing_map_api,
+    mowing_map_api_path,
+)
+
+
+async def test_signed_scene_and_background_are_private_and_path_scoped(
+    hass,
+    hass_client_no_auth,
+    hass_read_only_user,
+):
+    """A signed scene URL cannot authorize its separately signed background."""
+    assert await async_setup_component(hass, "http", {"http": {}})
+    entry = MockConfigEntry(domain=DOMAIN)
+    entry.add_to_hass(hass)
+    er.async_get(hass).async_get_or_create(
+        "camera",
+        DOMAIN,
+        "mower_map",
+        config_entry=entry,
+    )
+    scene = MowingMapScene(
+        "a" * 64,
+        0,
+        1,
+        "Garden",
+        b"private-png",
+        map_projection.vector_map_projection(0, 0, 1000, 500),
+        (0, 0, 1000, 500),
+    )
+    client = SimpleNamespace(
+        descriptor=SimpleNamespace(unique_id="mower"),
+        async_get_mowing_map_scene=AsyncMock(return_value=scene),
+        mowing_map_runtime_overlay=Mock(return_value={"position": None, "trail": []}),
+    )
+    hass.data[DOMAIN] = {
+        entry.entry_id: SimpleNamespace(
+            client=client,
+            entry=entry,
+            app_maps={
+                "map_list_valid": True,
+                "current_map_index": 0,
+                "maps": [
+                    {
+                        "idx": 0,
+                        "current": True,
+                        "created": True,
+                        "info": {"hash": "garden-a", "size": 100},
+                    }
+                ],
+            },
+        )
+    }
+    async_setup_mowing_map_api(hass)
+    http = await hass_client_no_auth()
+    path = mowing_map_api_path(entry.entry_id)
+    assert (await http.get(path)).status == 401
+    client.async_get_mowing_map_scene.assert_not_called()
+
+    token = await hass.auth.async_create_refresh_token(
+        hass_read_only_user,
+        client_id="https://example.invalid/",
+    )
+    signed = async_sign_path(
+        hass, path, timedelta(seconds=60), refresh_token_id=token.id
+    )
+    response = await http.get(signed)
+    assert response.status == 200
+    assert response.headers["Cache-Control"] == "private, no-store"
+    payload = await response.json()
+    assert payload["revision"] == scene.revision
+    background_path = payload["background_path"]
+    assert (await http.get(background_path)).status == 401
+    assert (
+        await http.get(background_path + "?" + signed.split("?", 1)[1])
+    ).status == 401
+    signed_background = async_sign_path(
+        hass,
+        background_path,
+        timedelta(seconds=60),
+        refresh_token_id=token.id,
+    )
+    background = await http.get(signed_background)
+    assert background.status == 200
+    assert await background.read() == b"private-png"
+    assert background.headers["Content-Type"] == "image/png"
+    client.async_get_mowing_map_scene.assert_awaited_once()

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -3275,6 +3275,7 @@ def test_failed_platform_setup_removes_coordinator_and_drains_resources() -> Non
                 return_value=cache,
             ),
             patch.object(integration_module, "async_setup_point_cloud_api"),
+            patch.object(integration_module, "async_setup_mowing_map_api"),
             patch.object(
                 integration_module,
                 "async_setup_services",
@@ -3358,6 +3359,7 @@ def test_successful_setup_shuts_down_coordinator_on_home_assistant_stop() -> Non
                 return_value=cache,
             ),
             patch.object(integration_module, "async_setup_point_cloud_api"),
+            patch.object(integration_module, "async_setup_mowing_map_api"),
             patch.object(
                 integration_module,
                 "async_setup_services",

--- a/tests/test_coordinator_tracking_continuity.py
+++ b/tests/test_coordinator_tracking_continuity.py
@@ -1,0 +1,72 @@
+"""Live map hydration must tolerate pose updates without crossing missions."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
+from custom_components.dreame_lawn_mower.performance import (
+    DreameLawnMowerPerformanceTracker,
+)
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
+
+
+@pytest.mark.parametrize("transition", ["pose", "mission", "docked", "offline"])
+def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        original = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        newest = SimpleNamespace(
+            available=transition != "offline",
+            activity="docked" if transition == "docked" else "mowing",
+            docked=transition == "docked",
+            mowing_session_active=transition != "docked",
+        )
+        coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+        coordinator._runtime_map_identity_verified = False
+        coordinator.app_maps_refreshed_at = object()
+        coordinator.app_maps_refresh_succeeded = False
+        coordinator.app_maps = {"current_map_index": 0}
+        coordinator.selected_map_index = 0
+        coordinator._record_device_snapshot(original, retain=True)
+        coordinator._published_device_snapshot_generation = 1
+        coordinator.data = original
+
+        async def read_map(*, force: bool) -> None:
+            assert force is True
+            coordinator.app_maps_refreshed_at = object()
+            coordinator.app_maps_refresh_succeeded = True
+            coordinator._record_device_snapshot(newest)
+            coordinator._published_device_snapshot_generation = (
+                coordinator._device_snapshot_generation
+            )
+            coordinator.data = newest
+            if transition == "mission":
+                coordinator.runtime_telemetry_cache._session_generation += 1
+
+        coordinator.async_refresh_app_maps = read_map
+        coordinator._async_refresh_runtime_status = AsyncMock(return_value=True)
+        tracker = DreameLawnMowerPerformanceTracker()
+        result = await coordinator._async_refresh_active_runtime(
+            tracker.start("test"), original
+        )
+
+        # The outer refresh must publish newest, never its obsolete snapshot.
+        assert result is False
+        assert coordinator._snapshot_for_publication(original) is newest
+        if transition == "pose":
+            coordinator._async_refresh_runtime_status.assert_awaited_once_with(
+                newest, runtime_map_index=0
+            )
+            assert coordinator._runtime_map_identity_verified is True
+        else:
+            coordinator._async_refresh_runtime_status.assert_not_awaited()
+            assert coordinator._runtime_map_identity_verified is False
+
+    asyncio.run(scenario())

--- a/tests/test_coordinator_tracking_continuity.py
+++ b/tests/test_coordinator_tracking_continuity.py
@@ -2,11 +2,14 @@
 
 import asyncio
 from types import SimpleNamespace
-from unittest.mock import AsyncMock
+from unittest.mock import AsyncMock, Mock
 
 import pytest
 
-from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
+from custom_components.dreame_lawn_mower.coordinator import (
+    DEVICE_SNAPSHOT_GENERATION_HISTORY,
+    DreameLawnMowerCoordinator,
+)
 from custom_components.dreame_lawn_mower.performance import (
     DreameLawnMowerPerformanceTracker,
 )
@@ -15,7 +18,9 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
 )
 
 
-@pytest.mark.parametrize("transition", ["pose", "mission", "docked", "offline"])
+@pytest.mark.parametrize(
+    "transition", ["pose", "mission", "docked", "offline", "evicted", "evicted_error"]
+)
 def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> None:
     async def scenario() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
@@ -29,6 +34,7 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
             mowing_session_active=transition != "docked",
         )
         coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+        coordinator.runtime_status_blob = None
         coordinator._runtime_map_identity_verified = False
         coordinator.app_maps_refreshed_at = object()
         coordinator.app_maps_refresh_succeeded = False
@@ -51,7 +57,31 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
                 coordinator.runtime_telemetry_cache._session_generation += 1
 
         coordinator.async_refresh_app_maps = read_map
-        coordinator._async_refresh_runtime_status = AsyncMock(return_value=True)
+        blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+
+        async def read_runtime(**kwargs: object) -> object:
+            if transition.startswith("evicted"):
+                # Simulate updates while the real telemetry read is pending.
+                await asyncio.sleep(0)
+                for _ in range(DEVICE_SNAPSHOT_GENERATION_HISTORY + 2):
+                    docked = SimpleNamespace(
+                        available=True, docked=True, mowing_session_active=False
+                    )
+                    coordinator._record_device_snapshot(docked)
+                    coordinator._published_device_snapshot_generation = (
+                        coordinator._device_snapshot_generation
+                    )
+                    coordinator.data = docked
+                assert id(newest) not in coordinator._device_snapshot_generations
+                assert coordinator.runtime_telemetry_cache._session_generation == 0
+                if transition == "evicted_error":
+                    raise RuntimeError("Delayed read failed")
+            return blob
+
+        coordinator.client = SimpleNamespace(
+            async_get_runtime_status_blob=AsyncMock(side_effect=read_runtime),
+            update_runtime_live_tracking=Mock(),
+        )
         tracker = DreameLawnMowerPerformanceTracker()
         result = await coordinator._async_refresh_active_runtime(
             tracker.start("test"), original
@@ -59,14 +89,18 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
 
         # The outer refresh must publish newest, never its obsolete snapshot.
         assert result is False
-        assert coordinator._snapshot_for_publication(original) is newest
+        assert coordinator._snapshot_for_publication(original) is coordinator.data
         if transition == "pose":
-            coordinator._async_refresh_runtime_status.assert_awaited_once_with(
-                newest, runtime_map_index=0
+            coordinator.client.update_runtime_live_tracking.assert_called_once_with(
+                blob, active=True, map_index=0
             )
+            assert coordinator.runtime_status_blob is blob
+            assert coordinator.runtime_telemetry_cache.blob is blob
             assert coordinator._runtime_map_identity_verified is True
         else:
-            coordinator._async_refresh_runtime_status.assert_not_awaited()
+            coordinator.client.update_runtime_live_tracking.assert_not_called()
+            assert coordinator.runtime_status_blob is None
+            assert coordinator.runtime_telemetry_cache.blob is None
             assert coordinator._runtime_map_identity_verified is False
 
     asyncio.run(scenario())

--- a/tests/test_mowing_map.py
+++ b/tests/test_mowing_map.py
@@ -1,0 +1,148 @@
+"""Contracts for stable mowing backgrounds and truthful runtime overlays."""
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from io import BytesIO
+
+import pytest
+from PIL import Image
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.map_visuals import (
+    map_render_style,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    DreameLawnMowerStatusBlob,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.mowing_map import (
+    MAX_TRAIL_POINTS,
+    build_mowing_map_scene,
+    mowing_map_overlay,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.vector_map import (
+    DreameLawnMowerVectorBoundary,
+    DreameLawnMowerVectorMap,
+    DreameLawnMowerVectorMowPath,
+    DreameLawnMowerVectorZone,
+)
+
+NOW = datetime(2026, 9, 6, 12, tzinfo=UTC)
+
+
+def garden():
+    return DreameLawnMowerVectorMap(
+        map_index=2,
+        map_id=7,
+        name="Garden",
+        boundary=DreameLawnMowerVectorBoundary(0, 0, 1000, 500),
+        zones=(
+            DreameLawnMowerVectorZone(
+                zone_id=1,
+                points=((0, 0), (1000, 0), (1000, 500), (0, 500)),
+            ),
+        ),
+    )
+
+
+def telemetry():
+    return DreameLawnMowerStatusBlob(
+        supported=True,
+        frame_valid=True,
+        received_at=NOW.isoformat(),
+        candidate_runtime_pose_x=200,
+        candidate_runtime_pose_y=200,
+        candidate_runtime_heading_deg=0,
+    )
+
+
+@pytest.mark.parametrize("rotation", [0, 90, 180, 270])
+def test_background_dimensions_and_overlay_share_projection(rotation):
+    scene = build_mowing_map_scene(garden(), style=map_render_style(rotation=rotation))
+    with Image.open(BytesIO(scene.image_png)) as image:
+        assert image.size == (scene.projection.width, scene.projection.height)
+    overlay = mowing_map_overlay(scene, telemetry(), map_index=2, active=True, now=NOW)
+    position = overlay["position"]
+    assert (position["x"], position["y"]) == scene.projection.point(200, 200)
+    assert position["heading"] == (270 + rotation) % 360
+    assert overlay["coverage_available"] is False
+
+
+def test_historical_paths_do_not_change_background_or_claim_mission_coverage():
+    original = garden()
+    style = map_render_style()
+    first = build_mowing_map_scene(original, style=style)
+    original.mow_paths = (DreameLawnMowerVectorMowPath(1, (((10, 10), (500, 200)),)),)
+    second = build_mowing_map_scene(original, style=style)
+    assert second.revision == first.revision
+    assert second.image_png == first.image_png
+    recreated = build_mowing_map_scene(replace(original, map_id=8), style=style)
+    assert recreated.revision != first.revision
+
+
+@pytest.mark.parametrize(
+    "change,status",
+    [
+        ({"frame_valid": False}, "unavailable"),
+        ({"received_at": (NOW - timedelta(seconds=91)).isoformat()}, "stale"),
+        ({"received_at": (NOW + timedelta(seconds=6)).isoformat()}, "stale"),
+        ({"received_at": "invalid"}, "unavailable"),
+        ({"candidate_runtime_pose_x": 1001}, "out_of_bounds"),
+        ({"candidate_runtime_pose_x": float("nan")}, "out_of_bounds"),
+    ],
+)
+def test_unverified_position_is_not_shown(change, status):
+    scene = build_mowing_map_scene(garden(), style=map_render_style())
+    overlay = mowing_map_overlay(
+        scene,
+        replace(telemetry(), **change),
+        map_index=2,
+        active=True,
+        now=NOW,
+    )
+    assert overlay["position"] is None
+    assert overlay["position_status"] == status
+
+
+def test_map_mismatch_hides_both_marker_and_trail():
+    scene = build_mowing_map_scene(garden(), style=map_render_style())
+    overlay = mowing_map_overlay(
+        scene,
+        telemetry(),
+        map_index=1,
+        active=True,
+        now=NOW,
+        track_segments=(((10, 10), (20, 20)),),
+    )
+    assert overlay["position"] is None
+    assert overlay["trail"] == []
+    assert overlay["position_status"] == "map_mismatch"
+
+
+def test_trail_preserves_gaps_and_stays_bounded():
+    scene = build_mowing_map_scene(garden(), style=map_render_style())
+    overlay = mowing_map_overlay(
+        scene,
+        telemetry(),
+        map_index=2,
+        active=True,
+        now=NOW,
+        track_segments=(((10, 10), (20, 20), (2000, 2000), (30, 30), (40, 40)),),
+    )
+    assert [len(part) for part in overlay["trail"]] == [2, 2]
+    crowded = mowing_map_overlay(
+        scene,
+        telemetry(),
+        map_index=2,
+        active=True,
+        now=NOW,
+        track_segments=(tuple((n % 500, 100) for n in range(MAX_TRAIL_POINTS + 100)),),
+    )
+    assert sum(len(part) for part in crowded["trail"]) == MAX_TRAIL_POINTS
+    ended = mowing_map_overlay(
+        scene,
+        telemetry(),
+        map_index=2,
+        active=False,
+        now=NOW,
+        track_segments=(((10, 10), (20, 20)),),
+    )
+    assert ended["trail"] == []

--- a/tests/test_mowing_map.py
+++ b/tests/test_mowing_map.py
@@ -58,6 +58,19 @@ def telemetry():
     )
 
 
+def test_background_composites_with_the_host_without_claiming_cut_coverage():
+    style = map_render_style("mint")
+    scene = build_mowing_map_scene(garden(), style=style)
+    with Image.open(BytesIO(scene.image_png)) as image:
+        assert image.getpixel((0, 0))[3] == 0
+        # An interior sample away from boundaries and the zone label.
+        x, y = scene.projection.point(200, 100)
+        assert 0 < image.getpixel((x, y))[3] <= 64
+    # The existing camera palette remains unchanged.
+    assert style.background[3] == 255
+    assert style.zone_fills[0][3] == 230
+
+
 @pytest.mark.parametrize("field", ["clean_points", "cruise_points"])
 def test_every_rendered_point_collection_counts_against_the_budget(field):
     vector = replace(garden(), **{field: ((10, 10),) * MAX_SCENE_POINTS})

--- a/tests/test_mowing_map.py
+++ b/tests/test_mowing_map.py
@@ -7,6 +7,9 @@ from io import BytesIO
 import pytest
 from PIL import Image
 
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    client_mowing_map,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.map_visuals import (
     map_render_style,
 )
@@ -14,6 +17,7 @@ from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import 
     DreameLawnMowerStatusBlob,
 )
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.mowing_map import (
+    MAX_SCENE_POINTS,
     MAX_TRAIL_POINTS,
     build_mowing_map_scene,
     mowing_map_overlay,
@@ -52,6 +56,29 @@ def telemetry():
         candidate_runtime_pose_y=200,
         candidate_runtime_heading_deg=0,
     )
+
+
+@pytest.mark.parametrize("field", ["clean_points", "cruise_points"])
+def test_every_rendered_point_collection_counts_against_the_budget(field):
+    vector = replace(garden(), **{field: ((10, 10),) * MAX_SCENE_POINTS})
+    with pytest.raises(ValueError, match="geometry budget"):
+        build_mowing_map_scene(vector, style=map_render_style())
+
+
+def test_input_budget_precedes_map_parsing_and_ignores_unneeded_history(monkeypatch):
+    monkeypatch.setattr(client_mowing_map, "MAX_SCENE_INPUT_UNITS", 10)
+    assert client_mowing_map.bounded_mowing_map_batch(
+        {
+            "MAP.0": "small",
+            "MAP.info": 5,
+            "M_PATH.0": "x" * 100,
+        }
+    ) == {"MAP.0": "small", "MAP.info": 5}
+    with pytest.raises(ValueError, match="input budget"):
+        client_mowing_map.bounded_mowing_map_batch({"MAP.0": "x" * 11})
+    monkeypatch.setattr(client_mowing_map, "MAX_SCENE_CHUNKS", 1)
+    with pytest.raises(ValueError, match="chunk budget"):
+        client_mowing_map.bounded_mowing_map_batch({"MAP.0": "a", "MAP.1": "b"})
 
 
 @pytest.mark.parametrize("rotation", [0, 90, 180, 270])

--- a/tests/test_mowing_map_api.py
+++ b/tests/test_mowing_map_api.py
@@ -1,0 +1,167 @@
+"""Read-only API authorization, coalescing, lifecycle and image identity contracts."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+from aiohttp import web
+
+from custom_components.dreame_lawn_mower import mowing_map_api as module
+from custom_components.dreame_lawn_mower.const import DOMAIN
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import map_projection
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.mowing_map import (
+    MowingMapScene,
+)
+
+
+def scene():
+    return MowingMapScene(
+        "a" * 64,
+        0,
+        1,
+        "Garden",
+        b"private-png",
+        map_projection.vector_map_projection(0, 0, 1000, 500),
+        (0, 0, 1000, 500),
+    )
+
+
+def environment(load):
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(
+            async_get_mowing_map_scene=load,
+            descriptor=SimpleNamespace(unique_id="mower"),
+        ),
+        entry=SimpleNamespace(options={}),
+        app_maps={
+            "map_list_valid": True,
+            "current_map_index": 0,
+            "maps": [
+                {
+                    "idx": 0,
+                    "current": True,
+                    "created": True,
+                    "info": {"hash": "garden-a", "size": 100},
+                }
+            ],
+        },
+    )
+    hass = SimpleNamespace(
+        data={DOMAIN: {"entry": coordinator}},
+        async_create_task=lambda coro, name: asyncio.create_task(coro, name=name),
+    )
+    return hass, coordinator, module.MowingMapAPI(hass)
+
+
+def test_readers_share_background_and_cancelled_waiter_does_not_cancel_worker():
+    async def run():
+        started, finish = asyncio.Event(), asyncio.Event()
+        calls = 0
+
+        async def load(**kwargs):
+            nonlocal calls
+            calls += 1
+            started.set()
+            await finish.wait()
+            return scene()
+
+        _, _, api = environment(load)
+        first = asyncio.create_task(api.scene("entry"))
+        await started.wait()
+        second = asyncio.create_task(api.scene("entry"))
+        first.cancel()
+        await asyncio.gather(first, return_exceptions=True)
+        finish.set()
+        assert (await second).scene.revision == "a" * 64
+        assert (await api.scene("entry")).scene.image_png == b"private-png"
+        assert calls == 1
+
+    asyncio.run(run())
+
+
+@pytest.mark.parametrize("change", ["generation", "rotation", "replacement", "unload"])
+def test_inflight_scene_cannot_publish_after_context_change(change):
+    async def run():
+        started, finish = asyncio.Event(), asyncio.Event()
+
+        async def load(**kwargs):
+            started.set()
+            await finish.wait()
+            return scene()
+
+        hass, coordinator, api = environment(load)
+        pending = asyncio.create_task(api.scene("entry"))
+        await started.wait()
+        if change == "generation":
+            coordinator.app_maps["maps"][0]["info"]["hash"] = "garden-b"
+        elif change == "rotation":
+            coordinator.entry.options["map_rotation"] = 90
+        elif change == "replacement":
+            hass.data[DOMAIN]["entry"] = environment(load)[1]
+        else:
+            hass.data[DOMAIN].pop("entry")
+        finish.set()
+        with pytest.raises((web.HTTPConflict, web.HTTPNotFound)):
+            await pending
+        assert not api._cache
+
+    asyncio.run(run())
+
+
+def test_failed_background_is_private_and_backed_off():
+    async def run():
+        calls = 0
+
+        async def load(**kwargs):
+            nonlocal calls
+            calls += 1
+            raise ValueError("private-vendor-payload")
+
+        _, _, api = environment(load)
+        for _ in range(2):
+            with pytest.raises(web.HTTPBadGateway) as failure:
+                await api.scene("entry")
+            assert "private-vendor" not in failure.value.text
+            assert failure.value.headers["Cache-Control"] == "private, no-store"
+        assert calls == 1
+
+    asyncio.run(run())
+
+
+def test_camera_read_permission_is_required(monkeypatch):
+    _, _, api = environment(None)
+    registry = SimpleNamespace(async_get_entity_id=lambda *args: "camera.garden_map")
+    monkeypatch.setattr(module.er, "async_get", lambda hass: registry)
+    permitted = Mock(return_value=False)
+    request = {
+        "hass_user": SimpleNamespace(
+            permissions=SimpleNamespace(check_entity=permitted)
+        )
+    }
+    with pytest.raises(web.HTTPForbidden):
+        api.authorize(request, "entry")
+    permitted.assert_called_once_with("camera.garden_map", module.POLICY_READ)
+    permitted.return_value = True
+    assert api.authorize(request, "entry") is api.coordinator("entry")
+
+
+def test_background_requires_exact_revision_and_current_context(monkeypatch):
+    async def run():
+        async def load(**kwargs):
+            return scene()
+
+        _, coordinator, api = environment(load)
+        monkeypatch.setattr(api, "authorize", lambda request, entry: coordinator)
+        await api.scene("entry")
+        view = module.MowingMapBackgroundView(api)
+        response = await view.get({}, "entry", "a" * 64)
+        assert response.body == b"private-png"
+        assert response.headers["Cache-Control"] == "private, no-store"
+        with pytest.raises(web.HTTPConflict):
+            await view.get({}, "entry", "b" * 64)
+        coordinator.app_maps["current_map_index"] = 1
+        with pytest.raises(web.HTTPConflict):
+            await view.get({}, "entry", "a" * 64)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Interactive mowing maps

Expose a read-only, authenticated map scene for interactive dashboards. The scene separates the garden background from live position and observed movement, so the card can pan and zoom without regenerating the map for each position update.

- Reuse the existing map projection, display rotation, and runtime telemetry cache.
- Bound geometry parsing and background caching, enforce camera read permission, and discard stale or mismatched live positions.
- Keep geometry out of entity state and recorder history. No additional mower operations are requested for overlay updates.
- Report observed movement honestly: it is not verified cut-area coverage.
- Render a transparent interactive background while preserving the selected zone colours and safety overlays; existing camera styles are unchanged.
- Allow live map hydration to continue with a newer same-mission snapshot when pose updates arrive during the map read, without publishing the obsolete snapshot.

This builds on #180. The matching frontend is [lovelace-lawn-mower-card #44](https://github.com/EvotecIT/lovelace-lawn-mower-card/pull/44), which consumes the scene advertised by the primary map camera. Release the integration capability before expecting interactive mode in the card; existing camera rendering remains available.

The authenticated scene, background delivery, and live mowing view have been checked in Home Assistant. Projected heading agrees with observed travel during a straight pass; no mower movement was initiated for validation.
