### PR TITLE
Retain verified mower positions and add observed mowing time

### DIFF
--- a/custom_components/dreame_lawn_mower/__init__.py
+++ b/custom_components/dreame_lawn_mower/__init__.py
@@ -24,6 +24,10 @@ from .coordinator import DreameLawnMowerCoordinator
 from .map_preview import CONF_MAP_RESTART_PREVIEW, async_remove_restart_preview
 from .mowing_map_api import MOWING_MAP_API_KEY, MowingMapAPI, async_setup_mowing_map_api
 from .notifications import DreameLawnMowerNotificationManager
+from .observation_checkpoint import (
+    ObservationCheckpoint,
+    async_remove_observation_checkpoint,
+)
 from .option_updates import EntryUpdateSnapshot
 from .performance import format_performance_sample
 from .point_cloud_api import (
@@ -102,6 +106,10 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
         did=coordinator.client.descriptor.did,
     )
     try:
+        coordinator.observation_checkpoint = ObservationCheckpoint(
+            hass, entry.entry_id, coordinator
+        )
+        await coordinator.observation_checkpoint.async_load()
         try:
             await setup_cycle.measure("lan_video_cache", lan_cache.async_load)
         except Exception as err:  # noqa: BLE001 - cloud setup remains available.
@@ -248,5 +256,6 @@ async def _async_update_listener(hass: HomeAssistant, entry: ConfigEntry) -> Non
 
 
 async def async_remove_entry(hass: HomeAssistant, entry: ConfigEntry) -> None:
-    """Remove the optional private lawn preview when its entry is deleted."""
+    """Remove private cached evidence when its entry is deleted."""
     await async_remove_restart_preview(hass, entry.entry_id)
+    await async_remove_observation_checkpoint(hass, entry.entry_id)

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -631,6 +631,12 @@ class DreameLawnMowerCoordinator(
                     bluetooth_error,
                 )
             self.async_set_updated_data(snapshot)
