### PR TITLE
Fix deterministic MOVA point-cloud refreshes

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_map_helpers.py
@@ -118,7 +118,12 @@ def _point_cloud_action_data(
     require_data: bool,
 ) -> Any:
     """Normalize point-cloud app-action failures without exposing raw payloads."""
-    if not isinstance(value, Mapping) or value.get("r") != 0:
+    result = value.get("r") if isinstance(value, Mapping) else None
+    if (
+        not isinstance(result, int)
+        or isinstance(result, bool)
+        or result != 0
+    ):
         raise DreameLawnMowerPointCloudError(f"The mower could not {operation}.")
     data = value.get("d")
     if require_data and not isinstance(data, Mapping):

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -99,6 +99,7 @@ if TYPE_CHECKING:
 
 # Dreame and MOVA can report 3D-map PCD payloads with a "*.bin" object name.
 _POINT_CLOUD_OBJECT_EXTENSIONS = frozenset({"pcd", "bin"})
+_POINT_CLOUD_ACKNOWLEDGED_FIXED_OBJECT_MODELS = frozenset({"mova.mower.g2583"})
 _POINT_CLOUD_ANNOUNCEMENT_PROPERTY_KEY = "99.20"
 _POINT_CLOUD_ANNOUNCEMENT_CLOCK_SKEW_MS = 5_000
 _POINT_CLOUD_ANNOUNCEMENT_PROBE_TIMEOUT_SECONDS = 2.0
