### PR TITLE
Keep map tracking responsive and recover stalled video

### DIFF
--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -544,6 +544,7 @@ class DreameLawnMowerCoordinator(
                 or getattr(self, "_runtime_map_identity_verified", False)
                 else None
             )
+            identity_generation = getattr(self, "_runtime_map_identity_generation", 0)
             runtime_status_blob: DreameLawnMowerStatusBlob | None = None
             runtime_status_error: Exception | None = None
             try:
@@ -567,6 +568,10 @@ class DreameLawnMowerCoordinator(
             # Both optional reads can yield while a newer authoritative fetch
             # publishes. Commit no runtime or Bluetooth side effects until the
             # cached snapshot is still current after every await.
+            if identity_generation != getattr(
+                self, "_runtime_map_identity_generation", 0
+            ):
+                return
             if self._device_snapshot_is_stale(snapshot) or (
                 observed_mission_generation is not None
                 and runtime_mission_session_generation(self.runtime_telemetry_cache)
@@ -2336,11 +2341,14 @@ class DreameLawnMowerCoordinator(
     async def async_switch_current_map(self, map_index: int) -> None:
         """Switch the active mower map and refresh all map-scoped state."""
         self._invalidate_runtime_map_identity()
-        try:
-            await self.client.async_switch_current_map(map_index)
-        finally:
-            # A read started during the command cannot establish the final map.
-            self._invalidate_runtime_map_identity()
+        if not hasattr(self, "_runtime_map_identity_lock"):
+            self._runtime_map_identity_lock = asyncio.Lock()
+        async with self._runtime_map_identity_lock:
+            try:
+                await self.client.async_switch_current_map(map_index)
+            finally:
+                # Expire outcomes even when the command's response is lost.
+                self._invalidate_runtime_map_identity()
         if self.selected_map_index != map_index:
             self._invalidate_schedule_map_hint()
         self.selected_map_index = map_index

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -2001,6 +2001,7 @@ class DreameLawnMowerCoordinator(
     ) -> dict[str, Any] | None:
         """Refresh cached app-map payloads without failing the main poll."""
         now = datetime.now(UTC)
+        identity_generation = getattr(self, "_runtime_map_identity_generation", 0)
         if (
             not force
             and self.app_maps is not None
@@ -2028,17 +2029,43 @@ class DreameLawnMowerCoordinator(
             )
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
             _LOGGER.debug("Failed to refresh app maps: %s", err)
+            refreshed_at = self.app_maps_refreshed_at
+            if (
+                isinstance(refreshed_at, datetime) and refreshed_at > now
+            ) or identity_generation != getattr(
+                self, "_runtime_map_identity_generation", 0
+            ):
+                return self.app_maps
             self.app_maps_refresh_succeeded = False
             return self.app_maps
 
         payload = dict(app_maps)
+        current_idx = active_map_index(payload)
+        identity_at = getattr(self, "_runtime_map_index_refreshed_at", None)
+        newer_geometry_at = self.app_maps_refreshed_at
+        if isinstance(newer_geometry_at, datetime) and newer_geometry_at > now:
+            return self.app_maps
+        if (
+            identity_at is not None
+            and now < identity_at
+            and current_idx != self._runtime_active_map_index
+        ) or (
+            identity_generation != getattr(self, "_runtime_map_identity_generation", 0)
+            and (
+                identity_at is None
+                or current_idx != self._runtime_active_map_index
+            )
+        ):
+            # A completed download cannot revive inventory from before a switch
+            # or contradict a newer MAPL read. Retry without changing selections.
+            self.app_maps_refreshed_at = None
+            self.app_maps_refresh_succeeded = False
+            return self.app_maps
         payload.setdefault("captured_at", now.isoformat())
         payload["source"] = source
         self.app_maps = payload
         self.app_maps_refreshed_at = now
         self.app_maps_refresh_succeeded = payload.get("map_list_valid") is True
-        current_idx = active_map_index(payload)
-        identity_at = getattr(self, "_runtime_map_index_refreshed_at", None)
         if (
             identity_at is not None
             and now >= identity_at

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -255,6 +255,7 @@ class DreameLawnMowerCoordinator(
         self._runtime_map_identity_lock = asyncio.Lock()
         self._runtime_map_index_refreshed_at: datetime | None = None
         self._runtime_active_map_index: int | None = None
+        self.client.runtime_map_identity_expires_at = None
         self._defer_active_runtime_during_setup = False
         self._foreground_refresh_count = 0
         self._metadata_refresh_count = 0
@@ -538,6 +539,7 @@ class DreameLawnMowerCoordinator(
                 session_started_at=session_started_at,
                 session_identity=session_identity,
             )
+            self._expire_runtime_map_identity()
             runtime_map_index = (
                 self._runtime_map_index()
                 if not runtime_active
@@ -579,6 +581,9 @@ class DreameLawnMowerCoordinator(
             ):
                 return
 
+            self._expire_runtime_map_identity()
+            if runtime_active and not self._runtime_map_identity_is_fresh():
+                runtime_map_index = None
             self._observe_runtime_mission_boundary(snapshot)
             if runtime_status_error is None:
                 try:

--- a/custom_components/dreame_lawn_mower/coordinator.py
+++ b/custom_components/dreame_lawn_mower/coordinator.py
@@ -252,6 +252,9 @@ class DreameLawnMowerCoordinator(
         self._metadata_refresh_pending = False
         self._metadata_refresh_publish = True
         self._runtime_map_identity_verified = False
+        self._runtime_map_identity_lock = asyncio.Lock()
+        self._runtime_map_index_refreshed_at: datetime | None = None
+        self._runtime_active_map_index: int | None = None
         self._defer_active_runtime_during_setup = False
         self._foreground_refresh_count = 0
         self._metadata_refresh_count = 0
@@ -2030,6 +2033,15 @@ class DreameLawnMowerCoordinator(
         self.app_maps_refreshed_at = now
         self.app_maps_refresh_succeeded = payload.get("map_list_valid") is True
         current_idx = active_map_index(payload)
+        identity_at = getattr(self, "_runtime_map_index_refreshed_at", None)
+        if (
+            identity_at is not None
+            and now >= identity_at
+            and self.app_maps_refresh_succeeded
+            and current_idx != self._runtime_active_map_index
+        ):
+            # An older geometry download must not replace a newer MAPL read.
+            self._invalidate_runtime_map_identity()
         known_map_indices = set(_app_map_index_hints(payload))
         map_hints_authoritative = _app_map_hints_are_authoritative(
             payload,
@@ -2323,7 +2335,12 @@ class DreameLawnMowerCoordinator(
 
     async def async_switch_current_map(self, map_index: int) -> None:
         """Switch the active mower map and refresh all map-scoped state."""
-        await self.client.async_switch_current_map(map_index)
+        self._invalidate_runtime_map_identity()
+        try:
+            await self.client.async_switch_current_map(map_index)
+        finally:
+            # A read started during the command cannot establish the final map.
+            self._invalidate_runtime_map_identity()
         if self.selected_map_index != map_index:
             self._invalidate_schedule_map_hint()
         self.selected_map_index = map_index

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -334,7 +334,11 @@ class DreameLawnMowerRefreshMixin:
                 self, "_runtime_map_identity_generation", 0
             ):
                 return False, None, identity_generation
-            if index != getattr(self, "_runtime_active_map_index", None):
+            if (
+                index != getattr(self, "_runtime_active_map_index", None)
+                or refreshed_at is None
+                or datetime.now(UTC) - refreshed_at >= RUNTIME_MAP_IDENTITY_INTERVAL
+            ):
                 # Supersede telemetry still awaiting the previous map's result.
                 self._invalidate_runtime_map_identity()
                 identity_generation = self._runtime_map_identity_generation
@@ -717,6 +721,7 @@ class DreameLawnMowerRefreshMixin:
         if (
             getattr(snapshot, "available", False)
             and runtime_tracking_active(snapshot)
+            and not getattr(self, "_runtime_map_identity_verified", False)
         ):
             await self._async_refresh_active_runtime(cycle, snapshot)
         return await self.async_refresh_app_maps(force=False)

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -237,8 +237,9 @@ class DreameLawnMowerRefreshMixin:
             self.runtime_telemetry_cache
         )
         observed_device_generation = getattr(self, "_device_snapshot_generation", None)
-        identity_generation = getattr(self, "_runtime_map_identity_generation", 0)
-        map_identity_refreshed, runtime_map_index = await cycle.measure(
+        (
+            map_identity_refreshed, runtime_map_index, identity_generation
+        ) = await cycle.measure(
             "active_map_identity",
             lambda: self._async_refresh_runtime_map_index(force=force_map_identity),
         )
@@ -299,7 +300,7 @@ class DreameLawnMowerRefreshMixin:
 
     async def _async_refresh_runtime_map_index(
         self, *, force: bool,
-    ) -> tuple[bool, int | None]:
+    ) -> tuple[bool, int | None, int]:
         """Read only MAPL for live tracking; never wait for a MAPD download."""
         requested_at = datetime.now(UTC)
         if not hasattr(self, "_runtime_map_identity_lock"):
@@ -312,25 +313,38 @@ class DreameLawnMowerRefreshMixin:
                 and (not force or refreshed_at >= requested_at)
                 and datetime.now(UTC) - refreshed_at < RUNTIME_MAP_IDENTITY_INTERVAL
             ):
-                return True, self._runtime_active_map_index
+                return True, self._runtime_active_map_index, identity_generation
             try:
                 index = await self.client.async_get_current_app_map_index()
+            except asyncio.CancelledError:
+                if identity_generation == getattr(
+                    self, "_runtime_map_identity_generation", 0
+                ):
+                    self._invalidate_runtime_map_identity()
+                raise
             except Exception as err:  # A stale map must not label fresh poses.
                 _LOGGER.debug("Failed to refresh runtime map identity: %s", err)
-                self._runtime_map_index_refreshed_at = None
-                self._runtime_map_identity_verified = False
-                return False, None
+                if identity_generation == getattr(
+                    self, "_runtime_map_identity_generation", 0
+                ):
+                    self._invalidate_runtime_map_identity()
+                    identity_generation = self._runtime_map_identity_generation
+                return False, None, identity_generation
             if identity_generation != getattr(
                 self, "_runtime_map_identity_generation", 0
             ):
-                return False, None
+                return False, None, identity_generation
+            if index != getattr(self, "_runtime_active_map_index", None):
+                # Supersede telemetry still awaiting the previous map's result.
+                self._invalidate_runtime_map_identity()
+                identity_generation = self._runtime_map_identity_generation
             self._runtime_active_map_index = index
             self._runtime_map_index_refreshed_at = datetime.now(UTC)
             # The complete map cache belongs to background hydration. Expire it
             # promptly on a switch without publishing old geometry as current.
             if index != active_map_index(getattr(self, "app_maps", None)):
                 self.app_maps_refreshed_at = None
-            return True, index
+            return True, index, identity_generation
 
     def _invalidate_runtime_map_identity(self) -> None:
         """Retire cached identity and any outstanding map-scoped runtime read."""

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import asyncio
 import logging
 from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import UTC, datetime, timedelta
 from functools import partial
 from typing import Any
 
@@ -48,6 +49,7 @@ METADATA_RETRY_DELAY_SECONDS = 2.0
 METADATA_SHUTDOWN_GRACE_SECONDS = 5.0
 SLOW_FOREGROUND_REFRESH_SECONDS = 15.0
 SLOW_METADATA_REFRESH_SECONDS = 30.0
+RUNTIME_MAP_IDENTITY_INTERVAL = timedelta(seconds=60)
 
 
 def runtime_tracking_active(snapshot: DreameLawnMowerSnapshot) -> bool:
@@ -193,7 +195,7 @@ class DreameLawnMowerRefreshMixin:
             # confirm that this foreground snapshot is still current.
             self._observe_runtime_mission_boundary(snapshot)
             self._schedule_metadata_refresh(
-                refresh_map_and_runtime=not runtime_active or defer_active_runtime,
+                refresh_map_and_runtime=True,
             )
             return self._snapshot_for_publication(snapshot)
         except asyncio.CancelledError:
@@ -231,16 +233,18 @@ class DreameLawnMowerRefreshMixin:
             "_runtime_map_identity_verified",
             False,
         )
-        previous_app_maps_refreshed_at = self.app_maps_refreshed_at
         mission_generation = runtime_mission_session_generation(
             self.runtime_telemetry_cache
         )
         observed_device_generation = getattr(self, "_device_snapshot_generation", None)
-        await cycle.measure(
-            "active_app_maps",
-            lambda: self.async_refresh_app_maps(force=force_map_identity),
+        identity_generation = getattr(self, "_runtime_map_identity_generation", 0)
+        map_identity_refreshed, runtime_map_index = await cycle.measure(
+            "active_map_identity",
+            lambda: self._async_refresh_runtime_map_index(force=force_map_identity),
         )
         runtime_snapshot = snapshot
+        if identity_generation != getattr(self, "_runtime_map_identity_generation", 0):
+            return False
         if (
             mission_generation is not None
             and mission_generation
@@ -265,16 +269,6 @@ class DreameLawnMowerRefreshMixin:
                 or not runtime_tracking_active(runtime_snapshot)
             ):
                 return False
-        map_identity_refreshed = bool(
-            getattr(self, "app_maps_refresh_succeeded", False)
-            and (
-                not force_map_identity
-                or self.app_maps_refreshed_at is not previous_app_maps_refreshed_at
-            )
-        )
-        runtime_map_index = (
-            self._runtime_map_index() if map_identity_refreshed else None
-        )
         runtime_current = await cycle.measure(
             "active_runtime_status",
             lambda: self._async_refresh_runtime_status(
@@ -282,6 +276,8 @@ class DreameLawnMowerRefreshMixin:
                 runtime_map_index=runtime_map_index,
             ),
         )
+        if identity_generation != getattr(self, "_runtime_map_identity_generation", 0):
+            return False
         if not runtime_current or self._snapshot_is_stale(runtime_snapshot):
             newest = self.data
             if (
@@ -289,7 +285,7 @@ class DreameLawnMowerRefreshMixin:
                 and mission_generation
                 == runtime_mission_session_generation(self.runtime_telemetry_cache)
                 and runtime_map_index is not None
-                and runtime_map_index == self._runtime_map_index()
+                and runtime_map_index == self._runtime_active_map_index
                 and getattr(newest, "available", False)
                 and runtime_tracking_active(newest)
             ):
@@ -301,6 +297,49 @@ class DreameLawnMowerRefreshMixin:
         self._runtime_map_identity_verified = map_identity_refreshed
         return runtime_snapshot is snapshot
 
+    async def _async_refresh_runtime_map_index(
+        self, *, force: bool,
+    ) -> tuple[bool, int | None]:
+        """Read only MAPL for live tracking; never wait for a MAPD download."""
+        requested_at = datetime.now(UTC)
+        if not hasattr(self, "_runtime_map_identity_lock"):
+            self._runtime_map_identity_lock = asyncio.Lock()
+        async with self._runtime_map_identity_lock:
+            identity_generation = getattr(self, "_runtime_map_identity_generation", 0)
+            refreshed_at = getattr(self, "_runtime_map_index_refreshed_at", None)
+            if (
+                refreshed_at is not None
+                and (not force or refreshed_at >= requested_at)
+                and datetime.now(UTC) - refreshed_at < RUNTIME_MAP_IDENTITY_INTERVAL
+            ):
+                return True, self._runtime_active_map_index
+            try:
+                index = await self.client.async_get_current_app_map_index()
+            except Exception as err:  # A stale map must not label fresh poses.
+                _LOGGER.debug("Failed to refresh runtime map identity: %s", err)
+                self._runtime_map_index_refreshed_at = None
+                self._runtime_map_identity_verified = False
+                return False, None
+            if identity_generation != getattr(
+                self, "_runtime_map_identity_generation", 0
+            ):
+                return False, None
+            self._runtime_active_map_index = index
+            self._runtime_map_index_refreshed_at = datetime.now(UTC)
+            # The complete map cache belongs to background hydration. Expire it
+            # promptly on a switch without publishing old geometry as current.
+            if index != active_map_index(getattr(self, "app_maps", None)):
+                self.app_maps_refreshed_at = None
+            return True, index
+
+    def _invalidate_runtime_map_identity(self) -> None:
+        """Retire cached identity and any outstanding map-scoped runtime read."""
+        self._runtime_map_identity_generation = (
+            getattr(self, "_runtime_map_identity_generation", 0) + 1
+        )
+        self._runtime_map_index_refreshed_at = None
+        self._runtime_map_identity_verified = False
+
     async def _async_refresh_runtime_status(
         self,
         snapshot: DreameLawnMowerSnapshot,
@@ -311,6 +350,7 @@ class DreameLawnMowerRefreshMixin:
         # Keep the fetch-order token independently of bounded snapshot history:
         # the snapshot can be borrowed from a realtime task that releases it.
         observed_device_generation = getattr(self, "_device_snapshot_generation", None)
+        identity_generation = getattr(self, "_runtime_map_identity_generation", 0)
         runtime_active = runtime_tracking_active(snapshot)
         session_started_at = runtime_mission_session_started_at(
             self.runtime_telemetry_cache
@@ -334,6 +374,10 @@ class DreameLawnMowerRefreshMixin:
                 refresh=False,
                 include_cloud=True,
             )
+            if identity_generation != getattr(
+                self, "_runtime_map_identity_generation", 0
+            ):
+                return False
             if self._snapshot_is_stale(
                 snapshot, observed_generation=observed_device_generation
             ) or (
@@ -379,6 +423,10 @@ class DreameLawnMowerRefreshMixin:
             )
             return True
         except Exception as err:  # noqa: BLE001 - best-effort extra metadata
+            if identity_generation != getattr(
+                self, "_runtime_map_identity_generation", 0
+            ):
+                return False
             if self._snapshot_is_stale(
                 snapshot, observed_generation=observed_device_generation
             ) or (
@@ -656,7 +704,7 @@ class DreameLawnMowerRefreshMixin:
             getattr(snapshot, "available", False)
             and runtime_tracking_active(snapshot)
         ):
-            return await self._async_refresh_active_runtime(cycle, snapshot)
+            await self._async_refresh_active_runtime(cycle, snapshot)
         return await self.async_refresh_app_maps(force=False)
 
     def _metadata_phase_needs_retry(self, phase: str, result: Any) -> bool:
@@ -866,6 +914,11 @@ class DreameLawnMowerRefreshMixin:
 
     def _runtime_map_index(self) -> int | None:
         """Return the map identity used to scope transient runtime overlays."""
+        if (
+            getattr(self, "_runtime_map_identity_verified", False)
+            and hasattr(self, "_runtime_active_map_index")
+        ):
+            return self._runtime_active_map_index
         return active_map_index(
             self.app_maps,
             selected_map_index=self.selected_map_index,

--- a/custom_components/dreame_lawn_mower/coordinator_refresh.py
+++ b/custom_components/dreame_lawn_mower/coordinator_refresh.py
@@ -277,6 +277,7 @@ class DreameLawnMowerRefreshMixin:
                 runtime_map_index=runtime_map_index,
             ),
         )
+        self._expire_runtime_map_identity()
         if identity_generation != getattr(self, "_runtime_map_identity_generation", 0):
             return False
         if not runtime_current or self._snapshot_is_stale(runtime_snapshot):
@@ -311,7 +312,7 @@ class DreameLawnMowerRefreshMixin:
             if (
                 refreshed_at is not None
                 and (not force or refreshed_at >= requested_at)
-                and datetime.now(UTC) - refreshed_at < RUNTIME_MAP_IDENTITY_INTERVAL
+                and self._runtime_map_identity_is_fresh()
             ):
                 return True, self._runtime_active_map_index, identity_generation
             try:
@@ -337,13 +338,16 @@ class DreameLawnMowerRefreshMixin:
             if (
                 index != getattr(self, "_runtime_active_map_index", None)
                 or refreshed_at is None
-                or datetime.now(UTC) - refreshed_at >= RUNTIME_MAP_IDENTITY_INTERVAL
+                or not self._runtime_map_identity_is_fresh()
             ):
                 # Supersede telemetry still awaiting the previous map's result.
                 self._invalidate_runtime_map_identity()
                 identity_generation = self._runtime_map_identity_generation
             self._runtime_active_map_index = index
             self._runtime_map_index_refreshed_at = datetime.now(UTC)
+            self.client.runtime_map_identity_expires_at = (
+                self._runtime_map_index_refreshed_at + RUNTIME_MAP_IDENTITY_INTERVAL
+            )
             # The complete map cache belongs to background hydration. Expire it
             # promptly on a switch without publishing old geometry as current.
             if index != active_map_index(getattr(self, "app_maps", None)):
@@ -357,6 +361,24 @@ class DreameLawnMowerRefreshMixin:
         )
         self._runtime_map_index_refreshed_at = None
         self._runtime_map_identity_verified = False
+        self.client.runtime_map_identity_expires_at = None
+
+    def _runtime_map_identity_is_fresh(self) -> bool:
+        """Check the MAPL lease independently of polling or telemetry activity."""
+        refreshed_at = getattr(self, "_runtime_map_index_refreshed_at", None)
+        return (
+            refreshed_at is not None
+            and timedelta(0) <= datetime.now(UTC) - refreshed_at
+            < RUNTIME_MAP_IDENTITY_INTERVAL
+        )
+
+    def _expire_runtime_map_identity(self) -> None:
+        """Fence pending readers when the cached MAPL lease expires."""
+        if not self._runtime_map_identity_is_fresh() and (
+            getattr(self, "_runtime_map_identity_verified", False)
+            or getattr(self, "_runtime_map_index_refreshed_at", None) is not None
+        ):
+            self._invalidate_runtime_map_identity()
 
     async def _async_refresh_runtime_status(
         self,
@@ -406,6 +428,10 @@ class DreameLawnMowerRefreshMixin:
                 != observed_mission_generation
             ):
                 return False
+            if runtime_active:
+                self._expire_runtime_map_identity()
+                if not self._runtime_map_identity_is_fresh():
+                    runtime_map_index = None
             self.runtime_status_blob = runtime_status_blob
             self.runtime_telemetry_cache.update(
                 self.runtime_status_blob,
@@ -456,6 +482,10 @@ class DreameLawnMowerRefreshMixin:
             ):
                 return False
             _LOGGER.debug("Failed to refresh runtime status blob: %s", err)
+            if runtime_active:
+                self._expire_runtime_map_identity()
+                if not self._runtime_map_identity_is_fresh():
+                    runtime_map_index = None
             self.runtime_status_blob = None
             self.client.update_runtime_live_tracking(
                 None,
@@ -717,6 +747,7 @@ class DreameLawnMowerRefreshMixin:
         self, cycle: DreameLawnMowerPerformanceCycle
     ) -> Any:
         """Verify active map identity even when MQTT postpones normal polling."""
+        self._expire_runtime_map_identity()
         snapshot = getattr(self, "data", None)
         if (
             getattr(snapshot, "available", False)
@@ -937,7 +968,10 @@ class DreameLawnMowerRefreshMixin:
             getattr(self, "_runtime_map_identity_verified", False)
             and hasattr(self, "_runtime_active_map_index")
         ):
-            return self._runtime_active_map_index
+            return (
+                self._runtime_active_map_index
+                if self._runtime_map_identity_is_fresh() else None
+            )
         return active_map_index(
             self.app_maps,
             selected_map_index=self.selected_map_index,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -90,6 +90,7 @@ from .client_settings import (
     SCHEDULE_READ_TIMEOUT_SECONDS as _SCHEDULE_READ_TIMEOUT_SECONDS,
 )
 from .client_settings import _DreameLawnMowerClientSettingsMixin
+from .client_tracking import _DreameLawnMowerClientTrackingMixin
 from .deadline import DeadlineExceededError as DeadlineExceededError
 from .deadline import run_with_deadline as run_with_deadline
 from .debug_ota_catalog import (
@@ -434,6 +435,7 @@ class DreameLawnMowerClient(
     _DreameLawnMowerClientDeviceSettingsMixin,
     _DreameLawnMowerClientSettingsMixin,
     _DreameLawnMowerClientMapsMixin,
+    _DreameLawnMowerClientTrackingMixin,
 ):
     """Small async wrapper around the reverse-engineered mower protocol."""
 
@@ -466,6 +468,9 @@ class DreameLawnMowerClient(
             ...,
         ] = ()
         self._last_runtime_track_blob_hex: str | None = None
+        self._runtime_map_identity_expires_at: datetime | None = datetime.max.replace(
+            tzinfo=UTC
+        )
         self._runtime_live_map_index: int | None = None
         self._runtime_live_task_id: int | None = None
         self._runtime_session_active: bool | None = None
@@ -498,75 +503,6 @@ class DreameLawnMowerClient(
         self._update_callback = callback
         if self._device is not None:
             self._device.listen(callback)
-
-    def update_runtime_live_tracking(
-        self,
-        status_blob: DreameLawnMowerStatusBlob | None,
-        *,
-        active: bool,
-        map_index: int | None = None,
-    ) -> None:
-        """Cache live overlays only against an explicitly verified map index.
-
-        An unknown map retires live context; it never inherits the previous slot.
-        Scoped historical position evidence remains available as last-known data.
-        """
-        if map_index is None or self._runtime_live_map_index not in (None, map_index):
-            self._position_tracker.invalidate_current()
-        self._position_tracker.record(status_blob, map_index=map_index)
-        self._latest_runtime_status_blob = (
-            status_blob if map_index is not None else None
-        )
-        self._runtime_session_active = active
-        if not active or map_index is None:
-            self._runtime_live_track_segments = ()
-            # Consume unscoped packets so recovery cannot rebind their cached
-            # coordinates to a map discovered only after they arrived.
-            self._last_runtime_track_blob_hex = (
-                getattr(status_blob, "hex", None) or self._last_runtime_track_blob_hex
-            )
-            self._runtime_live_map_index = None
-            self._runtime_live_task_id = None
-            return
-
-        task_id = getattr(status_blob, "candidate_runtime_task_id", None)
-        context_changed = (
-            self._runtime_live_map_index is not None
-            and map_index is not None
-            and self._runtime_live_map_index != map_index
-        ) or (
-            self._runtime_live_task_id is not None
-            and task_id is not None
-            and self._runtime_live_task_id != task_id
-        )
-        if context_changed:
-            self._runtime_live_track_segments = ()
-        if map_index is not None:
-            self._runtime_live_map_index = map_index
-        if task_id is not None:
-            self._runtime_live_task_id = task_id
-
-        if status_blob is None:
-            return
-
-        blob_hex = getattr(status_blob, "hex", None)
-        if blob_hex and blob_hex == self._last_runtime_track_blob_hex:
-            return
-
-        segments = getattr(status_blob, "candidate_runtime_track_segments", ()) or ()
-        if not segments:
-            if blob_hex:
-                self._last_runtime_track_blob_hex = blob_hex
-            return
-
-        self._runtime_live_track_segments = (
-            *self._runtime_live_track_segments,
-            *tuple(tuple(tuple(point) for point in segment) for segment in segments),
-        )
-        if len(self._runtime_live_track_segments) > 64:
-            self._runtime_live_track_segments = self._runtime_live_track_segments[-64:]
-        if blob_hex:
-            self._last_runtime_track_blob_hex = blob_hex
 
     @classmethod
     async def async_discover_devices(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client.py
@@ -506,18 +506,27 @@ class DreameLawnMowerClient(
         active: bool,
         map_index: int | None = None,
     ) -> None:
-        """Cache active-session runtime track history for live map overlays."""
+        """Cache live overlays only against an explicitly verified map index.
+
+        An unknown map retires live context; it never inherits the previous slot.
+        Scoped historical position evidence remains available as last-known data.
+        """
+        if map_index is None or self._runtime_live_map_index not in (None, map_index):
+            self._position_tracker.invalidate_current()
         self._position_tracker.record(status_blob, map_index=map_index)
-        self._latest_runtime_status_blob = status_blob
+        self._latest_runtime_status_blob = (
+            status_blob if map_index is not None else None
+        )
         self._runtime_session_active = active
-        if not active:
+        if not active or map_index is None:
             self._runtime_live_track_segments = ()
-            self._last_runtime_track_blob_hex = None
+            # Consume unscoped packets so recovery cannot rebind their cached
+            # coordinates to a map discovered only after they arrived.
+            self._last_runtime_track_blob_hex = (
+                getattr(status_blob, "hex", None) or self._last_runtime_track_blob_hex
+            )
             self._runtime_live_map_index = None
             self._runtime_live_task_id = None
-            return
-
-        if status_blob is None:
             return
 
         task_id = getattr(status_blob, "candidate_runtime_task_id", None)
@@ -532,11 +541,13 @@ class DreameLawnMowerClient(
         )
         if context_changed:
             self._runtime_live_track_segments = ()
-            self._last_runtime_track_blob_hex = None
         if map_index is not None:
             self._runtime_live_map_index = map_index
         if task_id is not None:
             self._runtime_live_task_id = task_id
+
+        if status_blob is None:
+            return
 
         blob_hex = getattr(status_blob, "hex", None)
         if blob_hex and blob_hex == self._last_runtime_track_blob_hex:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_core.py
@@ -542,13 +542,11 @@ class _DreameLawnMowerClientCoreMixin:
         refresh: bool = False,
         include_cloud: bool = True,
     ) -> DreameLawnMowerStatusBlob | None:
-        blob = self._sync_get_decoded_status_blob(
+        return self._sync_get_decoded_status_blob(
             MOWER_RUNTIME_STATUS_PROPERTY_KEY,
             refresh=refresh,
             include_cloud=include_cloud,
         )
-        self._latest_runtime_status_blob = blob
-        return blob
 
     def _sync_get_bluetooth_connected(
         self,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -349,21 +349,10 @@ class _DreameLawnMowerClientMapsMixin(
         runtime_blob = self._latest_runtime_status_blob
         if self._runtime_session_active is False:
             vector_map.mow_paths = ()
-        if (
-            runtime_blob is not None
-            and self._runtime_live_map_index is not None
-            and self._runtime_live_map_index != vector_map.map_index
-        ):
-            self._runtime_live_track_segments = ()
-            self._last_runtime_track_blob_hex = None
-            self._runtime_live_map_index = vector_map.map_index
         summary = vector_map_to_summary(vector_map)
         details = vector_map_to_details(vector_map)
         details["render_rotation"] = style.rotation if style else 0
-        runtime_context_matches = self._runtime_live_map_index in (
-            None,
-            vector_map.map_index,
-        )
+        runtime_context_matches = self._runtime_live_map_index == vector_map.map_index
         runtime_track_segments = (
             filter_runtime_track_segments(
                 vector_map,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -346,6 +346,7 @@ class _DreameLawnMowerClientMapsMixin(
                 ),
             )
 
+        self._expire_runtime_live_tracking()
         runtime_blob = self._latest_runtime_status_blob
         if self._runtime_session_active is False:
             vector_map.mow_paths = ()

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_mowing_map.py
@@ -64,6 +64,7 @@ class _DreameLawnMowerClientMowingMapMixin:
 
     def mowing_map_runtime_overlay(self, scene: MowingMapScene) -> dict[str, Any]:
         """Read the existing session cache without requesting mower operations."""
+        self._expire_runtime_live_tracking()
         position = self._position_tracker.resolve(
             map_index=scene.map_index,
             geometry=scene.position_identity,

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_tracking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_tracking.py
@@ -1,0 +1,116 @@
+"""Map-scoped runtime publication and host-provided identity lifetime."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from .models import DreameLawnMowerStatusBlob
+
+
+class _DreameLawnMowerClientTrackingMixin:
+    """Own live evidence retirement for both streamed and rendered maps."""
+
+    @property
+    def runtime_map_identity_expires_at(self) -> datetime | None:
+        """Return the absolute deadline for verified identity, or None if revoked.
+
+        Standalone callers own identity validity and default to no expiration.
+        A caching host sets its UTC deadline. None retires existing live evidence
+        without discarding map-scoped history; a new deadline restores admission.
+        """
+        return self._runtime_map_identity_expires_at
+
+    @runtime_map_identity_expires_at.setter
+    def runtime_map_identity_expires_at(self, deadline: datetime | None) -> None:
+        self._runtime_map_identity_expires_at = deadline
+        if deadline is None:
+            self._retire_runtime_live_tracking()
+        else:
+            self._expire_runtime_live_tracking()
+
+    def _retire_runtime_live_tracking(self) -> None:
+        """Revoke live publication, preserving history and consumed packets."""
+        self._position_tracker.invalidate_current()
+        self._latest_runtime_status_blob = None
+        self._runtime_live_track_segments = ()
+        self._runtime_live_map_index = None
+        self._runtime_live_task_id = None
+
+    def _expire_runtime_live_tracking(self) -> bool:
+        """Enforce identity lifetime even when no coordinator callback runs."""
+        deadline = self._runtime_map_identity_expires_at
+        if deadline is None or datetime.now(UTC) >= deadline:
+            self._retire_runtime_live_tracking()
+            return True
+        return False
+
+    def update_runtime_live_tracking(
+        self,
+        status_blob: DreameLawnMowerStatusBlob | None,
+        *,
+        active: bool,
+        map_index: int | None = None,
+    ) -> None:
+        """Cache live overlays only against an explicitly verified map index.
+
+        An unknown map retires live context; it never inherits the previous slot.
+        Scoped historical position evidence remains available as last-known data.
+        """
+        if self._expire_runtime_live_tracking():
+            map_index = None
+        if map_index is None or self._runtime_live_map_index not in (None, map_index):
+            self._position_tracker.invalidate_current()
+        self._position_tracker.record(status_blob, map_index=map_index)
+        self._latest_runtime_status_blob = (
+            status_blob if map_index is not None else None
+        )
+        self._runtime_session_active = active
+        if not active or map_index is None:
+            self._runtime_live_track_segments = ()
+            # Consume unscoped packets so recovery cannot rebind their cached
+            # coordinates to a map discovered only after they arrived.
+            self._last_runtime_track_blob_hex = (
+                getattr(status_blob, "hex", None) or self._last_runtime_track_blob_hex
+            )
+            self._runtime_live_map_index = None
+            self._runtime_live_task_id = None
+            return
+
+        task_id = getattr(status_blob, "candidate_runtime_task_id", None)
+        context_changed = (
+            self._runtime_live_map_index is not None
+            and map_index is not None
+            and self._runtime_live_map_index != map_index
+        ) or (
+            self._runtime_live_task_id is not None
+            and task_id is not None
+            and self._runtime_live_task_id != task_id
+        )
+        if context_changed:
+            self._runtime_live_track_segments = ()
+        if map_index is not None:
+            self._runtime_live_map_index = map_index
+        if task_id is not None:
+            self._runtime_live_task_id = task_id
+
+        if status_blob is None:
+            return
+
+        blob_hex = getattr(status_blob, "hex", None)
+        if blob_hex and blob_hex == self._last_runtime_track_blob_hex:
+            return
+
+        segments = getattr(status_blob, "candidate_runtime_track_segments", ()) or ()
+        if not segments:
+            if blob_hex:
+                self._last_runtime_track_blob_hex = blob_hex
+            return
+
+        self._runtime_live_track_segments = (
+            *self._runtime_live_track_segments,
+            *tuple(tuple(tuple(point) for point in segment) for segment in segments),
+        )
+        if len(self._runtime_live_track_segments) > 64:
+            self._runtime_live_track_segments = self._runtime_live_track_segments[-64:]
+        if blob_hex:
+            self._last_runtime_track_blob_hex = blob_hex

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
@@ -157,6 +157,11 @@ class MowerPositionTracker:
                 default=None,
             )
 
+    def invalidate_current(self) -> None:
+        """Retire live input while preserving scoped historical position evidence."""
+        with self._lock:
+            self._input = None
+
     def record(
         self, blob: Any, *, map_index: int | None, now: datetime | None = None
     ) -> None:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/position_tracking.py
@@ -207,6 +207,11 @@ class MowerPositionTracker:
         """Prefer current telemetry, or proven docking, then labelled history."""
         current = (now or datetime.now(UTC)).timestamp()
         with self._lock:
+            owned_position = self._input or self._last or self._dock
+            if owned_position is not None and owned_position.map_index != map_index:
+                # A projection is not a map switch. Only fresh, map-bound input
+                # can move the live owner and its historical geometry context.
+                return None
             if self._geometry != geometry:
                 if self._geometry is not None:
                     self._geometry_changed_at = current

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/vector_map.py
@@ -369,18 +369,10 @@ def render_vector_map_png(
         if len(zone.points) < 3 or not zone.name:
             continue
         px, py = polygon_label_point([to_pixel(x, y) for x, y in zone.points])
-        for dx in range(-label_halo_width, label_halo_width + 1):
-            for dy in range(-label_halo_width, label_halo_width + 1):
-                if dx == 0 and dy == 0:
-                    continue
-                draw.text(
-                    (px + dx, py + dy),
-                    zone.name,
-                    fill=style.label_halo,
-                    font=font,
-                    anchor="mm",
-                )
-        draw.text((px, py), zone.name, fill=style.label, font=font, anchor="mm")
+        draw.text(
+            (px, py), zone.name, fill=style.label, font=font, anchor="mm",
+            stroke_width=label_halo_width, stroke_fill=style.label_halo,
+        )
 
     buffer = BytesIO()
     image.save(buffer, format="PNG")

--- a/custom_components/dreame_lawn_mower/video_flv_relay.py
+++ b/custom_components/dreame_lawn_mower/video_flv_relay.py
@@ -720,7 +720,13 @@ class DreameLawnMowerFlvRelay:
                         ):
                             self._media_callback_sent = True
                             self._first_media_at = asyncio.get_running_loop().time()
+                            # The reader cannot observe frames while this owner
+                            # callback waits for locks or persists provisioning.
+                            media_deadline.reschedule(None)
                             await self._media_ready_callback(self.diagnostics)
+                            media_deadline.reschedule(
+                                asyncio.get_running_loop().time() + _VIDEO_FRAME_TIMEOUT
+                            )
                 raise RuntimeError("The mower video source ended.")
         except asyncio.CancelledError:
             raise

--- a/custom_components/dreame_lawn_mower/video_flv_relay.py
+++ b/custom_components/dreame_lawn_mower/video_flv_relay.py
@@ -32,6 +32,7 @@ _MAX_SPS_BYTES: Final = 4 * 1024
 _MAX_SPS_BIT_OPERATIONS: Final = 32 * 1024
 _UPSTREAM_READ_TIMEOUT: Final = 30.0
 _MEDIA_READY_TIMEOUT: Final = 15.0
+_VIDEO_FRAME_TIMEOUT: Final = 15.0
 _IDLE_GRACE: Final = 15.0
 _IDLE_POLL_INTERVAL: Final = 1.0
 
@@ -441,6 +442,7 @@ class DreameLawnMowerFlvRelay:
         self._media_callback_sent = False
         self._started_at: float | None = None
         self._first_media_at: float | None = None
+        self._last_video_frame_at: float | None = None
         self._last_failure: str | None = None
 
     @property
@@ -482,6 +484,10 @@ class DreameLawnMowerFlvRelay:
                 else None
             ),
             "relay_first_media_ready": self._first_media_at is not None,
+            "relay_last_video_frame_age_ms": (
+                round((now - self._last_video_frame_at) * 1000)
+                if self._last_video_frame_at is not None else None
+            ),
             "relay_last_failure": self._last_failure,
             **self._parser.diagnostics(),
         }
@@ -692,21 +698,41 @@ class DreameLawnMowerFlvRelay:
                 response.raise_for_status()
                 async with asyncio.timeout(_MEDIA_READY_TIMEOUT) as media_deadline:
                     async for chunk in response.content.iter_chunked(64 * 1024):
+                        previous_frames = self._parser.video_frames
                         for record in self._record_parser.feed(chunk):
                             await self._async_broadcast(record)
+                        if (
+                            self._parser.media_ready
+                            and self._parser.video_frames > previous_frames
+                        ):
+                            self._last_video_frame_at = (
+                                asyncio.get_running_loop().time()
+                            )
+                            # Bytes alone do not prove live video: audio,
+                            # metadata and partial tags must not keep a frozen
+                            # picture alive after the first keyframe.
+                            media_deadline.reschedule(
+                                self._last_video_frame_at + _VIDEO_FRAME_TIMEOUT
+                            )
                         if (
                             self._parser.media_ready
                             and not self._media_callback_sent
                         ):
                             self._media_callback_sent = True
                             self._first_media_at = asyncio.get_running_loop().time()
-                            media_deadline.reschedule(None)
                             await self._media_ready_callback(self.diagnostics)
                 raise RuntimeError("The mower video source ended.")
         except asyncio.CancelledError:
             raise
         except Exception as err:  # noqa: BLE001 - propagate a clean local stream end.
             safe_error = _safe_relay_failure(err)
+            if (
+                isinstance(err, TimeoutError)
+                and self._last_video_frame_at is not None
+                and asyncio.get_running_loop().time() - self._last_video_frame_at
+                >= _VIDEO_FRAME_TIMEOUT
+            ):
+                safe_error = "The mower video source stopped delivering video frames."
             self._last_failure = safe_error
             _LOGGER.debug("Dreame mower FLV relay stopped: %s", safe_error)
             # Detach the failed pump before cleanup may await native runtime
@@ -827,3 +853,4 @@ class DreameLawnMowerFlvRelay:
         self._media_callback_sent = False
         self._started_at = None
         self._first_media_at = None
+        self._last_video_frame_at = None

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -588,15 +588,14 @@ def test_active_runtime_tracking_uses_fresh_app_map_identity() -> None:
         ),
     )
 
-    async def refresh_app_maps(*, force: bool) -> dict[str, object]:
+    async def refresh_map_index() -> int:
         events.append("maps")
-        assert force is True
         coordinator.app_maps = {"current_map_index": 2}
         coordinator.app_maps_refreshed_at = datetime.now(UTC)
         coordinator.app_maps_refresh_succeeded = True
-        return coordinator.app_maps
+        return 2
 
-    coordinator.async_refresh_app_maps = refresh_app_maps
+    coordinator.client.async_get_current_app_map_index = refresh_map_index
     for name in (
         "async_refresh_batch_device_data",
         "async_refresh_firmware_update_support",
@@ -642,13 +641,12 @@ def test_active_runtime_tracking_survives_status_blob_failure() -> None:
         ),
     )
 
-    async def refresh_app_maps(*, force: bool) -> dict[str, object]:
-        assert force is True
+    async def refresh_map_index() -> int:
         coordinator.app_maps_refreshed_at = datetime.now(UTC)
         coordinator.app_maps_refresh_succeeded = True
-        return coordinator.app_maps
+        return 2
 
-    coordinator.async_refresh_app_maps = refresh_app_maps
+    coordinator.client.async_get_current_app_map_index = refresh_map_index
     for name in (
         "async_refresh_batch_device_data",
         "async_refresh_firmware_update_support",

--- a/tests/test_coordinator_availability.py
+++ b/tests/test_coordinator_availability.py
@@ -678,6 +678,7 @@ def test_cached_device_update_publishes_realtime_runtime_position() -> None:
     tracking_updates: list[tuple[object, bool, int | None]] = []
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator.app_maps = {"current_map_index": 2}
     coordinator.selected_map_index = 2
     coordinator.runtime_status_blob = None
@@ -731,6 +732,7 @@ def test_cached_settings_event_refreshes_cfg_once_per_event() -> None:
     )
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator._last_device_settings_event_at = None
     coordinator._device_settings_write_lock = asyncio.Lock()
     coordinator.app_maps = {"current_map_index": 0}
@@ -775,6 +777,7 @@ def test_cached_settings_event_retries_after_failed_cfg_refresh() -> None:
     )
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator._last_device_settings_event_at = None
     coordinator.app_maps = {"current_map_index": 0}
     coordinator.selected_map_index = 0
@@ -825,6 +828,7 @@ def test_cached_preference_event_refreshes_only_preferences_once() -> None:
     }
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator._last_device_settings_event_at = None
     coordinator._last_mowing_preferences_event_at = None
     coordinator._preference_write_lock = asyncio.Lock()
@@ -880,6 +884,7 @@ def test_cached_preference_event_retries_after_failed_decode() -> None:
     )
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator._last_device_settings_event_at = None
     coordinator._last_mowing_preferences_event_at = None
     coordinator._preference_write_lock = asyncio.Lock()
@@ -940,6 +945,7 @@ def test_cached_completion_survives_runtime_failure_and_later_idle_refresh() -> 
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator.app_maps = {"current_map_index": 2}
     coordinator.selected_map_index = 2
     coordinator.runtime_status_blob = None
@@ -988,6 +994,7 @@ def test_new_session_discards_prior_telemetry_before_completion() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator.app_maps = {"current_map_index": 2}
     coordinator.selected_map_index = 2
     coordinator.runtime_status_blob = None
@@ -1060,6 +1067,7 @@ def test_resumed_charging_session_preserves_current_telemetry() -> None:
     coordinator = object.__new__(DreameLawnMowerCoordinator)
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator.app_maps = {"current_map_index": 2}
     coordinator.selected_map_index = 2
     coordinator.runtime_status_blob = None
@@ -1118,6 +1126,7 @@ def test_foreground_charging_snapshot_preserves_current_session_cache() -> None:
     coordinator.runtime_status_blob = None
     coordinator.runtime_telemetry_cache = cache
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator._schedule_metadata_refresh = Mock()
     coordinator.client = SimpleNamespace(
         async_refresh=AsyncMock(return_value=charging),
@@ -1151,6 +1160,7 @@ def test_cached_device_update_does_not_confirm_connectivity() -> None:
     coordinator._record_connectivity_failure("action acknowledgement was lost")
     coordinator._client_update_task = Mock()
     coordinator._runtime_map_identity_verified = True
+    coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
     coordinator.app_maps = {"current_map_index": 2}
     coordinator.selected_map_index = 2
     coordinator.runtime_status_blob = None
@@ -1204,6 +1214,7 @@ def test_newer_video_safety_state_wins_over_delayed_cached_mqtt_update() -> None
         coordinator._client_update_pending = False
         coordinator._shutting_down = False
         coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
         coordinator._device_refresh_lock = asyncio.Lock()
         coordinator._device_snapshot_generation = 0
         coordinator._published_device_snapshot_generation = 0
@@ -1278,6 +1289,7 @@ def test_command_boundary_blocks_delayed_cached_mqtt_runtime_side_effects() -> N
         coordinator._client_update_pending = False
         coordinator._shutting_down = False
         coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
         coordinator._device_refresh_lock = asyncio.Lock()
         coordinator._device_snapshot_generation = 0
         coordinator._published_device_snapshot_generation = 0

--- a/tests/test_coordinator_identity_expiry.py
+++ b/tests/test_coordinator_identity_expiry.py
@@ -1,0 +1,120 @@
+"""Realtime callbacks must not keep map ownership alive beyond its lease."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
+from custom_components.dreame_lawn_mower.performance import (
+    DreameLawnMowerPerformanceTracker,
+)
+from tests.test_runtime_map_identity import _coordinator
+
+
+@pytest.mark.parametrize("age", [None, 0, 61])
+@pytest.mark.parametrize("expire_during_read", [False, True])
+def test_realtime_identity_expires_without_a_poll(age, expire_during_read) -> None:
+    async def scenario() -> None:
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        snapshot = SimpleNamespace(
+            available=True, mowing_session_active=True, activity="mowing"
+        )
+        blob = SimpleNamespace()
+        coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_active_map_index = 2
+        coordinator._runtime_map_index_refreshed_at = (
+            None if age is None else datetime.now(UTC) - timedelta(seconds=age)
+        )
+        coordinator.app_maps = {"current_map_index": 2}
+        coordinator.selected_map_index = 2
+        coordinator.runtime_status_blob = None
+        coordinator.runtime_telemetry_cache = SimpleNamespace(update=Mock())
+        coordinator.bluetooth_connected = None
+        coordinator._schedule_metadata_refresh = Mock()
+        coordinator.async_set_updated_data = Mock()
+
+        async def read_blob(**kwargs):
+            if expire_during_read:
+                coordinator._runtime_map_index_refreshed_at = (
+                    datetime.now(UTC) - timedelta(seconds=61)
+                )
+            return blob
+
+        coordinator.client = SimpleNamespace(
+            async_get_cached_snapshot=AsyncMock(return_value=snapshot),
+            async_get_runtime_status_blob=AsyncMock(side_effect=read_blob),
+            async_get_bluetooth_connected=AsyncMock(return_value=True),
+            update_runtime_live_tracking=Mock(),
+        )
+        expired = age != 0 or expire_during_read
+        # Repeated callbacks postpone polling; each must remain unscoped until
+        # the existing background owner verifies MAPL again.
+        for _ in range(3):
+            await coordinator._async_process_client_update()
+            assert coordinator.client.update_runtime_live_tracking.call_args.kwargs[
+                "map_index"
+            ] == (None if expired else 2)
+        assert coordinator._runtime_map_identity_verified is not expired
+        if expired:
+            coordinator._schedule_metadata_refresh.assert_called_with(
+                refresh_map_and_runtime=True
+            )
+        else:
+            coordinator._schedule_metadata_refresh.assert_not_called()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_poll_read_cannot_publish_after_identity_expires(fails) -> None:
+    async def scenario() -> None:
+        coordinator = _coordinator()
+        snapshot = SimpleNamespace(
+            available=True, mowing_session_active=True, activity="mowing"
+        )
+
+        async def read_blob(**kwargs):
+            coordinator._runtime_map_index_refreshed_at -= timedelta(seconds=61)
+            if fails:
+                raise TimeoutError("Delayed telemetry")
+            return SimpleNamespace()
+
+        coordinator.client.async_get_runtime_status_blob.side_effect = read_blob
+        result = await coordinator._async_refresh_active_runtime(
+            DreameLawnMowerPerformanceTracker().start("test"), snapshot
+        )
+        assert result is False
+        assert coordinator._runtime_map_identity_verified is False
+        assert coordinator.client.update_runtime_live_tracking.call_args.kwargs[
+            "map_index"
+        ] is None
+
+    asyncio.run(scenario())
+
+
+def test_background_refresh_recovers_expired_identity() -> None:
+    async def scenario() -> None:
+        coordinator = _coordinator()
+        coordinator.data = SimpleNamespace(
+            available=True, mowing_session_active=True, activity="mowing"
+        )
+        await coordinator._async_refresh_runtime_map_index(force=True)
+        coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_map_index_refreshed_at -= timedelta(seconds=61)
+        coordinator.client.async_get_current_app_map_index.return_value = 3
+        coordinator.async_refresh_app_maps = AsyncMock()
+
+        await coordinator._async_refresh_background_map_runtime(
+            DreameLawnMowerPerformanceTracker().start("test")
+        )
+        assert coordinator._runtime_map_identity_verified is True
+        assert coordinator._runtime_map_index() == 3
+        assert coordinator.client.update_runtime_live_tracking.call_args.kwargs[
+            "map_index"
+        ] == 3
+        coordinator.async_refresh_app_maps.assert_awaited_once_with(force=False)
+
+    asyncio.run(scenario())

--- a/tests/test_coordinator_performance.py
+++ b/tests/test_coordinator_performance.py
@@ -329,6 +329,7 @@ def test_newer_video_safety_snapshot_blocks_foreground_runtime_side_effects() ->
         coordinator.client = SimpleNamespace(
             async_refresh=refresh_snapshot,
             async_refresh_authoritative_snapshot=refresh_snapshot,
+            async_get_current_app_map_index=AsyncMock(return_value=2),
             async_get_runtime_status_blob=refresh_runtime,
             update_runtime_live_tracking=Mock(),
         )
@@ -390,6 +391,7 @@ def test_command_boundary_blocks_delayed_foreground_runtime_side_effects() -> No
         coordinator.runtime_status_blob = retained_runtime
         coordinator.runtime_telemetry_cache = cache
         coordinator.client = SimpleNamespace(
+            async_get_current_app_map_index=AsyncMock(return_value=2),
             async_get_runtime_status_blob=refresh_runtime,
             update_runtime_live_tracking=Mock(),
         )
@@ -788,6 +790,8 @@ def test_active_session_reuses_verified_map_identity_between_polls() -> None:
         coordinator = object.__new__(DreameLawnMowerCoordinator)
         coordinator.performance = DreameLawnMowerPerformanceTracker()
         coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_active_map_index = 2
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
         coordinator.app_maps = {"current_map_index": 2}
         coordinator.app_maps_refreshed_at = object()
         coordinator.app_maps_refresh_succeeded = True
@@ -801,6 +805,7 @@ def test_active_session_reuses_verified_map_identity_between_polls() -> None:
             activity="mowing",
         )
         coordinator.client = SimpleNamespace(
+            async_get_current_app_map_index=AsyncMock(side_effect=TimeoutError),
             async_get_runtime_status_blob=AsyncMock(return_value=status_blob),
             update_runtime_live_tracking=Mock(),
         )
@@ -812,7 +817,8 @@ def test_active_session_reuses_verified_map_identity_between_polls() -> None:
         await coordinator._async_refresh_active_runtime(cycle, snapshot)
         cycle.finish()
 
-        coordinator.async_refresh_app_maps.assert_awaited_once_with(force=False)
+        coordinator.async_refresh_app_maps.assert_not_awaited()
+        coordinator.client.async_get_current_app_map_index.assert_not_awaited()
         coordinator.client.update_runtime_live_tracking.assert_called_once_with(
             status_blob,
             active=True,
@@ -840,6 +846,7 @@ def test_failed_due_map_refresh_does_not_stamp_runtime_with_stale_identity() -> 
             activity="mowing",
         )
         coordinator.client = SimpleNamespace(
+            async_get_current_app_map_index=AsyncMock(side_effect=TimeoutError),
             async_get_runtime_status_blob=AsyncMock(return_value=status_blob),
             update_runtime_live_tracking=Mock(),
         )

--- a/tests/test_coordinator_tracking_continuity.py
+++ b/tests/test_coordinator_tracking_continuity.py
@@ -57,8 +57,7 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
         coordinator._published_device_snapshot_generation = 1
         coordinator.data = original
 
-        async def read_map(*, force: bool) -> None:
-            assert force is True
+        async def read_map() -> int:
             coordinator.app_maps_refreshed_at = object()
             coordinator.app_maps_refresh_succeeded = True
             coordinator._record_device_snapshot(newest)
@@ -69,7 +68,7 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
             if transition == "mission":
                 coordinator.runtime_telemetry_cache._session_generation += 1
 
-        coordinator.async_refresh_app_maps = read_map
+            return 0
         blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
 
         async def read_runtime(**kwargs: object) -> object:
@@ -91,6 +90,7 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
                     coordinator.runtime_telemetry_cache._session_generation += 1
                 if transition == "runtime_map":
                     coordinator.app_maps = {"current_map_index": 1}
+                    coordinator._invalidate_runtime_map_identity()
             if transition.startswith("evicted"):
                 # Simulate updates while the real telemetry read is pending.
                 await asyncio.sleep(0)
@@ -110,6 +110,7 @@ def test_slow_map_read_hydrates_only_current_same_mission(transition: str) -> No
             return blob
 
         coordinator.client = SimpleNamespace(
+            async_get_current_app_map_index=read_map,
             async_get_runtime_status_blob=AsyncMock(side_effect=read_runtime),
             update_runtime_live_tracking=Mock(),
         )

--- a/tests/test_legacy_module_ownership.py
+++ b/tests/test_legacy_module_ownership.py
@@ -153,6 +153,7 @@ def test_client_facade_composes_canonical_domain_owners() -> None:
     device_settings = load_internal_module("client_device_settings")
     maps = load_internal_module("client_maps")
     settings = load_internal_module("client_settings")
+    tracking = load_internal_module("client_tracking")
 
     assert facade.DreameLawnMowerClient.__bases__ == (
         camera._DreameLawnMowerCameraMixin,
@@ -160,6 +161,7 @@ def test_client_facade_composes_canonical_domain_owners() -> None:
         device_settings._DreameLawnMowerClientDeviceSettingsMixin,
         settings._DreameLawnMowerClientSettingsMixin,
         maps._DreameLawnMowerClientMapsMixin,
+        tracking._DreameLawnMowerClientTrackingMixin,
     )
 
 

--- a/tests/test_mowing_map.py
+++ b/tests/test_mowing_map.py
@@ -200,6 +200,7 @@ def test_camera_and_interactive_overlay_share_dock_evidence_after_session_ends()
     tracker.record(replace(telemetry(), received_at=now.isoformat()), map_index=2)
     client = SimpleNamespace(
         _position_tracker=tracker,
+        _expire_runtime_live_tracking=lambda: False,
         _latest_snapshot=SimpleNamespace(
             available=True,
             activity="docked",
@@ -234,6 +235,7 @@ def test_interactive_client_does_not_bypass_replaced_geometry_rejection():
     tracker.record(blob, map_index=2)
     client = SimpleNamespace(
         _position_tracker=tracker,
+        _expire_runtime_live_tracking=lambda: False,
         _latest_snapshot=SimpleNamespace(available=True, activity="mowing"),
         _latest_runtime_status_blob=blob,
         _runtime_live_task_id=None,

--- a/tests/test_position_tracking.py
+++ b/tests/test_position_tracking.py
@@ -52,6 +52,28 @@ def resolve(tracker, *, snapshot=None, now=NOW, index=0, geometry="lawn-a"):
     )
 
 
+@pytest.mark.parametrize("docked", [False, True])
+def test_foreign_map_projection_preserves_owned_position_evidence(docked):
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    snapshot = state(docked=docked)
+    original = resolve(tracker, snapshot=snapshot)
+    assert original is not None
+    checkpoint = tracker.checkpoint(now=NOW)
+    assert resolve(tracker, index=1, geometry="foreign", snapshot=snapshot) is None
+    assert tracker.checkpoint(now=NOW) == checkpoint
+    assert resolve(tracker, snapshot=snapshot) == original
+
+
+def test_new_verified_input_allows_actual_map_transition():
+    tracker = MowerPositionTracker()
+    tracker.record(pose(), map_index=0, now=NOW)
+    assert resolve(tracker).map_index == 0
+    later = NOW + timedelta(seconds=1)
+    tracker.record(pose(at=later), map_index=1, now=later)
+    assert resolve(tracker, index=1, geometry="new-map", now=later).map_index == 1
+
+
 @pytest.mark.parametrize("charging_state", ["charging", "charging_completed"])
 def test_charging_establishes_docking_but_not_map_coordinates(charging_state):
     snapshot = state(docked=True)

--- a/tests/test_realtime_map_hydration.py
+++ b/tests/test_realtime_map_hydration.py
@@ -1,6 +1,7 @@
 """Realtime positions must acquire map identity without waiting for a poll."""
 
 import asyncio
+from datetime import UTC, datetime
 from types import SimpleNamespace
 from unittest.mock import AsyncMock, Mock
 
@@ -31,6 +32,9 @@ def test_realtime_update_requests_missing_active_map_identity(active, verified):
     )
     coordinator._shutting_down = False
     coordinator._runtime_map_identity_verified = verified
+    coordinator._runtime_map_index_refreshed_at = (
+        datetime.now(UTC) if verified else None
+    )
     coordinator._last_device_settings_event_at = None
     coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
     coordinator.app_maps = {"current_map_index": 0}

--- a/tests/test_realtime_map_hydration.py
+++ b/tests/test_realtime_map_hydration.py
@@ -101,10 +101,9 @@ def test_background_map_phase_uses_latest_state_without_foreground_poll(
                 coordinator._async_refresh_active_runtime.call_args.args[1]
                 is coordinator.data
             )
-            coordinator.async_refresh_app_maps.assert_not_awaited()
         else:
             coordinator._async_refresh_active_runtime.assert_not_awaited()
-            coordinator.async_refresh_app_maps.assert_awaited_once_with(force=False)
+        coordinator.async_refresh_app_maps.assert_awaited_once_with(force=False)
 
     asyncio.run(scenario())
 
@@ -126,8 +125,7 @@ def test_background_map_read_cannot_revive_an_evicted_snapshot(transition):
         coordinator._published_device_snapshot_generation = 1
         coordinator.data = original
 
-        async def read_map(*, force):
-            assert force is True
+        async def read_map():
             coordinator.app_maps_refreshed_at = object()
             coordinator.app_maps_refresh_succeeded = True
             for _ in range(DEVICE_SNAPSHOT_GENERATION_HISTORY + 2):
@@ -147,10 +145,12 @@ def test_background_map_read_cannot_revive_an_evicted_snapshot(transition):
                     session_started_at=100.0
                 )
             assert id(original) not in coordinator._device_snapshot_generations
+            return 0
 
-        coordinator.async_refresh_app_maps = read_map
+        coordinator.async_refresh_app_maps = AsyncMock(return_value={})
         blob = SimpleNamespace(candidate_runtime_area_progress_percent=42.0)
         coordinator.client = SimpleNamespace(
+            async_get_current_app_map_index=read_map,
             async_get_runtime_status_blob=AsyncMock(return_value=blob),
             update_runtime_live_tracking=Mock(),
         )
@@ -160,7 +160,7 @@ def test_background_map_read_cannot_revive_an_evicted_snapshot(transition):
         result = await coordinator._async_refresh_background_map_runtime(
             DreameLawnMowerPerformanceTracker().start("test")
         )
-        assert result is False
+        assert result == {}
         if transition == "pose":
             assert (
                 coordinator._async_refresh_runtime_status.call_args.args[0]

--- a/tests/test_runtime_identity_publication.py
+++ b/tests/test_runtime_identity_publication.py
@@ -1,0 +1,143 @@
+"""Identity retirement reaches real map readers before suspended work resumes."""
+
+import asyncio
+from dataclasses import replace
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock, patch
+
+import pytest
+
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.map_visuals import (
+    map_render_style,
+)
+from custom_components.dreame_lawn_mower.dreame_lawn_mower_client.mowing_map import (
+    build_mowing_map_scene,
+)
+from tests.test_mowing_map import garden, telemetry
+from tests.test_runtime_map_identity import _coordinator
+from tests.test_vector_map import _batch_payload, _client
+
+
+def _seeded_client():
+    client = _client()
+    now = datetime.now(UTC)
+    client._latest_snapshot = SimpleNamespace(
+        available=True, activity="mowing", mowing_session_active=True
+    )
+    client.runtime_map_identity_expires_at = now + timedelta(seconds=60)
+    client.update_runtime_live_tracking(
+        replace(telemetry(), received_at=now.isoformat()), active=True, map_index=2
+    )
+    scene = build_mowing_map_scene(garden(), style=map_render_style())
+    assert client.mowing_map_runtime_overlay(scene)["position_status"] == "current"
+    return client, scene
+
+
+@pytest.mark.parametrize("reason", ["mqtt_expiry", "map_change", "failure", "cancel"])
+def test_invalidation_retires_overlay_before_pending_read_completes(reason):
+    async def scenario():
+        client, scene = _seeded_client()
+        coordinator = _coordinator()
+        coordinator.client = client
+        coordinator.data = client._latest_snapshot
+        coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_active_map_index = 2
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
+        coordinator.async_set_updated_data = Mock()
+        coordinator._schedule_metadata_refresh = Mock()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def pending_blob(**kwargs):
+            started.set()
+            await release.wait()
+            return None
+
+        client.async_get_runtime_status_blob = pending_blob
+        client.async_get_cached_snapshot = AsyncMock(return_value=coordinator.data)
+        client.async_get_bluetooth_connected = AsyncMock(return_value=False)
+        if reason == "mqtt_expiry":
+            coordinator._runtime_map_index_refreshed_at -= timedelta(seconds=61)
+            task = asyncio.create_task(coordinator._async_process_client_update())
+            await started.wait()
+        elif reason == "cancel":
+            client.async_get_current_app_map_index = pending_blob
+            task = asyncio.create_task(
+                coordinator._async_refresh_runtime_map_index(force=True)
+            )
+            await started.wait()
+            task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await task
+        else:
+            client.async_get_current_app_map_index = AsyncMock(return_value=3)
+            if reason == "failure":
+                client.async_get_current_app_map_index.side_effect = TimeoutError()
+            await coordinator._async_refresh_runtime_map_index(force=True)
+            task = None
+        try:
+            overlay = client.mowing_map_runtime_overlay(scene)
+            assert overlay["position_status"] == "last_known"
+            assert overlay["position"] is not None
+            assert overlay["trail"] == []
+            assert client._runtime_live_map_index is None
+        finally:
+            release.set()
+            if task is not None and not task.cancelled():
+                await task
+
+    asyncio.run(scenario())
+
+
+def test_overlay_and_packets_enforce_deadline_without_coordinator_callbacks():
+    client, scene = _seeded_client()
+    deadline = client.runtime_map_identity_expires_at
+    with patch(f"{client._expire_runtime_live_tracking.__module__}.datetime") as clock:
+        clock.now.return_value = deadline + timedelta(seconds=1)
+        overlay = client.mowing_map_runtime_overlay(scene)
+        assert overlay["position_status"] == "last_known"
+        assert overlay["trail"] == []
+        client.update_runtime_live_tracking(
+            replace(telemetry(), hex="late-packet"), active=True, map_index=2
+        )
+        assert client._runtime_live_map_index is None
+        assert client._latest_runtime_status_blob is None
+
+
+@pytest.mark.parametrize("active", [False, True])
+def test_revocation_requires_new_identity_before_accepting_poses(active):
+    client, scene = _seeded_client()
+    client.runtime_map_identity_expires_at = None
+    packet_time = datetime.now(UTC) + timedelta(seconds=1)
+    client.update_runtime_live_tracking(
+        replace(telemetry(), received_at=packet_time.isoformat(), hex="revoked"),
+        active=active, map_index=2,
+    )
+    assert client.mowing_map_runtime_overlay(scene)["position_status"] == "last_known"
+    assert client._runtime_live_map_index is None
+    client.runtime_map_identity_expires_at = packet_time + timedelta(seconds=60)
+    client.update_runtime_live_tracking(replace(
+        telemetry(), received_at=(packet_time + timedelta(seconds=1)).isoformat(),
+        hex="fresh-verified",
+    ), active=True, map_index=2)
+    assert client.mowing_map_runtime_overlay(scene)["position_status"] == "current"
+
+
+def test_vector_camera_enforces_deadline_without_coordinator_callbacks():
+    client = _client()
+    now = datetime.now(UTC)
+    client._latest_snapshot = SimpleNamespace(available=True, activity="mowing")
+    client._sync_get_vector_map_batch_data = lambda: _batch_payload()
+    client._safe_map_diagnostics = lambda **kwargs: None
+    client.runtime_map_identity_expires_at = now + timedelta(seconds=60)
+    client.update_runtime_live_tracking(replace(
+        telemetry(), received_at=now.isoformat(),
+        candidate_runtime_pose_x=50, candidate_runtime_pose_y=50,
+    ), active=True, map_index=0)
+    current = client._sync_refresh_vector_map_view(current_map_index=0)
+    assert current.details["position_status"] == "current"
+    with patch(f"{client._expire_runtime_live_tracking.__module__}.datetime") as clock:
+        clock.now.return_value = now + timedelta(seconds=61)
+        expired = client._sync_refresh_vector_map_view(current_map_index=0)
+    assert expired.details["position_status"] == "last_known"
+    assert "runtime_track_point_count" not in expired.details

--- a/tests/test_runtime_map_identity.py
+++ b/tests/test_runtime_map_identity.py
@@ -38,6 +38,7 @@ def test_background_geometry_does_not_repeat_verified_active_telemetry():
             available=True, activity="mowing", mowing_session_active=True
         )
         coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
         coordinator._async_refresh_active_runtime = AsyncMock()
         coordinator.async_refresh_app_maps = AsyncMock()
         await coordinator._async_refresh_background_map_runtime(
@@ -288,6 +289,7 @@ def test_cancelled_identity_read_expires_its_previous_verification():
         coordinator = _coordinator()
         await coordinator._async_refresh_runtime_map_index(force=True)
         coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
         previous = coordinator._runtime_map_identity_generation
         started = asyncio.Event()
 
@@ -353,6 +355,7 @@ def test_realtime_read_cannot_publish_after_identity_invalidation(boundary, fail
     async def scenario():
         coordinator = _coordinator()
         coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_map_index_refreshed_at = datetime.now(UTC)
         coordinator._runtime_active_map_index = 2
         coordinator._shutting_down = False
         coordinator._last_device_settings_event_at = None

--- a/tests/test_runtime_map_identity.py
+++ b/tests/test_runtime_map_identity.py
@@ -1,0 +1,143 @@
+"""Live map identity must stay independent of geometry and stale reads."""
+
+import asyncio
+from datetime import UTC, datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, Mock
+
+import pytest
+
+from custom_components.dreame_lawn_mower.coordinator import DreameLawnMowerCoordinator
+from custom_components.dreame_lawn_mower.performance import (
+    DreameLawnMowerPerformanceTracker,
+)
+from custom_components.dreame_lawn_mower.runtime_cache import (
+    DreameLawnMowerRuntimeTelemetryCache,
+)
+
+
+def _coordinator():
+    coordinator = object.__new__(DreameLawnMowerCoordinator)
+    coordinator.app_maps = {"current_map_index": 2}
+    coordinator.app_maps_refreshed_at = datetime.now(UTC)
+    coordinator.selected_map_index = 2
+    coordinator.runtime_status_blob = None
+    coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+    coordinator.client = SimpleNamespace(
+        async_get_current_app_map_index=AsyncMock(return_value=2),
+        async_get_runtime_status_blob=AsyncMock(return_value=None),
+        update_runtime_live_tracking=Mock(),
+    )
+    return coordinator
+
+
+def test_active_tracking_does_not_wait_for_geometry_download():
+    async def scenario():
+        coordinator = _coordinator()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def hydrate(*, force):
+            started.set()
+            await release.wait()
+
+        coordinator.async_refresh_app_maps = hydrate
+        hydration = asyncio.create_task(hydrate(force=False))
+        await started.wait()
+        snapshot = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        try:
+            assert await asyncio.wait_for(
+                coordinator._async_refresh_active_runtime(
+                    DreameLawnMowerPerformanceTracker().start("test"), snapshot
+                ), timeout=1,
+            )
+            assert not hydration.done()
+            coordinator.client.update_runtime_live_tracking.assert_called_once_with(
+                None, active=True, map_index=2
+            )
+        finally:
+            release.set()
+            await hydration
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("index", [None, 0, 3])
+def test_identity_refresh_expires_changed_geometry_and_reuses_fresh_read(index):
+    async def scenario():
+        coordinator = _coordinator()
+        coordinator.client.async_get_current_app_map_index.return_value = index
+        assert await coordinator._async_refresh_runtime_map_index(force=True) == (
+            True, index
+        )
+        assert coordinator.app_maps_refreshed_at is None
+        assert await coordinator._async_refresh_runtime_map_index(force=False) == (
+            True, index
+        )
+        coordinator.client.async_get_current_app_map_index.assert_awaited_once()
+        coordinator._runtime_map_index_refreshed_at -= timedelta(seconds=61)
+        await coordinator._async_refresh_runtime_map_index(force=False)
+        assert coordinator.client.async_get_current_app_map_index.await_count == 2
+
+    asyncio.run(scenario())
+
+
+def test_overlapping_forced_identity_reads_share_one_completed_request():
+    async def scenario():
+        coordinator = _coordinator()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def read():
+            started.set()
+            await release.wait()
+            return 2
+
+        coordinator.client.async_get_current_app_map_index.side_effect = read
+        first = asyncio.create_task(
+            coordinator._async_refresh_runtime_map_index(force=True)
+        )
+        await started.wait()
+        second = asyncio.create_task(
+            coordinator._async_refresh_runtime_map_index(force=True)
+        )
+        await asyncio.sleep(0)
+        release.set()
+        assert await first == await second == (True, 2)
+        coordinator.client.async_get_current_app_map_index.assert_awaited_once()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("boundary", ["identity", "telemetry"])
+def test_invalidated_map_read_cannot_restore_old_tracking(boundary):
+    async def scenario():
+        coordinator = _coordinator()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def read(*args, **kwargs):
+            started.set()
+            await release.wait()
+            return 2 if boundary == "identity" else None
+
+        method = (
+            coordinator.client.async_get_current_app_map_index
+            if boundary == "identity"
+            else coordinator.client.async_get_runtime_status_blob
+        )
+        method.side_effect = read
+        snapshot = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        task = asyncio.create_task(coordinator._async_refresh_active_runtime(
+            DreameLawnMowerPerformanceTracker().start("test"), snapshot
+        ))
+        await started.wait()
+        coordinator._invalidate_runtime_map_identity()
+        release.set()
+        assert await task is False
+        assert coordinator._runtime_map_identity_verified is False
+        assert coordinator._runtime_map_index_refreshed_at is None
+        coordinator.client.update_runtime_live_tracking.assert_not_called()
+
+    asyncio.run(scenario())

--- a/tests/test_runtime_map_identity.py
+++ b/tests/test_runtime_map_identity.py
@@ -31,6 +31,112 @@ def _coordinator():
     return coordinator
 
 
+def test_background_geometry_does_not_repeat_verified_active_telemetry():
+    async def scenario():
+        coordinator = _coordinator()
+        coordinator.data = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        coordinator._runtime_map_identity_verified = True
+        coordinator._async_refresh_active_runtime = AsyncMock()
+        coordinator.async_refresh_app_maps = AsyncMock()
+        await coordinator._async_refresh_background_map_runtime(
+            DreameLawnMowerPerformanceTracker().start("test")
+        )
+        coordinator._async_refresh_active_runtime.assert_not_awaited()
+        coordinator.async_refresh_app_maps.assert_awaited_once_with(force=False)
+    asyncio.run(scenario())
+
+
+def test_same_index_recovery_supersedes_unscoped_telemetry():
+    async def scenario():
+        coordinator = _coordinator()
+        await coordinator._async_refresh_runtime_map_index(force=True)
+        coordinator.client.async_get_current_app_map_index.side_effect = TimeoutError()
+        started, release = asyncio.Event(), asyncio.Event()
+        async def telemetry(**kwargs):
+            started.set()
+            await release.wait()
+        coordinator.client.async_get_runtime_status_blob.side_effect = telemetry
+        snapshot = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        task = asyncio.create_task(coordinator._async_refresh_active_runtime(
+            DreameLawnMowerPerformanceTracker().start("test"), snapshot
+        ))
+        await started.wait()
+        coordinator.client.async_get_current_app_map_index.side_effect = None
+        await coordinator._async_refresh_runtime_map_index(force=True)
+        release.set()
+        assert await task is False
+        coordinator.client.update_runtime_live_tracking.assert_not_called()
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("new_identity", [None, 3])
+def test_old_geometry_cannot_replace_newer_map_identity(new_identity):
+    async def scenario():
+        coordinator = _coordinator()
+        coordinator._invalidate_schedule_map_hint = Mock()
+        original = coordinator.app_maps
+        started, release = asyncio.Event(), asyncio.Event()
+        async def geometry(**kwargs):
+            started.set()
+            await release.wait()
+            return {"map_list_valid": True, "current_map_index": 2}
+        coordinator.client.async_get_app_maps = geometry
+        task = asyncio.create_task(coordinator.async_refresh_app_maps(force=True))
+        await started.wait()
+        coordinator.client.async_get_current_app_map_index.return_value = new_identity
+        await coordinator._async_refresh_runtime_map_index(force=True)
+        coordinator.selected_map_index = new_identity
+        release.set()
+        assert await task is original
+        assert coordinator.selected_map_index == new_identity
+        assert coordinator.app_maps_refreshed_at is None
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("fails", [False, True])
+def test_superseded_geometry_cannot_expire_a_newer_geometry_result(fails):
+    async def scenario():
+        coordinator = _coordinator()
+        started, release = asyncio.Event(), asyncio.Event()
+        async def geometry(**kwargs):
+            started.set()
+            await release.wait()
+            if fails:
+                raise TimeoutError("Older download failed")
+            return {"map_list_valid": True, "current_map_index": 2}
+        coordinator.client.async_get_app_maps = geometry
+        task = asyncio.create_task(coordinator.async_refresh_app_maps(force=True))
+        await started.wait()
+        newer = {"map_list_valid": True, "current_map_index": 3}
+        coordinator.app_maps = newer
+        coordinator.app_maps_refreshed_at = datetime.now(UTC)
+        coordinator.app_maps_refresh_succeeded = True
+        release.set()
+        assert await task is newer
+        assert coordinator.app_maps_refresh_succeeded is True
+        assert coordinator.app_maps_refreshed_at is not None
+    asyncio.run(scenario())
+
+
+def test_matching_geometry_can_finish_after_identity_refresh():
+    async def scenario():
+        coordinator = _coordinator()
+        coordinator._invalidate_schedule_map_hint = Mock()
+        async def geometry(**kwargs):
+            await coordinator._async_refresh_runtime_map_index(force=True)
+            return {"map_list_valid": True, "current_map_index": 2}
+        coordinator.client.async_get_app_maps = geometry
+        result = await coordinator.async_refresh_app_maps(force=True)
+        assert result["current_map_index"] == 2
+        assert coordinator.app_maps_refresh_succeeded is True
+        assert coordinator.app_maps_refreshed_at is not None
+    asyncio.run(scenario())
+
+
 def test_active_tracking_does_not_wait_for_geometry_download():
     async def scenario():
         coordinator = _coordinator()

--- a/tests/test_runtime_map_identity.py
+++ b/tests/test_runtime_map_identity.py
@@ -68,13 +68,12 @@ def test_identity_refresh_expires_changed_geometry_and_reuses_fresh_read(index):
     async def scenario():
         coordinator = _coordinator()
         coordinator.client.async_get_current_app_map_index.return_value = index
-        assert await coordinator._async_refresh_runtime_map_index(force=True) == (
+        assert (await coordinator._async_refresh_runtime_map_index(force=True))[:2] == (
             True, index
         )
         assert coordinator.app_maps_refreshed_at is None
-        assert await coordinator._async_refresh_runtime_map_index(force=False) == (
-            True, index
-        )
+        cached = await coordinator._async_refresh_runtime_map_index(force=False)
+        assert cached[:2] == (True, index)
         coordinator.client.async_get_current_app_map_index.assert_awaited_once()
         coordinator._runtime_map_index_refreshed_at -= timedelta(seconds=61)
         await coordinator._async_refresh_runtime_map_index(force=False)
@@ -103,7 +102,8 @@ def test_overlapping_forced_identity_reads_share_one_completed_request():
         )
         await asyncio.sleep(0)
         release.set()
-        assert await first == await second == (True, 2)
+        assert await first == await second
+        assert (await first)[:2] == (True, 2)
         coordinator.client.async_get_current_app_map_index.assert_awaited_once()
 
     asyncio.run(scenario())
@@ -139,5 +139,145 @@ def test_invalidated_map_read_cannot_restore_old_tracking(boundary):
         assert coordinator._runtime_map_identity_verified is False
         assert coordinator._runtime_map_index_refreshed_at is None
         coordinator.client.update_runtime_live_tracking.assert_not_called()
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("new_outcome", [None, 3, TimeoutError("MAPL unavailable")])
+def test_new_identity_outcome_supersedes_pending_telemetry(new_outcome):
+    async def scenario():
+        coordinator = _coordinator()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def telemetry(**kwargs):
+            started.set()
+            await release.wait()
+            return None
+
+        coordinator.client.async_get_runtime_status_blob.side_effect = telemetry
+        snapshot = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        first = asyncio.create_task(coordinator._async_refresh_active_runtime(
+            DreameLawnMowerPerformanceTracker().start("test"), snapshot
+        ))
+        await started.wait()
+        if isinstance(new_outcome, Exception):
+            coordinator.client.async_get_current_app_map_index.side_effect = new_outcome
+        else:
+            coordinator.client.async_get_current_app_map_index.return_value = (
+                new_outcome
+            )
+        await coordinator._async_refresh_runtime_map_index(force=True)
+        release.set()
+        assert await first is False
+        coordinator.client.update_runtime_live_tracking.assert_not_called()
+        assert coordinator._runtime_map_identity_verified is False
+
+    asyncio.run(scenario())
+
+
+def test_cancelled_identity_read_expires_its_previous_verification():
+    async def scenario():
+        coordinator = _coordinator()
+        await coordinator._async_refresh_runtime_map_index(force=True)
+        coordinator._runtime_map_identity_verified = True
+        previous = coordinator._runtime_map_identity_generation
+        started = asyncio.Event()
+
+        async def read():
+            started.set()
+            await asyncio.Future()
+
+        coordinator.client.async_get_current_app_map_index.side_effect = read
+        task = asyncio.create_task(
+            coordinator._async_refresh_runtime_map_index(force=True)
+        )
+        await started.wait()
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert coordinator._runtime_map_identity_generation > previous
+        assert coordinator._runtime_map_identity_verified is False
+        assert coordinator._runtime_map_index_refreshed_at is None
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("command_fails", [False, True])
+def test_identity_read_waits_for_map_switch_completion(command_fails):
+    async def scenario():
+        coordinator = _coordinator()
+        coordinator.selected_map_index = 3
+        coordinator.async_request_refresh = AsyncMock()
+        coordinator.async_refresh_app_maps = AsyncMock()
+        coordinator.async_refresh_vector_map_details = AsyncMock()
+        coordinator.async_update_listeners = Mock()
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def switch(index):
+            started.set()
+            await release.wait()
+            coordinator.client.async_get_current_app_map_index.return_value = index
+            if command_fails:
+                raise TimeoutError("Map switch response lost")
+
+        coordinator.client.async_switch_current_map = switch
+        command = asyncio.create_task(coordinator.async_switch_current_map(3))
+        await started.wait()
+        identity = asyncio.create_task(
+            coordinator._async_refresh_runtime_map_index(force=True)
+        )
+        await asyncio.sleep(0)
+        coordinator.client.async_get_current_app_map_index.assert_not_awaited()
+        release.set()
+        if command_fails:
+            with pytest.raises(TimeoutError):
+                await command
+        else:
+            await command
+        assert (await identity)[:2] == (True, 3)
+
+    asyncio.run(scenario())
+
+
+@pytest.mark.parametrize("boundary", ["telemetry", "bluetooth"])
+@pytest.mark.parametrize("fails", [False, True])
+def test_realtime_read_cannot_publish_after_identity_invalidation(boundary, fails):
+    async def scenario():
+        coordinator = _coordinator()
+        coordinator._runtime_map_identity_verified = True
+        coordinator._runtime_active_map_index = 2
+        coordinator._shutting_down = False
+        coordinator._last_device_settings_event_at = None
+        coordinator.async_set_updated_data = Mock()
+        coordinator._schedule_metadata_refresh = Mock()
+        snapshot = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        coordinator.client.async_get_cached_snapshot = AsyncMock(return_value=snapshot)
+        coordinator.client.async_get_bluetooth_connected = AsyncMock(return_value=False)
+        started, release = asyncio.Event(), asyncio.Event()
+
+        async def read(**kwargs):
+            started.set()
+            await release.wait()
+            if fails:
+                raise TimeoutError("Delayed optional read failed")
+            return None
+
+        method = (
+            coordinator.client.async_get_runtime_status_blob
+            if boundary == "telemetry"
+            else coordinator.client.async_get_bluetooth_connected
+        )
+        method.side_effect = read
+        task = asyncio.create_task(coordinator._async_process_client_update())
+        await started.wait()
+        coordinator._invalidate_runtime_map_identity()
+        release.set()
+        await task
+        coordinator.client.update_runtime_live_tracking.assert_not_called()
+        coordinator.async_set_updated_data.assert_not_called()
 
     asyncio.run(scenario())

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -640,6 +640,7 @@ def test_vector_map_view_includes_cached_runtime_track_overlay() -> None:
             received_at="2026-07-16T10:02:09+00:00",
         ),
         active=True,
+        map_index=0,
     )
 
     view = client._sync_refresh_vector_map_view()
@@ -677,6 +678,7 @@ def test_vector_map_view_exposes_runtime_position_without_track_points() -> None
             received_at="2026-07-16T10:02:09+00:00",
         ),
         active=True,
+        map_index=0,
     )
 
     view = client._sync_refresh_vector_map_view()
@@ -758,6 +760,115 @@ def test_runtime_track_resets_when_map_or_task_changes() -> None:
     assert client._runtime_live_map_index == 1
     assert client._runtime_live_task_id == 5
     assert client._runtime_live_track_segments == (((40, 40), (50, 50)),)
+
+
+@pytest.mark.parametrize("missing_blob", [False, True])
+def test_unverified_runtime_clears_retained_map_context(missing_blob):
+    client = _client()
+    first = SimpleNamespace(
+        hex="verified", candidate_runtime_task_id=4,
+        candidate_runtime_track_segments=(((10, 20), (30, 40)),),
+    )
+    client.update_runtime_live_tracking(first, active=True, map_index=0)
+    unverified = SimpleNamespace(
+        hex="unverified", candidate_runtime_task_id=4,
+        candidate_runtime_track_segments=(((40, 40), (50, 50)),),
+    )
+    client.update_runtime_live_tracking(
+        None if missing_blob else unverified, active=True, map_index=None
+    )
+    assert client._runtime_live_map_index is None
+    assert client._runtime_live_track_segments == ()
+    assert client._latest_runtime_status_blob is None
+    client.update_runtime_live_tracking(unverified, active=True, map_index=1)
+    assert client._runtime_live_map_index == 1
+    if not missing_blob:
+        assert client._runtime_live_track_segments == ()
+        unverified.hex = "fresh-verified"
+        client.update_runtime_live_tracking(unverified, active=True, map_index=1)
+    assert client._runtime_live_track_segments == (((40, 40), (50, 50)),)
+
+
+def test_cached_packet_cannot_move_between_verified_maps():
+    client = _client()
+    packet = SimpleNamespace(
+        hex="same-packet", candidate_runtime_track_segments=(((10, 20), (30, 40)),),
+    )
+    client.update_runtime_live_tracking(packet, active=True, map_index=0)
+    client.update_runtime_live_tracking(packet, active=True, map_index=1)
+    assert client._runtime_live_map_index == 1
+    assert client._runtime_live_track_segments == ()
+
+
+@pytest.mark.parametrize("publisher", ["poll", "realtime"])
+def test_coordinator_unverified_packets_cannot_extend_real_client_track(publisher):
+    from custom_components.dreame_lawn_mower.coordinator import (
+        DreameLawnMowerCoordinator,
+    )
+    from custom_components.dreame_lawn_mower.performance import (
+        DreameLawnMowerPerformanceTracker,
+    )
+    from custom_components.dreame_lawn_mower.runtime_cache import (
+        DreameLawnMowerRuntimeTelemetryCache,
+    )
+
+    async def scenario():
+        client = _client()
+        client.update_runtime_live_tracking(SimpleNamespace(
+            hex="prior", candidate_runtime_track_segments=(((10, 20), (30, 40)),),
+        ), active=True, map_index=0)
+        packet = SimpleNamespace(
+            hex="unverified", candidate_runtime_track_segments=(((40, 40), (50, 50)),),
+        )
+        snapshot = SimpleNamespace(
+            available=True, activity="mowing", mowing_session_active=True
+        )
+        client.async_get_current_app_map_index = AsyncMock(side_effect=TimeoutError())
+        client.async_get_runtime_status_blob = AsyncMock(return_value=packet)
+        client.async_get_cached_snapshot = AsyncMock(return_value=snapshot)
+        client.async_get_bluetooth_connected = AsyncMock(return_value=False)
+        coordinator = object.__new__(DreameLawnMowerCoordinator)
+        coordinator.client = client
+        coordinator.runtime_telemetry_cache = DreameLawnMowerRuntimeTelemetryCache()
+        coordinator._shutting_down = False
+        coordinator._last_device_settings_event_at = None
+        coordinator._runtime_map_identity_verified = False
+        coordinator.async_set_updated_data = Mock()
+        coordinator._schedule_metadata_refresh = Mock()
+        if publisher == "poll":
+            await coordinator._async_refresh_active_runtime(
+                DreameLawnMowerPerformanceTracker().start("test"), snapshot
+            )
+        else:
+            await coordinator._async_process_client_update()
+        assert client._runtime_live_map_index is None
+        assert client._runtime_live_track_segments == ()
+        assert client._latest_runtime_status_blob is None
+    asyncio.run(scenario())
+
+
+def test_verified_map_change_without_blob_retires_previous_track():
+    client = _client()
+    client.update_runtime_live_tracking(SimpleNamespace(
+        hex="verified", candidate_runtime_track_segments=(((10, 20), (30, 40)),),
+    ), active=True, map_index=0)
+    client.update_runtime_live_tracking(None, active=True, map_index=1)
+    assert client._runtime_live_map_index == 1
+    assert client._runtime_live_track_segments == ()
+
+
+def test_rendering_another_map_does_not_retarget_live_tracking():
+    client = _client()
+    client._sync_get_vector_map_batch_data = lambda: _batch_payload()
+    client._safe_map_diagnostics = lambda **kwargs: None
+    segments = (((10, 20), (30, 40)),)
+    client.update_runtime_live_tracking(SimpleNamespace(
+        hex="verified", candidate_runtime_track_segments=segments,
+    ), active=True, map_index=1)
+    view = client._sync_refresh_vector_map_view(current_map_index=0)
+    assert "runtime_track_point_count" not in view.details
+    assert client._runtime_live_map_index == 1
+    assert client._runtime_live_track_segments == segments
 
 
 def test_vector_map_view_withholds_position_from_another_map() -> None:

--- a/tests/test_vector_map.py
+++ b/tests/test_vector_map.py
@@ -800,6 +800,16 @@ def test_cached_packet_cannot_move_between_verified_maps():
     assert client._runtime_live_track_segments == ()
 
 
+def test_fetching_runtime_status_does_not_publish_unverified_overlay_input():
+    client = _client()
+    verified = SimpleNamespace(hex="verified")
+    client.update_runtime_live_tracking(verified, active=True, map_index=0)
+    unverified = SimpleNamespace(hex="unverified")
+    client._sync_get_decoded_status_blob = lambda *args, **kwargs: unverified
+    assert client._sync_get_runtime_status_blob() is unverified
+    assert client._latest_runtime_status_blob is verified
+
+
 @pytest.mark.parametrize("publisher", ["poll", "realtime"])
 def test_coordinator_unverified_packets_cannot_extend_real_client_track(publisher):
     from custom_components.dreame_lawn_mower.coordinator import (

--- a/tests/test_video_flv_relay.py
+++ b/tests/test_video_flv_relay.py
@@ -25,7 +25,9 @@ from custom_components.dreame_lawn_mower.video_flv_relay import (
 FLV_HEADER = b"FLV\x01\x01\x00\x00\x00\x09\x00\x00\x00\x00"
 
 
-@pytest.mark.parametrize("traffic", ["audio", "metadata", "partial", "video"])
+@pytest.mark.parametrize(
+    "traffic", ["audio", "metadata", "partial", "video", "callback"]
+)
 def test_relay_frame_deadline_ignores_nonvideo_and_allows_fresh_reconnect(traffic):
     async def scenario():
         pytest_socket.enable_socket()
@@ -58,7 +60,9 @@ def test_relay_frame_deadline_ignores_nonvideo_and_allows_fresh_reconnect(traffi
             try:
                 for _ in range(20):
                     await asyncio.sleep(0.025)
-                    await response.write(chunks[traffic])
+                    await response.write(
+                        chunks["video" if traffic == "callback" else traffic]
+                    )
                 flowing.set()
                 await stop.wait()
             except ConnectionResetError:
@@ -82,7 +86,9 @@ def test_relay_frame_deadline_ignores_nonvideo_and_allows_fresh_reconnect(traffi
             source_factory=lambda: asyncio.sleep(
                 0, result=f"http://127.0.0.1:{port}/source.flv"
             ),
-            media_ready=lambda diagnostics: asyncio.sleep(0),
+            media_ready=lambda diagnostics: asyncio.sleep(
+                0.35 if traffic == "callback" else 0
+            ),
             failed=failure,
             idle=lambda: asyncio.sleep(0),
         )
@@ -102,7 +108,7 @@ def test_relay_frame_deadline_ignores_nonvideo_and_allows_fresh_reconnect(traffi
                 response = await client.get(url)
                 responses.append(response)
                 assert await response.content.readexactly(len(initial)) == initial
-                if traffic == "video":
+                if traffic in {"video", "callback"}:
                     await asyncio.wait_for(flowing.wait(), 2)
                     assert failures == []
                     assert connections == 1

--- a/tests/test_video_flv_relay.py
+++ b/tests/test_video_flv_relay.py
@@ -25,6 +25,112 @@ from custom_components.dreame_lawn_mower.video_flv_relay import (
 FLV_HEADER = b"FLV\x01\x01\x00\x00\x00\x09\x00\x00\x00\x00"
 
 
+@pytest.mark.parametrize("traffic", ["audio", "metadata", "partial", "video"])
+def test_relay_frame_deadline_ignores_nonvideo_and_allows_fresh_reconnect(traffic):
+    async def scenario():
+        pytest_socket.enable_socket()
+        sequence = _tag(9, 0, b"\x17\x00\x00\x00\x00\x01\x64\x00\x1f")
+        keyframe = _tag(9, 0, b"\x17\x01\x00\x00\x00\x00\x00\x00\x01")
+        initial = FLV_HEADER + sequence + keyframe
+        chunks = {
+            "audio": _tag(8, 40, b"\xaf\x01\x01"),
+            "metadata": _tag(18, 40, b"metadata"),
+            "partial": b"x",
+            "video": _tag(9, 40, b"\x27\x01\x00\x00\x00\x00\x00\x00\x02"),
+        }
+        stop, failed, flowing = asyncio.Event(), asyncio.Event(), asyncio.Event()
+        connections = 0
+        failures = []
+
+        async def source(request):
+            nonlocal connections
+            connections += 1
+            attempt = connections
+            response = web.StreamResponse(headers={"Content-Type": "video/x-flv"})
+            await response.prepare(request)
+            await response.write(initial)
+            if attempt > 1:
+                await stop.wait()
+                return response
+            if traffic == "partial":
+                # A valid large tag header followed by incomplete payload bytes.
+                await response.write(_tag(9, 40, b"x" * 10000)[:11])
+            try:
+                for _ in range(20):
+                    await asyncio.sleep(0.025)
+                    await response.write(chunks[traffic])
+                flowing.set()
+                await stop.wait()
+            except ConnectionResetError:
+                pass
+            return response
+
+        async def failure(error):
+            failures.append(error)
+            failed.set()
+
+        application = web.Application()
+        application.router.add_get("/source.flv", source)
+        runner = web.AppRunner(application)
+        await runner.setup()
+        site = web.TCPSite(runner, "127.0.0.1", 0)
+        await site.start()
+        port = site._server.sockets[0].getsockname()[1]
+        client = ClientSession(connector=TCPConnector(resolver=ThreadedResolver()))
+        relay = DreameLawnMowerFlvRelay(
+            SimpleNamespace(async_create_task=asyncio.create_task),
+            source_factory=lambda: asyncio.sleep(
+                0, result=f"http://127.0.0.1:{port}/source.flv"
+            ),
+            media_ready=lambda diagnostics: asyncio.sleep(0),
+            failed=failure,
+            idle=lambda: asyncio.sleep(0),
+        )
+        responses = []
+        try:
+            with (
+                patch(
+                    "custom_components.dreame_lawn_mower.video_flv_relay."
+                    "async_get_clientsession", return_value=client,
+                ),
+                patch(
+                    "custom_components.dreame_lawn_mower.video_flv_relay."
+                    "_VIDEO_FRAME_TIMEOUT", 0.2,
+                ),
+            ):
+                url = await relay.async_start()
+                response = await client.get(url)
+                responses.append(response)
+                assert await response.content.readexactly(len(initial)) == initial
+                if traffic == "video":
+                    await asyncio.wait_for(flowing.wait(), 2)
+                    assert failures == []
+                    assert connections == 1
+                    assert relay.diagnostics["relay_last_video_frame_age_ms"] < 200
+                else:
+                    await asyncio.wait_for(failed.wait(), 2)
+                    assert failures == [
+                        "The mower video source stopped delivering video frames."
+                    ]
+                    # Existing subscribers end and the stable URL starts fresh.
+                    await asyncio.wait_for(response.read(), 1)
+                    replacement = await client.get(url)
+                    responses.append(replacement)
+                    assert (
+                        await replacement.content.readexactly(len(initial)) == initial
+                    )
+                    assert connections == 2
+        finally:
+            stop.set()
+            for response in responses:
+                response.close()
+            await relay.async_close()
+            await client.close()
+            await runner.cleanup()
+
+    asyncio.run(scenario())
+
+
 def _tag(tag_type: int, timestamp: int, payload: bytes) -> bytes:
     header = (
         bytes([tag_type])


### PR DESCRIPTION
Active map tracking reads the small map list independently of full geometry downloads. Identity expires after 60 seconds even when frequent realtime updates postpone polling. Changed, failed, cancelled, or expired identity immediately retires live overlays; camera and interactive map reads enforce the same deadline. Map-scoped historical positions remain clearly labelled, and cached packets cannot be rebound after recovery. Geometry refreshes in the background without overwriting newer inventory or repeating verified runtime reads.

Video playback retires a stream after 15 seconds without complete video frames, even if audio, metadata, or partial data continues arriving. The watchdog excludes readiness-callback processing time, and existing reconnect handling can start a fresh source. Zone labels use a single stroked draw, reducing enlarged-label rendering time while preserving theme colors and placement.

This PR builds on #188 and should land after it.

Validation: 1,959 lightweight tests passed with one existing skip; Ruff passed. Regression coverage includes overlapping reads, stale geometry, same-index recovery, expiry during pending telemetry, concurrent overlay requests, revoked identity, and fresh verified recovery. Independent review and targeted confirmation covered the identity lifetime contract, with the rendered historical-position fallback inspected. The earlier candidate also passed 67 Home Assistant component and translation tests; CI reruns those checks for this update.

Earlier supervised A2 validation produced Home Assistant HLS video with 100 decoded 640×360 frames and a camera snapshot, followed by verified camera shutdown and docking. A concurrent A2 map read completed before geometry hydration, with both map payload hashes verified. Five-theme render comparisons covered normal and enlarged labels with rotation. Subsequent identity and callback fixes have deterministic concurrency and real-socket regression coverage; physical playback was not repeated for those fixes.