### PR TITLE
Fix VIAX stable point-cloud announcements

### DIFF
--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/client_maps.py
@@ -955,6 +955,20 @@ class _DreameLawnMowerClientMapsMixin(
             # do not expose the dispatch hook.
             mark_generation_dispatched()
 
+        def acknowledged_fixed_object(object_name: str | None) -> bool:
+            """Return whether an exact-model action ack proves fixed-key refresh."""
+            extension = (
+                _app_object_extension(object_name) if object_name is not None else None
+            )
+            return (
+                extension is not None
+                and extension.casefold() == "bin"
+                and self._account_type == "mova"
+                and generation_acknowledged
+                and str(self._descriptor.model).strip().casefold()
+                in _POINT_CLOUD_ACKNOWLEDGED_FIXED_OBJECT_MODELS
+            )
+
         observed_clear = baseline_known and baseline_name is None
         saw_unusable_point_cloud = False
         saw_stale_point_cloud = False
@@ -1090,11 +1104,14 @@ class _DreameLawnMowerClientMapsMixin(
                     )
                     if stable_announced_name is not None:
                         stable_refresh_proven = (
-                            stable_announcement_baseline_known
-                            and (
-                                stable_announcement_baseline_identity is None
-                                or object_identity.differs_from(
-                                    stable_announcement_baseline_identity
+                            acknowledged_fixed_object(stable_announced_name)
+                            or (
+                                stable_announcement_baseline_known
+                                and (
+                                    stable_announcement_baseline_identity is None
+                                    or object_identity.differs_from(
+                                        stable_announcement_baseline_identity
+                                    )
                                 )
                             )
                         )
@@ -1235,10 +1252,7 @@ class _DreameLawnMowerClientMapsMixin(
                     # substitute for an observable object-identity change.
                     acknowledged_mova_fixed_object = (
                         fixed_object
-                        and self._account_type == "mova"
-                        and generation_acknowledged
-                        and str(self._descriptor.model).strip().casefold()
-                        in _POINT_CLOUD_ACKNOWLEDGED_FIXED_OBJECT_MODELS
+                        and acknowledged_fixed_object(object_name)
                     )
                     if fixed_object and not fixed_baseline_known:
                         saw_unverified_fixed_object = True
@@ -1284,6 +1298,9 @@ class _DreameLawnMowerClientMapsMixin(
                 ),
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
+                diagnostic_reason="fixed_baseline_inconclusive",
+                discovery_route="legacy_obj",
+                generation_acknowledged=generation_acknowledged,
             )
 
         if saw_unusable_point_cloud:
@@ -1298,6 +1315,11 @@ class _DreameLawnMowerClientMapsMixin(
                 ),
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
+                diagnostic_reason="published_object_invalid",
+                discovery_route=(
+                    "announcement_property" if use_announcement_path else "legacy_obj"
+                ),
+                generation_acknowledged=generation_acknowledged,
             )
 
         if saw_stale_point_cloud:
@@ -1312,6 +1334,11 @@ class _DreameLawnMowerClientMapsMixin(
                 ),
                 timeout_seconds=timeout,
                 retry_after_seconds=10,
+                diagnostic_reason="unchanged_object",
+                discovery_route=(
+                    "announcement_property" if use_announcement_path else "legacy_obj"
+                ),
+                generation_acknowledged=generation_acknowledged,
             )
 
         raise DreameLawnMowerPointCloudError(
@@ -1323,6 +1350,11 @@ class _DreameLawnMowerClientMapsMixin(
             ),
             timeout_seconds=timeout,
             retry_after_seconds=10,
+            diagnostic_reason="object_not_observed",
+            discovery_route=(
+                "announcement_property" if use_announcement_path else "legacy_obj"
+            ),
+            generation_acknowledged=generation_acknowledged,
         )
 
     def _sync_try_download_stored_point_cloud(

--- a/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
+++ b/custom_components/dreame_lawn_mower/dreame_lawn_mower_client/point_cloud.py
@@ -36,6 +36,9 @@ class DreameLawnMowerPointCloudError(ValueError):
         timeout_seconds: float | None = None,
         retry_after_seconds: int | None = None,
         vendor_error_code: int | None = None,
+        diagnostic_reason: str | None = None,
+        discovery_route: str | None = None,
+        generation_acknowledged: bool | None = None,
     ) -> None:
         super().__init__(message)
         self.code = code
@@ -45,6 +48,9 @@ class DreameLawnMowerPointCloudError(ValueError):
         self.timeout_seconds = timeout_seconds
         self.retry_after_seconds = retry_after_seconds
         self.vendor_error_code = vendor_error_code
+        self.diagnostic_reason = diagnostic_reason
+        self.discovery_route = discovery_route
+        self.generation_acknowledged = generation_acknowledged
 
 
 @dataclass(frozen=True, slots=True)

--- a/custom_components/dreame_lawn_mower/point_cloud_api.py
+++ b/custom_components/dreame_lawn_mower/point_cloud_api.py
@@ -499,6 +499,12 @@ class DreameLawnMowerPointCloudAPI:
             "allow_stored": allow_stored,
             "allow_unscoped_stored": allow_unscoped_stored,
         }
+        if error.diagnostic_reason is not None:
+            context["reason"] = error.diagnostic_reason
+        if error.discovery_route is not None:
+            context["discovery_route"] = error.discovery_route
+        if error.generation_acknowledged is not None:
+            context["generation_acknowledged"] = error.generation_acknowledged
         exception_type = None
         if unexpected_error is not None:
             exception_type = _exception_type_name(unexpected_error)

