### PR TITLE
Fix VIAX fixed-key 3D map generation

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -891,74 +891,31 @@ class _DreameLawnMowerClientMapsMixin(
             and baseline_extension is not None
             and baseline_extension.casefold() == "bin"
         )
+        fixed_baseline_known = False
         if fixed_object_baseline:
-            fixed_baseline_deadline = min(
-                deadline,
-                time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
-            )
-            try:
-                _, _, baseline_identity = self._sync_download_point_cloud_object(
+            fixed_baseline_known, baseline_identity = (
+                self._sync_probe_point_cloud_object_identity(
                     cloud,
                     baseline_name,
-                    deadline=fixed_baseline_deadline,
-                    download_timeout=min(
-                        download_timeout,
-                        _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
-                    ),
+                    deadline=deadline,
+                    download_timeout=download_timeout,
                     max_bytes=max_bytes,
                 )
-            except (DeviceException, DreameLawnMowerPointCloudError):
-                baseline_identity = None
+            )
 
         stable_announcement_baseline_known = False
         stable_announcement_baseline_identity: _PointCloudObjectIdentity | None = None
         if use_announcement_path and announcement_baseline is not None:
-            baseline_probe_deadline = min(
-                deadline,
-                time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+            (
+                stable_announcement_baseline_known,
+                stable_announcement_baseline_identity,
+            ) = self._sync_probe_point_cloud_object_identity(
+                cloud,
+                announcement_baseline[0],
+                deadline=deadline,
+                download_timeout=download_timeout,
+                max_bytes=max_bytes,
             )
-            try:
-                raw_baseline_url = self._sync_get_point_cloud_download_url(
-                    cloud,
-                    announcement_baseline[0],
-                    deadline=baseline_probe_deadline,
-                    require_response=True,
-                )
-            except (
-                DeviceException,
-                DreameLawnMowerPointCloudError,
-                json.JSONDecodeError,
-            ):
-                pass
-            else:
-                try:
-                    baseline_url = _point_cloud_download_url(raw_baseline_url)
-                except DreameLawnMowerPointCloudError:
-                    # Only the signer's explicit empty result proves the
-                    # stable object was unavailable before o:10. Malformed or
-                    # otherwise unusable signer responses remain inconclusive.
-                    stable_announcement_baseline_known = raw_baseline_url is None
-                else:
-                    remaining = baseline_probe_deadline - time.monotonic()
-                    if remaining > 0:
-                        try:
-                            _, _, stable_announcement_baseline_identity = (
-                                _download_point_cloud_content_with_identity(
-                                    baseline_url,
-                                    timeout=min(
-                                        download_timeout,
-                                        _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
-                                        remaining,
-                                    ),
-                                    max_bytes=max_bytes,
-                                )
-                            )
-                        except DreameLawnMowerPointCloudError:
-                            # HTTP, transport, size, and content failures do not
-                            # prove that a signable baseline object was absent.
-                            pass
-                        else:
-                            stable_announcement_baseline_known = True
 
         # Object baselines are preflight work for both forced and stored
         # requests. Give o:10 the complete advertised generation window after
@@ -1270,10 +1227,12 @@ class _DreameLawnMowerClientMapsMixin(
                 except (DeviceException, DreameLawnMowerPointCloudError):
                     saw_unusable_point_cloud = True
                 else:
-                    if fixed_object and baseline_identity is None:
+                    if fixed_object and not fixed_baseline_known:
                         saw_unverified_fixed_object = True
-                    elif fixed_object and not object_identity.differs_from(
-                        baseline_identity
+                    elif (
+                        fixed_object
+                        and baseline_identity is not None
+                        and not object_identity.differs_from(baseline_identity)
                     ):
                         saw_stale_point_cloud = True
                     else:
@@ -1485,6 +1444,60 @@ class _DreameLawnMowerClientMapsMixin(
             return True, normalized_name if fresh else None, observed
         return False, None, None
 
+    def _sync_probe_point_cloud_object_identity(
+        self,
+        cloud: Any,
+        object_name: str,
+        *,
+        deadline: float,
+        download_timeout: float,
+        max_bytes: int,
+    ) -> tuple[bool, _PointCloudObjectIdentity | None]:
+        """Return whether a pre-generation object baseline is conclusive."""
+        baseline_deadline = min(
+            deadline,
+            time.monotonic() + _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+        )
+        try:
+            raw_url = self._sync_get_point_cloud_download_url(
+                cloud,
+                object_name,
+                deadline=baseline_deadline,
+                require_response=True,
+            )
+        except (
+            DeviceException,
+            DreameLawnMowerPointCloudError,
+            json.JSONDecodeError,
+        ):
+            return False, None
+
+        try:
+            url = _point_cloud_download_url(raw_url)
+        except DreameLawnMowerPointCloudError:
+            # Only the signer's explicit empty result proves the object was
+            # unavailable before o:10. Malformed responses are inconclusive.
+            return raw_url is None, None
+
+        remaining = baseline_deadline - time.monotonic()
+        if remaining <= 0:
+            return False, None
+        try:
+            _, _, identity = _download_point_cloud_content_with_identity(
+                url,
+                timeout=min(
+                    download_timeout,
+                    _POINT_CLOUD_STORED_DOWNLOAD_TIMEOUT_SECONDS,
+                    remaining,
+                ),
+                max_bytes=max_bytes,
+            )
+        except DreameLawnMowerPointCloudError:
+            # Transport, size, and content failures do not prove that a
+            # signable baseline object was absent.
+            return False, None
+        return True, identity
+
     def _sync_download_point_cloud_object(
         self,
         cloud: Any,
@@ -1626,7 +1639,7 @@ class _DreameLawnMowerClientMapsMixin(
         *,
         deadline: float,
         require_response: bool = False,
-    ) -> str:
+    ) -> str | None:
         """Resolve a signed point-cloud URL within the generation deadline."""
         remaining = deadline - time.monotonic()
         if remaining <= 0:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -2076,6 +2076,59 @@ def test_download_point_cloud_waits_for_changed_mova_fixed_object(
     assert not hasattr(result, "object_name")
 
 
+def test_download_point_cloud_accepts_mova_fixed_object_absent_before_generation(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client()
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/map-0.bin"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/map-0.bin"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        return next(responses)
+
+    signer_options: list[dict[str, Any]] = []
+
+    def get_interim_file_url(name: str, **options: Any) -> str | None:
+        signer_options.append(options)
+        if len(signer_options) == 1:
+            return None
+        return "https://downloads.example.invalid/object"
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=get_interim_file_url,
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert signer_options[0]["require_response"] is True
+    assert "require_response" not in signer_options[1]
+    assert result.source == "generated"
+    assert result.content == content
+    assert result.metadata.points == 1
+
+
 def test_download_point_cloud_accepts_new_mova_object_validator(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -3524,8 +3577,15 @@ def test_legacy_baseline_preflight_is_bounded_before_generation(
     client = _client()
     clock = [100.0]
     object_deadlines: list[tuple[float, float]] = []
+    signer_options: list[dict[str, Any]] = []
     generation_deadlines: list[float] = []
-    cloud = SimpleNamespace(get_interim_file_url=lambda name, **options: None)
+
+    def get_interim_file_url(name: str, **options: Any) -> None:
+        signer_options.append(options)
+        clock[0] += 5.0
+        return None
+
+    cloud = SimpleNamespace(get_interim_file_url=get_interim_file_url)
     client._sync_get_cloud_protocol = lambda **kwargs: cloud
 
     def probe(*args: Any, **kwargs: Any) -> tuple[bool, None, None]:
@@ -3541,9 +3601,7 @@ def test_legacy_baseline_preflight_is_bounded_before_generation(
         raise RuntimeError("stop after generation deadline capture")
 
     def fail_object_download(*args: Any, **kwargs: Any) -> None:
-        object_deadlines.append(
-            (kwargs["deadline"], kwargs["download_timeout"])
-        )
+        object_deadlines.append((kwargs["deadline"], kwargs["download_timeout"]))
         clock[0] += 5.0
         raise DreameLawnMowerPointCloudError("not ready")
 
@@ -3563,7 +3621,15 @@ def test_legacy_baseline_preflight_is_bounded_before_generation(
             allow_stored=True,
         )
 
-    assert object_deadlines == [(115.0, 5.0), (120.0, 5.0)]
+    assert object_deadlines == [(115.0, 5.0)]
+    assert signer_options == [
+        {
+            "retry_count": 0,
+            "timeout": 5.0,
+            "deadline": 120.0,
+            "require_response": True,
+        }
+    ]
     assert generation_deadlines == [125.0]
 
 


### PR DESCRIPTION
## Summary

- preserve whether a fixed point-cloud baseline was conclusively observed before generation
- accept a same-name `.bin` object after generation only when the strict cloud signer explicitly reported it absent beforehand
- keep malformed signer responses, failed baseline downloads, and unchanged content fail-closed
- reuse the bounded identity probe for both legacy fixed-key objects and the A2 announcement path
- add regression coverage for the MOVA VIAX publication sequence

The integration owns point-cloud generation and freshness validation; the Lovelace card remains a thin consumer of its API. This addresses [EvotecIT/lovelace-lawn-mower-card#52](https://github.com/EvotecIT/lovelace-lawn-mower-card/issues/52).

## Validation

- `python -m pytest tests/test_point_cloud.py tests/test_point_cloud_api.py tests/test_map_camera.py -q`
- full platform-independent test suite on Python 3.13
- `python -m ruff check .`