### PR TITLE
Fix shared mower map rendering, refresh caching, and video availability

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -474,6 +474,7 @@ class DreameLawnMowerClient(
         self._last_camera_stream_diagnostics: Mapping[str, Any] = {}
         self._app_map_object_cache_lock = _threading.Lock()
         self._app_map_download_lock = _threading.Lock()
+        self._app_map_payload_cache: dict[int, dict[str, Any]] = {}
         self._point_cloud_generation_lock = _threading.Lock()
         self._latest_app_map_inventory_identity: str | None = None
         self._latest_app_map_object_inventory_identity: str | None = None

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_app_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_app_maps.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import hashlib
 import json
 from collections.abc import Mapping
+from copy import deepcopy
 from typing import Any
 
 from .client_map_helpers import (
@@ -46,6 +47,14 @@ class _DreameLawnMowerClientAppMapsMixin:
             map_list_result,
             map_entries,
         )
+        # Only retain slots confirmed by the latest authoritative inventory.
+        live_indices = {
+            entry["idx"] for entry in map_entries if entry.get("created")
+        } if map_list_valid else set()
+        self._app_map_payload_cache = {
+            idx: cached for idx, cached in self._app_map_payload_cache.items()
+            if idx in live_indices
+        }
         result: dict[str, Any] = {
             "source": "app_action_map",
             "available": False,
@@ -89,6 +98,7 @@ class _DreameLawnMowerClientAppMapsMixin:
                         # last chunk; the mobile app may also be reading maps.
                         map_result["retry_reason"] = str(err)
             except Exception as err:  # noqa: BLE001 - probes keep per-map evidence
+                self._app_map_payload_cache.pop(entry["idx"], None)
                 map_result["available"] = False
                 map_result["error"] = str(err)
                 result["errors"].append({"idx": entry.get("idx"), "error": str(err)})
@@ -129,6 +139,21 @@ class _DreameLawnMowerClientAppMapsMixin:
         if isinstance(info.get("idx"), int) and info["idx"] != entry["idx"]:
             raise DreameLawnMowerConnectionError("App map metadata index mismatch.")
         entry["reported_size"] = size
+        cache = self._app_map_payload_cache
+        cached = cache.get(entry["idx"])
+        if (
+            cached is not None
+            and isinstance(expected_hash, str)
+            and cached["md5"] == expected_hash.lower()
+            and cached["reported_size"] == size
+        ):
+            entry.update(deepcopy(cached))
+            entry["payload_cached"] = True
+            entry["chunk_count"] = 0
+            if not include_payload:
+                entry.pop("payload", None)
+            return
+        cache.pop(entry["idx"], None)
         payload_text, chunk_count, received_size = self._sync_get_app_map_text(
             size=size, chunk_size=chunk_size
         )
@@ -162,8 +187,21 @@ class _DreameLawnMowerClientAppMapsMixin:
                 "summary": _app_map_payload_summary(parsed_payload),
             }
         )
+        payload = _json_safe(parsed_payload, max_depth=12)
+        # A hash-verified payload belongs to this client and map slot. Read MAPI
+        # on every refresh, but avoid MAPD for unchanged geometry. Never cache
+        # unverified data or caller-owned mutable dictionaries.
+        if hash_match is True:
+            cache[entry["idx"]] = deepcopy({
+                key: entry[key] for key in (
+                    "reported_size", "received_size", "decoded_size", "chunk_count",
+                    "md5", "hash_match", "available", "payload_keys", "summary",
+                )
+            })
+            cache[entry["idx"]]["payload"] = deepcopy(payload)
+        entry["payload_cached"] = False
         if include_payload:
-            entry["payload"] = _json_safe(parsed_payload, max_depth=12)
+            entry["payload"] = payload
 
     def _sync_get_app_map_text(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -703,6 +703,7 @@ def _app_map_entry_view_metadata(entry: Mapping[str, Any]) -> dict[str, Any]:
         "reported_size": entry.get("reported_size") or info.get("size"),
         "received_size": entry.get("received_size"),
         "chunk_count": entry.get("chunk_count"),
+        "payload_cached": entry.get("payload_cached"),
         "hash_match": entry.get("hash_match"),
         "download_attempts": entry.get("download_attempts"),
         "retry_reason": entry.get("retry_reason"),

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -355,8 +355,14 @@ def render_vector_map_png(
         }.get(position_status)
         if label:
             draw.text(
-                (12, 12), label, font=map_font(14), fill=style.label_text,
-                stroke_width=2, stroke_fill=style.label_halo,
+                (round(12 * pixel_scale), round(12 * pixel_scale)),
+                label,
+                font=map_font(round(
+                    14 * _normalize_label_scale(label_scale) * pixel_scale
+                )),
+                fill=style.label,
+                stroke_width=label_halo_width,
+                stroke_fill=style.label_halo,
             )
 
     for zone in vector_map.zones:

--- a/custom_components/dreame_lawn_mower/sensor_map_data.py
+++ b/custom_components/dreame_lawn_mower/sensor_map_data.py
@@ -862,6 +862,7 @@ def _app_map_entry_summary(entry: dict[str, Any]) -> dict[str, Any]:
         "hash_match": entry.get("hash_match"),
         "force_load": entry.get("force_load"),
         "chunk_count": entry.get("chunk_count"),
+        "payload_cached": entry.get("payload_cached"),
         "total_area": summary.get("total_area"),
         "map_area_total": summary.get("map_area_total"),
         "map_area_count": summary.get("map_area_count"),

--- a/custom_components/dreame_lawn_mower/video_camera_state.py
+++ b/custom_components/dreame_lawn_mower/video_camera_state.py
@@ -105,13 +105,19 @@ class DreameLawnMowerVideoStateMixin:
         """Return whether live video can be requested from Home Assistant."""
         if not self._runtime_configured:
             return False
+        snapshot = self.coordinator.data
+        # Capability remains supported, but HA must not offer playback while
+        # the mower's state explicitly forbids video (including cached routes).
+        # Keep stream_source dormant and discoverable so WebRTC is ready again
+        # as soon as the next snapshot clears the gate.
+        if camera_stream_block_reason(snapshot) is not None:
+            return False
         # Do not make an already-open camera disappear during a brief mower
         # connectivity loss. Existing HA Stream/WebRTC consumers need the
         # entity to remain addressable while their bounded reconnect path
         # refreshes safety state and waits for Wi-Fi to recover.
         if self._session is not None or getattr(self, "stream", None) is not None:
             return True
-        snapshot = self.coordinator.data
         if snapshot is not None and not getattr(snapshot, "available", True):
             return False
         cached_lan_ready = (

--- a/docs/video-transport.md
+++ b/docs/video-transport.md
@@ -27,6 +27,17 @@ refreshed, the camera fails closed. Cached provisioning avoids repeating
 video-specific configuration calls; it does not bypass live mower safety
 checks.
 
+Live Video is temporarily unavailable while the mower is docked, returning,
+mapping, or reporting an unrecognized active state. Its `video_block_reason`
+attribute explains the restriction; camera support and saved provisioning are
+retained. Availability returns when a new mower snapshot clears the restriction.
+The integration never moves the mower to enable video.
+
+On older versions, trying playback in the dock can instead produce a WebRTC EOF
+or an RTSP `404 Not Found` because the mower does not publish video there. A
+working stream outside the station confirms that this dock restriction is not
+itself a transport compatibility failure.
+
 The integration exposes a dormant loopback FLV relay to Home Assistant. The
 first actual media GET starts XP2P, while camera capability discovery remains
 local. The relay owns the mower's single-consumer source and fans it out to

--- a/tests/test_app_maps.py
+++ b/tests/test_app_maps.py
@@ -685,6 +685,94 @@ def test_app_maps_can_omit_sensitive_payload_coordinates() -> None:
     assert result["maps"][0]["payload_keys"] == ["map"]
 
 
+def test_app_maps_reuse_verified_payload_without_redownloading_or_leaking_mutations():
+    client = _client()
+    payload = {"map": [{"area": 1, "data": [[1, 2]]}]}
+    cloud = _FakeAppMapCloud(payload)
+    client._sync_get_cloud_protocol = lambda: cloud
+    first = client._sync_get_app_maps(include_payload=False, include_objects=False)
+    assert first["maps"][0]["hash_match"] is True
+    assert first["maps"][0]["payload_cached"] is False
+    assert "payload" not in first["maps"][0]
+    first["maps"][0]["summary"].clear()
+    cloud.calls.clear()
+    second = client._sync_get_app_maps(include_payload=True, include_objects=False)
+    assert [call["t"] for call in cloud.calls] == ["MAPL", "MAPI"]
+    assert second["maps"][0]["payload_cached"] is True
+    assert second["maps"][0]["chunk_count"] == 0
+    assert second["maps"][0]["payload"] == payload
+    assert second["maps"][0]["summary"]
+    second["maps"][0]["payload"].clear()
+    third = client._sync_get_app_maps(include_payload=True, include_objects=False)
+    assert third["maps"][0]["payload"] == payload
+    fourth = client._sync_get_app_maps(include_payload=False, include_objects=False)
+    assert "payload" not in fourth["maps"][0]
+
+
+def test_app_maps_refresh_changed_payload_and_never_reuse_failed_download():
+    client = _client()
+    cloud = _FakeAppMapCloud({"map": [{"area": 1, "data": [[1, 2]]}]})
+    client._sync_get_cloud_protocol = lambda: cloud
+    assert client._sync_get_app_maps(include_objects=False)["available"]
+    changed = {"map": [{"area": 2, "data": [[3, 4]]}]}
+    cloud.payload_text = json.dumps(changed, separators=(",", ":"))
+    cloud.payload_hash = hashlib.md5(cloud.payload_text.encode()).hexdigest()
+    cloud.chunk_overrides = {0: ("bad", 3)}
+    failed = client._sync_get_app_maps(include_objects=False)
+    assert failed["available"] is False
+    cloud.chunk_overrides.clear()
+    cloud.calls.clear()
+    result = client._sync_get_app_maps(include_payload=True, include_objects=False)
+    assert any(call["t"] == "MAPD" for call in cloud.calls)
+    assert result["maps"][0]["payload"] == changed
+    assert result["maps"][0]["payload_cached"] is False
+
+
+def test_app_maps_without_hash_are_downloaded_on_every_refresh():
+    client = _client()
+    cloud = _FakeAppMapCloud({"map": []})
+    cloud.payload_hash = None
+    client._sync_get_cloud_protocol = lambda: cloud
+    for _ in range(2):
+        cloud.calls.clear()
+        result = client._sync_get_app_maps(include_objects=False)
+        assert result["available"] is True
+        assert result["maps"][0]["hash_match"] is None
+        assert any(call["t"] == "MAPD" for call in cloud.calls)
+
+
+def test_app_map_cache_tracks_slots_and_preserves_fresh_current_map_selection():
+    client = _client()
+    cloud = _FakeAppMapCloud({"map": []})
+    client._sync_get_cloud_protocol = lambda: cloud
+    native_call = cloud.call_app_action
+    slots = [[0, 1, 1, 1, 0], [1, 0, 1, 0, 0]]
+
+    def call(payload, **kwargs):
+        response = native_call(payload, **kwargs)
+        if payload.get("t") == "MAPL":
+            response["out"][0]["d"] = slots
+        return response
+
+    cloud.call_app_action = call
+    first = client._sync_get_app_maps(include_objects=False)
+    assert first["current_map_index"] == 0
+    assert sum(c["t"] == "MAPD" for c in cloud.calls) == 2
+    slots[:] = [[0, 0, 1, 1, 0], [1, 1, 1, 0, 0]]
+    cloud.calls.clear()
+    switched = client._sync_get_app_maps(include_objects=False)
+    assert switched["current_map_index"] == 1
+    assert [m["current"] for m in switched["maps"]] == [False, True]
+    assert all(m["payload_cached"] for m in switched["maps"])
+    assert all(c["t"] != "MAPD" for c in cloud.calls)
+    slots[:] = [[0, 0, 0, 0, 0], [1, 1, 1, 0, 0]]
+    client._sync_get_app_maps(include_objects=False)
+    slots[:] = [[0, 0, 1, 0, 0], [1, 1, 1, 0, 0]]
+    recreated = client._sync_get_app_maps(include_objects=False)
+    assert recreated["maps"][0]["payload_cached"] is False
+    assert recreated["maps"][1]["payload_cached"] is True
+
+
 def test_app_map_object_urls_are_opt_in() -> None:
     client = _client()
     cloud = _FakeAppMapCloud({"map": [{"area": 1, "data": [[1, 2]]}]})
@@ -804,6 +892,7 @@ def test_map_view_falls_back_to_rendered_app_map() -> None:
                 "reported_size": len(cloud.payload_text.encode("utf-8")),
                 "received_size": len(cloud.payload_text.encode("utf-8")),
                 "chunk_count": 1,
+                "payload_cached": False,
                 "hash_match": True,
                 "download_attempts": 1,
                 "payload_keys": ["map", "point", "spot", "total_area", "trajectory"],

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -11,6 +11,9 @@ from unittest.mock import AsyncMock, Mock, patch
 import pytest
 from PIL import Image
 
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.map_visuals import (
+    MAP_RENDER_STYLES,
+)
 from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.vector_map import (
     filter_runtime_track_segments,
     parse_batch_vector_map,
@@ -29,6 +32,31 @@ from dreame_lawn_mower_client.models import (
     DreameLawnMowerMapSummary,
     DreameLawnMowerMapView,
 )
+
+
+@pytest.mark.parametrize("style", MAP_RENDER_STYLES.values(), ids=MAP_RENDER_STYLES)
+@pytest.mark.parametrize("position_status", ["current", "last_known", "known_dock"])
+def test_vector_map_renders_position_captions_in_every_theme(style, position_status):
+    vector_map = parse_batch_vector_map(_batch_payload())
+    png = render_vector_map_png(
+        vector_map, style=style, runtime_position=(50, 50),
+        position_status=position_status,
+    )
+    assert png is not None
+    with Image.open(BytesIO(png)) as image:
+        image.load()
+        assert image.format == "PNG"
+        assert image.width > 0 and image.height > 0
+        if position_status != "current":
+            # Captions must actually be painted, not silently skipped.
+            current = render_vector_map_png(
+                vector_map, style=style, runtime_position=(50, 50),
+            )
+            with Image.open(BytesIO(current)) as baseline:
+                caption_box = (0, 0, image.width, image.height // 6)
+                assert image.crop(caption_box).tobytes() != (
+                    baseline.crop(caption_box).tobytes()
+                )
 
 
 def _client() -> DreameLawnMowerClient:

--- a/tests/test_video_camera.py
+++ b/tests/test_video_camera.py
@@ -1001,7 +1001,7 @@ def test_video_camera_dock_transition_recovers_from_stale_raw_returning() -> Non
     assert asyncio.run(_run()) == (
         1,
         1,
-        True,
+        False,
         (
             "Camera stream handshake probe is blocked while the mower is "
             "docked. The Dreame app requires moving the mower out of the "
@@ -1529,6 +1529,41 @@ def test_video_camera_direct_stream_source_returns_dormant_local_relay() -> None
         "http://127.0.0.1:12345/private.flv",
         1,
     )
+
+
+@pytest.mark.parametrize("blocked_state", ["charging", "returning", "mapping"])
+@pytest.mark.parametrize("active_session", [False, True])
+def test_video_availability_gates_cached_routes_without_losing_discovery(
+    blocked_state, active_session,
+):
+    async def run():
+        snapshot = SimpleNamespace(
+            available=True, state=blocked_state, activity=blocked_state,
+            raw_attributes={"mapping": blocked_state == "mapping"},
+        )
+        entity = _uninitialized_entity(snapshot=snapshot)
+        entity._provisioning_cache.inputs = object()
+        entity._provisioning_cache.device_config = object()
+        entity._video_capability_observed = True
+        if active_session:
+            entity._session = object()
+
+        class Relay:
+            async def async_start(self):
+                return "http://127.0.0.1:12345/dormant.flv"
+
+        entity._flv_relay = Relay()
+        assert entity.available is False
+        assert entity.extra_state_attributes["video_block_reason"]
+        assert entity.extra_state_attributes["video_capability"] == "supported"
+        # Provider discovery must remain local and survive a docked reload.
+        assert await entity.stream_source() == "http://127.0.0.1:12345/dormant.flv"
+        snapshot.state = snapshot.activity = "mowing"
+        snapshot.raw_attributes = {}
+        assert entity.available is True
+        assert entity.extra_state_attributes["video_block_reason"] is None
+
+    asyncio.run(run())
 
 
 def test_video_camera_direct_stream_source_failure_does_not_touch_ha_stream() -> None:


### PR DESCRIPTION
Fixes #186.

The shared vector-map renderer could fail when drawing a last-known mower position or an observed dock because the caption used a nonexistent style field. Both captions now use the shared theme color and scale with the rendered map and label setting.

Saved-map refreshes still read MAPL and each map's MAPI metadata, but reuse an in-memory payload when its previously verified hash and size are unchanged. The cache is isolated per client and map slot, evicts removed slots and failed downloads, and protects cached data from caller mutation. Maps without a verifiable hash continue downloading normally. Diagnostics expose cache reuse and report zero downloaded chunks on a cache hit. The attached issue diagnostics show 102 MAPD requests across two saved maps that this avoids on an unchanged refresh.

Live Video now becomes temporarily unavailable while the existing mower-state guard blocks playback, including docked, returning, and mapping states. Camera capability, provisioning, and dormant WebRTC discovery remain intact so availability can recover when the guard clears. The video note explains the dock restriction and older EOF/RTSP 404 symptoms.

These fixes apply to the shared Dreame/MOVA paths without a model-specific exception.

Validation: 1,902 lightweight tests passed (one skipped), 67 Home Assistant component/translation tests passed on Linux/WSL, Ruff passed, and an independent read-only review found no actionable defects. Visually inspected all five themes with current, last-known, and observed-dock positions. The reporter's yard geometry was redacted; physical-mower playback and the live Home Assistant UI were not tested with this candidate.