+            if runtime_active and not getattr(
+                self, "_runtime_map_identity_verified", False
+            ):
+                # Push updates reset HA's polling interval. Acquire missing map
+                # identity through the existing coalesced background owner.
+                self._schedule_metadata_refresh(refresh_map_and_runtime=True)
             settings_event_at = getattr(snapshot, "device_settings_event_at", None)
             preferences_event_at = getattr(
                 snapshot,

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -86,6 +86,7 @@ from .schedule_cache import (
     schedule_entry_has_usable_data,
     schedule_payload_has_usable_data,
 )
+from .session_timing import observe_mowing_time
 
 CLIENT_UPDATE_SHUTDOWN_GRACE_SECONDS = 1.0
 
@@ -359,6 +360,8 @@ class DreameLawnMowerCoordinator(
             self._published_device_snapshot_generation = generation
         if getattr(data, "available", True):
             self._observe_runtime_mission_boundary(data)
+        else:
+            observe_mowing_time(self, data, None)
         super().async_set_updated_data(data)
 
     def _observe_runtime_mission_boundary(
@@ -402,6 +405,7 @@ class DreameLawnMowerCoordinator(
                 cached_session_identity=session_identity,
             ),
         )
+        observe_mowing_time(self, snapshot, mission_active)
         return mission_active
 
     def _retain_feature_capability_evidence(

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -2403,6 +2403,9 @@ class DreameLawnMowerCoordinator(
                 await super().async_shutdown()
                 self._base_shutdown_complete = True
             await self._async_stop_owned_tasks()
+            checkpoint = getattr(self, "observation_checkpoint", None)
+            if checkpoint is not None:
+                await checkpoint.async_close()
 
     async def async_shutdown_for_home_assistant_stop(self) -> None:
         """Stop owned work and close the client without draining metadata."""

--- a/custom_components/dreame_lawn_mower/coordinator_connectivity.py
+++ b/custom_components/dreame_lawn_mower/coordinator_connectivity.py
@@ -93,6 +93,9 @@ class DreameLawnMowerConnectivityMixin:
         error: BaseException | str | None,
     ) -> DreameLawnMowerSnapshot | None:
         """Record a link interruption and return safe retained state when fresh."""
+        timer = getattr(self, "observed_mowing_timer", None)
+        if timer is not None:
+            timer.interrupt()
         now = datetime.now(UTC)
         if not self.connection_degraded:
             self._connectivity_degraded_since = now

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -235,25 +235,35 @@ class DreameLawnMowerRefreshMixin:
         mission_generation = runtime_mission_session_generation(
             self.runtime_telemetry_cache
         )
+        observed_device_generation = getattr(self, "_device_snapshot_generation", None)
         await cycle.measure(
             "active_app_maps",
             lambda: self.async_refresh_app_maps(force=force_map_identity),
         )
         runtime_snapshot = snapshot
-        if self._snapshot_is_stale(snapshot):
+        if (
+            mission_generation is not None
+            and mission_generation
+            != runtime_mission_session_generation(self.runtime_telemetry_cache)
+        ):
+            return False
+        if self._snapshot_is_stale(
+            snapshot, observed_generation=observed_device_generation
+        ):
             # A pose update can overtake the slower map read without changing
             # the mission. Hydrate the newest published snapshot, never revive
             # the stale foreground snapshot or cross a mission boundary.
-            if (
-                mission_generation is None
-                or mission_generation
-                != runtime_mission_session_generation(self.runtime_telemetry_cache)
-            ):
+            if mission_generation is None:
                 return False
-            runtime_snapshot = self._snapshot_for_publication(snapshot)
-            if not getattr(
-                runtime_snapshot, "available", False
-            ) or not runtime_tracking_active(runtime_snapshot):
+            # A borrowed snapshot can be evicted from bounded history while
+            # maps load. Its independent token still proves it is obsolete.
+            runtime_snapshot = self.data
+            if (
+                runtime_snapshot is snapshot
+                or self._snapshot_is_stale(runtime_snapshot)
+                or not getattr(runtime_snapshot, "available", False)
+                or not runtime_tracking_active(runtime_snapshot)
+            ):
                 return False
         map_identity_refreshed = bool(
             getattr(self, "app_maps_refresh_succeeded", False)
@@ -273,6 +283,20 @@ class DreameLawnMowerRefreshMixin:
             ),
         )
         if not runtime_current or self._snapshot_is_stale(runtime_snapshot):
+            newest = self.data
+            if (
+                mission_generation is not None
+                and mission_generation
+                == runtime_mission_session_generation(self.runtime_telemetry_cache)
+                and runtime_map_index is not None
+                and runtime_map_index == self._runtime_map_index()
+                and getattr(newest, "available", False)
+                and runtime_tracking_active(newest)
+            ):
+                # New pose callbacks invalidate a borrowed snapshot, not the
+                # independently verified map identity. Let the next callback
+                # bind its fresh packet without publishing this stale read.
+                self._runtime_map_identity_verified = map_identity_refreshed
             return False
         self._runtime_map_identity_verified = map_identity_refreshed
         return runtime_snapshot is snapshot
@@ -425,7 +449,7 @@ class DreameLawnMowerRefreshMixin:
                 core_operations.append(
                     (
                         "app_maps",
-                        lambda: self.async_refresh_app_maps(force=False),
+                        lambda: self._async_refresh_background_map_runtime(cycle),
                     )
                 )
 
@@ -622,6 +646,18 @@ class DreameLawnMowerRefreshMixin:
                 self._schedule_metadata_refresh(
                     refresh_map_and_runtime=True,
                 )
+
+    async def _async_refresh_background_map_runtime(
+        self, cycle: DreameLawnMowerPerformanceCycle
+    ) -> Any:
+        """Verify active map identity even when MQTT postpones normal polling."""
+        snapshot = getattr(self, "data", None)
+        if (
+            getattr(snapshot, "available", False)
+            and runtime_tracking_active(snapshot)
+        ):
+            return await self._async_refresh_active_runtime(cycle, snapshot)
+        return await self.async_refresh_app_maps(force=False)
 
     def _metadata_phase_needs_retry(self, phase: str, result: Any) -> bool:
         """Return whether one core phase has not populated its cache yet."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -190,6 +190,7 @@ from .point_cloud import (
     DreameLawnMowerPointCloudError,
 )
 from .point_cloud import parse_pcd_metadata as parse_pcd_metadata
+from .position_tracking import MowerPositionTracker as _MowerPositionTracker
 from .runtime_state import RESUME_MOWING_REQUEST as RESUME_MOWING_REQUEST
 from .runtime_state import (
     snapshot_session_control_state,
@@ -459,6 +460,7 @@ class DreameLawnMowerClient(
         self._update_callback: _typing.Callable[[], None] | None = None
         self._latest_snapshot: DreameLawnMowerSnapshot | None = None
         self._latest_runtime_status_blob: DreameLawnMowerStatusBlob | None = None
+        self._position_tracker = _MowerPositionTracker()
         self._runtime_live_track_segments: tuple[
             tuple[tuple[int, int], ...],
             ...,
@@ -504,6 +506,7 @@ class DreameLawnMowerClient(
         map_index: int | None = None,
     ) -> None:
         """Cache active-session runtime track history for live map overlays."""
+        self._position_tracker.record(status_blob, map_index=map_index)
         self._latest_runtime_status_blob = status_blob
         self._runtime_session_active = active
         if not active:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -849,12 +849,11 @@ class _DreameLawnMowerClientCoreMixin:
         runtime_details = runtime_view.details
         if not isinstance(runtime_details, Mapping):
             return map_view
-        if (
-            runtime_details.get("runtime_pose_x") is None
-            or runtime_details.get("runtime_pose_y") is None
+        if not any(
+            key in runtime_details
+            for key in ("runtime_pose_x", "position_status", "docked")
         ):
             return map_view
-
         details = dict(map_view.details or {})
         for key in (
             "runtime_pose_x",
@@ -862,6 +861,10 @@ class _DreameLawnMowerClientCoreMixin:
             "runtime_heading_deg",
             "runtime_region_id",
             "runtime_position_updated_at",
+            "position_status",
+            "position_source",
+            "position_observed_at",
+            "docked",
         ):
             value = runtime_details.get(key)
             if value is not None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -43,12 +43,12 @@ from .client_map_helpers import (
     _point_cloud_object_name,
     _PointCloudObjectIdentity,
     _render_app_map_payload_png,
-    _runtime_blob_position,
     _select_app_map_payload,
     _validate_point_cloud_map_index,
     _validate_positive_number,
 )
 from .client_mowing_map import _DreameLawnMowerClientMowingMapMixin
+from .client_position import apply_position_metadata, vector_map_position
 from .client_shared_helpers import (
     _app_action_data,
     _property_entry_received_at,
@@ -89,7 +89,6 @@ from .point_cloud import (
 from .vector_map import (
     filter_runtime_track_segments,
     parse_batch_vector_map,
-    position_within_vector_map,
     render_vector_map_png,
     vector_map_to_details,
     vector_map_to_summary,
@@ -280,7 +279,8 @@ class _DreameLawnMowerClientMapsMixin(
         )
         if _map_view_has_live_path(vector_view) or (
             isinstance(vector_view.details, Mapping)
-            and vector_view.details.get("runtime_position_valid") is True
+            and vector_view.details.get("position_status")
+            in {"current", "known_dock", "last_known"}
         ):
             return vector_view
 
@@ -377,12 +377,11 @@ class _DreameLawnMowerClientMapsMixin(
         )
         runtime_pose_x = getattr(runtime_blob, "candidate_runtime_pose_x", None)
         runtime_pose_y = getattr(runtime_blob, "candidate_runtime_pose_y", None)
-        runtime_position = (
-            _runtime_blob_position(runtime_blob) if runtime_context_matches else None
-        )
-        runtime_position_valid = position_within_vector_map(
-            vector_map,
-            runtime_position,
+        position = vector_map_position(self, vector_map)
+        runtime_position = (position.x, position.y) if position is not None else None
+        runtime_position_valid = position is not None and position.status == "current"
+        summary = apply_position_metadata(
+            position, snapshot=self._latest_snapshot, details=details, summary=summary
         )
         if runtime_pose_x is not None and runtime_pose_y is not None:
             details["runtime_pose_x"] = runtime_pose_x
@@ -425,7 +424,10 @@ class _DreameLawnMowerClientMapsMixin(
                 vector_map,
                 label_scale=label_scale,
                 runtime_track_segments=runtime_track_segments,
-                runtime_position=runtime_position if runtime_position_valid else None,
+                runtime_position=runtime_position,
+                position_status=(
+                    position.status if position is not None else "unavailable"
+                ),
                 style=style,
             )
         except Exception as err:  # noqa: BLE001 - diagnostics path

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
@@ -8,6 +8,7 @@ from typing import Any
 
 from .map_visuals import MapRenderStyle
 from .mowing_map import MowingMapScene, build_mowing_map_scene, mowing_map_overlay
+from .position_tracking import snapshot_is_docked
 from .vector_map import parse_batch_vector_map
 
 MAX_SCENE_INPUT_UNITS = 4 * 1024 * 1024
@@ -63,7 +64,17 @@ class _DreameLawnMowerClientMowingMapMixin:
 
     def mowing_map_runtime_overlay(self, scene: MowingMapScene) -> dict[str, Any]:
         """Read the existing session cache without requesting mower operations."""
+        position = self._position_tracker.resolve(
+            map_index=scene.map_index,
+            geometry=scene.position_identity,
+            contains=scene.contains,
+            snapshot=self._latest_snapshot,
+        )
         blob = self._latest_runtime_status_blob
+        # The tracker owns geometry binding, including negative decisions.
+        # A raw packet must not resurrect a rejected position in the projector.
+        if position is None or not getattr(self._latest_snapshot, "available", False):
+            blob = None
         if (
             blob is not None
             and blob.candidate_runtime_task_id is not None
@@ -76,4 +87,6 @@ class _DreameLawnMowerClientMowingMapMixin:
             map_index=self._runtime_live_map_index,
             active=self._runtime_session_active is True,
             track_segments=self._runtime_live_track_segments,
+            retained_position=position,
+            docked=snapshot_is_docked(self._latest_snapshot),
         )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_position.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_position.py
@@ -1,0 +1,50 @@
+"""Shared position selection for client map consumers."""
+
+from __future__ import annotations
+
+from dataclasses import replace
+from typing import Any
+
+from .position_tracking import MowerPosition, map_position_identity, snapshot_is_docked
+from .vector_map import position_within_vector_map
+
+
+def vector_map_position(client: Any, vector_map: Any) -> MowerPosition | None:
+    """Resolve the same geometry-scoped evidence as the interactive overlay."""
+    return client._position_tracker.resolve(
+        map_index=vector_map.map_index,
+        geometry=map_position_identity(vector_map),
+        contains=lambda x, y: position_within_vector_map(vector_map, (x, y)),
+        snapshot=client._latest_snapshot,
+    )
+
+
+def apply_position_metadata(
+    position: MowerPosition | None,
+    *,
+    snapshot: Any,
+    details: dict[str, Any],
+    summary: Any,
+) -> Any:
+    """Keep physical docking distinct from having drawable dock coordinates."""
+    details["docked"] = snapshot_is_docked(snapshot)
+    details["position_status"] = "unavailable"
+    details["position_source"] = None
+    details["position_observed_at"] = None
+    details["position_x"] = None
+    details["position_y"] = None
+    details["position_heading"] = None
+    if position is not None:
+        details.update(position.details())
+        details.update(
+            position_x=position.x,
+            position_y=position.y,
+            position_heading=position.heading,
+        )
+    if summary is not None:
+        return replace(
+            summary,
+            robot_present=position is not None,
+            charger_present=position is not None and position.status == "known_dock",
+        )
+    return summary

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/mowing_map.py
@@ -12,12 +12,16 @@ from typing import Any
 from .map_projection import MapProjection, vector_map_projection
 from .map_visuals import MapRenderStyle
 from .models import DreameLawnMowerStatusBlob
+from .position_tracking import (
+    POSITION_MAX_AGE_SECONDS,
+    MowerPosition,
+    map_position_identity,
+)
 from .vector_map import DreameLawnMowerVectorMap, render_vector_map_png
 
 MAX_SCENE_POINTS = 50_000
 MAX_BACKGROUND_BYTES = 4 * 1024 * 1024
 MAX_TRAIL_POINTS = 4096
-POSITION_MAX_AGE_SECONDS = 90
 
 
 @dataclass(frozen=True, slots=True)
@@ -31,6 +35,7 @@ class MowingMapScene:
     image_png: bytes
     projection: MapProjection
     bounds: tuple[int, int, int, int]
+    position_identity: str = ""
 
     def contains(self, x: Any, y: Any) -> bool:
         """Accept finite native coordinates inside this map's bounding box."""
@@ -91,6 +96,7 @@ def build_mowing_map_scene(
         image_png,
         projection,
         (boundary.x1, boundary.y1, boundary.x2, boundary.y2),
+        map_position_identity(vector_map),
     )
 
 
@@ -102,6 +108,8 @@ def mowing_map_overlay(
     active: bool,
     track_segments: Sequence[Sequence[tuple[int, int]]] = (),
     now: datetime | None = None,
+    retained_position: MowerPosition | None = None,
+    docked: bool = False,
 ) -> dict[str, Any]:
     """Project fresh, identity-matched telemetry without fetching or rendering.
 
@@ -116,9 +124,38 @@ def mowing_map_overlay(
         "coverage_available": False,
         "trail_kind": "observed_movement",
         "max_age_seconds": POSITION_MAX_AGE_SECONDS,
+        "docked": docked,
+        "position_observed_at": None,
     }
+    if retained_position is not None and (
+        retained_position.map_index != scene.map_index
+        or not scene.contains(retained_position.x, retained_position.y)
+    ):
+        retained_position = None
+    if retained_position is not None and scene.contains(
+        retained_position.x, retained_position.y
+    ):
+        px, py = scene.projection.point(retained_position.x, retained_position.y)
+        result.update(retained_position.details())
+        result["position"] = {
+            "x": px,
+            "y": py,
+            "heading": (
+                (270 - retained_position.heading + scene.projection.rotation) % 360
+            )
+            if retained_position.heading is not None
+            else None,
+        }
+        # Current markers expire against their measurement, never a refreshed
+        # assessment. Only explicitly retained labels use the assessment time.
+        result["updated_at"] = (
+            result["position_observed_at"]
+            if retained_position.status == "current"
+            else (now or datetime.now(UTC)).isoformat()
+        )
     if map_index != scene.map_index:
-        result["position_status"] = "map_mismatch"
+        if retained_position is None:
+            result["position_status"] = "map_mismatch"
         return result
     if blob is None or not blob.frame_valid:
         return result
@@ -130,11 +167,13 @@ def mowing_map_overlay(
     except (ValueError, TypeError, OverflowError):
         return result
     if not -5 <= age <= POSITION_MAX_AGE_SECONDS:
-        result["position_status"] = "stale"
+        if retained_position is None:
+            result["position_status"] = "stale"
         return result
-    result["updated_at"] = updated.isoformat()
+    if retained_position is None:
+        result["updated_at"] = updated.isoformat()
     x, y = blob.candidate_runtime_pose_x, blob.candidate_runtime_pose_y
-    if scene.contains(x, y):
+    if retained_position is None and scene.contains(x, y):
         px, py = scene.projection.point(x, y)
         heading = blob.candidate_runtime_heading_deg
         result["position"] = {
@@ -147,9 +186,10 @@ def mowing_map_overlay(
             else None,
         }
         result["position_status"] = "current"
-    else:
+        result["position_observed_at"] = updated.isoformat()
+    elif retained_position is None:
         result["position_status"] = "out_of_bounds"
-    if active:
+    if active and result["position_status"] == "current":
         # Retain recent segments, never joining across invalid points or gaps.
         remaining = MAX_TRAIL_POINTS
         retained: list[list[list[int]]] = []

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
@@ -151,7 +151,15 @@ class MowerPositionTracker:
                 self._last = self._dock = None
             position = self._input
             docked = snapshot_is_docked(snapshot)
-            docked_at = position_timestamp(getattr(snapshot, "state_event_at", None))
+            # A docked heartbeat can precede the physical charging property.
+            # Its flag must not borrow an older returning/paused timestamp to
+            # promote a pre-arrival position into observed dock coordinates.
+            docked_at = (
+                position_timestamp(getattr(snapshot, "state_event_at", None))
+                if getattr(snapshot, "state", None)
+                in {"charging", "charging_completed"}
+                else None
+            )
             if (
                 position is not None
                 and position.map_index == map_index

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
@@ -1,0 +1,190 @@
+"""Map-scoped live, last-known and observed dock positions."""
+
+from __future__ import annotations
+
+import hashlib
+import math
+from collections.abc import Callable
+from dataclasses import dataclass, replace
+from datetime import UTC, datetime
+from threading import RLock
+from typing import Any
+
+POSITION_MAX_AGE_SECONDS = 90
+LAST_POSITION_MAX_AGE_SECONDS = 24 * 60 * 60
+DOCK_POSITION_MAX_AGE_SECONDS = 7 * 24 * 60 * 60
+
+
+def position_timestamp(value: Any) -> float | None:
+    """Normalize an observation timestamp without accepting naive dates."""
+    if isinstance(value, str):
+        try:
+            parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+            return parsed.timestamp() if parsed.tzinfo is not None else None
+        except (ValueError, OverflowError):
+            return None
+    if isinstance(value, (int, float)) and not isinstance(value, bool):
+        return float(value) if math.isfinite(value) else None
+    return None
+
+
+def snapshot_is_docked(snapshot: Any) -> bool:
+    """Charging and charging-completed both establish physical docking.
+
+    This is state evidence only; it never manufactures dock coordinates.
+    """
+    return bool(
+        snapshot is not None
+        and getattr(snapshot, "available", False)
+        and getattr(snapshot, "activity", None) not in {"mowing", "returning"}
+        and (
+            getattr(snapshot, "docked", False)
+            or getattr(snapshot, "charging", False)
+            or getattr(snapshot, "state", None) in {"charging", "charging_completed"}
+        )
+    )
+
+
+def map_position_identity(vector_map: Any) -> str:
+    """Invalidate retained locations when a map slot's geometry is replaced."""
+    boundary = vector_map.boundary
+    geometry = (
+        vector_map.map_index,
+        vector_map.map_id,
+        (boundary.x1, boundary.y1, boundary.x2, boundary.y2) if boundary else None,
+        tuple((zone.zone_id, zone.points) for zone in vector_map.zones),
+        tuple((path.path_id, path.points) for path in vector_map.paths),
+    )
+    return hashlib.sha256(repr(geometry).encode()).hexdigest()
+
+
+@dataclass(frozen=True, slots=True)
+class MowerPosition:
+    """A native-coordinate position with the time and origin of its evidence."""
+
+    x: int
+    y: int
+    heading: float | None
+    observed_at: float
+    map_index: int
+    status: str = "current"
+
+    def details(self) -> dict[str, Any]:
+        """Metadata shared by camera and interactive-map consumers."""
+        return {
+            "position_status": self.status,
+            "position_observed_at": datetime.fromtimestamp(
+                self.observed_at, UTC
+            ).isoformat(),
+            "position_source": "observed_docked_pose"
+            if self.status == "known_dock"
+            else "runtime_telemetry",
+        }
+
+
+class MowerPositionTracker:
+    """Retain validated positions without reusing trails as dock evidence.
+
+    Coordinates are bound to the map observed when their packet arrived, then
+    validated against its geometry. The cache is bounded to one map and is not
+    persisted; a cold start with only a heartbeat must remain unpositioned.
+    """
+
+    def __init__(self) -> None:
+        self._lock = RLock()
+        self._input: MowerPosition | None = None
+        self._last: MowerPosition | None = None
+        self._dock: MowerPosition | None = None
+        self._last_event: float | None = None
+        self._geometry: str | None = None
+        self._geometry_changed_at: float | None = None
+
+    def record(
+        self, blob: Any, *, map_index: int | None, now: datetime | None = None
+    ) -> None:
+        """Bind a new position packet to its already-verified app map slot."""
+        if blob is None or not getattr(blob, "frame_valid", False):
+            return
+        observed = position_timestamp(getattr(blob, "received_at", None))
+        current = (now or datetime.now(UTC)).timestamp()
+        if observed is None or observed > current + 5:
+            return
+        x, y = (
+            getattr(blob, "candidate_runtime_pose_x", None),
+            getattr(blob, "candidate_runtime_pose_y", None),
+        )
+        if not all(isinstance(v, int) and not isinstance(v, bool) for v in (x, y)):
+            return
+        with self._lock:
+            if self._last_event is not None and observed <= self._last_event:
+                return
+            self._last_event = observed
+            # Do not bind this same cached packet to a newly selected map later.
+            if map_index is None:
+                self._input = None
+                return
+            heading = getattr(blob, "candidate_runtime_heading_deg", None)
+            if (
+                not isinstance(heading, (int, float))
+                or isinstance(heading, bool)
+                or not math.isfinite(heading)
+            ):
+                heading = None
+            self._input = MowerPosition(x, y, heading, observed, map_index)
+
+    def resolve(
+        self,
+        *,
+        map_index: int,
+        geometry: str,
+        contains: Callable[[int, int], bool],
+        snapshot: Any,
+        now: datetime | None = None,
+    ) -> MowerPosition | None:
+        """Prefer current telemetry, or proven docking, then labelled history."""
+        current = (now or datetime.now(UTC)).timestamp()
+        with self._lock:
+            if self._geometry != geometry:
+                if self._geometry is not None:
+                    self._geometry_changed_at = current
+                self._geometry = geometry
+                self._last = self._dock = None
+            position = self._input
+            docked = snapshot_is_docked(snapshot)
+            docked_at = position_timestamp(getattr(snapshot, "state_event_at", None))
+            if (
+                position is not None
+                and position.map_index == map_index
+                and -5 <= current - position.observed_at <= POSITION_MAX_AGE_SECONDS
+                and (
+                    self._geometry_changed_at is None
+                    or position.observed_at >= self._geometry_changed_at
+                )
+                and contains(position.x, position.y)
+            ):
+                self._last = position
+                # A pose recorded before returning to the station is not the
+                # dock. Require an ordered pose while the device is docked.
+                if (
+                    docked
+                    and docked_at is not None
+                    and docked_at <= position.observed_at
+                ):
+                    self._dock = replace(position, status="known_dock")
+                if not docked and getattr(snapshot, "available", False):
+                    return position
+            if docked and self._dock is not None:
+                if (
+                    0
+                    <= current - self._dock.observed_at
+                    <= DOCK_POSITION_MAX_AGE_SECONDS
+                ):
+                    return self._dock
+            if self._last is not None:
+                if (
+                    0
+                    <= current - self._last.observed_at
+                    <= LAST_POSITION_MAX_AGE_SECONDS
+                ):
+                    return replace(self._last, status="last_known", heading=None)
+            return None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import hashlib
 import math
 from collections.abc import Callable
-from dataclasses import dataclass, replace
+from dataclasses import asdict, dataclass, replace
 from datetime import UTC, datetime
 from threading import RLock
 from typing import Any
@@ -24,7 +24,11 @@ def position_timestamp(value: Any) -> float | None:
         except (ValueError, OverflowError):
             return None
     if isinstance(value, (int, float)) and not isinstance(value, bool):
-        return float(value) if math.isfinite(value) else None
+        try:
+            timestamp = float(value)
+            return timestamp if math.isfinite(timestamp) else None
+        except OverflowError:
+            return None
     return None
 
 
@@ -86,8 +90,8 @@ class MowerPositionTracker:
     """Retain validated positions without reusing trails as dock evidence.
 
     Coordinates are bound to the map observed when their packet arrived, then
-    validated against its geometry. The cache is bounded to one map and is not
-    persisted; a cold start with only a heartbeat must remain unpositioned.
+    validated against its geometry. A bounded checkpoint may retain one map's
+    historical evidence, but it can never restore a live input packet.
     """
 
     def __init__(self) -> None:
@@ -98,6 +102,60 @@ class MowerPositionTracker:
         self._last_event: float | None = None
         self._geometry: str | None = None
         self._geometry_changed_at: float | None = None
+
+    def checkpoint(self, *, now: datetime | None = None) -> dict[str, Any] | None:
+        """Export at most two validated poses and a geometry fingerprint."""
+        current = (now or datetime.now(UTC)).timestamp()
+        with self._lock:
+            if self._geometry is None:
+                return None
+            last = self._last
+            dock = self._dock
+            if (
+                last
+                and not 0 <= current - last.observed_at <= LAST_POSITION_MAX_AGE_SECONDS
+            ):
+                last = None
+            if (
+                dock
+                and not 0 <= current - dock.observed_at <= DOCK_POSITION_MAX_AGE_SECONDS
+            ):
+                dock = None
+            if last is None and dock is None:
+                return None
+            return {
+                "geometry": self._geometry,
+                "last": asdict(replace(last, status="last_known", heading=None))
+                if last
+                else None,
+                "dock": asdict(dock) if dock else None,
+            }
+
+    def restore_checkpoint(self, record: Any, *, now: datetime | None = None) -> None:
+        """Restore history only; fresh map geometry must match before display."""
+        if not isinstance(record, dict) or set(record) != {"geometry", "last", "dock"}:
+            return
+        geometry = record["geometry"]
+        if (
+            not isinstance(geometry, str)
+            or len(geometry) != 64
+            or any(char not in "0123456789abcdef" for char in geometry)
+        ):
+            return
+        current = (now or datetime.now(UTC)).timestamp()
+        last = _checkpoint_position(record["last"], "last_known", current)
+        dock = _checkpoint_position(record["dock"], "known_dock", current)
+        with self._lock:
+            # Setup must load before live callbacks begin. Never overwrite live
+            # evidence if a late or repeated restore reaches this owner.
+            if self._input is not None or self._geometry is not None:
+                return
+            self._geometry = geometry
+            self._last, self._dock = last, dock
+            self._last_event = max(
+                (pose.observed_at for pose in (last, dock) if pose is not None),
+                default=None,
+            )
 
     def record(
         self, blob: Any, *, map_index: int | None, now: datetime | None = None
@@ -183,16 +241,61 @@ class MowerPositionTracker:
                     return position
             if docked and self._dock is not None:
                 if (
-                    0
+                    self._dock.map_index == map_index
+                    and contains(self._dock.x, self._dock.y)
+                    and 0
                     <= current - self._dock.observed_at
                     <= DOCK_POSITION_MAX_AGE_SECONDS
                 ):
                     return self._dock
             if self._last is not None:
                 if (
-                    0
+                    self._last.map_index == map_index
+                    and contains(self._last.x, self._last.y)
+                    and 0
                     <= current - self._last.observed_at
                     <= LAST_POSITION_MAX_AGE_SECONDS
                 ):
                     return replace(self._last, status="last_known", heading=None)
             return None
+
+
+def _checkpoint_position(record: Any, status: str, now: float) -> MowerPosition | None:
+    """Validate untrusted persisted pose scalars before they enter the tracker."""
+    if not isinstance(record, dict) or set(record) != {
+        "x",
+        "y",
+        "heading",
+        "observed_at",
+        "map_index",
+        "status",
+    }:
+        return None
+    age_limit = (
+        DOCK_POSITION_MAX_AGE_SECONDS
+        if status == "known_dock"
+        else LAST_POSITION_MAX_AGE_SECONDS
+    )
+    observed = position_timestamp(record["observed_at"])
+    if (
+        record["status"] != status
+        or observed is None
+        or not 0 <= now - observed <= age_limit
+        or not all(
+            type(record[key]) is int and abs(record[key]) <= 2**31 - 1
+            for key in ("x", "y")
+        )
+        or type(record["map_index"]) is not int
+        or not 0 <= record["map_index"] <= 65535
+    ):
+        return None
+    heading = record["heading"]
+    if heading is not None and (
+        type(heading) not in (int, float)
+        or not 0 <= heading <= 360
+        or not math.isfinite(heading)
+    ):
+        return None
+    return MowerPosition(
+        record["x"], record["y"], heading, observed, record["map_index"], status
+    )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/session_checkpoint.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/session_checkpoint.py
@@ -1,0 +1,91 @@
+"""Small, validated observation summaries shared by timer and persistence."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass, replace
+from datetime import datetime
+from typing import Any
+
+MAX_RUN_AGE_SECONDS = 30 * 86400
+
+
+def session_identity(value: Any) -> int | None:
+    """Keep only bounded firmware task identifiers, not process counters."""
+    return value if type(value) is int and 0 <= value <= 2**64 - 1 else None
+
+
+@dataclass(frozen=True, slots=True)
+class ObservedRun:
+    """One observation interval summary, not proof of firmware completion."""
+
+    seconds: float
+    started_at: datetime
+    updated_at: datetime
+    partial: bool
+    state: str
+    identity: int | None
+
+    def interrupted(self) -> ObservedRun:
+        """Preserve useful time without claiming the missing ending was seen."""
+        return replace(self, partial=True, state="interrupted")
+
+    def as_dict(self) -> dict[str, Any]:
+        """Serialize a fixed set of scalar fields only."""
+        return {
+            "seconds": self.seconds,
+            "started_at": self.started_at.isoformat(),
+            "updated_at": self.updated_at.isoformat(),
+            "partial": self.partial,
+            "state": self.state,
+            "identity": self.identity,
+        }
+
+
+def decode_run(record: Any, *, now: datetime) -> ObservedRun | None:
+    """Reject invalid numbers, dates, identities and implausible durations."""
+    if not isinstance(record, dict) or set(record) != {
+        "seconds",
+        "started_at",
+        "updated_at",
+        "partial",
+        "state",
+        "identity",
+    }:
+        return None
+    seconds = record["seconds"]
+    if (
+        type(seconds) not in (int, float)
+        or not 0 <= seconds <= MAX_RUN_AGE_SECONDS
+        or not math.isfinite(seconds)
+        or type(record["partial"]) is not bool
+        or not isinstance(record["state"], str)
+        or record["state"]
+        not in {"mowing", "paused", "ended", "uncertain", "interrupted"}
+        or (
+            record["identity"] is not None
+            and session_identity(record["identity"]) is None
+        )
+    ):
+        return None
+    try:
+        start = datetime.fromisoformat(record["started_at"])
+        updated = datetime.fromisoformat(record["updated_at"])
+        if (
+            start.tzinfo is None
+            or updated.tzinfo is None
+            or not 0 <= (now - updated).total_seconds() <= MAX_RUN_AGE_SECONDS
+            or not 0 <= (updated - start).total_seconds() <= MAX_RUN_AGE_SECONDS
+            or seconds > (updated - start).total_seconds() + 1
+        ):
+            return None
+    except (ValueError, TypeError, OverflowError):
+        return None
+    return ObservedRun(
+        float(seconds),
+        start,
+        updated,
+        record["partial"],
+        record["state"],
+        record["identity"],
+    )

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/session_timing.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/session_timing.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
 
+from .session_checkpoint import ObservedRun, decode_run, session_identity
+
 
 @dataclass(slots=True)
 class ObservedMowingTimer:
@@ -15,8 +17,8 @@ class ObservedMowingTimer:
 
     The existing mission owner supplies the generation and session boundary.
     This timer does not interpret firmware task codes or infer blade activity.
-    Values are deliberately process-local: startup during a mission begins a
-    partial observation, rather than restoring an apparently exact duration.
+    Checkpoints restore only observed intervals. A fresh matching task identity
+    is required to continue a saved run, and the offline interval is excluded.
     """
 
     seconds: float = 0.0
@@ -28,6 +30,9 @@ class ObservedMowingTimer:
     _last_tick: float | None = None
     _was_mowing: bool = False
     _observed_idle: bool = False
+    last_run: ObservedRun | None = None
+    _identity: int | None = None
+    _recovery: ObservedRun | None = None
 
     @property
     def minutes(self) -> float | None:
@@ -43,6 +48,9 @@ class ObservedMowingTimer:
         max_gap_seconds: float = 130.0,
         now: datetime | None = None,
         monotonic: float | None = None,
+        identity: int | None = None,
+        identity_observed_at: float | None = None,
+        new_start_at: float | None = None,
     ) -> None:
         """Advance on successful, ordered observations from the session owner.
 
@@ -56,18 +64,54 @@ class ObservedMowingTimer:
             return
         timestamp = now or datetime.now(UTC)
         active = session_active is True
+        if self._recovery is not None and session_active is not None:
+            saved = self._recovery
+            self._recovery = None
+            if (
+                active
+                and saved.identity is not None
+                and session_identity(identity) == saved.identity
+                and identity_observed_at is not None
+                and saved.updated_at.timestamp()
+                <= identity_observed_at
+                <= timestamp.timestamp() + 5
+                and (
+                    new_start_at is None or new_start_at <= saved.updated_at.timestamp()
+                )
+                and 0 <= (timestamp - saved.updated_at).total_seconds() <= 86400
+            ):
+                self.seconds = saved.seconds
+                self.started_at = saved.started_at
+                self.generation = generation
+                self.partial = True
+                self._last_tick = None
+                self._was_mowing = False
+            else:
+                self.last_run = saved.interrupted()
         continuous = (
             self._last_tick is not None
             and 0 <= tick - self._last_tick <= max_gap_seconds
         )
         new_generation = self.generation != generation
+        if not new_generation and self.state == "ended":
+            # Uncertain/offline samples cannot reopen a completed generation.
+            # Preserve its summary while retaining only fresh idle continuity.
+            self._last_tick = tick if session_active is False else None
+            self._was_mowing = False
+            self._observed_idle = session_active is False
+            return
         if new_generation:
+            if self.started_at is not None and self.state != "ended":
+                self.last_run = self._run("interrupted")
             self.seconds = 0.0
             self.started_at = None
             self.partial = not (self._observed_idle and continuous)
             self.generation = generation
             self._last_tick = None
             self._was_mowing = False
+            self._identity = None
+        if active and session_identity(identity) is not None:
+            self._identity = identity
         if active and mowing and self.started_at is None:
             self.started_at = timestamp
         if self.started_at is not None and self._last_tick is not None:
@@ -83,6 +127,8 @@ class ObservedMowingTimer:
             self.state = "mowing" if mowing else "paused"
             self._observed_idle = False
         elif session_active is False:
+            if self.started_at is not None and self.state != "ended":
+                self.last_run = self._run("ended", updated_at=timestamp)
             self.state = "ended" if self.started_at is not None else "unavailable"
             self._observed_idle = True
         else:
@@ -96,9 +142,41 @@ class ObservedMowingTimer:
         self._last_tick = None
         self._was_mowing = False
         self._observed_idle = False
-        if self.started_at is not None:
+        if self.started_at is not None and self.state != "ended":
             self.partial = True
             self.state = "interrupted"
+
+    def _run(self, state: str, *, updated_at: datetime | None = None) -> ObservedRun:
+        """Capture one bounded summary, never a stream of samples."""
+        assert self.started_at is not None and self.updated_at is not None
+        return ObservedRun(
+            self.seconds,
+            self.started_at,
+            updated_at or self.updated_at,
+            self.partial or state == "interrupted",
+            state,
+            self._identity,
+        )
+
+    def checkpoint(self) -> dict[str, Any]:
+        """Export wall-clock evidence only; monotonic ticks cannot be restored."""
+        current = self._recovery
+        if self.started_at is not None and self.state != "ended":
+            current = self._run(self.state)
+        return {
+            "current": current.as_dict() if current else None,
+            "previous": self.last_run.as_dict() if self.last_run else None,
+        }
+
+    def restore_checkpoint(self, record: Any, *, now: datetime | None = None) -> None:
+        """Stage validated saved evidence without publishing it as a live run."""
+        if not isinstance(record, dict):
+            return
+        timestamp = now or datetime.now(UTC)
+        self.last_run = decode_run(record.get("previous"), now=timestamp)
+        self._recovery = decode_run(record.get("current"), now=timestamp)
+        if self._recovery is not None and self._recovery.state == "ended":
+            self._recovery = None
 
     def attributes(self) -> dict[str, Any]:
         """Explain the measurement so consumers do not present it as exact."""

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/session_timing.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/session_timing.py
@@ -1,0 +1,114 @@
+"""Observed mowing intervals, separate from device-reported mowing duration."""
+
+from __future__ import annotations
+
+import math
+import time
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Any
+
+
+@dataclass(slots=True)
+class ObservedMowingTimer:
+    """Count observed mowing state without guessing across gaps or restarts.
+
+    The existing mission owner supplies the generation and session boundary.
+    This timer does not interpret firmware task codes or infer blade activity.
+    Values are deliberately process-local: startup during a mission begins a
+    partial observation, rather than restoring an apparently exact duration.
+    """
+
+    seconds: float = 0.0
+    generation: int | None = None
+    started_at: datetime | None = None
+    updated_at: datetime | None = None
+    partial: bool = True
+    state: str = "unavailable"
+    _last_tick: float | None = None
+    _was_mowing: bool = False
+    _observed_idle: bool = False
+
+    @property
+    def minutes(self) -> float | None:
+        """Return observed minutes, never substituting for native telemetry."""
+        return round(self.seconds / 60, 1) if self.started_at is not None else None
+
+    def observe(
+        self,
+        *,
+        generation: int,
+        session_active: bool | None,
+        mowing: bool,
+        max_gap_seconds: float = 130.0,
+        now: datetime | None = None,
+        monotonic: float | None = None,
+    ) -> None:
+        """Advance on successful, ordered observations from the session owner.
+
+        Pauses, returning and docking do not accumulate time. Intervals longer
+        than the host's observation budget are excluded and marked partial.
+        A state transition is sampled, not an exact blade-on/off measurement.
+        """
+        tick = time.monotonic() if monotonic is None else monotonic
+        if not math.isfinite(tick) or max_gap_seconds <= 0:
+            self.interrupt()
+            return
+        timestamp = now or datetime.now(UTC)
+        active = session_active is True
+        continuous = (
+            self._last_tick is not None
+            and 0 <= tick - self._last_tick <= max_gap_seconds
+        )
+        new_generation = self.generation != generation
+        if new_generation:
+            self.seconds = 0.0
+            self.started_at = None
+            self.partial = not (self._observed_idle and continuous)
+            self.generation = generation
+            self._last_tick = None
+            self._was_mowing = False
+        if active and mowing and self.started_at is None:
+            self.started_at = timestamp
+        if self.started_at is not None and self._last_tick is not None:
+            interval = tick - self._last_tick
+            if not 0 <= interval <= max_gap_seconds:
+                self.partial = True
+            elif self._was_mowing:
+                self.seconds += interval
+        self._last_tick = tick
+        self._was_mowing = active and mowing
+        self.updated_at = timestamp
+        if active:
+            self.state = "mowing" if mowing else "paused"
+            self._observed_idle = False
+        elif session_active is False:
+            self.state = "ended" if self.started_at is not None else "unavailable"
+            self._observed_idle = True
+        else:
+            self._observed_idle = False
+            self.state = "uncertain" if self.started_at is not None else "unavailable"
+            if self.started_at is not None:
+                self.partial = True
+
+    def interrupt(self) -> None:
+        """Freeze at the last successful observation after connectivity loss."""
+        self._last_tick = None
+        self._was_mowing = False
+        self._observed_idle = False
+        if self.started_at is not None:
+            self.partial = True
+            self.state = "interrupted"
+
+    def attributes(self) -> dict[str, Any]:
+        """Explain the measurement so consumers do not present it as exact."""
+        return {
+            "source": "observed_mowing_state",
+            "partial": self.partial,
+            "includes_pauses": False,
+            "measurement_state": self.state,
+            "observed_since": self.started_at.isoformat() if self.started_at else None,
+            "last_observed_at": self.updated_at.isoformat()
+            if self.updated_at
+            else None,
+        }

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -233,6 +233,7 @@ def render_vector_map_png(
     label_scale: float = 1.0,
     runtime_track_segments: Sequence[Sequence[tuple[int, int]]] | None = None,
     runtime_position: tuple[int, int] | None = None,
+    position_status: str = "current",
     style: MapRenderStyle | None = None,
 ) -> bytes | None:
     """Render a mower vector map to PNG bytes."""
@@ -342,7 +343,21 @@ def render_vector_map_png(
 
     if runtime_position is not None:
         px, py = to_pixel(runtime_position[0], runtime_position[1])
-        draw_position_marker(image, draw, (px, py), style)
+        marker_style = (
+            replace(style, current_position=(130, 140, 150, 220))
+            if position_status == "last_known"
+            else style
+        )
+        draw_position_marker(image, draw, (px, py), marker_style)
+        label = {
+            "last_known": "Last known mower position",
+            "known_dock": "Mower at observed dock",
+        }.get(position_status)
+        if label:
+            draw.text(
+                (12, 12), label, font=map_font(14), fill=style.label_text,
+                stroke_width=2, stroke_fill=style.label_halo,
+            )
 
     for zone in vector_map.zones:
         if len(zone.points) < 3 or not zone.name:

--- a/custom_components/dreame_lawn_mower/entity.py
+++ b/custom_components/dreame_lawn_mower/entity.py
@@ -9,7 +9,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .coordinator import DreameLawnMowerCoordinator
 
 _OFFLINE_REPORTING_ENTITY_KEYS = frozenset(
-    {"online", "device_connected", "cloud_connected"}
+    {"online", "device_connected", "cloud_connected", "last_observed_run_duration"}
 )
 
 

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -66,6 +66,7 @@ from .services import (
     _guard_preference_write_request,
     preference_change_request,
 )
+from .session_timing import observed_mowing_time_attributes
 
 ACTIVITY_MAP = {
     ACTIVITY_DOCKED: LawnMowerActivity.DOCKED,
@@ -359,6 +360,7 @@ class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
             "mowing_mode_name": snapshot.mowing_mode_name,
             "mowed_area": snapshot.mowed_area,
             "mowing_time": snapshot.mowing_time,
+            **observed_mowing_time_attributes(self.coordinator),
             "active_segment_count": getattr(snapshot, "active_segment_count", None),
             "current_zone_id": getattr(snapshot, "current_zone_id", None),
             "current_zone_name": getattr(snapshot, "current_zone_name", None),

--- a/custom_components/dreame_lawn_mower/lawn_mower.py
+++ b/custom_components/dreame_lawn_mower/lawn_mower.py
@@ -180,6 +180,8 @@ async def async_setup_entry(
 class DreameLawnMower(DreameLawnMowerEntity, LawnMowerEntity):
     """Main mower entity."""
 
+    _unrecorded_attributes = frozenset({"observed_mowing_time_details"})
+
     _attr_supported_features = (
         LawnMowerEntityFeature.START_MOWING
         | LawnMowerEntityFeature.PAUSE

--- a/custom_components/dreame_lawn_mower/map_attributes.py
+++ b/custom_components/dreame_lawn_mower/map_attributes.py
@@ -14,6 +14,9 @@ _RUNTIME_POSITION_DETAIL_KEYS = frozenset(
         "runtime_heading_deg",
         "runtime_region_id",
         "runtime_position_updated_at",
+        "position_x",
+        "position_y",
+        "position_heading",
     }
 )
 
@@ -121,6 +124,10 @@ def map_camera_attributes(
             "position_heading": details.get("runtime_heading_deg"),
             "position_segment": details.get("runtime_region_id"),
             "position_updated_at": details.get("runtime_position_updated_at"),
+            "position_status": details.get("position_status", "unavailable"),
+            "position_source": details.get("position_source"),
+            "position_observed_at": details.get("position_observed_at"),
+            "docked": details.get("docked"),
             "map_has_live_path": details.get("has_live_path"),
             "map_available_vector_map_count": details.get("available_map_count"),
             "map_available_vector_maps": details.get("available_maps"),
@@ -167,4 +174,13 @@ def map_camera_attributes(
         )
         if runtime_updated_at != details.get("runtime_position_updated_at"):
             attributes["runtime_position_valid"] = None
+    if "position_status" in details:
+        # Validated map-scoped position wins over an unvalidated raw packet.
+        # Retained positions never become raw runtime_pose telemetry.
+        attributes.update(
+            position_x=details.get("position_x"),
+            position_y=details.get("position_y"),
+            position_heading=details.get("position_heading"),
+            position_updated_at=details.get("position_observed_at"),
+        )
     return attributes

--- a/custom_components/dreame_lawn_mower/observation_checkpoint.py
+++ b/custom_components/dreame_lawn_mower/observation_checkpoint.py
@@ -1,0 +1,270 @@
+"""Bounded, low-write HA persistence for observation evidence, not telemetry."""
+
+from __future__ import annotations
+
+import asyncio
+import hashlib
+import json
+import logging
+import math
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+from homeassistant.core import CoreState
+from homeassistant.helpers.storage import Store
+
+from .const import DOMAIN
+from .dreame_lawn_mower_client.session_timing import ObservedMowingTimer
+
+_LOGGER = logging.getLogger(__name__)
+MAX_CHECKPOINT_BYTES = 16 * 1024
+CHECKPOINT_INTERVAL_SECONDS = 60
+TRANSITION_DELAY_SECONDS = 2
+MIN_TRANSITION_INTERVAL_SECONDS = 10
+MAX_CHECKPOINT_AGE_SECONDS = 30 * 86400
+
+
+class ObservationStore(Store):
+    """Keep HA's atomic storage while exposing immediate write failures.
+
+    Store logs and consumes write errors. The scheduler needs that outcome to
+    avoid acknowledging a failed checkpoint and suppressing an identical retry.
+    Drain HA's queued shutdown write before releasing this owner, so a later
+    entry removal cannot leave an old final-write listener behind.
+    """
+
+    async def async_save(self, data: Any) -> None:
+        self._checkpoint_write_error: Exception | None = None
+        await super().async_save(data)
+        if self.hass.state is CoreState.stopping:
+            await self._async_handle_write_data()
+        if self._checkpoint_write_error is not None:
+            raise self._checkpoint_write_error
+
+    async def _async_write_data(self, data: dict) -> None:
+        try:
+            await super()._async_write_data(data)
+        except Exception as err:
+            self._checkpoint_write_error = err
+            raise
+
+
+def checkpoint_store(hass: Any, entry_id: str) -> Store:
+    """Use one private, overwritten HA store per mower configuration entry."""
+    return ObservationStore(
+        hass,
+        1,
+        f"{DOMAIN}.{entry_id}.observation_checkpoint",
+        private=True,
+        atomic_writes=True,
+    )
+
+
+def checkpoint_fits(record: Any, key: str) -> bool:
+    """Bound the complete on-disk envelope, including HA storage metadata."""
+    try:
+        envelope = {"version": 1, "minor_version": 1, "key": key, "data": record}
+        return (
+            len(json.dumps(envelope, indent=2, allow_nan=False).encode())
+            <= MAX_CHECKPOINT_BYTES
+        )
+    except (TypeError, ValueError, OverflowError, RecursionError):
+        return False
+
+
+class ObservationCheckpoint:
+    """Load once, coalesce transitions, checkpoint progress, and drain on close.
+
+    The timer and position tracker own validation and reconciliation. This
+    adapter only owns HA storage and write scheduling. No recorder history,
+    routes, map geometry, images, tokens or raw packets enter this file.
+    """
+
+    def __init__(self, hass: Any, entry_id: str, coordinator: Any) -> None:
+        self._hass = hass
+        self._coordinator = coordinator
+        self._key = f"{DOMAIN}.{entry_id}.observation_checkpoint"
+        self._store = checkpoint_store(hass, entry_id)
+        self._scope = hashlib.sha256(
+            str(coordinator.client.descriptor.unique_id).encode()
+        ).hexdigest()
+        self._lock = asyncio.Lock()
+        self._handle: asyncio.TimerHandle | None = None
+        self._task: asyncio.Task | None = None
+        self._closed = False
+        self._close_complete = False
+        self._removed = False
+        self._last_signature: str | None = None
+        self._transition: tuple[Any, ...] | None = None
+        self._failed = False
+        self._loading = False
+        self._load_started = False
+        self._load_failed = False
+        self._last_write_at: float | None = None
+        if getattr(coordinator, "observed_mowing_timer", None) is None:
+            coordinator.observed_mowing_timer = ObservedMowingTimer()
+
+    async def async_load(self) -> None:
+        """Load before first refresh; storage failures must not disable control."""
+        if self._load_started or self._closed:
+            return
+        self._load_started = True
+        self._loading = True
+        try:
+            record = await self._store.async_load()
+        except asyncio.CancelledError:
+            self._load_failed = True
+            raise
+        except Exception as err:  # noqa: BLE001 - optional recovery evidence
+            self._load_failed = True
+            self._log_failure(err)
+            return
+        finally:
+            self._loading = False
+        if (
+            self._closed
+            or not isinstance(record, dict)
+            or set(record) != {"scope", "saved_at", "timing", "position"}
+        ):
+            return
+        now = datetime.now(UTC)
+        saved_at = record["saved_at"]
+        if (
+            record["scope"] != self._scope
+            or type(saved_at) not in (int, float)
+            or not 0 <= saved_at <= now.timestamp()
+            or not 0 <= now.timestamp() - saved_at <= MAX_CHECKPOINT_AGE_SECONDS
+            or not math.isfinite(saved_at)
+            or not checkpoint_fits(record, self._key)
+        ):
+            return
+        self._coordinator.observed_mowing_timer.restore_checkpoint(
+            record["timing"], now=now
+        )
+        self._coordinator.client._position_tracker.restore_checkpoint(
+            record["position"], now=now
+        )
+        self._last_signature = self._signature(self._capture())
+
+    def _capture(self) -> dict[str, Any]:
+        return {
+            "scope": self._scope,
+            "timing": self._coordinator.observed_mowing_timer.checkpoint(),
+            "position": self._coordinator.client._position_tracker.checkpoint(),
+        }
+
+    @staticmethod
+    def _signature(record: dict[str, Any]) -> str:
+        # Repeated paused/idle observations update a timestamp, not measured
+        # duration. They must not generate a write every minute indefinitely.
+        timing = dict(record["timing"])
+        current = timing.get("current")
+        if current is not None:
+            current = dict(current)
+            current.pop("updated_at", None)
+            timing["current"] = current
+        return json.dumps({**record, "timing": timing}, sort_keys=True, allow_nan=False)
+
+    def async_schedule_save(self) -> None:
+        """Schedule one write; frequent updates cannot postpone it forever."""
+        if self._closed:
+            return
+        timer = self._coordinator.observed_mowing_timer
+        transition = (timer.generation, timer.state, timer.partial)
+        changed = self._transition != transition
+        self._transition = transition
+        delay = (
+            TRANSITION_DELAY_SECONDS
+            if changed and not self._failed
+            else CHECKPOINT_INTERVAL_SECONDS
+        )
+        if changed and self._last_write_at is not None:
+            delay = max(
+                delay,
+                MIN_TRANSITION_INTERVAL_SECONDS
+                - (self._hass.loop.time() - self._last_write_at),
+            )
+        when = self._hass.loop.time() + delay
+        if self._handle is not None:
+            if self._handle.when() <= when:
+                return
+            self._handle.cancel()
+        self._handle = self._hass.loop.call_later(delay, self._start_write)
+
+    def _start_write(self) -> None:
+        self._handle = None
+        if not self._closed and (self._task is None or self._task.done()):
+            self._task = self._hass.async_create_task(self.async_flush())
+
+    async def async_flush(self) -> None:
+        """Serialize saves and suppress identical checkpoints, including at stop."""
+        async with self._lock:
+            if self._loading or self._load_failed or self._removed:
+                return
+            record = self._capture()
+            signature = self._signature(record)
+            if signature == self._last_signature:
+                return
+            record["saved_at"] = time.time()
+            if not checkpoint_fits(record, self._key):
+                self._log_failure(ValueError("Checkpoint size limit exceeded"))
+                return
+            try:
+                write = self._hass.async_create_task(self._store.async_save(record))
+                try:
+                    await asyncio.shield(write)
+                except asyncio.CancelledError:
+                    # HA may finish an executor write after cancellation. Keep
+                    # the lock until it drains, especially before removal.
+                    await write
+                    raise
+            except Exception as err:  # noqa: BLE001 - retain control on disk errors
+                self._log_failure(err)
+                return
+            self._last_signature = signature
+            self._last_write_at = self._hass.loop.time()
+            self._failed = False
+            if not self._closed and self._signature(self._capture()) != signature:
+                self.async_schedule_save()
+
+    def _log_failure(self, err: Exception) -> None:
+        if not self._failed:
+            _LOGGER.warning(
+                "Mower observation checkpoint unavailable (%s)", type(err).__name__
+            )
+        self._failed = True
+
+    async def async_close(self) -> None:
+        """Stop scheduling before draining the last save on reload or shutdown."""
+        if self._close_complete:
+            return
+        self._closed = True
+        if self._handle is not None:
+            self._handle.cancel()
+            self._handle = None
+        if self._task is not None:
+            try:
+                await asyncio.shield(self._task)
+            except asyncio.CancelledError:
+                if not self._task.cancelled():
+                    raise
+        await self.async_flush()
+        self._close_complete = True
+
+    async def async_remove(self) -> None:
+        """Drain and remove without allowing a late write to recreate the file."""
+        await self.async_close()
+        async with self._lock:
+            self._removed = True
+            await self._store.async_remove()
+
+
+async def async_remove_observation_checkpoint(hass: Any, entry_id: str) -> None:
+    """Remove evidence even when the config entry failed to load."""
+    coordinator = hass.data.get(DOMAIN, {}).get(entry_id)
+    checkpoint = getattr(coordinator, "observation_checkpoint", None)
+    if isinstance(checkpoint, ObservationCheckpoint):
+        await checkpoint.async_remove()
+    else:
+        await checkpoint_store(hass, entry_id).async_remove()

--- a/custom_components/dreame_lawn_mower/runtime_cache.py
+++ b/custom_components/dreame_lawn_mower/runtime_cache.py
@@ -261,8 +261,14 @@ def runtime_mission_new_session(snapshot: Any) -> bool:
         )
     ):
         return True
+    return _runtime_new_session_notice_is_current(snapshot)
+
+
+def _runtime_new_session_notice_is_current(snapshot: Any) -> bool:
+    """Validate retained start notices independently of fresh task heartbeats."""
     if getattr(snapshot, "status_notice_name", None) not in _NEW_SESSION_STATUS_NOTICES:
         return False
+    terminal_event_at = _runtime_terminal_evidence_event_at(snapshot)
     notice_event_at = _event_timestamp(
         getattr(snapshot, "status_notice_event_at", None)
     )
@@ -327,14 +333,15 @@ def runtime_mission_new_session_event_at(snapshot: Any) -> float | None:
     """Return ordered realtime evidence for the current mission start."""
     if snapshot is None or not runtime_mission_new_session(snapshot):
         return None
+    if _runtime_new_session_notice_is_current(snapshot):
+        notice_at = _event_timestamp(getattr(snapshot, "status_notice_event_at", None))
+        if notice_at is not None:
+            return notice_at
     task_status = getattr(snapshot, "task_status", None)
     if task_status in _NEW_SESSION_TASK_STATUSES:
         event_at = _event_timestamp(getattr(snapshot, "task_status_event_at", None))
         if event_at is not None:
             return event_at
-    notice_name = getattr(snapshot, "status_notice_name", None)
-    if notice_name in _NEW_SESSION_STATUS_NOTICES:
-        return _event_timestamp(getattr(snapshot, "status_notice_event_at", None))
     return None
 
 
@@ -456,6 +463,16 @@ def runtime_mission_new_session_evidence(snapshot: Any) -> tuple[Any, ...] | Non
     task_id = runtime_mission_session_identity(snapshot)
     if task_id is not None:
         return ("task", task_id)
+    # Unlike a repeated/resumed starting phase, a start notice identifies an
+    # explicit replacement even when both properties are present together.
+    notice_name = getattr(snapshot, "status_notice_name", None)
+    notice_event_at = getattr(snapshot, "status_notice_event_at", None)
+    if (
+        _runtime_new_session_notice_is_current(snapshot)
+        and isinstance(notice_event_at, int | float)
+        and not isinstance(notice_event_at, bool)
+    ):
+        return ("notice", notice_name, float(notice_event_at))
     task_status = getattr(snapshot, "task_status", None)
     task_status_event_at = getattr(snapshot, "task_status_event_at", None)
     if (
@@ -464,14 +481,6 @@ def runtime_mission_new_session_evidence(snapshot: Any) -> tuple[Any, ...] | Non
         and not isinstance(task_status_event_at, bool)
     ):
         return ("task_status", task_status, float(task_status_event_at))
-    notice_name = getattr(snapshot, "status_notice_name", None)
-    notice_event_at = getattr(snapshot, "status_notice_event_at", None)
-    if (
-        notice_name in _NEW_SESSION_STATUS_NOTICES
-        and isinstance(notice_event_at, int | float)
-        and not isinstance(notice_event_at, bool)
-    ):
-        return ("notice", notice_name, float(notice_event_at))
     return None
 
 
@@ -570,6 +579,29 @@ class DreameLawnMowerRuntimeTelemetryCache:
         session_identity: int | None = None,
     ) -> None:
         """Apply authoritative mission state before optional telemetry work."""
+        if (
+            new_session
+            and active_session
+            and self._session_active
+            and not self._new_session_evidence_pending
+            and new_session_evidence is not None
+            and (
+                (
+                    new_session_evidence[:2] == ("task_status", "starting")
+                    and session_identity is None
+                )
+                or (
+                    session_identity is not None
+                    and new_session_evidence == ("task", session_identity)
+                    and self._session_identity in (None, session_identity)
+                )
+            )
+        ):
+            # Starting is also emitted repeatedly during departure and resume.
+            # A new reception timestamp or the first id of an active mission
+            # cannot establish a replacement. Fresh commands, changed task ids,
+            # explicit start notices and an observed inactive boundary still can.
+            new_session = False
         invalidated = False
         ordered_evidence_is_current = bool(
             not self._new_session_evidence_pending

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -208,7 +208,10 @@ from .sensor_runtime import (  # noqa: F401
     _runtime_status_blob_summary,
     _runtime_status_blob_total_area_sqm,
 )
-from .sensor_session import DreameLawnMowerObservedMowingTimeSensor
+from .sensor_session import (
+    DreameLawnMowerLastObservedRunSensor,
+    DreameLawnMowerObservedMowingTimeSensor,
+)
 from .sensor_work_log import (
     DreameLawnMowerTotalMowedAreaSensor,
     DreameLawnMowerTotalMowingSessionsSensor,
@@ -491,7 +494,10 @@ async def async_setup_entry(
         + [DreameLawnMowerMowingProgressSensor(coordinator)]
         + [DreameLawnMowerTotalMowedAreaSensor(coordinator)]
         + [DreameLawnMowerTotalMowingTimeSensor(coordinator)]
-        + [DreameLawnMowerObservedMowingTimeSensor(coordinator)]
+        + [
+            DreameLawnMowerObservedMowingTimeSensor(coordinator),
+            DreameLawnMowerLastObservedRunSensor(coordinator),
+        ]
         + [DreameLawnMowerTotalMowingSessionsSensor(coordinator)]
         + [DreameLawnMowerAppMapObjectCountSensor(coordinator)]
         + [DreameLawnMowerFirmwareUpdateStatusSensor(coordinator)]

--- a/custom_components/dreame_lawn_mower/sensor.py
+++ b/custom_components/dreame_lawn_mower/sensor.py
@@ -208,6 +208,7 @@ from .sensor_runtime import (  # noqa: F401
     _runtime_status_blob_summary,
     _runtime_status_blob_total_area_sqm,
 )
+from .sensor_session import DreameLawnMowerObservedMowingTimeSensor
 from .sensor_work_log import (
     DreameLawnMowerTotalMowedAreaSensor,
     DreameLawnMowerTotalMowingSessionsSensor,
@@ -490,6 +491,7 @@ async def async_setup_entry(
         + [DreameLawnMowerMowingProgressSensor(coordinator)]
         + [DreameLawnMowerTotalMowedAreaSensor(coordinator)]
         + [DreameLawnMowerTotalMowingTimeSensor(coordinator)]
+        + [DreameLawnMowerObservedMowingTimeSensor(coordinator)]
         + [DreameLawnMowerTotalMowingSessionsSensor(coordinator)]
         + [DreameLawnMowerAppMapObjectCountSensor(coordinator)]
         + [DreameLawnMowerFirmwareUpdateStatusSensor(coordinator)]

--- a/custom_components/dreame_lawn_mower/sensor_session.py
+++ b/custom_components/dreame_lawn_mower/sensor_session.py
@@ -4,7 +4,11 @@ from __future__ import annotations
 
 from typing import Any
 
-from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+from homeassistant.components.sensor import (
+    SensorDeviceClass,
+    SensorEntity,
+    SensorEntityDescription,
+)
 
 from .entity import DreameLawnMowerEntity
 
@@ -16,6 +20,7 @@ class DreameLawnMowerObservedMowingTimeSensor(DreameLawnMowerEntity, SensorEntit
     _attr_device_class = SensorDeviceClass.DURATION
     _attr_native_unit_of_measurement = "min"
     _attr_icon = "mdi:timer-outline"
+    _unrecorded_attributes = frozenset({"last_observed_at"})
 
     def __init__(self, coordinator: Any) -> None:
         super().__init__(coordinator)
@@ -30,3 +35,46 @@ class DreameLawnMowerObservedMowingTimeSensor(DreameLawnMowerEntity, SensorEntit
     def extra_state_attributes(self) -> dict[str, Any]:
         timer = getattr(self.coordinator, "observed_mowing_timer", None)
         return timer.attributes() if timer is not None else {}
+
+
+class DreameLawnMowerLastObservedRunSensor(DreameLawnMowerEntity, SensorEntity):
+    """Keep the previous observed run useful after docking or a restart."""
+
+    _attr_name = "Last Observed Run Duration"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "min"
+    _attr_icon = "mdi:timer-check-outline"
+    entity_description = SensorEntityDescription(key="last_observed_run_duration")
+
+    def __init__(self, coordinator: Any) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = (
+            f"{self._descriptor.unique_id}_last_observed_run_duration"
+        )
+
+    @property
+    def available(self) -> bool:
+        """Historical evidence remains readable while the mower is offline."""
+        timer = getattr(self.coordinator, "observed_mowing_timer", None)
+        return timer is not None and timer.last_run is not None
+
+    @property
+    def native_value(self) -> float | None:
+        timer = getattr(self.coordinator, "observed_mowing_timer", None)
+        run = timer.last_run if timer is not None else None
+        return round(run.seconds / 60, 1) if run is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        timer = getattr(self.coordinator, "observed_mowing_timer", None)
+        run = timer.last_run if timer is not None else None
+        if run is None:
+            return {}
+        return {
+            "source": "observed_mowing_state",
+            "partial": run.partial,
+            "measurement_state": run.state,
+            "observed_since": run.started_at.isoformat(),
+            "last_observed_at": run.updated_at.isoformat(),
+            "includes_pauses": False,
+        }

--- a/custom_components/dreame_lawn_mower/sensor_session.py
+++ b/custom_components/dreame_lawn_mower/sensor_session.py
@@ -1,0 +1,32 @@
+"""Locally observed timing, kept distinct from device-reported duration."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from homeassistant.components.sensor import SensorDeviceClass, SensorEntity
+
+from .entity import DreameLawnMowerEntity
+
+
+class DreameLawnMowerObservedMowingTimeSensor(DreameLawnMowerEntity, SensorEntity):
+    """Report time observed in mowing state, with explicit completeness limits."""
+
+    _attr_name = "Observed Mowing Time"
+    _attr_device_class = SensorDeviceClass.DURATION
+    _attr_native_unit_of_measurement = "min"
+    _attr_icon = "mdi:timer-outline"
+
+    def __init__(self, coordinator: Any) -> None:
+        super().__init__(coordinator)
+        self._attr_unique_id = f"{self._descriptor.unique_id}_observed_mowing_time"
+
+    @property
+    def native_value(self) -> float | None:
+        timer = getattr(self.coordinator, "observed_mowing_timer", None)
+        return timer.minutes if timer is not None else None
+
+    @property
+    def extra_state_attributes(self) -> dict[str, Any]:
+        timer = getattr(self.coordinator, "observed_mowing_timer", None)
+        return timer.attributes() if timer is not None else {}

--- a/custom_components/dreame_lawn_mower/session_timing.py
+++ b/custom_components/dreame_lawn_mower/session_timing.py
@@ -4,8 +4,15 @@ from __future__ import annotations
 
 from typing import Any
 
+from .dreame_lawn_mower_client.position_tracking import position_timestamp
 from .dreame_lawn_mower_client.session_timing import ObservedMowingTimer
-from .runtime_cache import runtime_mission_session_generation
+from .runtime_cache import (
+    _runtime_new_session_notice_is_current,
+    runtime_mission_cached_session_identity,
+    runtime_mission_session_generation,
+    runtime_mission_session_identity,
+    runtime_mission_session_started_at,
+)
 
 
 def observe_mowing_time(
@@ -17,18 +24,35 @@ def observe_mowing_time(
         timer = coordinator.observed_mowing_timer = ObservedMowingTimer()
     if not getattr(snapshot, "available", False):
         timer.interrupt()
+        checkpoint = getattr(coordinator, "observation_checkpoint", None)
+        if checkpoint is not None:
+            checkpoint.async_schedule_save()
         return
     interval = getattr(coordinator, "update_interval", None)
     max_gap = max(130.0, interval.total_seconds() * 2 + 10) if interval else 130.0
+    cache = getattr(coordinator, "runtime_telemetry_cache", None)
     timer.observe(
-        generation=runtime_mission_session_generation(
-            getattr(coordinator, "runtime_telemetry_cache", None)
-        )
-        or 0,
+        generation=runtime_mission_session_generation(cache) or 0,
         session_active=mission_active,
         mowing=getattr(snapshot, "activity", None) == "mowing",
         max_gap_seconds=max_gap,
+        identity=runtime_mission_session_identity(
+            snapshot,
+            session_started_at=runtime_mission_session_started_at(cache),
+            cached_session_identity=runtime_mission_cached_session_identity(cache),
+        ),
+        identity_observed_at=position_timestamp(
+            getattr(snapshot, "task_status_event_at", None)
+        ),
+        new_start_at=position_timestamp(
+            getattr(snapshot, "status_notice_event_at", None)
+        )
+        if _runtime_new_session_notice_is_current(snapshot)
+        else None,
     )
+    checkpoint = getattr(coordinator, "observation_checkpoint", None)
+    if checkpoint is not None:
+        checkpoint.async_schedule_save()
 
 
 def observed_mowing_time_attributes(coordinator: Any) -> dict[str, Any]:

--- a/custom_components/dreame_lawn_mower/session_timing.py
+++ b/custom_components/dreame_lawn_mower/session_timing.py
@@ -1,0 +1,42 @@
+"""Thin wiring from the existing mission owner to observed-duration consumers."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from .dreame_lawn_mower_client.session_timing import ObservedMowingTimer
+from .runtime_cache import runtime_mission_session_generation
+
+
+def observe_mowing_time(
+    coordinator: Any, snapshot: Any, mission_active: bool | None
+) -> None:
+    """Record successful observations after the coordinator's ordering checks."""
+    timer = getattr(coordinator, "observed_mowing_timer", None)
+    if timer is None:
+        timer = coordinator.observed_mowing_timer = ObservedMowingTimer()
+    if not getattr(snapshot, "available", False):
+        timer.interrupt()
+        return
+    interval = getattr(coordinator, "update_interval", None)
+    max_gap = max(130.0, interval.total_seconds() * 2 + 10) if interval else 130.0
+    timer.observe(
+        generation=runtime_mission_session_generation(
+            getattr(coordinator, "runtime_telemetry_cache", None)
+        )
+        or 0,
+        session_active=mission_active,
+        mowing=getattr(snapshot, "activity", None) == "mowing",
+        max_gap_seconds=max_gap,
+    )
+
+
+def observed_mowing_time_attributes(coordinator: Any) -> dict[str, Any]:
+    """Expose the same measurement contract to mower attributes and sensors."""
+    timer = getattr(coordinator, "observed_mowing_timer", None)
+    return {
+        "observed_mowing_time": timer.minutes if timer is not None else None,
+        "observed_mowing_time_details": timer.attributes()
+        if timer is not None
+        else None,
+    }

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -20,6 +20,7 @@ Common user-facing helpers include:
 - `sensor.<device>_error`
 - `sensor.<device>_battery`
 - `sensor.<device>_mowing_progress`
+- `sensor.<device>_observed_mowing_time`
 - `sensor.<device>_selected_mowing_action`
 - `sensor.<device>_selected_map`
 - `sensor.<device>_selected_target`
@@ -56,6 +57,25 @@ Common user-facing helpers include:
 - `binary_sensor.<device>_returning`
 - `calendar.<device>_schedule`
 - `camera.<device>_live_video` on supported Linux hosts
+
+## Mowing time
+
+**Current Mowing Time** is reported by the mower. It remains unavailable when
+the firmware supplies no duration; a completed work-log total is not a current
+session measurement.
+
+**Observed Mowing Time** is a separate, integration-measured duration in minutes.
+It accumulates between successful observations of the mowing state, excludes
+observed pauses and docking, and freezes across connection failures. It is a
+sampled state duration, not a measurement of blade activity. A new confirmed
+session resets it; before mowing is observed it has no value.
+
+Its `partial` attribute is true if observation began mid-session or a connection
+gap left time unobserved. An integration restart does not restore or backfill
+the timer. The mower entity also exposes `observed_mowing_time` and
+`observed_mowing_time_details` attributes for consumers that do not use the sensor.
+
+## Optional diagnostics
 
 Many reverse-engineering and validation helpers are disabled by default. Enable
 them from the entity registry only when troubleshooting:

--- a/docs/entities.md
+++ b/docs/entities.md
@@ -21,6 +21,7 @@ Common user-facing helpers include:
 - `sensor.<device>_battery`
 - `sensor.<device>_mowing_progress`
 - `sensor.<device>_observed_mowing_time`
+- `sensor.<device>_last_observed_run_duration`
 - `sensor.<device>_selected_mowing_action`
 - `sensor.<device>_selected_map`
 - `sensor.<device>_selected_target`
@@ -71,9 +72,37 @@ sampled state duration, not a measurement of blade activity. A new confirmed
 session resets it; before mowing is observed it has no value.
 
 Its `partial` attribute is true if observation began mid-session or a connection
-gap left time unobserved. An integration restart does not restore or backfill
-the timer. The mower entity also exposes `observed_mowing_time` and
+gap left time unobserved. After a restart, saved time continues only when fresh
+telemetry identifies the same firmware task within 24 hours. Time while Home
+Assistant was offline is excluded, and the restored measurement is partial.
+If task identity is missing or changed, the saved observation becomes an
+interrupted previous-run summary instead of being added to a new session.
+The mower entity also exposes `observed_mowing_time` and
 `observed_mowing_time_details` attributes for consumers that do not use the sensor.
+
+**Last Observed Run Duration** retains the previous observation after a session
+ends or is replaced. Its `measurement_state` distinguishes an observed ending
+from an interruption; neither is proof that the mower completed its target area.
+Saved summaries older than 30 days are not restored.
+
+### Restart storage
+
+The integration overwrites one private checkpoint per mower, limited to 16 KiB
+including storage metadata. It contains only the current observation, one
+previous-run summary, and minimal retained position/map identity evidence. It
+does not contain routes, point clouds, images, credentials, or raw telemetry.
+
+Progress is checkpointed on a 60-second schedule while observations change.
+State transitions are coalesced and rate-limited, and orderly shutdown or reload
+flushes the latest observation. A sudden crash can lose progress since the last
+checkpoint; it cannot make offline time count as mowing. Atomic replacement
+protects the previous file if a write fails. Removing the integration entry
+removes its checkpoint. Corrupt or incompatible saved data does not block normal
+mower operation.
+
+The changing observation timestamp is excluded from Recorder history, while
+the numeric duration remains available for normal HA history. This checkpoint
+limit is separate from Recorder retention and the optional saved map preview.
 
 ## Optional diagnostics
 

--- a/docs/maps.md
+++ b/docs/maps.md
@@ -43,7 +43,7 @@ position or mission telemetry. The companion Lawn Mower Card labels it **Saved
 preview** until a fresh map replaces it. Disabling the option removes the stored
 preview.
 
-Transient paths and positions are scoped to the selected map and mowing task.
+Transient paths are scoped to the selected map and mowing task.
 Changing either clears the prior session trail. A mower position outside the
 selected map boundary is retained in diagnostics but withheld from the image,
 and persisted mower trail data is not presented as live while the session is
@@ -63,6 +63,20 @@ kept out of entity attributes and recorder state. A missing map identity or stal
 position does not produce a live marker. Movement trails are not cut-area masks:
 the interactive background omits historical mowing paths and decorative stripes
 instead of presenting them as verified completed coverage.
+
+When fresh coordinates stop arriving, a compatible card can show a muted
+**Last known position** for up to 24 hours. **At dock · observed position** requires
+a valid position received while the mower is confirmed docked or charging;
+that observation can be reused for up to seven days while it remains docked.
+Both positions are tied to the map geometry and retain their observation time.
+Neither restores an old movement trail or survives an integration restart.
+
+Charging confirms that the mower is at its station, but does not supply the
+station's coordinates. After a cold start, a docked mower that sends only
+position-free heartbeats therefore shows **Docked · map position unavailable**.
+The integration does not use a maintenance point or the last route endpoint
+as an invented dock location. Camera attributes expose `position_status`,
+`position_source`, and `position_observed_at` for the same retained evidence.
 
 ## Appearance and rotation
 

--- a/docs/maps.md
+++ b/docs/maps.md
@@ -69,11 +69,14 @@ When fresh coordinates stop arriving, a compatible card can show a muted
 a valid position received while the mower is confirmed docked or charging;
 that observation can be reused for up to seven days while it remains docked.
 Both positions are tied to the map geometry and retain their observation time.
-Neither restores an old movement trail or survives an integration restart.
+The bounded observation checkpoint can retain them across an integration
+restart, but fresh map geometry must match before they are displayed. Restored
+evidence never becomes a live position or restores an old movement trail.
 
 Charging confirms that the mower is at its station, but does not supply the
-station's coordinates. After a cold start, a docked mower that sends only
-position-free heartbeats therefore shows **Docked · map position unavailable**.
+station's coordinates. After a cold start without valid saved position evidence,
+a docked mower that sends only position-free heartbeats therefore shows
+**Docked · map position unavailable**.
 The integration does not use a maintenance point or the last route endpoint
 as an invented dock location. Camera attributes expose `position_status`,
 `position_source`, and `position_observed_at` for the same retained evidence.

--- a/tests/components/dreame_lawn_mower/test_observation_storage.py
+++ b/tests/components/dreame_lawn_mower/test_observation_storage.py
@@ -1,0 +1,221 @@
+"""Real HA storage artifacts across new owners, shutdown, and entry removal."""
+
+import json
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+from homeassistant.const import (
+    EVENT_HOMEASSISTANT_FINAL_WRITE,
+    EVENT_HOMEASSISTANT_STOP,
+)
+from homeassistant.core import CoreState, HomeAssistant
+from homeassistant.util.file import AtomicWriter
+
+from custom_components.dreame_lawn_mower import async_remove_entry
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    position_tracking,
+    session_timing,
+)
+from custom_components.dreame_lawn_mower.observation_checkpoint import (
+    MAX_CHECKPOINT_BYTES,
+    ObservationCheckpoint,
+)
+
+
+@pytest.fixture(autouse=True)
+def auto_enable_custom_integrations():
+    """Do not request the shared hass fixture, which mocks all storage IO.
+
+    These tests construct isolated HA instances and invoke the integration's
+    storage owner directly; no integration discovery or cloud setup is needed.
+    """
+
+
+def coordinator():
+    return SimpleNamespace(
+        client=SimpleNamespace(
+            descriptor=SimpleNamespace(unique_id="mower-test"),
+            _position_tracker=position_tracking.MowerPositionTracker(),
+        ),
+        observed_mowing_timer=session_timing.ObservedMowingTimer(),
+    )
+
+
+async def test_actual_checkpoint_file_survives_new_ha_owner_and_is_removed(tmp_path):
+    """Use actual disk IO, not the normal in-memory hass_storage fixture."""
+    first_hass = HomeAssistant(str(tmp_path))
+    second_hass = HomeAssistant(str(tmp_path))
+    first, second = coordinator(), coordinator()
+    now = datetime.now(UTC) - timedelta(minutes=10)
+    first.observed_mowing_timer.observe(
+        generation=1,
+        session_active=True,
+        mowing=True,
+        identity=77,
+        now=now,
+        monotonic=0,
+    )
+    first.observed_mowing_timer.observe(
+        generation=1,
+        session_active=True,
+        mowing=True,
+        identity=77,
+        now=now + timedelta(seconds=60),
+        monotonic=60,
+    )
+    first_store = ObservationCheckpoint(first_hass, "test-entry", first)
+    second_store = ObservationCheckpoint(second_hass, "test-entry", second)
+    try:
+        await first_store.async_close()
+        path = tmp_path / ".storage" / first_store._key
+        raw = await first_hass.async_add_executor_job(path.read_bytes)
+        assert len(raw) <= MAX_CHECKPOINT_BYTES
+        envelope = json.loads(raw)
+        assert envelope["data"]["timing"]["current"]["seconds"] == 60
+        assert envelope["version"] == 1
+
+        await second_store.async_load()
+        second.observed_mowing_timer.observe(
+            generation=5,
+            session_active=True,
+            mowing=True,
+            identity=77,
+            identity_observed_at=datetime.now(UTC).timestamp(),
+            now=datetime.now(UTC),
+            monotonic=0,
+        )
+        assert second.observed_mowing_timer.minutes == 1
+        assert second.observed_mowing_timer.partial
+        await second_store.async_close()
+        files = await first_hass.async_add_executor_job(
+            lambda: list(path.parent.iterdir())
+        )
+        assert [item.name for item in files] == [first_store._key]
+        await async_remove_entry(second_hass, SimpleNamespace(entry_id="test-entry"))
+        assert not await second_hass.async_add_executor_job(path.exists)
+    finally:
+        await first_store.async_close()
+        await second_store.async_close()
+        await first_hass.async_stop()
+        await second_hass.async_stop()
+
+
+async def test_invalid_checkpoint_cannot_prevent_a_new_observation(tmp_path):
+    hass = HomeAssistant(str(tmp_path))
+    owner = coordinator()
+    checkpoint = ObservationCheckpoint(hass, "test-entry", owner)
+    try:
+        await checkpoint._store.async_save({"unexpected": "old or invalid schema"})
+        await checkpoint.async_load()
+        owner.observed_mowing_timer.observe(
+            generation=1,
+            session_active=True,
+            mowing=True,
+            monotonic=0,
+        )
+        assert owner.observed_mowing_timer.minutes == 0
+        assert owner.observed_mowing_timer.partial
+        await checkpoint.async_close()
+        record = await checkpoint._store.async_load()
+        assert record["timing"]["current"]["seconds"] == 0
+    finally:
+        await checkpoint.async_close()
+        await hass.async_stop()
+
+
+async def test_orderly_ha_stop_flushes_progress_before_the_periodic_save(tmp_path):
+    hass = HomeAssistant(str(tmp_path))
+    owner = coordinator()
+    checkpoint = ObservationCheckpoint(hass, "test-entry", owner)
+    now = datetime.now(UTC) - timedelta(minutes=5)
+
+    def observe(second):
+        owner.observed_mowing_timer.observe(
+            generation=1,
+            session_active=True,
+            mowing=True,
+            identity=77,
+            now=now + timedelta(seconds=second),
+            monotonic=second,
+        )
+
+    async def stop(_):
+        await checkpoint.async_close()
+
+    hass.bus.async_listen_once(EVENT_HOMEASSISTANT_STOP, stop)
+    try:
+        await hass.async_start()
+        observe(0)
+        observe(30)
+        await checkpoint.async_flush()
+        observe(60)
+        checkpoint.async_schedule_save()
+        await hass.async_stop()
+        path = tmp_path / ".storage" / checkpoint._key
+        raw = await hass.async_add_executor_job(path.read_bytes)
+        assert json.loads(raw)["data"]["timing"]["current"]["seconds"] == 60
+        assert len(raw) <= MAX_CHECKPOINT_BYTES
+    finally:
+        await checkpoint.async_close()
+        await hass.async_stop()
+
+
+async def test_failed_atomic_replace_preserves_the_previous_checkpoint(tmp_path):
+    hass = HomeAssistant(str(tmp_path))
+    owner = coordinator()
+    checkpoint = ObservationCheckpoint(hass, "test-entry", owner)
+    now = datetime.now(UTC) - timedelta(minutes=5)
+    try:
+        for second in (0, 30):
+            owner.observed_mowing_timer.observe(
+                generation=1,
+                session_active=True,
+                mowing=True,
+                now=now + timedelta(seconds=second),
+                monotonic=second,
+            )
+        await checkpoint.async_flush()
+        path = tmp_path / ".storage" / checkpoint._key
+        original = await hass.async_add_executor_job(path.read_bytes)
+        owner.observed_mowing_timer.observe(
+            generation=1,
+            session_active=True,
+            mowing=True,
+            now=now + timedelta(seconds=60),
+            monotonic=60,
+        )
+        with patch.object(AtomicWriter, "commit", side_effect=OSError("disk full")):
+            await checkpoint.async_flush()
+        assert await hass.async_add_executor_job(path.read_bytes) == original
+        await checkpoint.async_flush()
+        recovered = await hass.async_add_executor_job(path.read_bytes)
+        assert json.loads(recovered)["data"]["timing"]["current"]["seconds"] == 60
+        files = await hass.async_add_executor_job(lambda: list(path.parent.iterdir()))
+        assert [item.name for item in files] == [checkpoint._key]
+        assert owner.observed_mowing_timer.minutes == 1
+    finally:
+        await checkpoint.async_close()
+        await hass.async_stop()
+
+
+async def test_shutdown_then_fallback_removal_cannot_recreate_checkpoint(tmp_path):
+    hass = HomeAssistant(str(tmp_path))
+    checkpoint = ObservationCheckpoint(hass, "test-entry", coordinator())
+    path = tmp_path / ".storage" / checkpoint._key
+    try:
+        hass.set_state(CoreState.stopping)
+        await checkpoint.async_close()
+        # Unload has released the coordinator; removal uses a new Store owner.
+        await async_remove_entry(hass, SimpleNamespace(entry_id="test-entry"))
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
+        await hass.async_block_till_done()
+        assert not await hass.async_add_executor_job(path.exists)
+        await checkpoint.async_close()
+        hass.bus.async_fire(EVENT_HOMEASSISTANT_FINAL_WRITE)
+        await hass.async_block_till_done()
+        assert not await hass.async_add_executor_job(path.exists)
+    finally:
+        hass.set_state(CoreState.not_running)
+        await hass.async_stop()

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -3257,6 +3257,9 @@ def test_failed_platform_setup_removes_coordinator_and_drains_resources() -> Non
 
         with (
             patch.object(
+                integration_module, "ObservationCheckpoint", return_value=cache
+            ),
+            patch.object(
                 integration_module, "async_remove_restart_preview", AsyncMock()
             ),
             patch.object(
@@ -3341,6 +3344,9 @@ def test_successful_setup_shuts_down_coordinator_on_home_assistant_stop() -> Non
 
         with (
             patch.object(
+                integration_module, "ObservationCheckpoint", return_value=cache
+            ),
+            patch.object(
                 integration_module, "async_remove_restart_preview", AsyncMock()
             ),
             patch.object(
@@ -3411,6 +3417,9 @@ def test_initial_connection_failure_keeps_complete_platform_setup_pending() -> N
         entry = SimpleNamespace(entry_id="entry-1", data={}, options={})
 
         with (
+            patch.object(
+                integration_module, "ObservationCheckpoint", return_value=cache
+            ),
             patch.object(
                 integration_module, "async_remove_restart_preview", AsyncMock()
             ),

--- a/tests/test_coordinator_tracking_continuity.py
+++ b/tests/test_coordinator_tracking_continuity.py
@@ -19,7 +19,20 @@ from custom_components.dreame_lawn_mower.runtime_cache import (
 
 
 @pytest.mark.parametrize(
-    "transition", ["pose", "mission", "docked", "offline", "evicted", "evicted_error"]
+    "transition",
+    [
+        "pose",
+        "runtime_pose",
+        "runtime_mission",
+        "runtime_map",
+        "runtime_offline",
+        "runtime_docked",
+        "mission",
+        "docked",
+        "offline",
+        "evicted",
+        "evicted_error",
+    ],
 )
 def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> None:
     async def scenario() -> None:
@@ -60,6 +73,24 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
         blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
 
         async def read_runtime(**kwargs: object) -> object:
+            if transition.startswith("runtime_"):
+                # Frequent position callbacks must not starve independently
+                # verified map identity while a cloud telemetry read yields.
+                pose = SimpleNamespace(
+                    available=transition != "runtime_offline",
+                    activity="docked" if transition == "runtime_docked" else "mowing",
+                    docked=transition == "runtime_docked",
+                    mowing_session_active=transition != "runtime_docked",
+                )
+                coordinator._record_device_snapshot(pose)
+                coordinator._published_device_snapshot_generation = (
+                    coordinator._device_snapshot_generation
+                )
+                coordinator.data = pose
+                if transition == "runtime_mission":
+                    coordinator.runtime_telemetry_cache._session_generation += 1
+                if transition == "runtime_map":
+                    coordinator.app_maps = {"current_map_index": 1}
             if transition.startswith("evicted"):
                 # Simulate updates while the real telemetry read is pending.
                 await asyncio.sleep(0)
@@ -101,6 +132,8 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
             coordinator.client.update_runtime_live_tracking.assert_not_called()
             assert coordinator.runtime_status_blob is None
             assert coordinator.runtime_telemetry_cache.blob is None
-            assert coordinator._runtime_map_identity_verified is False
+            assert coordinator._runtime_map_identity_verified is (
+                transition == "runtime_pose"
+            )
 
     asyncio.run(scenario())

--- a/tests/test_mowing_map.py
+++ b/tests/test_mowing_map.py
@@ -3,6 +3,7 @@
 from dataclasses import replace
 from datetime import UTC, datetime, timedelta
 from io import BytesIO
+from types import SimpleNamespace
 
 import pytest
 from PIL import Image
@@ -186,3 +187,85 @@ def test_trail_preserves_gaps_and_stays_bounded():
         track_segments=(((10, 10), (20, 20)),),
     )
     assert ended["trail"] == []
+
+
+def test_camera_and_interactive_overlay_share_dock_evidence_after_session_ends():
+    from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+        client_position,
+        position_tracking,
+    )
+
+    now = datetime.now(UTC)
+    tracker = position_tracking.MowerPositionTracker()
+    tracker.record(replace(telemetry(), received_at=now.isoformat()), map_index=2)
+    client = SimpleNamespace(
+        _position_tracker=tracker,
+        _latest_snapshot=SimpleNamespace(
+            available=True,
+            activity="docked",
+            docked=True,
+            state_event_at=(now - timedelta(seconds=2)).timestamp(),
+        ),
+        _latest_runtime_status_blob=None,
+        _runtime_live_map_index=None,
+        _runtime_session_active=False,
+        _runtime_live_track_segments=(),
+    )
+    position = client_position.vector_map_position(client, garden())
+    scene = build_mowing_map_scene(garden(), style=map_render_style())
+    mixin = client_mowing_map._DreameLawnMowerClientMowingMapMixin
+    overlay = mixin.mowing_map_runtime_overlay(client, scene)
+    assert position.status == overlay["position_status"] == "known_dock"
+    assert overlay["position_observed_at"] == position.details()["position_observed_at"]
+    assert overlay["position"]["x"] == scene.projection.point(position.x, position.y)[0]
+    assert overlay["trail"] == []
+    assert overlay["docked"] is True
+
+
+def test_interactive_client_does_not_bypass_replaced_geometry_rejection():
+    from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+        position_tracking,
+    )
+
+    now = datetime.now(UTC)
+    blob = replace(telemetry(), received_at=now.isoformat())
+    tracker = position_tracking.MowerPositionTracker()
+    tracker.record(blob, map_index=2)
+    client = SimpleNamespace(
+        _position_tracker=tracker,
+        _latest_snapshot=SimpleNamespace(available=True, activity="mowing"),
+        _latest_runtime_status_blob=blob,
+        _runtime_live_task_id=None,
+        _runtime_live_map_index=2,
+        _runtime_session_active=True,
+        _runtime_live_track_segments=(((10, 10), (20, 20)),),
+    )
+    mixin = client_mowing_map._DreameLawnMowerClientMowingMapMixin
+    first = build_mowing_map_scene(garden(), style=map_render_style())
+    assert mixin.mowing_map_runtime_overlay(client, first)["position"] is not None
+    replaced = build_mowing_map_scene(
+        replace(garden(), map_id=8), style=map_render_style()
+    )
+    overlay = mixin.mowing_map_runtime_overlay(client, replaced)
+    assert overlay["position"] is None
+    assert overlay["trail"] == []
+
+
+def test_current_marker_expiry_remains_bound_to_measurement_time():
+    from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+        position_tracking,
+    )
+
+    observed = NOW - timedelta(seconds=89)
+    position = position_tracking.MowerPosition(200, 200, 0, observed.timestamp(), 2)
+    scene = build_mowing_map_scene(garden(), style=map_render_style())
+    overlay = mowing_map_overlay(
+        scene,
+        replace(telemetry(), received_at=observed.isoformat()),
+        map_index=2,
+        active=True,
+        retained_position=position,
+        now=NOW,
+    )
+    assert overlay["position_status"] == "current"
+    assert overlay["updated_at"] == overlay["position_observed_at"]

--- a/tests/test_mowing_map.py
+++ b/tests/test_mowing_map.py
@@ -203,6 +203,7 @@ def test_camera_and_interactive_overlay_share_dock_evidence_after_session_ends()
         _latest_snapshot=SimpleNamespace(
             available=True,
             activity="docked",
+            state="charging",
             docked=True,
             state_event_at=(now - timedelta(seconds=2)).timestamp(),
         ),

--- a/tests/test_observation_checkpoint.py
+++ b/tests/test_observation_checkpoint.py
@@ -225,78 +225,86 @@ def setup_checkpoint(monkeypatch, record=None):
     )
 
 
-@pytest.mark.asyncio
-async def test_frequent_samples_cannot_starve_checkpoints_or_write_each_heartbeat(
+def test_frequent_samples_cannot_starve_checkpoints_or_write_each_heartbeat(
     monkeypatch,
 ):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    checkpoint.async_schedule_save()
-    await clock.advance(2)
-    await checkpoint._task
-    assert len(saved) == 1
-    for second in range(3, 123):
-        observe(coordinator.observed_mowing_timer, 60 + second)
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
         checkpoint.async_schedule_save()
-        await clock.advance(1)
-        if checkpoint._task is not None:
-            await checkpoint._task
-    assert 2 <= len(saved) <= 3
-    await checkpoint.async_close()
-    assert saved[-1]["timing"]["current"]["seconds"] == 182
-    assert persistence.checkpoint_fits(saved[-1], checkpoint._key)
-    assert len(json.dumps(saved[-1]).encode()) < 2048
-    assert set(saved[-1]) == {"scope", "saved_at", "timing", "position"}
+        await clock.advance(2)
+        await checkpoint._task
+        assert len(saved) == 1
+        for second in range(3, 123):
+            observe(coordinator.observed_mowing_timer, 60 + second)
+            checkpoint.async_schedule_save()
+            await clock.advance(1)
+            if checkpoint._task is not None:
+                await checkpoint._task
+        assert 2 <= len(saved) <= 3
+        await checkpoint.async_close()
+        assert saved[-1]["timing"]["current"]["seconds"] == 182
+        assert persistence.checkpoint_fits(saved[-1], checkpoint._key)
+        assert len(json.dumps(saved[-1]).encode()) < 2048
+        assert set(saved[-1]) == {"scope", "saved_at", "timing", "position"}
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_paused_timestamps_do_not_produce_repeated_disk_writes(monkeypatch):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    observe(coordinator.observed_mowing_timer, 90, mowing=False)
-    checkpoint.async_schedule_save()
-    await clock.advance(2)
-    for second in range(100, 1000, 60):
-        observe(coordinator.observed_mowing_timer, second, mowing=False)
+def test_paused_timestamps_do_not_produce_repeated_disk_writes(monkeypatch):
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+        observe(coordinator.observed_mowing_timer, 90, mowing=False)
         checkpoint.async_schedule_save()
-        await clock.advance(60)
-    await checkpoint.async_close()
-    assert len(saved) == 1
+        await clock.advance(2)
+        for second in range(100, 1000, 60):
+            observe(coordinator.observed_mowing_timer, second, mowing=False)
+            checkpoint.async_schedule_save()
+            await clock.advance(60)
+        await checkpoint.async_close()
+        assert len(saved) == 1
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_store_failure_does_not_disable_control_or_spam_logs(monkeypatch, caplog):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    store.async_save.side_effect = OSError("disk full")
-    await checkpoint.async_flush()
-    await checkpoint.async_flush()
-    assert caplog.text.count("checkpoint unavailable") == 1
-    store.async_save.side_effect = None
-    await checkpoint.async_flush()
-    assert store.async_save.await_count == 3
+def test_store_failure_does_not_disable_control_or_spam_logs(monkeypatch, caplog):
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+        store.async_save.side_effect = OSError("disk full")
+        await checkpoint.async_flush()
+        await checkpoint.async_flush()
+        assert caplog.text.count("checkpoint unavailable") == 1
+        store.async_save.side_effect = None
+        await checkpoint.async_flush()
+        assert store.async_save.await_count == 3
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
-async def test_remove_waits_for_inflight_write_and_prevents_recreation(monkeypatch):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    entered, release = asyncio.Event(), asyncio.Event()
+def test_remove_waits_for_inflight_write_and_prevents_recreation(monkeypatch):
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+        entered, release = asyncio.Event(), asyncio.Event()
 
-    async def slow_save(record):
-        entered.set()
-        await release.wait()
-        saved.append(record)
+        async def slow_save(record):
+            entered.set()
+            await release.wait()
+            saved.append(record)
 
-    store.async_save.side_effect = slow_save
-    checkpoint.async_schedule_save()
-    await clock.advance(2)
-    await entered.wait()
-    removing = asyncio.create_task(checkpoint.async_remove())
-    await asyncio.sleep(0)
-    checkpoint.async_schedule_save()
-    assert store.async_remove.await_count == 0
-    release.set()
-    await removing
-    await clock.advance(100)
-    assert store.async_remove.await_count == 1
-    assert len(saved) == 1
+        store.async_save.side_effect = slow_save
+        checkpoint.async_schedule_save()
+        await clock.advance(2)
+        await entered.wait()
+        removing = asyncio.create_task(checkpoint.async_remove())
+        await asyncio.sleep(0)
+        checkpoint.async_schedule_save()
+        assert store.async_remove.await_count == 0
+        release.set()
+        await removing
+        await clock.advance(100)
+        assert store.async_remove.await_count == 1
+        assert len(saved) == 1
+
+    asyncio.run(scenario())
 
 
 def test_checkpoint_size_includes_storage_envelope_and_rejects_oversize():
@@ -330,57 +338,64 @@ def test_previous_run_sensor_and_recorder_exclusions():
     )
 
 
-@pytest.mark.asyncio
-async def test_cancelled_write_is_drained_before_entry_removal(monkeypatch):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    entered, release = asyncio.Event(), asyncio.Event()
+def test_cancelled_write_is_drained_before_entry_removal(monkeypatch):
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+        entered, release = asyncio.Event(), asyncio.Event()
 
-    async def slow_save(record):
-        entered.set()
-        await release.wait()
-        saved.append(record)
+        async def slow_save(record):
+            entered.set()
+            await release.wait()
+            saved.append(record)
 
-    store.async_save.side_effect = slow_save
-    checkpoint.async_schedule_save()
-    await clock.advance(2)
-    await entered.wait()
-    checkpoint._task.cancel()
-    removing = asyncio.create_task(checkpoint.async_remove())
-    await asyncio.sleep(0)
-    assert store.async_remove.await_count == 0
-    release.set()
-    await removing
-    assert store.async_remove.await_count == 1
-    count = len(saved)
-    checkpoint.async_schedule_save()
-    await clock.advance(100)
-    assert len(saved) == count
-
-
-@pytest.mark.asyncio
-async def test_cancelled_load_never_overwrites_unread_evidence(monkeypatch):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    store.async_load.side_effect = asyncio.CancelledError
-    with pytest.raises(asyncio.CancelledError):
-        await checkpoint.async_load()
-    await checkpoint.async_close()
-    assert not saved
-
-
-@pytest.mark.asyncio
-async def test_rapid_transitions_are_rate_limited(monkeypatch):
-    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
-    for second in range(120):
-        observe(coordinator.observed_mowing_timer, 60 + second, mowing=second % 2 == 0)
+        store.async_save.side_effect = slow_save
         checkpoint.async_schedule_save()
-        await clock.advance(1)
-        if checkpoint._task is not None:
-            await checkpoint._task
-    assert len(saved) <= 12
-    await checkpoint.async_close()
+        await clock.advance(2)
+        await entered.wait()
+        checkpoint._task.cancel()
+        removing = asyncio.create_task(checkpoint.async_remove())
+        await asyncio.sleep(0)
+        assert store.async_remove.await_count == 0
+        release.set()
+        await removing
+        assert store.async_remove.await_count == 1
+        count = len(saved)
+        checkpoint.async_schedule_save()
+        await clock.advance(100)
+        assert len(saved) == count
+
+    asyncio.run(scenario())
 
 
-@pytest.mark.asyncio
+def test_cancelled_load_never_overwrites_unread_evidence(monkeypatch):
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+        store.async_load.side_effect = asyncio.CancelledError
+        with pytest.raises(asyncio.CancelledError):
+            await checkpoint.async_load()
+        await checkpoint.async_close()
+        assert not saved
+
+    asyncio.run(scenario())
+
+
+def test_rapid_transitions_are_rate_limited(monkeypatch):
+    async def scenario():
+        checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+        for second in range(120):
+            observe(
+                coordinator.observed_mowing_timer, 60 + second, mowing=second % 2 == 0
+            )
+            checkpoint.async_schedule_save()
+            await clock.advance(1)
+            if checkpoint._task is not None:
+                await checkpoint._task
+        assert len(saved) <= 12
+        await checkpoint.async_close()
+
+    asyncio.run(scenario())
+
+
 @pytest.mark.parametrize(
     "field,value",
     [
@@ -391,18 +406,21 @@ async def test_rapid_transitions_are_rate_limited(monkeypatch):
         ("timing", {"unexpected": "a" * 16384}),
     ],
 )
-async def test_invalid_store_envelope_cannot_restore_a_run(monkeypatch, field, value):
-    first, _, _, _, saved = setup_checkpoint(monkeypatch)
-    await first.async_close()
-    record = saved[-1]
-    record[field] = value
-    second, owner, _, _, _ = setup_checkpoint(monkeypatch, record=record)
-    owner.observed_mowing_timer = ObservedMowingTimer()
-    await second.async_load()
-    observe(owner.observed_mowing_timer, 120)
-    assert owner.observed_mowing_timer.minutes == 0
-    assert owner.observed_mowing_timer.last_run is None
-    await second.async_close()
+def test_invalid_store_envelope_cannot_restore_a_run(monkeypatch, field, value):
+    async def scenario():
+        first, _, _, _, saved = setup_checkpoint(monkeypatch)
+        await first.async_close()
+        record = saved[-1]
+        record[field] = value
+        second, owner, _, _, _ = setup_checkpoint(monkeypatch, record=record)
+        owner.observed_mowing_timer = ObservedMowingTimer()
+        await second.async_load()
+        observe(owner.observed_mowing_timer, 120)
+        assert owner.observed_mowing_timer.minutes == 0
+        assert owner.observed_mowing_timer.last_run is None
+        await second.async_close()
+
+    asyncio.run(scenario())
 
 
 def test_stale_terminal_snapshot_cannot_replace_saved_mission_identity():

--- a/tests/test_observation_checkpoint.py
+++ b/tests/test_observation_checkpoint.py
@@ -1,0 +1,448 @@
+"""Restart evidence and bounded writes without inventing unobserved activity."""
+
+import asyncio
+import copy
+import json
+import math
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+from custom_components.dreame_lawn_mower import observation_checkpoint as persistence
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    position_tracking,
+    session_checkpoint,
+    session_timing,
+)
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
+from custom_components.dreame_lawn_mower.sensor_session import (
+    DreameLawnMowerLastObservedRunSensor,
+    DreameLawnMowerObservedMowingTimeSensor,
+)
+from custom_components.dreame_lawn_mower.session_timing import observe_mowing_time
+
+NOW = datetime.now(UTC) - timedelta(hours=1)
+MowerPositionTracker = position_tracking.MowerPositionTracker
+ObservedMowingTimer = session_timing.ObservedMowingTimer
+decode_run = session_checkpoint.decode_run
+
+
+def observe(timer, second, *, identity=71, generation=1, active=True, mowing=True):
+    timer.observe(
+        generation=generation,
+        session_active=active,
+        mowing=mowing,
+        now=NOW + timedelta(seconds=second),
+        monotonic=float(second),
+        identity=identity,
+        identity_observed_at=NOW.timestamp() + second,
+    )
+
+
+def measured_timer():
+    timer = ObservedMowingTimer()
+    observe(timer, 0)
+    observe(timer, 60)
+    return timer
+
+
+def test_matching_fresh_mission_restores_without_counting_the_offline_gap():
+    first = measured_timer()
+    second = ObservedMowingTimer()
+    second.restore_checkpoint(first.checkpoint(), now=NOW + timedelta(seconds=300))
+    assert second.minutes is None
+    observe(second, 300, generation=5)
+    assert second.minutes == 1
+    assert second.partial
+    assert second.started_at == first.started_at
+    observe(second, 360, generation=5)
+    assert second.minutes == 2
+    assert second.last_run is None
+
+
+@pytest.mark.parametrize("identity", [None, 72])
+def test_unknown_or_different_mission_keeps_an_interrupted_previous_summary(identity):
+    second = ObservedMowingTimer()
+    second.restore_checkpoint(
+        measured_timer().checkpoint(), now=NOW + timedelta(seconds=300)
+    )
+    observe(second, 300, identity=identity)
+    assert second.minutes == 0
+    assert second.last_run.seconds == 60
+    assert second.last_run.partial
+    assert second.last_run.state == "interrupted"
+
+
+@pytest.mark.parametrize("event_at,new_start", [(50, None), (300, 200)])
+def test_stale_task_identity_or_new_start_cannot_join_saved_time(event_at, new_start):
+    second = ObservedMowingTimer()
+    second.restore_checkpoint(
+        measured_timer().checkpoint(), now=NOW + timedelta(seconds=300)
+    )
+    second.observe(
+        generation=1,
+        session_active=True,
+        mowing=True,
+        identity=71,
+        identity_observed_at=NOW.timestamp() + event_at,
+        new_start_at=NOW.timestamp() + new_start if new_start is not None else None,
+        now=NOW + timedelta(seconds=300),
+        monotonic=0,
+    )
+    assert second.minutes == 0
+    assert second.last_run.seconds == 60
+
+
+def test_previous_run_is_retained_after_end_restart_and_new_session():
+    timer = measured_timer()
+    observe(timer, 90, active=False, mowing=False)
+    assert timer.last_run.seconds == 90
+    observe(timer, 150, active=False, mowing=False)
+    assert timer.last_run.updated_at == NOW + timedelta(seconds=90)
+    second = ObservedMowingTimer()
+    second.restore_checkpoint(timer.checkpoint(), now=NOW + timedelta(seconds=300))
+    observe(second, 300, identity=72)
+    assert second.last_run.seconds == 90
+    assert second.last_run.state == "ended"
+    assert second.minutes == 0
+
+
+@pytest.mark.parametrize(
+    "key,value",
+    [
+        ("seconds", math.nan),
+        ("seconds", math.inf),
+        ("seconds", -1),
+        ("seconds", 999999),
+        ("seconds", True),
+        ("identity", True),
+        ("identity", 2**80),
+        ("state", []),
+        ("partial", "false"),
+        ("started_at", "2026-09-07T00:00:00"),
+        ("updated_at", "invalid"),
+    ],
+)
+def test_corrupt_run_fields_are_rejected(key, value):
+    record = measured_timer().checkpoint()["current"]
+    record[key] = value
+    assert decode_run(record, now=NOW + timedelta(seconds=300)) is None
+
+
+def test_restored_position_is_not_live_and_requires_map_and_bounds_match():
+    first = MowerPositionTracker()
+    blob = SimpleNamespace(
+        frame_valid=True,
+        received_at=NOW.timestamp(),
+        candidate_runtime_pose_x=10,
+        candidate_runtime_pose_y=20,
+        candidate_runtime_heading_deg=90,
+    )
+    first.record(blob, map_index=0, now=NOW)
+    snapshot = SimpleNamespace(available=True, activity="mowing")
+    first.resolve(
+        map_index=0,
+        geometry="a" * 64,
+        contains=lambda *_: True,
+        snapshot=snapshot,
+        now=NOW,
+    )
+    record = first.checkpoint(now=NOW)
+    second = MowerPositionTracker()
+    second.restore_checkpoint(record, now=NOW + timedelta(seconds=10))
+    kwargs = dict(
+        map_index=0,
+        geometry="a" * 64,
+        contains=lambda *_: True,
+        snapshot=snapshot,
+        now=NOW + timedelta(seconds=10),
+    )
+    assert second.resolve(**kwargs).status == "last_known"
+    assert second.resolve(**{**kwargs, "contains": lambda *_: False}) is None
+    assert second.resolve(**{**kwargs, "map_index": 1}) is None
+    assert second.resolve(**{**kwargs, "geometry": "b" * 64}) is None
+
+
+class Clock:
+    """Deterministic event-loop timer boundary; write tasks use real asyncio."""
+
+    def __init__(self):
+        self.now = 0
+        self.handles = []
+
+    def time(self):
+        return self.now
+
+    def call_later(self, delay, callback):
+        handle = SimpleNamespace(
+            at=self.now + delay, cancelled=False, callback=callback
+        )
+        handle.when = lambda: handle.at
+        handle.cancel = lambda: setattr(handle, "cancelled", True)
+        self.handles.append(handle)
+        return handle
+
+    async def advance(self, seconds):
+        self.now += seconds
+        due = [h for h in self.handles if not h.cancelled and h.at <= self.now]
+        for handle in due:
+            handle.cancel()
+            handle.callback()
+        await asyncio.sleep(0)
+
+
+def setup_checkpoint(monkeypatch, record=None):
+    saved = []
+
+    async def save(value):
+        saved.append(copy.deepcopy(value))
+
+    store = SimpleNamespace(
+        async_load=AsyncMock(return_value=record),
+        async_save=AsyncMock(side_effect=save),
+        async_remove=AsyncMock(),
+    )
+    monkeypatch.setattr(persistence, "checkpoint_store", lambda *_: store)
+    clock = Clock()
+    hass = SimpleNamespace(loop=clock, async_create_task=asyncio.create_task)
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(
+            descriptor=SimpleNamespace(unique_id="mower-one"),
+            _position_tracker=MowerPositionTracker(),
+        ),
+        observed_mowing_timer=measured_timer(),
+    )
+    return (
+        persistence.ObservationCheckpoint(hass, "entry-one", coordinator),
+        coordinator,
+        clock,
+        store,
+        saved,
+    )
+
+
+@pytest.mark.asyncio
+async def test_frequent_samples_cannot_starve_checkpoints_or_write_each_heartbeat(
+    monkeypatch,
+):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    checkpoint.async_schedule_save()
+    await clock.advance(2)
+    await checkpoint._task
+    assert len(saved) == 1
+    for second in range(3, 123):
+        observe(coordinator.observed_mowing_timer, 60 + second)
+        checkpoint.async_schedule_save()
+        await clock.advance(1)
+        if checkpoint._task is not None:
+            await checkpoint._task
+    assert 2 <= len(saved) <= 3
+    await checkpoint.async_close()
+    assert saved[-1]["timing"]["current"]["seconds"] == 182
+    assert persistence.checkpoint_fits(saved[-1], checkpoint._key)
+    assert len(json.dumps(saved[-1]).encode()) < 2048
+    assert set(saved[-1]) == {"scope", "saved_at", "timing", "position"}
+
+
+@pytest.mark.asyncio
+async def test_paused_timestamps_do_not_produce_repeated_disk_writes(monkeypatch):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    observe(coordinator.observed_mowing_timer, 90, mowing=False)
+    checkpoint.async_schedule_save()
+    await clock.advance(2)
+    for second in range(100, 1000, 60):
+        observe(coordinator.observed_mowing_timer, second, mowing=False)
+        checkpoint.async_schedule_save()
+        await clock.advance(60)
+    await checkpoint.async_close()
+    assert len(saved) == 1
+
+
+@pytest.mark.asyncio
+async def test_store_failure_does_not_disable_control_or_spam_logs(monkeypatch, caplog):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    store.async_save.side_effect = OSError("disk full")
+    await checkpoint.async_flush()
+    await checkpoint.async_flush()
+    assert caplog.text.count("checkpoint unavailable") == 1
+    store.async_save.side_effect = None
+    await checkpoint.async_flush()
+    assert store.async_save.await_count == 3
+
+
+@pytest.mark.asyncio
+async def test_remove_waits_for_inflight_write_and_prevents_recreation(monkeypatch):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def slow_save(record):
+        entered.set()
+        await release.wait()
+        saved.append(record)
+
+    store.async_save.side_effect = slow_save
+    checkpoint.async_schedule_save()
+    await clock.advance(2)
+    await entered.wait()
+    removing = asyncio.create_task(checkpoint.async_remove())
+    await asyncio.sleep(0)
+    checkpoint.async_schedule_save()
+    assert store.async_remove.await_count == 0
+    release.set()
+    await removing
+    await clock.advance(100)
+    assert store.async_remove.await_count == 1
+    assert len(saved) == 1
+
+
+def test_checkpoint_size_includes_storage_envelope_and_rejects_oversize():
+    key = "dreame_lawn_mower." + "a" * 32 + ".observation_checkpoint"
+    assert persistence.checkpoint_fits({"padding": "a" * 15000}, key)
+    assert not persistence.checkpoint_fits({"padding": "a" * 16300}, key)
+    assert not persistence.checkpoint_fits({"number": math.nan}, key)
+
+
+def test_previous_run_sensor_and_recorder_exclusions():
+    timer = measured_timer()
+    observe(timer, 90, active=False, mowing=False)
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(descriptor=SimpleNamespace(unique_id="test")),
+        observed_mowing_timer=timer,
+    )
+    sensor = DreameLawnMowerLastObservedRunSensor(coordinator)
+    assert sensor.native_value == 1.5
+    assert sensor.extra_state_attributes["measurement_state"] == "ended"
+    assert sensor.extra_state_attributes["source"] == "observed_mowing_state"
+    coordinator.data = SimpleNamespace(available=False)
+    coordinator.last_update_success = False
+    assert sensor.available
+    current = DreameLawnMowerObservedMowingTimeSensor(coordinator)
+    assert not current.available
+    timer.last_run = None
+    assert not sensor.available
+    assert (
+        "last_observed_at"
+        in DreameLawnMowerObservedMowingTimeSensor._unrecorded_attributes
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancelled_write_is_drained_before_entry_removal(monkeypatch):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    entered, release = asyncio.Event(), asyncio.Event()
+
+    async def slow_save(record):
+        entered.set()
+        await release.wait()
+        saved.append(record)
+
+    store.async_save.side_effect = slow_save
+    checkpoint.async_schedule_save()
+    await clock.advance(2)
+    await entered.wait()
+    checkpoint._task.cancel()
+    removing = asyncio.create_task(checkpoint.async_remove())
+    await asyncio.sleep(0)
+    assert store.async_remove.await_count == 0
+    release.set()
+    await removing
+    assert store.async_remove.await_count == 1
+    count = len(saved)
+    checkpoint.async_schedule_save()
+    await clock.advance(100)
+    assert len(saved) == count
+
+
+@pytest.mark.asyncio
+async def test_cancelled_load_never_overwrites_unread_evidence(monkeypatch):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    store.async_load.side_effect = asyncio.CancelledError
+    with pytest.raises(asyncio.CancelledError):
+        await checkpoint.async_load()
+    await checkpoint.async_close()
+    assert not saved
+
+
+@pytest.mark.asyncio
+async def test_rapid_transitions_are_rate_limited(monkeypatch):
+    checkpoint, coordinator, clock, store, saved = setup_checkpoint(monkeypatch)
+    for second in range(120):
+        observe(coordinator.observed_mowing_timer, 60 + second, mowing=second % 2 == 0)
+        checkpoint.async_schedule_save()
+        await clock.advance(1)
+        if checkpoint._task is not None:
+            await checkpoint._task
+    assert len(saved) <= 12
+    await checkpoint.async_close()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "field,value",
+    [
+        ("scope", "different-device"),
+        ("saved_at", 10**1000),
+        ("saved_at", math.nan),
+        ("saved_at", -1),
+        ("timing", {"unexpected": "a" * 16384}),
+    ],
+)
+async def test_invalid_store_envelope_cannot_restore_a_run(monkeypatch, field, value):
+    first, _, _, _, saved = setup_checkpoint(monkeypatch)
+    await first.async_close()
+    record = saved[-1]
+    record[field] = value
+    second, owner, _, _, _ = setup_checkpoint(monkeypatch, record=record)
+    owner.observed_mowing_timer = ObservedMowingTimer()
+    await second.async_load()
+    observe(owner.observed_mowing_timer, 120)
+    assert owner.observed_mowing_timer.minutes == 0
+    assert owner.observed_mowing_timer.last_run is None
+    await second.async_close()
+
+
+def test_stale_terminal_snapshot_cannot_replace_saved_mission_identity():
+    timer = measured_timer()
+    cache = DreameLawnMowerRuntimeTelemetryCache(
+        _session_generation=1,
+        _session_identity=71,
+        _session_started_at=NOW.timestamp(),
+        _session_active=True,
+    )
+    coordinator = SimpleNamespace(
+        observed_mowing_timer=timer, runtime_telemetry_cache=cache
+    )
+    snapshot = SimpleNamespace(
+        available=True,
+        activity="mowing",
+        task_status="finished",
+        task_status_event_at=NOW.timestamp() - 1,
+        mission_task_id=70,
+    )
+    observe_mowing_time(coordinator, snapshot, True)
+    assert timer.checkpoint()["current"]["identity"] == 71
+
+
+@pytest.mark.parametrize("uncertainty", ["disconnect", "unknown"])
+def test_ended_run_is_not_resurrected_by_later_uncertainty(uncertainty):
+    timer = measured_timer()
+    observe(timer, 90, active=False, mowing=False)
+    ended = timer.last_run
+    if uncertainty == "disconnect":
+        timer.interrupt()
+    else:
+        observe(timer, 100, active=None, mowing=False)
+    record = timer.checkpoint()
+    assert record["current"] is None
+    observe(timer, 120, active=False, mowing=False)
+    assert timer.last_run == ended
+    observe(timer, 130, generation=2)
+    assert timer.last_run == ended
+    restarted = ObservedMowingTimer()
+    restarted.restore_checkpoint(record, now=NOW + timedelta(seconds=300))
+    observe(restarted, 300, identity=72)
+    assert restarted.last_run == ended

--- a/tests/test_observed_mowing_time.py
+++ b/tests/test_observed_mowing_time.py
@@ -1,0 +1,128 @@
+"""Observed duration never claims device time or unseen mowing intervals."""
+
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import session_timing
+from custom_components.dreame_lawn_mower.sensor_session import (
+    DreameLawnMowerObservedMowingTimeSensor,
+)
+
+NOW = datetime(2026, 9, 7, 8, tzinfo=UTC)
+ObservedMowingTimer = session_timing.ObservedMowingTimer
+
+
+def observe(timer, second, *, generation=1, active=True, mowing=True):
+    timer.observe(
+        generation=generation,
+        session_active=active,
+        mowing=mowing,
+        now=NOW + timedelta(seconds=second),
+        monotonic=float(second),
+    )
+
+
+def test_mid_session_start_is_partial_and_does_not_backfill():
+    timer = ObservedMowingTimer()
+    observe(timer, 1000)
+    assert timer.minutes == 0
+    assert timer.partial
+    observe(timer, 1060)
+    assert timer.minutes == 1
+    assert timer.attributes()["source"] == "observed_mowing_state"
+
+
+def test_pause_and_docking_freeze_time_and_same_session_resume_continues():
+    timer = ObservedMowingTimer()
+    observe(timer, 0, generation=0, active=False, mowing=False)
+    observe(timer, 10)
+    observe(timer, 70, mowing=False)
+    observe(timer, 100, mowing=False)
+    assert timer.minutes == 1
+    observe(timer, 160)
+    observe(timer, 220, active=False, mowing=False)
+    assert timer.minutes == 2
+    assert timer.state == "ended"
+    assert not timer.partial
+    observe(timer, 280, active=False, mowing=False)
+    assert timer.minutes == 2
+    observe(timer, 290, generation=2)
+    assert timer.minutes == 0
+
+
+def test_docked_start_with_unknown_or_resumable_task_does_not_claim_zero_minutes():
+    for active in (True, False, None):
+        timer = ObservedMowingTimer()
+        observe(timer, 0, active=active, mowing=False)
+        observe(timer, 60, active=active, mowing=False)
+        assert timer.minutes is None
+
+
+@pytest.mark.parametrize("interrupt", [True, False])
+def test_disconnect_or_long_observation_gap_is_not_counted(interrupt):
+    timer = ObservedMowingTimer()
+    observe(timer, 0)
+    observe(timer, 60)
+    if interrupt:
+        timer.interrupt()
+    observe(timer, 1000)
+    assert timer.minutes == 1
+    assert timer.partial
+    observe(timer, 1060)
+    assert timer.minutes == 2
+
+
+def test_new_process_does_not_restore_a_complete_session_timer():
+    first = ObservedMowingTimer()
+    observe(first, 0)
+    observe(first, 120)
+    restarted = ObservedMowingTimer()
+    observe(restarted, 150)
+    assert first.minutes == 2
+    assert restarted.minutes == 0
+    assert restarted.partial
+
+
+def test_sensor_reports_the_separate_observation_and_its_limits():
+    timer = ObservedMowingTimer()
+    observe(timer, 0)
+    observe(timer, 60)
+    coordinator = SimpleNamespace(
+        client=SimpleNamespace(descriptor=SimpleNamespace(unique_id="test")),
+        data=SimpleNamespace(available=True),
+        last_update_success=True,
+        observed_mowing_timer=timer,
+    )
+    sensor = DreameLawnMowerObservedMowingTimeSensor(coordinator)
+    assert sensor.native_value == 1
+    assert sensor.unique_id == "test_observed_mowing_time"
+    assert sensor.extra_state_attributes["partial"] is True
+    assert sensor.extra_state_attributes["includes_pauses"] is False
+
+
+def test_unavailable_snapshot_interrupts_coordinator_observation():
+    from custom_components.dreame_lawn_mower.session_timing import observe_mowing_time
+
+    timer = ObservedMowingTimer()
+    observe(timer, 0)
+    observe(timer, 60)
+    coordinator = SimpleNamespace(observed_mowing_timer=timer)
+    observe_mowing_time(
+        coordinator, SimpleNamespace(available=False, activity="mowing"), True
+    )
+    observe(timer, 120)
+    assert timer.minutes == 1
+    assert timer.partial
+
+
+@pytest.mark.parametrize("uncertain", [False, True])
+def test_new_session_after_gap_or_unknown_state_is_partial(uncertain):
+    timer = ObservedMowingTimer()
+    observe(timer, 0, generation=0, active=False, mowing=False)
+    if uncertain:
+        observe(timer, 10, generation=0, active=None, mowing=False)
+    observe(timer, 20 if uncertain else 1000, generation=1)
+    assert timer.minutes == 0
+    assert timer.partial

--- a/tests/test_position_tracking.py
+++ b/tests/test_position_tracking.py
@@ -1,0 +1,158 @@
+"""Position provenance and docking require ordered, map-scoped evidence."""
+
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    position_tracking,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.app_protocol import (
+    decode_mower_status_blob,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.models import (
+    DreameLawnMowerStatusBlob,
+)
+
+NOW = datetime(2026, 9, 7, 8, tzinfo=UTC)
+MowerPositionTracker = position_tracking.MowerPositionTracker
+snapshot_is_docked = position_tracking.snapshot_is_docked
+
+
+def state(*, docked=False, at=NOW):
+    return SimpleNamespace(
+        available=True,
+        docked=docked,
+        activity="docked" if docked else "mowing",
+        state="charging_completed" if docked else "mowing",
+        state_event_at=at.timestamp(),
+    )
+
+
+def pose(at=NOW, *, x=20):
+    return DreameLawnMowerStatusBlob(
+        supported=True,
+        frame_valid=True,
+        received_at=at.isoformat(),
+        candidate_runtime_pose_x=x,
+        candidate_runtime_pose_y=30,
+        candidate_runtime_heading_deg=45,
+    )
+
+
+def resolve(tracker, *, snapshot=None, now=NOW, index=0, geometry="lawn-a"):
+    return tracker.resolve(
+        map_index=index,
+        geometry=geometry,
+        contains=lambda x, y: 0 <= x <= 100 and 0 <= y <= 100,
+        snapshot=snapshot or state(),
+        now=now,
+    )
+
+
+@pytest.mark.parametrize("charging_state", ["charging", "charging_completed"])
+def test_charging_establishes_docking_but_not_map_coordinates(charging_state):
+    snapshot = state(docked=True)
+    snapshot.state = charging_state
+    assert snapshot_is_docked(snapshot)
+    blob = decode_mower_status_blob(
+        list(bytes.fromhex("ce000000000000000000806401ff000000bc7fce"))
+    )
+    tracker = MowerPositionTracker()
+    tracker.record(replace(blob, received_at=NOW.isoformat()), map_index=0, now=NOW)
+    assert resolve(tracker, snapshot=snapshot) is None
+
+
+def test_pose_from_before_docking_is_only_last_known_not_dock_evidence():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker).status == "current"
+    later = NOW + timedelta(seconds=60)
+    result = resolve(tracker, snapshot=state(docked=True, at=later), now=later)
+    assert result.status == "last_known"
+    assert result.heading is None
+    assert result.observed_at == NOW.timestamp()
+
+
+def test_fresh_pose_while_charging_learns_dock_and_survives_missing_packets():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    result = resolve(
+        tracker, snapshot=state(docked=True, at=NOW - timedelta(seconds=5))
+    )
+    assert result.status == "known_dock"
+    tracker.record(None, map_index=0, now=NOW)
+    result = resolve(tracker, snapshot=state(docked=True), now=NOW + timedelta(hours=2))
+    assert result.status == "known_dock"
+    assert (result.x, result.y) == (20, 30)
+    assert result.details()["position_source"] == "observed_docked_pose"
+
+
+def test_stale_pose_can_only_be_retained_if_it_was_validated_while_fresh():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker, now=NOW + timedelta(minutes=10)) is None
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    resolve(tracker)
+    assert resolve(tracker, now=NOW + timedelta(minutes=10)).status == "last_known"
+    assert resolve(tracker, now=NOW + timedelta(days=2)) is None
+
+
+@pytest.mark.parametrize("index,geometry", [(1, "lawn-b"), (0, "lawn-a-recreated")])
+def test_replaced_map_geometry_invalidates_retained_coordinates(index, geometry):
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker) is not None
+    later = NOW + timedelta(seconds=30)
+    assert resolve(tracker, index=index, geometry=geometry, now=later) is None
+    # Re-reading the original packet must not bind it to a different map.
+    tracker.record(pose(), map_index=index, now=later)
+    assert resolve(tracker, index=index, geometry=geometry, now=later) is None
+
+
+def test_unbound_or_invalid_input_never_becomes_a_live_position():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=None, now=NOW)
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker) is None
+    tracker.record(pose(NOW + timedelta(seconds=1), x=1000), map_index=0, now=NOW)
+    assert resolve(tracker) is None
+    tracker.record(pose(NOW + timedelta(hours=1)), map_index=0, now=NOW)
+    assert resolve(tracker) is None
+
+
+def test_offline_snapshot_never_labels_a_cached_pose_as_current():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker).status == "current"
+    snapshot = state()
+    snapshot.available = False
+    result = resolve(tracker, snapshot=snapshot, now=NOW + timedelta(seconds=10))
+    assert result.status == "last_known"
+    assert result.heading is None
+
+
+@pytest.mark.parametrize("seconds", [10, 100])
+def test_offline_snapshot_demotes_an_observed_dock_to_last_known(seconds):
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    snapshot = state(docked=True)
+    assert resolve(tracker, snapshot=snapshot).status == "known_dock"
+    snapshot.available = False
+    result = resolve(tracker, snapshot=snapshot, now=NOW + timedelta(seconds=seconds))
+    assert result.status == "last_known"
+    assert result.heading is None
+
+
+def test_fresh_non_dock_pose_cannot_extend_expired_dock_evidence():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker, snapshot=state(docked=True)).status == "known_dock"
+    later = NOW + timedelta(days=8)
+    tracker.record(pose(later - timedelta(seconds=10), x=40), map_index=0, now=later)
+    result = resolve(tracker, snapshot=state(docked=True, at=later), now=later)
+    assert result.status == "last_known"
+    assert result.x == 40