--- a/tests/test_point_cloud.py
+++ b/tests/test_point_cloud.py
@@ -1045,6 +1045,106 @@ def test_download_point_cloud_accepts_indexed_stable_announcement(
     assert result.content == content
 
 
+def test_download_point_cloud_accepts_unchanged_viax_announcement_after_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client(
+        model="mova.mower.g2583",
+        display_model="VIAX 500",
+    )
+    calls: list[dict[str, Any]] = []
+    responses = iter(
+        [
+            {"r": 0},
+            {"r": 0, "d": {"name": ["private/stable-map.bin"]}},
+        ]
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        calls.append(payload)
+        if payload.get("m") == "a":
+            kwargs["on_dispatch"]()
+        return next(responses)
+
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stable-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    result = client._sync_download_app_map_point_cloud(0, 5, 0.1, 10, 1024)
+
+    assert calls == [
+        {"m": "a", "p": 0, "o": 10, "d": {"idx": 0}},
+        {"m": "g", "t": "OBJ", "d": {"type": "3dmap"}},
+    ]
+    assert result.source == "generated"
+    assert result.content == content
+
+
+def test_download_point_cloud_rejects_unchanged_viax_announcement_without_ack(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    client = _mova_client(
+        model="mova.mower.g2583",
+        display_model="VIAX 500",
+    )
+
+    def call_app_action(payload: dict[str, Any], **kwargs: Any) -> dict[str, Any]:
+        if payload.get("m") == "a":
+            kwargs["on_dispatch"]()
+            return {"r": False}
+        return {"r": 0, "d": {"name": ["private/stable-map.bin"]}}
+
+    content = _binary_pcd((1.0, 2.0, 3.0, 0x123456))
+    client._sync_call_app_action = call_app_action
+    client._sync_get_cloud_protocol = lambda **kwargs: SimpleNamespace(
+        get_properties=lambda key, **options: [
+            {
+                "key": key,
+                "value": "private/stable-map.bin",
+                "updateDate": 1,
+            }
+        ],
+        get_interim_file_url=lambda name, **options: (
+            "https://downloads.example.invalid/object"
+        ),
+    )
+    monkeypatch.setattr(
+        _internal_client_module,
+        "_open_point_cloud_response",
+        lambda request, *, timeout, deadline: _FakeResponse(
+            content,
+            request.full_url,
+        ),
+    )
+
+    with pytest.raises(DreameLawnMowerPointCloudError) as captured:
+        client._sync_download_app_map_point_cloud(0, 0.05, 0.001, 10, 1024)
+
+    assert captured.value.code == "point_cloud_not_published"
+    assert captured.value.diagnostic_reason == "unchanged_object"
+    assert captured.value.discovery_route == "announcement_property"
+    assert captured.value.generation_acknowledged is False
+
+
 def test_download_point_cloud_rejects_unchanged_signable_stable_announcement(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:

--- a/tests/test_point_cloud_api.py
+++ b/tests/test_point_cloud_api.py
@@ -833,6 +833,9 @@ def test_point_cloud_api_records_safe_failure_and_timing() -> None:
             ),
             timeout_seconds=45,
             retry_after_seconds=10,
+            diagnostic_reason="unchanged_object",
+            discovery_route="announcement_property",
+            generation_acknowledged=True,
         )
 
     coordinator = SimpleNamespace(
@@ -857,6 +860,9 @@ def test_point_cloud_api_records_safe_failure_and_timing() -> None:
     assert event["context"]["map_index"] == 0
     assert event["context"]["allow_stored"] is False
     assert event["context"]["vendor_error_code"] is None
+    assert event["context"]["reason"] == "unchanged_object"
+    assert event["context"]["discovery_route"] == "announcement_property"
+    assert event["context"]["generation_acknowledged"] is True
     assert private_detail not in repr(event)
     performance = coordinator.performance.as_dict()
     assert performance["summary"]["point_cloud_generation"]["outcomes"] == {


### PR DESCRIPTION
## Summary

- apply the exact VIAX fixed-object acknowledgement contract to both the dedicated 99.20 announcement route and the legacy OBJ route
- retain the map-index binding, exact model allowlist, .bin restriction, validated generation reply, signed download, and PCD validation gates
- record privacy-safe failure reason, discovery route, and acknowledgement state in diagnostics

## Why

The diagnostics attached to [lovelace-lawn-mower-card issue #52](https://github.com/EvotecIT/lovelace-lawn-mower-card/issues/52#issuecomment-5647428674) prove that integration 0.2.95 was installed, but the VIAX 500 still timed out. The earlier fix covered the legacy OBJ path only. This firmware exposes the unchanged fixed object through property 99.20, whose separate freshness check continued rejecting it for the full timeout.

## Validation

- full repository Ruff check
- focused point-cloud client and API test suites
- exact positive replay for mova.mower.g2583 using stable 99.20 plus indexed OBJ
- fail-closed replay for a false generation acknowledgement
- independent read-only closure review with no actionable findings

The broader WSL test run reached completion. Unrelated failures were limited to the local Python 3.12/Home Assistant storage API mismatch, an existing timing-sensitive blueprint case, and an HTTP teardown thread; the changed owner suites passed.