@@ -1236,6 +1237,8 @@ class _DreameLawnMowerClientMapsMixin(
                         fixed_object
                         and self._account_type == "mova"
                         and generation_acknowledged
+                        and str(self._descriptor.model).strip().casefold()
+                        in _POINT_CLOUD_ACKNOWLEDGED_FIXED_OBJECT_MODELS
                     )
                     if fixed_object and not fixed_baseline_known:
                         saw_unverified_fixed_object = True

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -929,6 +929,7 @@ class _DreameLawnMowerClientMapsMixin(
             if generation_requested_at_ms is None:
                 generation_requested_at_ms = int(time.time() * 1000)
 
+        generation_acknowledged = False
         try:
             self._sync_call_point_cloud_action(
                 {"m": "a", "p": 0, "o": 10, "d": {"idx": map_index}},
@@ -937,6 +938,7 @@ class _DreameLawnMowerClientMapsMixin(
                 require_data=False,
                 on_dispatch=mark_generation_dispatched,
             )
+            generation_acknowledged = True
         except DreameLawnMowerPointCloudError as err:
             if generation_requested_at_ms is None or err.code not in {
                 "point_cloud_timeout",
@@ -1227,12 +1229,21 @@ class _DreameLawnMowerClientMapsMixin(
                 except (DeviceException, DreameLawnMowerPointCloudError):
                     saw_unusable_point_cloud = True
                 else:
+                    # MOVA can keep a fixed object byte-for-byte deterministic
+                    # after o:10. A successful action reply is the only safe
+                    # substitute for an observable object-identity change.
+                    acknowledged_mova_fixed_object = (
+                        fixed_object
+                        and self._account_type == "mova"
+                        and generation_acknowledged
+                    )
                     if fixed_object and not fixed_baseline_known:
                         saw_unverified_fixed_object = True
                     elif (
                         fixed_object
                         and baseline_identity is not None
                         and not object_identity.differs_from(baseline_identity)
+                        and not acknowledged_mova_fixed_object
                     ):
                         saw_stale_point_cloud = True
                     else:

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/protocol_cloud.py
@@ -1017,13 +1017,13 @@ class DreameMowerDreameHomeCloudProtocol:
         response_code = (
             api_response.get("code") if isinstance(api_response, Mapping) else None
         )
-        if (
-            raise_on_api_error
-            and isinstance(response_code, int)
-            and not isinstance(response_code, bool)
-            and response_code != 0
-        ):
-            raise DreameLawnMowerCloudAPIError(response_code)
+        if raise_on_api_error:
+            if not isinstance(response_code, int) or isinstance(response_code, bool):
+                raise DeviceException(
+                    "Dreame cloud API returned an invalid response code."
+                )
+            if response_code != 0:
+                raise DreameLawnMowerCloudAPIError(response_code)
         if isinstance(api_response, Mapping) and api_response.get("code") == 80001:
             # Seems to be a valid error message from the server which translates to:
             #   "The device may be offline and the command sending timed out."

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -2135,6 +2135,45 @@ def test_download_point_cloud_accepts_unchanged_mova_fixed_object_after_ack(
     assert result.metadata.points == 1
 
 
+def test_download_point_cloud_rejects_unchanged_unverified_mova_model_after_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client()
+    calls: list[dict[str, Any]] = []
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        if payload.get("m") == "a":
+            kwargs["on_dispatch"]()
+            return {"r": 0}
+        return {"r": 0, "d": {"name": ["private/existing-map.bin"]}}
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(0, 0.05, 0.001, 10, 1024)
+
+    assert captured.value.code == "point_cloud_not_published"
+    assert calls[:2] == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+    ]
+
+
 def test_download_point_cloud_accepts_mova_fixed_object_absent_before_generation(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -2135,17 +2135,18 @@ def test_download_point_cloud_accepts_unchanged_mova_fixed_object_after_ack(
     assert result.metadata.points == 1
 
 
-def test_download_point_cloud_rejects_unchanged_unverified_mova_model_after_ack(
+def test_download_point_cloud_rejects_false_viax_generation_reply(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    client = _mova_client()
-    calls: list[dict[str, Any]] = []
+    client = _mova_client(
+        model="mova.mower.g2583",
+        display_model="VIAX 500",
+    )
 
     def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
-        calls.append(payload)
         if payload.get("m") == "a":
             kwargs["on_dispatch"]()
-            return {"r": 0}
+            return {"r": False}
         return {"r": 0, "d": {"name": ["private/existing-map.bin"]}}
 
     client._sync_call_app_action = call_app_action
@@ -2168,10 +2169,49 @@ def test_download_point_cloud_rejects_unchanged_unverified_mova_model_after_ack(
         client._sync_download_app_map_point_cloud(0, 0.05, 0.001, 10, 1024)
 
     assert captured.value.code == "point_cloud_not_published"
-    assert calls[:2] == [
+
+
+def test_download_point_cloud_waits_for_changed_unverified_mova_model_after_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client()
+    calls: list[dict[str, Any]] = []
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        if payload.get("m") == "a":
+            kwargs["on_dispatch"]()
+            return {"r": 0}
+        return {"r": 0, "d": {"name": ["private/existing-map.bin"]}}
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    baseline_content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    refreshed_content = _binary_pcd((4.0, 5.0, 6.0, 0x654321))
+    downloads = iter([baseline_content, baseline_content, refreshed_content])
+    monkeypatch.setattr(client_module.time, "sleep", lambda _: None)
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            next(downloads),
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
         {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
         {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
     ]
+    assert result.content == refreshed_content
 
 
 def test_download_point_cloud_accepts_mova_fixed_object_absent_before_generation(
@@ -2831,6 +2871,41 @@ def test_point_cloud_action_can_raise_safe_cloud_api_code() -> None:
 
     assert captured.value.code == 80001
     assert "80001" in str(captured.value)
+
+
+@pytest.mark.parametrize(
+    "response",
+    [
+        {"data": {"result": {"r": 0}}},
+        {"code": None, "data": {"result": {"r": 0}}},
+        {"code": "0", "data": {"result": {"r": 0}}},
+        {"code": 0.0, "data": {"result": {"r": 0}}},
+        {"code": False, "data": {"result": {"r": 0}}},
+        {"code": True, "data": {"result": {"r": 0}}},
+    ],
+)
+def test_point_cloud_action_rejects_malformed_cloud_api_code(
+    response: dict[str, Any],
+) -> None:
+    protocol_type = _internal_protocol_module.DreameMowerDreameHomeCloudProtocol
+    cloud = object.__new__(protocol_type)
+    cloud._request_lock = threading.RLock()
+    cloud._strings = [f"value-{index}" for index in range(57)]
+    cloud._host = "host.example.invalid"
+    cloud._did = "device-1"
+    cloud._id = 1
+    cloud._api_call = lambda *args, **kwargs: response
+
+    with pytest.raises(
+        _internal_exceptions_module.DeviceException,
+        match="invalid response code",
+    ):
+        cloud.call_app_action(
+            {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+            retry_count=0,
+            redact_response=True,
+            raise_on_api_error=True,
+        )
 
 
 def test_point_cloud_wraps_safe_cloud_api_rejection() -> None:

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -111,7 +111,11 @@ def _point_cloud_protocol() -> Any:
     return cloud
 
 
-def _mova_client() -> DreameLawnMowerClient:
+def _mova_client(
+    *,
+    model: str = "mova.mower.g2408",
+    display_model: str = "A2",
+) -> DreameLawnMowerClient:
     return DreameLawnMowerClient(
         username="user@example.invalid",
         password="secret",
@@ -120,8 +124,8 @@ def _mova_client() -> DreameLawnMowerClient:
         descriptor=DreameLawnMowerDescriptor(
             did="device-1",
             name="Garage Mower",
-            model="mova.mower.g2408",
-            display_model="A2",
+            model=model,
+            display_model=display_model,
             account_type="mova",
             country="eu",
         ),
@@ -2011,7 +2015,7 @@ def test_download_point_cloud_bounds_invalid_announced_object_downloads(
     assert download_count == 2
 
 
-def test_download_point_cloud_waits_for_changed_mova_fixed_object(
+def test_download_point_cloud_waits_for_changed_mova_fixed_object_after_lost_reply(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     client = _mova_client()
@@ -2019,7 +2023,6 @@ def test_download_point_cloud_waits_for_changed_mova_fixed_object(
     responses = iter(
         [
             {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
-            {"r": 0},
             {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
             {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
             {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
@@ -2028,6 +2031,12 @@ def test_download_point_cloud_waits_for_changed_mova_fixed_object(
 
     def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
         calls.append(payload)
+        if payload.get("m") == "a":
+            kwargs["on_dispatch"]()
+            raise DreameLawnMowerPointCloudError(
+                "generation reply lost",
+                code="point_cloud_mower_response_invalid",
+            )
         return next(responses)
 
     signed_url = "https://downloads.example.invalid/object?private=signature"
@@ -2074,6 +2083,56 @@ def test_download_point_cloud_waits_for_changed_mova_fixed_object(
     assert result.metadata.points == 1
     assert not hasattr(result, "url")
     assert not hasattr(result, "object_name")
+
+
+def test_download_point_cloud_accepts_unchanged_mova_fixed_object_after_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client(
+        model="mova.mower.g2583",
+        display_model="VIAX 500",
+    )
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/existing-map.bin"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        if payload.get("m") == "a":
+            kwargs["on_dispatch"]()
+        return next(responses)
+
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.source == "generated"
+    assert result.content == content
+    assert result.metadata.points == 1
 
 
 def test_download_point_cloud_accepts_mova_fixed_object_absent_before_generation(


### PR DESCRIPTION
## Summary

- accept the VIAX 500 fixed `.bin` point cloud when the mower positively acknowledges generation, even if the object remains byte-for-byte unchanged
- keep other MOVA models and all lost, timed-out, rejected, or malformed generation replies fail-closed until an observable object change appears
- require strict integer-zero success codes in both the cloud envelope and mower response before recording acknowledgment
- cover the reported `mova.mower.g2583` path, sibling-model freshness, and malformed boolean/string/float/null responses

## Why

The reporter confirmed the first remediation is installed in `v0.2.94`, but VIAX 500 continues to publish the same fixed object name, content hash, ETag, and last-modified value after generation. The prior freshness rule therefore waited for a change that this device never exposes. A fully validated generation response is now accepted as the narrow substitute signal only for the reported VIAX 500 model.

## Validation

- `python -m ruff check .`
- `python -m pytest tests/test_point_cloud.py -q`
- `python -m pytest tests/test_point_cloud.py tests/test_point_cloud_api.py tests/test_map_camera.py -q`
- `python -m pytest tests --ignore=tests/components --ignore=tests/test_translations.py -q`
- independent review, defect-class closure audit, and targeted confirmation

Addresses EvotecIT/lovelace-lawn-mower-card#52.