--- a/tests/test_position_tracking.py
+++ b/tests/test_position_tracking.py
@@ -76,6 +76,19 @@ def test_pose_from_before_docking_is_only_last_known_not_dock_evidence():
     assert result.observed_at == NOW.timestamp()
 
 
+def test_docked_heartbeat_cannot_borrow_a_returning_state_timestamp():
+    """Arrival heartbeat can lead the charging property, as on the live A2."""
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker).status == "current"
+    arrival = state(docked=True, at=NOW - timedelta(seconds=30))
+    arrival.state = "returning"
+    result = resolve(tracker, snapshot=arrival, now=NOW + timedelta(seconds=5))
+    assert snapshot_is_docked(arrival)
+    assert result.status == "last_known"
+    assert result.observed_at == NOW.timestamp()
+
+
 def test_fresh_pose_while_charging_learns_dock_and_survives_missing_packets():
     tracker = MowerPositionTracker()
     tracker.record(pose(), map_index=0, now=NOW)

--- a/tests/test_realtime_map_hydration.py
+++ b/tests/test_realtime_map_hydration.py
@@ -1,0 +1,176 @@
+"""Realtime positions must acquire map identity without waiting for a poll."""
+
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.dreame_lawn_mower.coordinator import (
+    DEVICE_SNAPSHOT_GENERATION_HISTORY,
+    DreameLawnMowerCoordinator,
+)
+from custom_components.dreame_lawn_mower.performance import (
+    DreameLawnMowerPerformanceTracker,
+)
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
+
+
+@pytest.mark.parametrize(
+    "active,verified", [(True, False), (True, True), (False, False)]
+)
+def test_realtime_update_requests_missing_active_map_identity(active, verified):
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    snapshot = SimpleNamespace(
+        available=True,
+        activity="mowing" if active else "docked",
+        docked=not active,
+        mowing_session_active=active,
+    )
+    coordinator._shutting_down = False
+    coordinator._runtime_map_identity_verified = verified
+    coordinator._last_device_settings_event_at = None
+    coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+    coordinator.app_maps = {"current_map_index": 0}
+    coordinator.selected_map_index = 0
+    coordinator.client = SimpleNamespace(
+        async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+        async_get_runtime_status_blob=AsyncMock(return_value=None),
+        async_get_bluetooth_connected=AsyncMock(return_value=False),
+        update_runtime_live_tracking=Mock(),
+    )
+    coordinator.async_set_updated_data = Mock()
+    coordinator._schedule_metadata_refresh = Mock()
+    asyncio.run(coordinator._async_process_client_update())
+    coordinator.async_set_updated_data.assert_called_once_with(snapshot)
+    if active and not verified:
+        coordinator._schedule_metadata_refresh.assert_called_once_with(
+            refresh_map_and_runtime=True
+        )
+    else:
+        coordinator._schedule_metadata_refresh.assert_not_called()
+
+
+@pytest.mark.parametrize("active_at_execution", [True, False])
+def test_background_map_phase_uses_latest_state_without_foreground_poll(
+    active_at_execution,
+):
+    async def scenario():
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.data = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        coordinator.performance = DreameLawnMowerPerformanceTracker()
+        coordinator._shutting_down = False
+        coordinator._metadata_refresh_task = None
+        coordinator._metadata_refresh_semaphore = asyncio.Semaphore(0)
+        coordinator.async_update_listeners = Mock()
+        coordinator.async_refresh_app_maps = AsyncMock()
+        coordinator._async_refresh_active_runtime = AsyncMock(return_value=True)
+        for name in (
+            "_async_refresh_bluetooth_state",
+            "async_refresh_firmware_update_support",
+            "async_refresh_app_map_objects",
+            "async_refresh_vector_map_details",
+            "async_refresh_weather_protection",
+            "async_refresh_maintenance_status",
+            "async_refresh_work_log_totals",
+            "async_refresh_voice_settings",
+            "async_refresh_schedules",
+            "async_refresh_batch_device_data",
+        ):
+            setattr(coordinator, name, AsyncMock())
+        task = asyncio.create_task(
+            coordinator._async_refresh_metadata(refresh_map_and_runtime=True)
+        )
+        coordinator._metadata_refresh_task = task
+        await asyncio.sleep(0)
+        coordinator.data = SimpleNamespace(
+            available=True,
+            activity="mowing" if active_at_execution else "docked",
+            docked=not active_at_execution,
+            mowing_session_active=active_at_execution,
+        )
+        coordinator._metadata_refresh_semaphore.release()
+        await task
+        if active_at_execution:
+            coordinator._async_refresh_active_runtime.assert_awaited_once()
+            assert (
+                coordinator._async_refresh_active_runtime.call_args.args[1]
+                is coordinator.data
+            )
+            coordinator.async_refresh_app_maps.assert_not_awaited()
+        else:
+            coordinator._async_refresh_active_runtime.assert_not_awaited()
+            coordinator.async_refresh_app_maps.assert_awaited_once_with(force=False)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("transition", ["docked", "mission", "pose"])
+def test_background_map_read_cannot_revive_an_evicted_snapshot(transition):
+    async def scenario():
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        original = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+        coordinator._runtime_map_identity_verified = False
+        coordinator.app_maps_refreshed_at = object()
+        coordinator.app_maps_refresh_succeeded = False
+        coordinator.app_maps = {"current_map_index": 0}
+        coordinator.selected_map_index = 0
+        coordinator._record_device_snapshot(original)
+        coordinator._published_device_snapshot_generation = 1
+        coordinator.data = original
+
+        async def read_map(*, force):
+            assert force is True
+            coordinator.app_maps_refreshed_at = object()
+            coordinator.app_maps_refresh_succeeded = True
+            for _ in range(DEVICE_SNAPSHOT_GENERATION_HISTORY + 2):
+                newest = SimpleNamespace(
+                    available=True,
+                    activity="docked" if transition == "docked" else "mowing",
+                    docked=transition == "docked",
+                    mowing_session_active=transition != "docked",
+                )
+                coordinator._record_device_snapshot(newest)
+                coordinator._published_device_snapshot_generation = (
+                    coordinator._device_snapshot_generation
+                )
+                coordinator.data = newest
+            if transition == "mission":
+                coordinator.runtime_telemetry_cache.begin_new_session(
+                    session_started_at=100.0
+                )
+            assert id(original) not in coordinator._device_snapshot_generations
+
+        coordinator.async_refresh_app_maps = read_map
+        blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
+        coordinator.client = SimpleNamespace(
+            async_get_runtime_status_blob=AsyncMock(return_value=blob),
+            update_runtime_live_tracking=Mock(),
+        )
+        coordinator._async_refresh_runtime_status = AsyncMock(
+            wraps=coordinator._async_refresh_runtime_status
+        )
+        result = await coordinator._async_refresh_background_map_runtime(
+            DreameLawnMowerPerformanceTracker().start("test")
+        )
+        assert result is False
+        if transition == "pose":
+            assert (
+                coordinator._async_refresh_runtime_status.call_args.args[0]
+                is coordinator.data
+            )
+            coordinator.client.update_runtime_live_tracking.assert_called_once_with(
+                blob, active=True, map_index=0
+            )
+        else:
+            coordinator.client.update_runtime_live_tracking.assert_not_called()
+            assert coordinator.runtime_telemetry_cache.blob is None
+
+    asyncio.run(scenario())

--- a/tests/test_session_boundary_continuity.py
+++ b/tests/test_session_boundary_continuity.py
@@ -1,0 +1,150 @@
+"""Real starting heartbeats must not split a paused or starting mission."""
+
+from datetime import timedelta
+from types import SimpleNamespace
+
+import pytest
+
+from custom_components.dreame_lawn_mower.coordinator import (
+    DreameLawnMowerCoordinator,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client import (
+    session_timing,
+)
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+    runtime_mission_new_session_event_at,
+    runtime_mission_new_session_evidence,
+    runtime_mission_session_generation,
+)
+
+
+@pytest.mark.parametrize("task_id", [None, 71])
+def test_starting_heartbeats_and_resume_preserve_one_observed_mission(
+    monkeypatch, task_id
+):
+    """A2 reports starting repeatedly and again on resume, without a task id."""
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+    coordinator.update_interval = timedelta(seconds=60)
+    tick = [0.0]
+    monkeypatch.setattr(session_timing.time, "monotonic", lambda: tick[0])
+
+    def publish(second, activity, task_status, active=True):
+        tick[0] = float(second)
+        snapshot = SimpleNamespace(
+            available=True,
+            activity=activity,
+            state=activity,
+            state_event_at=float(second),
+            task_status=task_status,
+            task_status_event_at=float(second),
+            task_resumable=activity == "paused",
+            mowing_session_active=active,
+            mission_task_id=task_id if active else None,
+        )
+        coordinator._observe_runtime_mission_boundary(snapshot)
+
+    publish(0, "idle", "idle", False)
+    publish(10, "mowing", "starting")
+    generation = runtime_mission_session_generation(coordinator.runtime_telemetry_cache)
+    started_at = coordinator.observed_mowing_timer.started_at
+    publish(20, "mowing", "starting")
+    publish(30, "mowing", "starting")
+    publish(40, "mowing", "mowing")
+    publish(50, "paused", "paused")
+    assert coordinator.observed_mowing_timer.seconds == 40
+    publish(80, "paused", "paused")
+    assert coordinator.observed_mowing_timer.seconds == 40
+    publish(90, "mowing", "starting")
+    publish(100, "mowing", "starting")
+    publish(110, "mowing", "mowing")
+    assert coordinator.observed_mowing_timer.minutes == 1.0
+    assert coordinator.observed_mowing_timer.started_at == started_at
+    assert (
+        runtime_mission_session_generation(coordinator.runtime_telemetry_cache)
+        == generation
+    )
+
+
+def test_starting_echo_cannot_erase_metrics_after_command_or_late_identity():
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    cache.begin_new_session(session_started_at=10.0)
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task_status", "starting", 11.0),
+        new_session_event_at=11.0,
+    )
+    metrics = SimpleNamespace(candidate_runtime_area_progress_percent=12.0)
+    cache.update(metrics, active_session=True)
+    generation = runtime_mission_session_generation(cache)
+    for event_at, identity in ((12.0, None), (13.0, 71), (14.0, 71)):
+        cache.observe_session_state(
+            active_session=True,
+            new_session=True,
+            new_session_evidence=("task", identity)
+            if identity is not None
+            else ("task_status", "starting", event_at),
+            new_session_event_at=event_at,
+            session_identity=identity,
+        )
+        assert cache.blob is metrics
+        assert runtime_mission_session_generation(cache) == generation
+
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=("task", 72),
+        new_session_event_at=20.0,
+        session_identity=72,
+    )
+    assert cache.blob is None
+    assert runtime_mission_session_generation(cache) == generation + 1
+
+
+def test_explicit_replacement_notice_wins_over_an_ambiguous_starting_heartbeat():
+    cache = DreameLawnMowerRuntimeTelemetryCache()
+    metrics = SimpleNamespace(candidate_runtime_area_progress_percent=12.0)
+    cache.update(metrics, active_session=True)
+    generation = runtime_mission_session_generation(cache)
+    snapshot = SimpleNamespace(
+        mowing_session_active=True,
+        task_status="starting",
+        task_status_event_at=31.0,
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=30.0,
+        mission_task_id=None,
+    )
+    evidence = runtime_mission_new_session_evidence(snapshot)
+    event_at = runtime_mission_new_session_event_at(snapshot)
+    assert evidence == ("notice", "mowing_task_started", 30.0)
+    assert event_at == 30.0
+    cache.observe_session_state(
+        active_session=True,
+        new_session=True,
+        new_session_evidence=evidence,
+        new_session_event_at=event_at,
+    )
+    assert cache.blob is None
+    assert runtime_mission_session_generation(cache) == generation + 1
+
+
+@pytest.mark.parametrize("notice_at", [10.0, 30.0])
+def test_retained_notice_before_terminal_boundary_cannot_backdate_next_start(notice_at):
+    snapshot = SimpleNamespace(
+        state="idle",
+        state_event_at=30.0,
+        mowing_session_active=True,
+        task_status="starting",
+        task_status_event_at=40.0,
+        status_notice_name="mowing_task_started",
+        status_notice_event_at=notice_at,
+        mission_task_id=None,
+    )
+    assert runtime_mission_new_session_event_at(snapshot) == 40.0
+    assert runtime_mission_new_session_evidence(snapshot) == (
+        "task_status",
+        "starting",
+        40.0,
+    )

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -663,17 +663,23 @@ def test_vector_map_view_exposes_runtime_position_without_track_points() -> None
 
 
 def test_map_view_prefers_valid_runtime_position_before_track_exists() -> None:
+    from datetime import UTC, datetime
+
     client = _client()
+    client._latest_snapshot = SimpleNamespace(available=True, activity="mowing")
     client._sync_refresh_app_map_view = lambda **kwargs: DreameLawnMowerMapView(  # type: ignore[method-assign]  # noqa: ARG005
         source="app_action_map",
         summary=DreameLawnMowerMapSummary(available=True),
         image_png=b"app-map",
+        app_maps={"current_map_index": 0},
     )
     client._sync_get_vector_map_batch_data = lambda: _batch_payload()
     client._safe_map_diagnostics = lambda **kwargs: None
     client.update_runtime_live_tracking(
         SimpleNamespace(
             hex="runtime-pose-only",
+            frame_valid=True,
+            received_at=datetime.now(UTC).isoformat(),
             candidate_runtime_track_segments=(),
             candidate_runtime_pose_x=50,
             candidate_runtime_pose_y=40,


### PR DESCRIPTION
## Mower position and observed time

Retain verified position evidence and observed mowing duration without replacing firmware-reported measurements.

- Share one map-scoped position tracker between the camera and interactive map. Retained markers keep their observation time and never restore an old route. A dock position requires coordinates observed at or after confirmed charging.
- Verify active map identity in the background so frequent realtime updates cannot postpone it indefinitely. Reject outdated reads and preserve session continuity across repeated departure and resume heartbeats.
- Add Observed Mowing Time and Last Observed Run Duration sensors. Observed time excludes pauses and unobserved connection gaps; the previous-run summary distinguishes an observed ending from an interruption.
- Recover saved time after a restart only when fresh telemetry identifies the same firmware task within 24 hours. Missing or changed task identity preserves the saved observation as an interrupted previous run instead of joining it to a new mission. Offline time is never counted.
- Restore retained positions only against matching map geometry and their original expiry limits, never as live telemetry.

## Bounded restart storage

One private checkpoint per mower is overwritten rather than appended, with a 16 KiB limit including storage metadata. It holds only the current observation, one previous-run summary, and minimal position/map identity evidence—not routes, point clouds, images, credentials, or raw telemetry.

Progress saves run on a 60-second schedule, transitions are coalesced and rate-limited, and orderly shutdown or reload flushes the latest observation. Atomic replacement protects the previous checkpoint if a write fails. Removing the integration entry removes its checkpoint. Volatile observation timestamps are excluded from Recorder history while numeric duration remains available to HA history.

A sudden crash can lose progress since the last checkpoint. Restored timing is partial, and saved summaries older than 30 days are not restored. Firmware-reported Current Mowing Time remains unavailable when the mower supplies no value; observed duration is not proof of blade-on time or exact cut coverage.

## Companion card and release order

[Lawn Mower Card](https://github.com/EvotecIT/lovelace-lawn-mower-card) is the downstream presentation consumer. [Card PR #47](https://github.com/EvotecIT/lovelace-lawn-mower-card/pull/47) labels current, last-known, observed-dock, and docked-without-coordinates states and displays partial observed time. Release that support before or together with this integration change; an older card does not render the retained-position statuses. The timing sensors also work with standard Home Assistant cards.

Charging confirms docking, not station coordinates. A cold start without valid saved coordinates cannot draw a dock marker from position-free heartbeats.

Related to #177.
